### PR TITLE
fix(proxy): an error frame the gateway cannot type is still an error frame

### DIFF
--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -1,6 +1,10 @@
 package anthropic
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
 
 // RewriteModel rewrites the top-level "model" field of an Anthropic Messages
 // request body to the resolved upstream model id, leaving every other field
@@ -180,9 +184,13 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			Usage *antUsage `json:"usage"`
 		} `json:"message"`
 		Usage *antUsage `json:"usage"`
-		Error *struct {
-			Message string `json:"message"`
-		} `json:"error"`
+		// json.RawMessage, not a typed object: a relay is free to send a bare
+		// string here, and a typed field failed the WHOLE event unmarshal — so
+		// the event lost its type too, the error went uncounted, and the frame
+		// was forwarded to the caller with no key-shape masking at all,
+		// credential included. util.ErrorMemberCarries is the same rule the
+		// OpenAI-compatible path reads this member with.
+		Error json.RawMessage `json:"error"`
 		Delta *struct {
 			Text        string `json:"text"`
 			Thinking    string `json:"thinking"`
@@ -211,8 +219,8 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			info.OutputTokens, info.HasOutput = ev.Usage.OutputTokens, true
 		}
 	case "error":
-		if ev.Error != nil {
-			info.ErrorMessage = ev.Error.Message
+		if util.ErrorMemberCarries(ev.Error) {
+			info.ErrorMessage = util.ErrorMemberMessage(ev.Error)
 		}
 	case "content_block_delta":
 		if ev.Delta != nil {

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -141,7 +141,7 @@ func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, ch
 		if info.ErrorMessage != "" {
 			st.lastErrMsg = info.ErrorMessage
 			st.errorChunkCount++
-			debuglog.Warn("proxy: native anthropic SSE error event", "error_message", info.ErrorMessage, "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+			debuglog.Warn("proxy: native anthropic SSE error event", "error_message", st.errLogAttr(info.ErrorMessage), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 		}
 	}
 	line := ev.raw

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"encoding/json"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
 )
 
 // errorFrameCorpus is the set of "error" member shapes providers actually send,
@@ -237,7 +238,7 @@ func TestErrLogAttr_MasksAndBounds(t *testing.T) {
 	}
 
 	if bounded := st.errLogAttr(strings.Repeat("x", 5000)); len(bounded) > 1000 {
-		t.Errorf("unbounded provider text: %d chars", len(bounded))
+		t.Errorf("unbounded provider text: %d bytes", len(bounded))
 	}
 }
 
@@ -247,10 +248,7 @@ func TestHandleStreamingResponse_ErrorFrameLogIsMasked(t *testing.T) {
 	h := newUnitHandler()
 	defer stopUnitHandler(h)
 
-	var logged strings.Builder
-	restore := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(restore) })
+	capture := captureProxyLogs(t)
 
 	const quoted = "sk-theirs-1234567890abcdefghij"
 	resp := &http.Response{
@@ -268,38 +266,61 @@ func TestHandleStreamingResponse_ErrorFrameLogIsMasked(t *testing.T) {
 		masker:       logData.masker,
 	})
 
-	out := logged.String()
-	if !strings.Contains(out, "SSE error chunk") {
-		t.Fatalf("the error frame was not logged at all, so nothing was masked: %q", out)
+	if len(capture.find("SSE error chunk")) == 0 {
+		t.Fatal("the error frame was not logged at all, so nothing was masked")
 	}
-	if strings.Contains(out, quoted) {
-		t.Errorf("credential reached the application log: %q", out)
+	// Every record, not just that one: the site the fix was written for was
+	// masked while a second one beside it still logged the credential raw.
+	for _, rec := range capture.all() {
+		for key, val := range rec.attrs {
+			if strings.Contains(val, quoted) {
+				t.Errorf("credential reached the application log: %q attr %q = %q", rec.msg, key, val)
+			}
+		}
 	}
 }
 
 // An error frame is the provider reporting its own failure, so it charges the
-// breaker. The payload here puts a key before "error", which is the case the
-// P1-B accumulator is blind to: with the frame also dropped as unparseable, a
-// provider erroring on every single request produced a stream this gateway read
-// as a clean, merely empty one — and unparsedChunks then held even the
-// empty-stream charge back, so the circuit never opened.
-func TestJudgeStreamForBreaker_UntypeableErrorFrameCharges(t *testing.T) {
+// breaker until the circuit opens. The payload puts a key before "error", the
+// case the P1-B accumulator is blind to: with the frame also dropped as
+// unparseable, a provider erroring on every single request produced a stream
+// this gateway read as clean and merely empty — and unparsedChunks then held
+// even the empty-stream charge back, so the circuit stayed closed forever.
+func TestJudgeStreamForBreaker_UntypeableErrorFrameOpensTheCircuit(t *testing.T) {
 	h := newUnitHandler()
 	defer stopUnitHandler(h)
+	h.circuitBreaker = failover.NewCircuitBreaker(nil)
 
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`data: {"model":"llama3","error":"model not found"}` + "\n\ndata: [DONE]\n\n")),
-		Header:     make(http.Header),
+	providerID := uuid.New()
+	const providerName = "mock"
+	if h.circuitBreaker.IsOpen(providerID, providerName) {
+		t.Fatal("circuit is open before any request")
 	}
-	w := httptest.NewRecorder()
-	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
-	logData := newErrorFrameLog()
 
-	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+	// One under the threshold, then the one that trips it.
+	for i := range h.circuitBreaker.Threshold {
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`data: {"model":"llama3","error":"model not found"}` + "\n\ndata: [DONE]\n\n")),
+			Header:     make(http.Header),
+		}
+		w := httptest.NewRecorder()
+		req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+		logData := newErrorFrameLog()
 
-	if !providerAtFault(logData.errorKind) {
-		t.Fatalf("errorKind = %q, want a kind the provider answers for", logData.errorKind)
+		h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+			cancelOrigin:     "failover_timeout",
+			circuitBreakerOn: true,
+			providerID:       providerID,
+			providerName:     providerName,
+		})
+
+		if !providerAtFault(logData.errorKind) {
+			t.Fatalf("request %d: errorKind = %q, want a kind the provider answers for", i+1, logData.errorKind)
+		}
+		if open := h.circuitBreaker.IsOpen(providerID, providerName); open != (i+1 >= h.circuitBreaker.Threshold) {
+			t.Errorf("after %d failures: open = %v, threshold %d", i+1, open, h.circuitBreaker.Threshold)
+		}
 	}
 }
 

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -280,6 +280,42 @@ func TestHandleStreamingResponse_ErrorFrameLogIsMasked(t *testing.T) {
 	}
 }
 
+// The key-shape regex matches prose, which is why it is gated on the frame
+// being an error at all. Several relays put "error":null (or an empty member)
+// on every ordinary frame, so a gate that fires on the member's mere presence
+// runs the regex over the model's answer — and an assistant writing out an API
+// key format, a Bearer header or an AWS access key id has its output silently
+// rewritten to [redacted] mid-stream.
+func TestHandleStreamingResponse_ContentIsNeverKeyShapeMasked(t *testing.T) {
+	for _, member := range []string{`null`, `""`, `{}`, `[]`, `false`, `0`} {
+		t.Run(member, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			const answer = `set OPENAI_API_KEY=sk-proj-ABCDEFGHIJKLMNOP123 then run it`
+			frame := `{"error":` + member + `,"choices":[{"delta":{"content":"` + answer + `"}}]}`
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + frame + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			logData := newErrorFrameLog()
+			logData.masker = newCredentialMasker("sk-ours-0000000000000000000000")
+
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				cancelOrigin: "failover_timeout",
+				masker:       logData.masker,
+			})
+
+			if !strings.Contains(w.Body.String(), answer) {
+				t.Errorf("the model's answer was rewritten in flight: %q", w.Body.String())
+			}
+		})
+	}
+}
+
 // An error frame is the provider reporting its own failure, so it charges the
 // breaker until the circuit opens. The payload puts a key before "error", the
 // case the P1-B accumulator is blind to: with the frame also dropped as

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -115,35 +115,50 @@ func TestHandleStreamingResponse_BareStringErrorIsForwarded(t *testing.T) {
 	}
 }
 
-// The provider's credential can be quoted inside an error of any shape. The
-// key-shape scrub is gated on the frame being an error, so a shape the gateway
-// could not type skipped it — and skipped the exact-key pass with it, because
-// an unparseable frame is masked nowhere at all.
+// A credential can be quoted inside an error of any shape, and the key-shape
+// scrub — the layer that catches a key which is not this gateway's own — is
+// gated on the frame being an error. A shape the gateway could not type failed
+// that gate, and the exact-key pass with it, because the invalid-JSON branch
+// masks nothing at all.
+//
+// The quoted token is deliberately NOT the configured credential: the exact
+// mask cannot see it, so only the shape scrub can, which is what makes this
+// read the gate rather than the pass beneath it. The request log is asserted
+// alongside the client, because the observer takes the message before the
+// masking runs.
 func TestHandleStreamingResponse_BareStringErrorIsMasked(t *testing.T) {
 	h := newUnitHandler()
 	defer stopUnitHandler(h)
 
-	const key = "sk-test-1234567890abcdefghijklmn"
+	const ownKey = "sk-ours-0000000000000000000000"
+	const quoted = "sk-theirs-1234567890abcdefghij"
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`data: {"error":"invalid key ` + key + `"}` + "\n\n")),
+		Body:       io.NopCloser(strings.NewReader(`data: {"error":"invalid key ` + quoted + `"}` + "\n\n")),
 		Header:     make(http.Header),
 	}
 	w := httptest.NewRecorder()
 	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
 	logData := newErrorFrameLog()
-	logData.masker = newCredentialMasker(key)
+	logData.masker = newCredentialMasker(ownKey)
 
 	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
 		cancelOrigin: "failover_timeout",
 		masker:       logData.masker,
 	})
 
-	if strings.Contains(w.Body.String(), key) {
-		t.Errorf("provider credential reached the caller: %q", w.Body.String())
+	body := w.Body.String()
+	if !strings.Contains(body, "invalid key") {
+		t.Fatalf("error frame was not forwarded, so nothing was masked: %q", body)
 	}
-	if strings.Contains(logData.errorMessage, key) {
-		t.Errorf("provider credential reached the request log: %q", logData.errorMessage)
+	if strings.Contains(body, quoted) {
+		t.Errorf("key-shaped token reached the caller: %q", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Errorf("key-shaped token was not redacted for the caller: %q", body)
+	}
+	if strings.Contains(logData.errorMessage, quoted) {
+		t.Errorf("key-shaped token reached the request log: %q", logData.errorMessage)
 	}
 }
 

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -1,0 +1,186 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// errorFrameCorpus is the set of "error" member shapes providers actually send,
+// with the one verdict this package is entitled to have about each: whether it
+// leaves a caller something to read. carriesErrorObject already answers exactly
+// this for a whole body, so every consumer of an error member must agree with
+// it — the probe that decides a hedged race, and the stream observer that
+// decides what the request log and the circuit breaker see.
+var errorFrameCorpus = []struct {
+	name    string
+	payload string
+	isError bool
+	wantMsg string
+}{
+	{"openai object", `{"error":{"message":"rate limited"}}`, true, "rate limited"},
+	{"ollama bare string", `{"error":"model not found"}`, true, "model not found"},
+	{"object without message", `{"error":{"code":500}}`, true, `{"code":500}`},
+	{"list", `{"error":["bad","worse"]}`, true, `["bad","worse"]`},
+	{"number", `{"error":503}`, true, "503"},
+	{"error after another key", `{"model":"llama3","error":"model not found"}`, true, "model not found"},
+	{"null", `{"error":null}`, false, ""},
+	{"empty object", `{"error":{}}`, false, ""},
+	{"empty string", `{"error":""}`, false, ""},
+	{"empty list", `{"error":[]}`, false, ""},
+	{"no error member", `{"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
+}
+
+// A frame the probe calls an error must also be counted as one by the stream
+// observer. They are two readings of the same bytes: when they disagree the
+// hedged race is lost by a provider whose error the request log then never
+// records, and the circuit breaker sees a clean stream.
+func TestErrorFrameShapes_ObserverMatchesProbe(t *testing.T) {
+	t.Parallel()
+	for _, tc := range errorFrameCorpus {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var chunk streamChunk
+			if err := json.Unmarshal([]byte(tc.payload), &chunk); err != nil {
+				t.Fatalf("streamChunk unmarshal %s: %v", tc.payload, err)
+			}
+			st := &streamState{}
+			st.observeDataChunk(chunk, false, 1, &requestLogData{modelID: "m", providerName: "p"})
+
+			gotErr := st.errorChunkCount > 0
+			if gotErr != tc.isError {
+				t.Errorf("observer counted error=%v, want %v", gotErr, tc.isError)
+			}
+			if st.lastErrMsg != tc.wantMsg {
+				t.Errorf("lastErrMsg = %q, want %q", st.lastErrMsg, tc.wantMsg)
+			}
+
+			frame, probeMsg := classifyProbeFrame(tc.payload)
+			probeErr := frame == probeFrameError
+			if probeErr != tc.isError {
+				t.Errorf("probe classified error=%v, want %v", probeErr, tc.isError)
+			}
+			if tc.isError && probeMsg != tc.wantMsg {
+				t.Errorf("probe message = %q, want %q", probeMsg, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// An error member the gateway cannot type is still an error member, and the
+// frame carrying it is still the provider's answer. Dropping it as unparseable
+// bytes hands the caller a stream that simply stops, and leaves the request log
+// with no error at all when the provider put any key before "error" (the P1-B
+// accumulator only recognises a payload that STARTS with {"error").
+func TestHandleStreamingResponse_BareStringErrorIsForwarded(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{"error first", `{"error":"model not found"}`},
+		{"error after another key", `{"model":"llama3","error":"model not found"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + tc.payload + "\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			logData := newErrorFrameLog()
+
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !strings.Contains(w.Body.String(), "model not found") {
+				t.Errorf("error frame was not forwarded to the caller, body = %q", w.Body.String())
+			}
+			if logData.state != "failed" {
+				t.Errorf("state = %q, want failed", logData.state)
+			}
+			if !strings.Contains(logData.errorMessage, "model not found") {
+				t.Errorf("errorMessage = %q, want it to carry the provider's text", logData.errorMessage)
+			}
+		})
+	}
+}
+
+// The provider's credential can be quoted inside an error of any shape. The
+// key-shape scrub is gated on the frame being an error, so a shape the gateway
+// could not type skipped it — and skipped the exact-key pass with it, because
+// an unparseable frame is masked nowhere at all.
+func TestHandleStreamingResponse_BareStringErrorIsMasked(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	const key = "sk-test-1234567890abcdefghijklmn"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`data: {"error":"invalid key ` + key + `"}` + "\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+	logData.masker = newCredentialMasker(key)
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		cancelOrigin: "failover_timeout",
+		masker:       logData.masker,
+	})
+
+	if strings.Contains(w.Body.String(), key) {
+		t.Errorf("provider credential reached the caller: %q", w.Body.String())
+	}
+	if strings.Contains(logData.errorMessage, key) {
+		t.Errorf("provider credential reached the request log: %q", logData.errorMessage)
+	}
+}
+
+// An error frame is the provider reporting its own failure, so it charges the
+// breaker. It used to be dropped as unparseable instead, and unparsedChunks
+// holds the empty-stream charge back — so a provider erroring on every request
+// in a shape the gateway could not type never opened its circuit.
+func TestJudgeStreamForBreaker_UntypeableErrorFrameCharges(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`data: {"error":"model not found"}` + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if logData.errorKind == "" {
+		t.Errorf("an error frame must produce an error kind, got none (state %q)", logData.state)
+	}
+}
+
+func newErrorFrameLog() *requestLogData {
+	ld := &requestLogData{
+		modelID:        "test-model",
+		providerID:     uuid.New(),
+		streaming:      true,
+		state:          "pending",
+		insertWg:       sync.WaitGroup{},
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+	}
+	ld.insertWg.Add(1)
+	return ld
+}

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -219,6 +220,60 @@ func TestHandleStreamingResponse_BareStringErrorIsMasked(t *testing.T) {
 	}
 	if strings.Contains(logData.errorMessage, quoted) {
 		t.Errorf("key-shaped token reached the request log: %q", logData.errorMessage)
+	}
+}
+
+// The observers run before the stream's masking block, so the provider text
+// they hold has been scrubbed by nothing — and an application log is a
+// different store with a different audience from the request log: the live log
+// viewer, the app-logs API, the OTLP export.
+func TestErrLogAttr_MasksAndBounds(t *testing.T) {
+	t.Parallel()
+	st := &streamState{masker: newCredentialMasker("sk-ours-0000000000000000000000")}
+
+	got := st.errLogAttr("bad key sk-ours-0000000000000000000000 relayed from sk-theirs-1234567890abcdefghij")
+	if strings.Contains(got, "sk-ours") || strings.Contains(got, "sk-theirs") {
+		t.Errorf("credential survived: %q", got)
+	}
+
+	if bounded := st.errLogAttr(strings.Repeat("x", 5000)); len(bounded) > 1000 {
+		t.Errorf("unbounded provider text: %d chars", len(bounded))
+	}
+}
+
+// The same, through the pipeline, because the masking is only worth anything at
+// the call site that actually logs.
+func TestHandleStreamingResponse_ErrorFrameLogIsMasked(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	var logged strings.Builder
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+
+	const quoted = "sk-theirs-1234567890abcdefghij"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`data: {"error":"invalid key ` + quoted + `"}` + "\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+	logData.masker = newCredentialMasker("sk-ours-0000000000000000000000")
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		cancelOrigin: "failover_timeout",
+		masker:       logData.masker,
+	})
+
+	out := logged.String()
+	if !strings.Contains(out, "SSE error chunk") {
+		t.Fatalf("the error frame was not logged at all, so nothing was masked: %q", out)
+	}
+	if strings.Contains(out, quoted) {
+		t.Errorf("credential reached the application log: %q", out)
 	}
 }
 

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -243,40 +243,64 @@ func TestErrLogAttr_MasksAndBounds(t *testing.T) {
 }
 
 // The same, through the pipeline, because the masking is only worth anything at
-// the call site that actually logs.
+// the call site that actually logs — and there is more than one. A whole error
+// frame goes to the observer; a truncated one goes to the accumulator, whose
+// flush had its own copy of the logging and its own copy of the leak.
 func TestHandleStreamingResponse_ErrorFrameLogIsMasked(t *testing.T) {
-	h := newUnitHandler()
-	defer stopUnitHandler(h)
-
-	capture := captureProxyLogs(t)
-
 	const quoted = "sk-theirs-1234567890abcdefghij"
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`data: {"error":"invalid key ` + quoted + `"}` + "\n\n")),
-		Header:     make(http.Header),
-	}
-	w := httptest.NewRecorder()
-	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
-	logData := newErrorFrameLog()
-	logData.masker = newCredentialMasker("sk-ours-0000000000000000000000")
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantLog string
+	}{
+		{
+			name:    "whole frame",
+			body:    `data: {"error":"invalid key ` + quoted + `"}` + "\n\n",
+			wantLog: "SSE error chunk",
+		},
+		{
+			name:    "truncated fragment",
+			body:    `data: {"error":{"message":"invalid key ` + quoted,
+			wantLog: "accumulated SSE error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
 
-	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
-		cancelOrigin: "failover_timeout",
-		masker:       logData.masker,
-	})
+			capture := captureProxyLogs(t)
 
-	if len(capture.find("SSE error chunk")) == 0 {
-		t.Fatal("the error frame was not logged at all, so nothing was masked")
-	}
-	// Every record, not just that one: the site the fix was written for was
-	// masked while a second one beside it still logged the credential raw.
-	for _, rec := range capture.all() {
-		for key, val := range rec.attrs {
-			if strings.Contains(val, quoted) {
-				t.Errorf("credential reached the application log: %q attr %q = %q", rec.msg, key, val)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+				Header:     make(http.Header),
 			}
-		}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			logData := newErrorFrameLog()
+			logData.masker = newCredentialMasker("sk-ours-0000000000000000000000")
+
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+				cancelOrigin: "failover_timeout",
+				masker:       logData.masker,
+			})
+
+			if len(capture.find(tc.wantLog)) == 0 {
+				t.Fatalf("%q was never logged, so nothing was masked", tc.wantLog)
+			}
+			// Every record, not just that one: the site the fix was written for
+			// was masked while others beside it still logged the text raw.
+			for _, rec := range capture.all() {
+				for key, val := range rec.attrs {
+					if strings.Contains(val, quoted) {
+						t.Errorf("credential reached the application log: %q attr %q = %q", rec.msg, key, val)
+					}
+				}
+			}
+			if strings.Contains(logData.errorMessage, quoted) {
+				t.Errorf("credential reached the request log: %q", logData.errorMessage)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -40,12 +40,16 @@ var errorFrameCorpus = []struct {
 	{"empty list", `{"error":[]}`, false, ""},
 	// The C convention: an "error" member that reports there wasn't one. Every
 	// frame of every 200 stream from such a relay reaches the emptiness rule.
-	{"false", `{"error":false,"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
-	{"zero", `{"error":0,"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
+	{"false", `{"error":false,"choices":[{"delta":{"content":"CONTENTMARKER"}}]}`, false, ""},
+	{"zero", `{"error":0,"choices":[{"delta":{"content":"CONTENTMARKER"}}]}`, false, ""},
+	// The same convention one level down, which is where a relay actually puts
+	// it: a no-error struct stamped on every frame.
+	{"zeroed error struct", `{"error":{"code":0,"message":"","type":""},"choices":[{"delta":{"content":"CONTENTMARKER"}}]}`, false, ""},
+	{"all-null error", `{"error":{"code":null,"message":null}}`, false, ""},
 	// An empty member riding alongside real output. The payload starts with
 	// {"error", which is all the P1-B accumulator looks at.
-	{"empty member with a delta", `{"error":"","choices":[{"delta":{"content":"hi"}}]}`, false, ""},
-	{"no error member", `{"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
+	{"empty member with a delta", `{"error":"","choices":[{"delta":{"content":"CONTENTMARKER"}}]}`, false, ""},
+	{"no error member", `{"choices":[{"delta":{"content":"CONTENTMARKER"}}]}`, false, ""},
 }
 
 // A frame the probe calls an error must also be counted as one by the stream
@@ -117,22 +121,10 @@ func TestErrorFrameShapes_PipelineMatchesCorpus(t *testing.T) {
 				t.Errorf("an ordinary frame recorded an error: %q", logData.errorMessage)
 			}
 			// Whatever else it records, it never records the model's output.
-			if strings.Contains(logData.errorMessage, "hi") {
+			if strings.Contains(logData.errorMessage, "CONTENTMARKER") {
 				t.Errorf("response content reached the request log: %q", logData.errorMessage)
 			}
 		})
-	}
-}
-
-// Every reading in the package hands errorMemberCarries a member that came out
-// of a successful unmarshal, so bytes that are not JSON at all cannot arrive
-// through them. The guard is the helper's contract for anyone who calls it
-// with a raw member of their own: garbage carries nothing, rather than
-// counting as an error the provider never reported.
-func TestErrorMemberCarries_MalformedRaw(t *testing.T) {
-	t.Parallel()
-	if errorMemberCarries(json.RawMessage(`{"message":"trunc`)) {
-		t.Error("unparseable bytes must not count as an error member")
 	}
 }
 
@@ -237,8 +229,10 @@ func TestErrLogAttr_MasksAndBounds(t *testing.T) {
 		t.Errorf("credential survived: %q", got)
 	}
 
-	if bounded := st.errLogAttr(strings.Repeat("x", 5000)); len(bounded) > 1000 {
-		t.Errorf("unbounded provider text: %d bytes", len(bounded))
+	// The cap is 500 bytes; a little slack for whatever the sanitizer appends,
+	// but not enough for a widening to go unnoticed.
+	if bounded := st.errLogAttr(strings.Repeat("x", 5000)); len(bounded) > 550 {
+		t.Errorf("provider text bounded at %d bytes, want ~500", len(bounded))
 	}
 }
 
@@ -396,4 +390,40 @@ func newErrorFrameLog() *requestLogData {
 	}
 	ld.insertWg.Add(1)
 	return ld
+}
+
+// The native Anthropic passthrough reads the same member with its own decoder,
+// and it forwards the frame's bytes rather than rebuilding them — so a shape it
+// could not type cost the event its TYPE as well, and the key-shape scrub is
+// gated on that type. The frame then reached the caller verbatim, with whatever
+// credential a relay had quoted inside it, while the error itself went
+// uncounted and the request log recorded a truncated stream instead.
+func TestHandleStreamingResponse_NativeAnthropicBareStringError(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	const quoted = "sk-theirs-1234567890abcdefghij"
+	body := "event: error\ndata: " + `{"type":"error","error":"overloaded ` + quoted + `"}` + "\n\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/messages", http.NoBody))
+	logData := newErrorFrameLog()
+	logData.masker = newCredentialMasker("sk-ours-0000000000000000000000")
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{
+		cancelOrigin:   "failover_timeout",
+		masker:         logData.masker,
+		rawPassthrough: true,
+	})
+
+	if strings.Contains(w.Body.String(), quoted) {
+		t.Errorf("relayed credential reached the caller: %q", w.Body.String())
+	}
+	if !strings.Contains(logData.errorMessage, "overloaded") {
+		t.Errorf("errorMessage = %q, want the provider's own error", logData.errorMessage)
+	}
 }

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -74,6 +74,18 @@ func TestErrorFrameShapes_ObserverMatchesProbe(t *testing.T) {
 	}
 }
 
+// Every reading in the package hands errorMemberCarries a member that came out
+// of a successful unmarshal, so bytes that are not JSON at all cannot arrive
+// through them. The guard is the helper's contract for anyone who calls it
+// with a raw member of their own: garbage carries nothing, rather than
+// counting as an error the provider never reported.
+func TestErrorMemberCarries_MalformedRaw(t *testing.T) {
+	t.Parallel()
+	if errorMemberCarries(json.RawMessage(`{"message":"trunc`)) {
+		t.Error("unparseable bytes must not count as an error member")
+	}
+}
+
 // An error member the gateway cannot type is still an error member, and the
 // frame carrying it is still the provider's answer. Dropping it as unparseable
 // bytes hands the caller a stream that simply stops, and leaves the request log

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -30,11 +30,19 @@ var errorFrameCorpus = []struct {
 	{"object without message", `{"error":{"code":500}}`, true, `{"code":500}`},
 	{"list", `{"error":["bad","worse"]}`, true, `["bad","worse"]`},
 	{"number", `{"error":503}`, true, "503"},
+	{"true", `{"error":true}`, true, "true"},
 	{"error after another key", `{"model":"llama3","error":"model not found"}`, true, "model not found"},
 	{"null", `{"error":null}`, false, ""},
 	{"empty object", `{"error":{}}`, false, ""},
 	{"empty string", `{"error":""}`, false, ""},
 	{"empty list", `{"error":[]}`, false, ""},
+	// The C convention: an "error" member that reports there wasn't one. Every
+	// frame of every 200 stream from such a relay reaches the emptiness rule.
+	{"false", `{"error":false,"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
+	{"zero", `{"error":0,"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
+	// An empty member riding alongside real output. The payload starts with
+	// {"error", which is all the P1-B accumulator looks at.
+	{"empty member with a delta", `{"error":"","choices":[{"delta":{"content":"hi"}}]}`, false, ""},
 	{"no error member", `{"choices":[{"delta":{"content":"hi"}}]}`, false, ""},
 }
 
@@ -69,6 +77,46 @@ func TestErrorFrameShapes_ObserverMatchesProbe(t *testing.T) {
 			}
 			if tc.isError && probeMsg != tc.wantMsg {
 				t.Errorf("probe message = %q, want %q", probeMsg, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// The same corpus through the whole streaming pipeline, which is the only place
+// the readings can actually be seen to agree. observeDataChunk is one of four
+// paths that write st.lastErrMsg, and the unit test above cannot see the other
+// three: the P1-B accumulator in particular took every payload starting with
+// {"error" — including one whose member is empty and whose delta carries the
+// model's answer — and recorded the ENTIRE payload as the error message, so a
+// frame the corpus calls ordinary failed the request and wrote response content
+// into the request log.
+func TestErrorFrameShapes_PipelineMatchesCorpus(t *testing.T) {
+	for _, tc := range errorFrameCorpus {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + tc.payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			logData := newErrorFrameLog()
+
+			h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			failed := logData.state == "failed"
+			if failed != tc.isError {
+				t.Errorf("state = %q (errorMessage %q), want failed=%v", logData.state, logData.errorMessage, tc.isError)
+			}
+			if !tc.isError && logData.errorMessage != "" {
+				t.Errorf("an ordinary frame recorded an error: %q", logData.errorMessage)
+			}
+			// Whatever else it records, it never records the model's output.
+			if strings.Contains(logData.errorMessage, "hi") {
+				t.Errorf("response content reached the request log: %q", logData.errorMessage)
 			}
 		})
 	}
@@ -197,14 +245,6 @@ func TestJudgeStreamForBreaker_UntypeableErrorFrameCharges(t *testing.T) {
 
 	if !providerAtFault(logData.errorKind) {
 		t.Fatalf("errorKind = %q, want a kind the provider answers for", logData.errorKind)
-	}
-
-	// The verdict itself, over the state such a stream leaves behind: an
-	// unparsed frame is a charge the gateway cannot honestly make, an error
-	// frame is one it can.
-	st := &streamState{errorChunkCount: 1}
-	if v := judgeStreamForBreaker(st, logData, logData.errorMessage, true); v.failureReason == "" || v.success {
-		t.Errorf("verdict = %+v, want a provider failure", v)
 	}
 }
 

--- a/internal/proxy/error_frame_shape_test.go
+++ b/internal/proxy/error_frame_shape_test.go
@@ -163,16 +163,18 @@ func TestHandleStreamingResponse_BareStringErrorIsMasked(t *testing.T) {
 }
 
 // An error frame is the provider reporting its own failure, so it charges the
-// breaker. It used to be dropped as unparseable instead, and unparsedChunks
-// holds the empty-stream charge back — so a provider erroring on every request
-// in a shape the gateway could not type never opened its circuit.
+// breaker. The payload here puts a key before "error", which is the case the
+// P1-B accumulator is blind to: with the frame also dropped as unparseable, a
+// provider erroring on every single request produced a stream this gateway read
+// as a clean, merely empty one — and unparsedChunks then held even the
+// empty-stream charge back, so the circuit never opened.
 func TestJudgeStreamForBreaker_UntypeableErrorFrameCharges(t *testing.T) {
 	h := newUnitHandler()
 	defer stopUnitHandler(h)
 
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`data: {"error":"model not found"}` + "\n\ndata: [DONE]\n\n")),
+		Body:       io.NopCloser(strings.NewReader(`data: {"model":"llama3","error":"model not found"}` + "\n\ndata: [DONE]\n\n")),
 		Header:     make(http.Header),
 	}
 	w := httptest.NewRecorder()
@@ -181,8 +183,16 @@ func TestJudgeStreamForBreaker_UntypeableErrorFrameCharges(t *testing.T) {
 
 	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
 
-	if logData.errorKind == "" {
-		t.Errorf("an error frame must produce an error kind, got none (state %q)", logData.state)
+	if !providerAtFault(logData.errorKind) {
+		t.Fatalf("errorKind = %q, want a kind the provider answers for", logData.errorKind)
+	}
+
+	// The verdict itself, over the state such a stream leaves behind: an
+	// unparsed frame is a charge the gateway cannot honestly make, an error
+	// frame is one it can.
+	st := &streamState{errorChunkCount: 1}
+	if v := judgeStreamForBreaker(st, logData, logData.errorMessage, true); v.failureReason == "" || v.success {
+		t.Errorf("verdict = %+v, want a provider failure", v)
 	}
 }
 

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 func extractStreamingUsage(data string) *Usage {
@@ -179,28 +181,28 @@ func parseChunkPayload(payload string) (parsedChunk, bool) {
 }
 
 // parseAccumulatedError extracts a human-readable message from accumulated SSE
-// error bytes: a frame the gateway saw begin with {"error" and could not parse,
-// because the provider cut it short or split it across data lines.
+// error bytes: one line the gateway saw begin with {"error" and could not
+// parse, because the provider cut it short.
 //
 // It reads only the "error" member, never the rest of the frame. Returning the
 // raw bytes was how the model's own answer reached request_logs.error_message:
 // a stream cut mid-frame on a provider that puts "error" first hands this
 // function a fragment like {"error":null,"choices":[{"delta":{"content":"…
-// and the whole thing was recorded. The member cannot contain another key's
-// value, so reading only it is the bound that makes the no-content-logging rule
-// hold on bytes nobody can parse.
+// and the whole thing was recorded.
 //
-// The complete member is preferred, and errorMemberMessage renders it whatever
-// its shape. When the member itself is what got truncated there is nothing to
-// decode, and its own bytes stand as the message — everything after {"error":
-// belongs to it, since nothing else can have started yet.
+// A member that decoded whole is judged by the same emptiness rule as everywhere
+// else, so a relay's no-error stamp — false, 0, {}, an all-zero struct — does
+// not fail a request merely because the frame around it was truncated.
 func parseAccumulatedError(data []byte) string {
 	member, complete := accumulatedErrorMember(data)
 	if len(member) == 0 {
 		return ""
 	}
 	if complete {
-		return errorMemberMessage(member)
+		if !util.ErrorMemberCarries(member) {
+			return ""
+		}
+		return util.ErrorMemberMessage(member)
 	}
 	return string(member)
 }
@@ -208,11 +210,21 @@ func parseAccumulatedError(data []byte) string {
 // accumulatedErrorMember returns the bytes of the "error" member of a fragment
 // the accumulator collected, and whether they decode as a whole JSON value.
 //
-// It walks the object key by key rather than assuming a position, so it finds
-// the member under the Anthropic wrapper ({"type":"error","error":{…}}) as well
-// as first. Every other key's value is decoded and thrown away: a walk that
-// stops at a truncated key it does not want returns nothing at all, which is
-// what keeps a frame cut off mid-content from yielding that content.
+// It walks the object key by key rather than assuming a position, and every
+// other key's value is decoded and thrown away. Two rules keep another key's
+// value from ever being returned as the member:
+//
+//   - a decode failure on a key that is not "error" ends the walk with nothing;
+//   - a decode failure on "error" itself yields the remaining bytes ONLY when
+//     the input simply ran out (an unexpected EOF). Any other failure means the
+//     value is malformed rather than incomplete — a raw tab or an ANSI escape
+//     inside the provider's error string is enough, and JSON forbids both
+//     unescaped — and the bytes after it are then the REST OF THE FRAME, which
+//     is how the model's answer got into the log in the first place. There is
+//     no message worth salvaging at that price.
+//
+// The last "error" wins, matching what json.Unmarshal does with a duplicate key
+// everywhere else this member is read.
 func accumulatedErrorMember(data []byte) (member []byte, complete bool) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.Token()
@@ -222,30 +234,30 @@ func accumulatedErrorMember(data []byte) (member []byte, complete bool) {
 	for dec.More() {
 		keyTok, err := dec.Token()
 		if err != nil {
-			return nil, false
+			return member, complete
 		}
 		key, _ := keyTok.(string)
 		// Offset of the colon that follows the key; the value begins after it.
 		valueStart := dec.InputOffset()
 		var value json.RawMessage
 		if err := dec.Decode(&value); err != nil {
-			if key != "error" {
-				return nil, false
+			if key != "error" || !errors.Is(err, io.ErrUnexpectedEOF) {
+				return member, complete
 			}
-			// The member itself is where the bytes ran out. Nothing else can
-			// have started, so the remainder is the member and nothing more.
+			// The member is where the bytes ran out. Nothing else can have
+			// started, so the remainder is the member and nothing more.
 			rest := bytes.TrimSpace(data[valueStart:])
 			rest = bytes.TrimSpace(bytes.TrimPrefix(rest, []byte(":")))
 			if len(rest) == 0 {
-				return nil, false
+				return member, complete
 			}
 			return rest, false
 		}
 		if key == "error" {
-			return value, true
+			member, complete = value, true
 		}
 	}
-	return nil, false
+	return member, complete
 }
 
 func generateRequestHash() string {

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -177,40 +178,74 @@ func parseChunkPayload(payload string) (parsedChunk, bool) {
 	return p, true
 }
 
-// parseAccumulatedError attempts to extract a human-readable error message
-// from accumulated SSE error bytes. Some providers (e.g. OpenAI, go-openai)
-// split error JSON across multiple SSE data lines. This function tries to
-// parse the accumulated bytes as a complete JSON error object, supporting
-// both the OpenAI format ({"error":{"message":"..."}}) and the Anthropic
-// format ({"type":"error","error":{"message":"..."}}).
+// parseAccumulatedError extracts a human-readable message from accumulated SSE
+// error bytes: a frame the gateway saw begin with {"error" and could not parse,
+// because the provider cut it short or split it across data lines.
+//
+// It reads only the "error" member, never the rest of the frame. Returning the
+// raw bytes was how the model's own answer reached request_logs.error_message:
+// a stream cut mid-frame on a provider that puts "error" first hands this
+// function a fragment like {"error":null,"choices":[{"delta":{"content":"…
+// and the whole thing was recorded. The member cannot contain another key's
+// value, so reading only it is the bound that makes the no-content-logging rule
+// hold on bytes nobody can parse.
+//
+// The complete member is preferred, and errorMemberMessage renders it whatever
+// its shape. When the member itself is what got truncated there is nothing to
+// decode, and its own bytes stand as the message — everything after {"error":
+// belongs to it, since nothing else can have started yet.
 func parseAccumulatedError(data []byte) string {
-	if len(data) == 0 {
+	member, complete := accumulatedErrorMember(data)
+	if len(member) == 0 {
 		return ""
 	}
-	// Try OpenAI error format: {"error":{"message":"..."}}
-	var openaiErr struct {
-		Error *struct{ Message string } `json:"error"`
+	if complete {
+		return errorMemberMessage(member)
 	}
-	if json.Unmarshal(data, &openaiErr) == nil && openaiErr.Error != nil {
-		return openaiErr.Error.Message
+	return string(member)
+}
+
+// accumulatedErrorMember returns the bytes of the "error" member of a fragment
+// the accumulator collected, and whether they decode as a whole JSON value.
+//
+// It walks the object key by key rather than assuming a position, so it finds
+// the member under the Anthropic wrapper ({"type":"error","error":{…}}) as well
+// as first. Every other key's value is decoded and thrown away: a walk that
+// stops at a truncated key it does not want returns nothing at all, which is
+// what keeps a frame cut off mid-content from yielding that content.
+func accumulatedErrorMember(data []byte) (member []byte, complete bool) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil || tok != json.Delim('{') {
+		return nil, false
 	}
-	// Try Anthropic error format: {"type":"error","error":{"type":"...","message":"..."}}
-	var anthErr struct {
-		Type  string `json:"type"`
-		Error *struct {
-			Type    string `json:"type"`
-			Message string `json:"message"`
-		} `json:"error"`
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, _ := keyTok.(string)
+		// Offset of the colon that follows the key; the value begins after it.
+		valueStart := dec.InputOffset()
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			if key != "error" {
+				return nil, false
+			}
+			// The member itself is where the bytes ran out. Nothing else can
+			// have started, so the remainder is the member and nothing more.
+			rest := bytes.TrimSpace(data[valueStart:])
+			rest = bytes.TrimSpace(bytes.TrimPrefix(rest, []byte(":")))
+			if len(rest) == 0 {
+				return nil, false
+			}
+			return rest, false
+		}
+		if key == "error" {
+			return value, true
+		}
 	}
-	if json.Unmarshal(data, &anthErr) == nil && anthErr.Error != nil {
-		return anthErr.Error.Message
-	}
-	// Can't parse as structured error — return raw bytes if they start with
-	// { (heuristic for truncated JSON).
-	if data[0] == '{' {
-		return string(data)
-	}
-	return ""
+	return nil, false
 }
 
 func generateRequestHash() string {

--- a/internal/proxy/helpers_test.go
+++ b/internal/proxy/helpers_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
@@ -527,11 +528,29 @@ func TestParseAccumulatedError_AnthropicOverloaded(t *testing.T) {
 	}
 }
 
+// A truncated member yields its own bytes — the best that can be said about
+// bytes nothing can parse — and not the frame that wrapped it.
 func TestParseAccumulatedError_TruncatedJSON(t *testing.T) {
 	data := []byte(`{"error":{"message":"Rate limi`)
 	got := parseAccumulatedError(data)
-	if got != `{"error":{"message":"Rate limi` {
-		t.Errorf("parseAccumulatedError(truncated JSON) = %q, want raw string", got)
+	if got != `{"message":"Rate limi` {
+		t.Errorf("parseAccumulatedError(truncated JSON) = %q, want the member's bytes", got)
+	}
+}
+
+// The reason the member is read rather than the payload: a frame cut off
+// mid-content, on a provider that puts "error" first, used to record the
+// model's answer as the error message.
+func TestParseAccumulatedError_TruncatedFrameKeepsContentOut(t *testing.T) {
+	for _, data := range []string{
+		`{"error":null,"choices":[{"delta":{"content":"THE SECRET ANSWER`,
+		`{"error":"","choices":[{"delta":{"content":"THE SECRET ANSWER`,
+		`{"choices":[{"delta":{"content":"THE SECRET ANSWER`,
+		`{"choices":[{"delta":{"content":"THE SECRET ANSWER"}}],"error":`,
+	} {
+		if got := parseAccumulatedError([]byte(data)); strings.Contains(got, "SECRET") {
+			t.Errorf("content escaped into the error message: %q", got)
+		}
 	}
 }
 
@@ -626,12 +645,12 @@ func TestParseAccumulatedError_NonAccumulated(t *testing.T) {
 		t.Errorf("expected empty string for non-JSON error, got %q", result)
 	}
 
-	// Test with JSON that doesn't match error formats - returns raw JSON
+	// JSON with no error member has no error message to report; returning the
+	// body would be reporting whatever else the provider put in it.
 	jsonData := []byte(`{"foo":"bar"}`)
 	result = parseAccumulatedError(jsonData)
-	// Function returns raw bytes if they start with { (heuristic for truncated JSON)
-	if result != `{"foo":"bar"}` {
-		t.Errorf("expected raw JSON string, got %q", result)
+	if result != "" {
+		t.Errorf("expected empty string for a body with no error member, got %q", result)
 	}
 }
 

--- a/internal/proxy/helpers_test.go
+++ b/internal/proxy/helpers_test.go
@@ -547,10 +547,45 @@ func TestParseAccumulatedError_TruncatedFrameKeepsContentOut(t *testing.T) {
 		`{"error":"","choices":[{"delta":{"content":"THE SECRET ANSWER`,
 		`{"choices":[{"delta":{"content":"THE SECRET ANSWER`,
 		`{"choices":[{"delta":{"content":"THE SECRET ANSWER"}}],"error":`,
+		// Not truncated — MALFORMED. A raw tab in the provider's error string
+		// is enough (JSON forbids it unescaped), and so is an ANSI escape from
+		// a local server echoing stderr. The decode fails in the same place a
+		// truncation does, but here the bytes after the member really are the
+		// rest of the frame.
+		"{\"error\":\"rate limit\thit\",\"choices\":[{\"delta\":{\"content\":\"THE SECRET ANSWER\"}}]}",
+		"{\"error\":\"\x1b[31mred\",\"choices\":[{\"delta\":{\"content\":\"THE SECRET ANSWER\"}}]}",
+		`{"error":"bad \q escape","choices":[{"delta":{"content":"THE SECRET ANSWER"}}]}`,
+		`{"error":NaN,"choices":[{"delta":{"content":"THE SECRET ANSWER"}}]}`,
+		`{"error":'single',"choices":[{"delta":{"content":"THE SECRET ANSWER"}}]}`,
 	} {
 		if got := parseAccumulatedError([]byte(data)); strings.Contains(got, "SECRET") {
 			t.Errorf("content escaped into the error message: %q", got)
 		}
+	}
+}
+
+// A frame truncated around a relay's no-error stamp is not a failed request.
+// The member decoded whole, so the shared emptiness rule judges it, exactly as
+// it would on a frame that arrived intact.
+func TestParseAccumulatedError_EmptyMemberInTruncatedFrame(t *testing.T) {
+	for _, data := range []string{
+		`{"error":false,"choices":[{"delta":{"content":"hi`,
+		`{"error":0,"choices":[{"delta":{"content":"hi`,
+		`{"error":[],"choices":[{"delta":{"content":"hi`,
+		`{"error":{},"choices":[{"delta":{"content":"hi`,
+		`{"error":{"code":0,"message":"","type":""},"choices":[{"delta":{"content":"hi`,
+	} {
+		if got := parseAccumulatedError([]byte(data)); got != "" {
+			t.Errorf("%s recorded an error: %q", data, got)
+		}
+	}
+}
+
+// A duplicate key resolves the way json.Unmarshal resolves it everywhere else
+// this member is read: the last one wins.
+func TestParseAccumulatedError_LastErrorKeyWins(t *testing.T) {
+	if got := parseAccumulatedError([]byte(`{"error":"first","error":"second","x":`)); got != "second" {
+		t.Errorf("got %q, want second", got)
 	}
 }
 

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -427,41 +427,43 @@ func withBreakerThresholdOne(t *testing.T, h *Handler) {
 // the existing tests document as impossible to trigger deterministically
 // (see TestProbeFirstToken_ScannerErrorRecovery_PipeRace). Testing the decision
 // covers both callers of it.
+// It is driven from errorFrameCorpus rather than a table of its own. The whole
+// point of the shared emptiness rule is that the probe and the stream observer
+// cannot disagree about a shape, and two hand-maintained tables is precisely
+// how they would: a shape added to one and not the other reintroduces the drift
+// by the back door. Only payloads that are not JSON objects at all are listed
+// here, because the corpus is a corpus of frames.
 func TestErrorEnvelopeMessage(t *testing.T) {
-	tests := []struct {
-		name    string
-		frame   string
-		wantMsg string
-		wantOk  bool
-	}{
-		{"provider error", `{"error":{"message":"boom"}}`, "boom", true},
-		{"anthropic error event", `{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`, "overloaded", true},
-		// Ollama answers with a bare string. carriesErrorObject has always
-		// counted that as an error; the first version of this check unmarshalled
-		// the frame into a streamChunk, which fails outright on this shape, so a
-		// local Ollama box in a hedged group reproduced the whole incident.
-		{"ollama bare string", `{"error":"model not found"}`, "model not found", true},
-		{"object without a message", `{"error":{"code":500}}`, `{"code":500}`, true},
-		{"ordinary token", `{"choices":[{"delta":{"content":"hi"}}]}`, "", false},
-		{"explicit null error", `{"error":null,"choices":[]}`, "", false},
-		{"unparseable frame", `{not json`, "", false},
-		// Empty of every shape leaves a caller nothing to read, so it is not an
-		// error frame — the same judgement carriesErrorObject makes.
-		{"empty error object", `{"error":{}}`, "", false},
-		{"empty error string", `{"error":""}`, "", false},
-		{"empty error list", `{"error":[]}`, "", false},
-		{"json array", `[1,2,3]`, "", false},
-	}
-	for _, tc := range tests {
+	for _, tc := range errorFrameCorpus {
 		t.Run(tc.name, func(t *testing.T) {
-			msg, ok := errorEnvelopeMessage(tc.frame)
-			if ok != tc.wantOk {
-				t.Fatalf("ok = %v, want %v (msg %q)", ok, tc.wantOk, msg)
+			msg, ok := errorEnvelopeMessage(tc.payload)
+			if ok != tc.isError {
+				t.Fatalf("ok = %v, want %v (msg %q)", ok, tc.isError, msg)
 			}
 			if msg != tc.wantMsg {
 				t.Errorf("msg = %q, want %q", msg, tc.wantMsg)
 			}
 		})
+	}
+
+	// A frame with no object to hold a member at all.
+	for _, frame := range []string{`{not json`, `[1,2,3]`, `"a string"`, ``} {
+		t.Run("not an object: "+frame, func(t *testing.T) {
+			if msg, ok := errorEnvelopeMessage(frame); ok {
+				t.Errorf("ok = true (msg %q), want false", msg)
+			}
+		})
+	}
+}
+
+// The Anthropic wrapper is the same member one level in, and the probe reads it
+// through the same rule. It is not in the corpus because the observer sees this
+// shape through the P1-C branch instead, keyed on the preceding "event: error"
+// line rather than on the member.
+func TestErrorEnvelopeMessage_AnthropicWrapper(t *testing.T) {
+	msg, ok := errorEnvelopeMessage(`{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`)
+	if !ok || msg != "overloaded" {
+		t.Errorf("got (%q, %v), want (overloaded, true)", msg, ok)
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -392,28 +392,18 @@ func (e *emptyStreamError) Error() string {
 // Only the message is extracted here, and the shapes carriesErrorObject accepts
 // are wider than {"error":{"message":...}}, so the fallbacks are not decoration.
 func errorEnvelopeMessage(content string) (msg string, ok bool) {
-	raw := []byte(content)
-	if !carriesErrorObject(raw) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(content), &envelope); err != nil {
 		return "", false
 	}
-	var chunk streamChunk
-	if err := json.Unmarshal(raw, &chunk); err == nil && chunk.Error != nil && chunk.Error.Message != "" {
-		return chunk.Error.Message, true
+	raw := envelope["error"]
+	if !errorMemberCarries(raw) {
+		return "", false
 	}
 	// A bare string, a list, a number, or an object without a "message": render
 	// what the provider put there rather than dropping a frame already judged to
 	// be an error. Bounded by the caller's sanitizer.
-	var envelope struct {
-		Error json.RawMessage `json:"error"`
-	}
-	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Error) > 0 {
-		var bare string
-		if json.Unmarshal(envelope.Error, &bare) == nil {
-			return bare, true
-		}
-		return string(envelope.Error), true
-	}
-	return "provider reported an error with no message", true
+	return errorMemberMessage(raw), true
 }
 
 // probeFrame is what one SSE data payload means to the first-token probe.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -382,15 +382,15 @@ func (e *emptyStreamError) Error() string {
 // is an error envelope instead of a token, and ok == false for every ordinary
 // frame.
 //
-// Whether the frame IS an error is carriesErrorObject's question, not a second
+// Whether the frame IS an error is errorMemberCarries' question, not a second
 // opinion: this package already decided what counts (a populated error member of
-// any shape, including Ollama's bare string; not null/{}/""/[], which leave a
-// caller nothing to read). Answering it twice is how the two drift, and either
-// direction is a bug — a miss lets a broken provider win a hedged race, a false
-// positive fails over a healthy stream.
+// any shape, including Ollama's bare string; not null/{}/""/[]/false/0, which
+// leave a caller nothing to read). Answering it twice is how the two drift, and
+// either direction is a bug — a miss lets a broken provider win a hedged race, a
+// false positive fails over a healthy stream.
 //
-// Only the message is extracted here, and the shapes carriesErrorObject accepts
-// are wider than {"error":{"message":...}}, so the fallbacks are not decoration.
+// Only the message is extracted here, and errorMemberMessage renders shapes
+// wider than {"error":{"message":...}}, so its fallbacks are not decoration.
 func errorEnvelopeMessage(content string) (msg string, ok bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(content), &envelope); err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -382,14 +382,14 @@ func (e *emptyStreamError) Error() string {
 // is an error envelope instead of a token, and ok == false for every ordinary
 // frame.
 //
-// Whether the frame IS an error is errorMemberCarries' question, not a second
+// Whether the frame IS an error is util.ErrorMemberCarries. question, not a second
 // opinion: this package already decided what counts (a populated error member of
 // any shape, including Ollama's bare string; not null/{}/""/[]/false/0, which
 // leave a caller nothing to read). Answering it twice is how the two drift, and
 // either direction is a bug — a miss lets a broken provider win a hedged race, a
 // false positive fails over a healthy stream.
 //
-// Only the message is extracted here, and errorMemberMessage renders shapes
+// Only the message is extracted here, and util.ErrorMemberMessage renders shapes
 // wider than {"error":{"message":...}}, so its fallbacks are not decoration.
 func errorEnvelopeMessage(content string) (msg string, ok bool) {
 	var envelope map[string]json.RawMessage
@@ -397,13 +397,13 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 		return "", false
 	}
 	raw := envelope["error"]
-	if !errorMemberCarries(raw) {
+	if !util.ErrorMemberCarries(raw) {
 		return "", false
 	}
 	// A bare string, a list, a number, or an object without a "message": render
 	// what the provider put there rather than dropping a frame already judged to
 	// be an error. Bounded by the caller's sanitizer.
-	return errorMemberMessage(raw), true
+	return util.ErrorMemberMessage(raw), true
 }
 
 // probeFrame is what one SSE data payload means to the first-token probe.

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -715,6 +715,14 @@ func TestForwardUpstreamError_Non2xxWithoutErrorObjectGetsEnvelope(t *testing.T)
 		"empty error list":      `{"id":"chatcmpl_u5tt67g6rmf","error":[]}`,
 		"not an object":         `["upstream said no"]`,
 		"not json at all":       `<html><body>400 Bad Request</body></html>`,
+		// The C convention: an "error" member reporting there wasn't one. The
+		// body may still carry detail, but not where a client reads `.error`,
+		// which is the same position as any other body without an error member.
+		"false error": `{"id":"chatcmpl_u5tt67g6rmf","error":false,"message":"context_length_exceeded"}`,
+		"zero error":  `{"id":"chatcmpl_u5tt67g6rmf","error":0}`,
+		// The same convention one level down: a relay's no-error struct.
+		"zeroed error struct": `{"error":{"code":0,"message":"","type":""}}`,
+		"all-null error":      `{"error":{"code":null,"message":null,"type":null}}`,
 	}
 
 	for name, upstreamBody := range bodies {

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -361,7 +361,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		if chunk.Error != nil {
+		if errorMemberCarries(chunk.Error) {
 			masked = maskKeyShapedTokens(masked)
 		}
 		if string(masked) != payload {

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -116,13 +116,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 	}
 
 	// Flush any remaining accumulated error bytes at stream end.
-	if len(st.errAccum) > 0 {
-		if accumulatedMsg := parseAccumulatedError(st.errAccum); accumulatedMsg != "" {
-			st.lastErrMsg = accumulatedMsg
-			st.errorChunkCount++
-			debuglog.Warn("proxy: accumulated SSE error (stream end)", "error_message", accumulatedMsg, "model", logData.modelID, "provider", logData.providerName, "chunks", reader.chunkCount)
-		}
-	}
+	st.flushAccumulatedError("proxy: accumulated SSE error (stream end)", reader.chunkCount, logData)
 
 logUpdate:
 	// Stop the watchdog before reading its stall flag, matching the prior
@@ -224,7 +218,7 @@ func (h *Handler) emitComment(sink *streamSink, st *streamState, ev sseEvent, ch
 	}
 	// Flush any accumulated error when a non-data line arrives
 	// (the error payload has already been captured in the data line).
-	st.flushAccumulatedError(chunkCount, logData)
+	st.flushAccumulatedError("proxy: accumulated SSE error", chunkCount, logData)
 	if err := sink.write(line); err != nil {
 		st.clientDisconnected = true
 		debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
@@ -361,12 +355,17 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		// Presence, not errorMemberCarries: what the member MEANS decides the
-		// request log and the breaker, but a frame that names an error can
-		// quote a credential whether or not this gateway judges the member
-		// populated, and the shape pass is the only layer that catches a key
-		// which is not our own.
-		if len(chunk.Error) > 0 {
+		// errorMemberCarries, not the member's mere presence. The regex runs
+		// over the WHOLE frame, and it can match prose — so on a frame that is
+		// not really an error it rewrites the model's answer. "error":null
+		// alongside a delta is an ordinary per-frame shape for several
+		// relays, and gating on presence redacted a key-shaped token out of
+		// the content those frames carry: an assistant explaining an AIza… or
+		// a Bearer header had its answer altered mid-stream. That is a worse
+		// failure than missing the third masking layer on a frame whose error
+		// member is empty, where the credential could only be in the content
+		// the regex must not touch anyway.
+		if errorMemberCarries(chunk.Error) {
 			masked = maskKeyShapedTokens(masked)
 		}
 		if string(masked) != payload {
@@ -441,20 +440,21 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	}
 	if !written && !jsonValid {
 		// Drop invalid/truncated JSON instead of forwarding broken bytes.
-		preview := payload
-		if len(preview) > 80 {
-			runes := []rune(preview)
-			if len(runes) > 80 {
-				preview = string(runes[:80]) + "..."
-			}
-		}
+		//
+		// The size, not the bytes. This used to log an 80-rune preview of the
+		// payload, and the commonest reason a frame fails to parse is that the
+		// stream was cut mid-delta — so the preview was the model's answer,
+		// written into the app log, the live viewer and the OTLP export. The
+		// length is what an operator can act on ("frames are arriving
+		// truncated"); the content is the provider's to keep.
+		//
 		// Counted so the end-of-stream verdict knows its view of what was
 		// delivered is incomplete, and does not charge the provider for an
 		// emptiness it cannot actually vouch for.
 		st.unparsedChunks++
 		debuglog.Warn("proxy: skipping invalid JSON chunk from upstream",
 			"model", logData.modelID, "provider", logData.providerName,
-			"chunk_number", chunkCount, "payload_preview", preview)
+			"chunk_number", chunkCount, "payload_bytes", len(payload))
 		sink.swallowBlank = true
 		return false
 	}

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, opts streamOptions) {
@@ -355,7 +356,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		// errorMemberCarries, not the member's mere presence. The regex runs
+		// util.ErrorMemberCarries, not the member's mere presence. The regex runs
 		// over the WHOLE frame, and it can match prose — so on a frame that is
 		// not really an error it rewrites the model's answer. "error":null
 		// alongside a delta is an ordinary per-frame shape for several
@@ -365,7 +366,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// failure than missing the third masking layer on a frame whose error
 		// member is empty, where the credential could only be in the content
 		// the regex must not touch anyway.
-		if errorMemberCarries(chunk.Error) {
+		if util.ErrorMemberCarries(chunk.Error) {
 			masked = maskKeyShapedTokens(masked)
 		}
 		if string(masked) != payload {

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -361,7 +361,12 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		if errorMemberCarries(chunk.Error) {
+		// Presence, not errorMemberCarries: what the member MEANS decides the
+		// request log and the breaker, but a frame that names an error can
+		// quote a credential whether or not this gateway judges the member
+		// populated, and the shape pass is the only layer that catches a key
+		// which is not our own.
+		if len(chunk.Error) > 0 {
 			masked = maskKeyShapedTokens(masked)
 		}
 		if string(masked) != payload {

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -316,7 +316,10 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 
 	debuglog.Info("proxy: streaming finished", "model", logData.modelID, "provider", logData.providerName, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "true_ttft_ms", opts.trueTtftMs, "duration_ms", totalDuration, "chunks", st.chunkCount, "bytes_written", sink.bytesWritten, "prompt_tokens", st.promptTokens, "completion_tokens", st.completionTokens, "error_chunks", st.errorChunkCount, "has_error", errMsg != "")
 	if errMsg != "" {
-		debuglog.Warn("proxy: streaming error", "model", logData.modelID, "provider", logData.providerName, "error", errMsg, "upstream_status", statusCode, "attempt", opts.attempt, "duration_ms", totalDuration)
+		// errLogAttr, not errMsg: the row above it is masked, the client frame
+		// beside it is masked, and this line was the one place the provider's
+		// raw text — a relayed credential included — reached the app log.
+		debuglog.Warn("proxy: streaming error", "model", logData.modelID, "provider", logData.providerName, "error", st.errLogAttr(errMsg), "upstream_status", statusCode, "attempt", opts.attempt, "duration_ms", totalDuration)
 	} else {
 		debuglog.Debug("proxy: streaming completed successfully", "model", logData.modelID, "provider", logData.providerName, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "duration_ms", totalDuration)
 	}

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -31,7 +31,7 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 	if strings.HasPrefix(payload, `{"error"`) && !json.Valid([]byte(payload)) {
 		st.errAccum = append(st.errAccum, []byte(payload)...)
 	} else {
-		st.flushAccumulatedError(chunkCount, logData)
+		st.flushAccumulatedError("proxy: accumulated SSE error", chunkCount, logData)
 	}
 
 	// P1-C: a data line after "event: error" is an Anthropic error payload,
@@ -59,16 +59,19 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 
 // flushAccumulatedError parses and records any P1-B accumulated split-error bytes
 // (an {"error":…} object split across SSE data lines), then clears the buffer. A
-// no-op when nothing is accumulated. Shared by the comment-line handler and
-// captureSSEError's non-error data-line branch so the two flush sites co-evolve.
-func (st *streamState) flushAccumulatedError(chunkCount int, logData *requestLogData) {
+// no-op when nothing is accumulated. Every flush site goes through here — the
+// comment-line handler, captureSSEError's non-error data-line branch, and the
+// stream-end sweep — so they cannot drift; `what` is the only thing that differs
+// between them, and a copy of this body is how the stream-end sweep came to log
+// the provider's error text unmasked while the other two did not.
+func (st *streamState) flushAccumulatedError(what string, chunkCount int, logData *requestLogData) {
 	if len(st.errAccum) == 0 {
 		return
 	}
 	if accumulatedMsg := parseAccumulatedError(st.errAccum); accumulatedMsg != "" {
 		st.lastErrMsg = accumulatedMsg
 		st.errorChunkCount++
-		debuglog.Warn("proxy: accumulated SSE error", "error_message", st.errLogAttr(accumulatedMsg), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+		debuglog.Warn(what, "error_message", st.errLogAttr(accumulatedMsg), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 	}
 	st.errAccum = nil
 }
@@ -83,9 +86,15 @@ func (st *streamState) flushAccumulatedError(chunkCount int, logData *requestLog
 // likes. The observers also run BEFORE the stream's masking block, so the text
 // they hold has been scrubbed by nothing at all.
 //
-// 500 characters, matching the probe's own error sanitizer, rather than the
-// request log's 10000: a log attribute is for recognising the failure, and the
-// full text is already on the row.
+// 500 bytes — SanitizeLogBody's limit is a byte count, so CJK error text from
+// MiniMax or Z.ai is cut at roughly a third of that in characters. It matches
+// the probe's own error sanitizer rather than the request log's 10000: a log
+// attribute is for recognising the failure, and the full text is already on the
+// row. SanitizeLogBody also redacts UUIDs, so a provider echoing a request id
+// back inside its error does not put one in the app log.
+//
+// A zero-value masker (a keyless local provider) masks by shape only, which is
+// what every other site on those paths does too.
 func (st *streamState) errLogAttr(msg string) string {
 	return util.SanitizeLogBody(string(st.masker.mask([]byte(msg))), 500)
 }

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -99,8 +99,15 @@ type streamChunk struct {
 		FinishReason       *string `json:"finish_reason"`
 		NativeFinishReason *string `json:"native_finish_reason"` // P2-7: OpenRouter passthrough
 	} `json:"choices"`
-	Usage *Usage                    `json:"usage"`
-	Error *struct{ Message string } `json:"error"`
+	Usage *Usage `json:"usage"`
+	// json.RawMessage, not a typed object: providers put an error of any shape
+	// here — Ollama's bare string, a list, a number — and a typed field failed
+	// the WHOLE chunk unmarshal, so the frame was dropped as corrupt bytes
+	// instead of forwarded, and the error it reported was recorded only when
+	// the payload happened to START with {"error" (the P1-B prefix). What the
+	// member means is errorMemberCarries/errorMemberMessage's answer, shared
+	// with the probe so the two readings cannot drift.
+	Error json.RawMessage `json:"error"`
 }
 
 // observeDataChunk applies the four non-emitting, side-channel observers over a
@@ -197,12 +204,13 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		st.lastContent = currentContent
 	}
-	if chunk.Error != nil && !anthropicErrorCounted {
+	if !anthropicErrorCounted && errorMemberCarries(chunk.Error) {
 		// Only count if P1-C didn't already handle this as an
 		// Anthropic error event (which shares the same data line).
-		st.lastErrMsg = chunk.Error.Message
+		msg := errorMemberMessage(chunk.Error)
+		st.lastErrMsg = msg
 		st.errorChunkCount++
-		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", chunk.Error.Message, "chunk_number", chunkCount)
+		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", msg, "chunk_number", chunkCount)
 		// Clear st.errAccum: chunk.Error already captured this error,
 		// so P1-B's next flush must not re-count it.
 		st.errAccum = nil

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -18,7 +18,17 @@ import (
 // from the preceding "event:" line and is consumed (reset) here. No client output.
 func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *string, chunkCount int, logData *requestLogData) bool {
 	// P1-B: accumulate error JSON split across data lines; flush on a non-error line.
-	if strings.HasPrefix(payload, `{"error"`) {
+	//
+	// Only a FRAGMENT is accumulated. A payload that parses is a whole frame,
+	// whatever it starts with, and the observer reads its error member properly;
+	// handing it to the accumulator instead put it in front of
+	// parseAccumulatedError, whose last resort is to return the entire payload
+	// as the error message. A frame like
+	// {"error":"","choices":[{"delta":{"content":…}}]} — an empty error member
+	// riding alongside a real delta — therefore wrote the model's output into
+	// request_logs.error_message, and marked the request failed for an error no
+	// reader of that member agrees is there.
+	if strings.HasPrefix(payload, `{"error"`) && !json.Valid([]byte(payload)) {
 		st.errAccum = append(st.errAccum, []byte(payload)...)
 	} else {
 		st.flushAccumulatedError(chunkCount, logData)
@@ -41,7 +51,7 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 			st.lastErrMsg = anthErr.Error.Message
 			anthropicErrorCounted = true
 			st.errorChunkCount++
-			debuglog.Warn("proxy: Anthropic SSE error event", "error_type", anthErr.Error.Type, "error_message", anthErr.Error.Message, "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+			debuglog.Warn("proxy: Anthropic SSE error event", "error_type", anthErr.Error.Type, "error_message", st.errLogAttr(anthErr.Error.Message), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 		}
 	}
 	return anthropicErrorCounted
@@ -58,9 +68,26 @@ func (st *streamState) flushAccumulatedError(chunkCount int, logData *requestLog
 	if accumulatedMsg := parseAccumulatedError(st.errAccum); accumulatedMsg != "" {
 		st.lastErrMsg = accumulatedMsg
 		st.errorChunkCount++
-		debuglog.Warn("proxy: accumulated SSE error", "error_message", accumulatedMsg, "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+		debuglog.Warn("proxy: accumulated SSE error", "error_message", st.errLogAttr(accumulatedMsg), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 	}
 	st.errAccum = nil
+}
+
+// errLogAttr prepares provider error text for an application-log attribute:
+// masked, then bounded.
+//
+// The request log gets both of those at finalize, but the app log had neither.
+// It is a different audience and a different store — the live log viewer, the
+// app-logs API, the OTLP export — and provider error text is exactly where a
+// relay quotes a credential ("invalid key sk-…") or runs to whatever length it
+// likes. The observers also run BEFORE the stream's masking block, so the text
+// they hold has been scrubbed by nothing at all.
+//
+// 500 characters, matching the probe's own error sanitizer, rather than the
+// request log's 10000: a log attribute is for recognising the failure, and the
+// full text is already on the row.
+func (st *streamState) errLogAttr(msg string) string {
+	return util.SanitizeLogBody(string(st.masker.mask([]byte(msg))), 500)
 }
 
 // repeatedContentLimit is the consecutive-identical-content threshold (P2-5) at
@@ -210,7 +237,7 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		msg := errorMemberMessage(chunk.Error)
 		st.lastErrMsg = msg
 		st.errorChunkCount++
-		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", msg, "chunk_number", chunkCount)
+		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", st.errLogAttr(msg), "chunk_number", chunkCount)
 		// Clear st.errAccum: chunk.Error already captured this error,
 		// so P1-B's next flush must not re-count it.
 		st.errAccum = nil

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -9,17 +9,22 @@ import (
 )
 
 // captureSSEError handles the two error-extraction quirks over a data line:
-// P1-B split-error accumulation (providers that split an {"error":…} object
-// across multiple SSE data lines — accumulate until a non-error line arrives,
-// then parse) and P1-C Anthropic typed error events (a data line following an
-// "event: error" line). Any extracted message is recorded into streamState; it
+// P1-B truncated-error salvage (a data line the provider cut short, held until
+// a line arrives that is not one, then parsed) and P1-C Anthropic typed error
+// events (a data line following an "event: error" line).
+//
+// P1-B is named for split errors, and its comments long claimed to reassemble
+// one, but it cannot: a CONTINUATION line does not start with {"error", so it
+// takes the flush branch rather than the append. What the buffer actually holds
+// is the last {"error"-prefixed line that would not parse — a truncated frame,
+// which is the case worth salvaging and the only one it ever sees. Any extracted message is recorded into streamState; it
 // returns whether it counted an Anthropic error for this line so the later
 // chunk.Error observer does not double-count it. lastAnthropicEvent is the carry
 // from the preceding "event:" line and is consumed (reset) here. No client output.
 func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *string, chunkCount int, logData *requestLogData) bool {
-	// P1-B: accumulate error JSON split across data lines; flush on a non-error line.
+	// P1-B: hold a truncated error line; flush on any other line.
 	//
-	// Only a FRAGMENT is accumulated. A payload that parses is a whole frame,
+	// Only a FRAGMENT is held. A payload that parses is a whole frame,
 	// whatever it starts with, and the observer reads its error member properly;
 	// handing it to the accumulator instead put it in front of
 	// parseAccumulatedError, whose last resort is to return the entire payload
@@ -57,8 +62,8 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 	return anthropicErrorCounted
 }
 
-// flushAccumulatedError parses and records any P1-B accumulated split-error bytes
-// (an {"error":…} object split across SSE data lines), then clears the buffer. A
+// flushAccumulatedError parses and records any P1-B held error bytes (a
+// truncated {"error":…} line), then clears the buffer. A
 // no-op when nothing is accumulated. Every flush site goes through here — the
 // comment-line handler, captureSSEError's non-error data-line branch, and the
 // stream-end sweep — so they cannot drift; `what` is the only thing that differs
@@ -141,7 +146,7 @@ type streamChunk struct {
 	// the WHOLE chunk unmarshal, so the frame was dropped as corrupt bytes
 	// instead of forwarded, and the error it reported was recorded only when
 	// the payload happened to START with {"error" (the P1-B prefix). What the
-	// member means is errorMemberCarries/errorMemberMessage's answer, shared
+	// member means is util.ErrorMemberCarries/ErrorMemberMessage's answer, shared
 	// with the probe so the two readings cannot drift.
 	Error json.RawMessage `json:"error"`
 }
@@ -240,10 +245,10 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		st.lastContent = currentContent
 	}
-	if !anthropicErrorCounted && errorMemberCarries(chunk.Error) {
+	if !anthropicErrorCounted && util.ErrorMemberCarries(chunk.Error) {
 		// Only count if P1-C didn't already handle this as an
 		// Anthropic error event (which shares the same data line).
-		msg := errorMemberMessage(chunk.Error)
+		msg := util.ErrorMemberMessage(chunk.Error)
 		st.lastErrMsg = msg
 		st.errorChunkCount++
 		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", st.errLogAttr(msg), "chunk_number", chunkCount)

--- a/internal/proxy/stream_observers_test.go
+++ b/internal/proxy/stream_observers_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -103,19 +104,40 @@ func TestCaptureSSEError(t *testing.T) {
 	t.Run("P1-B accumulate then flush on non-error line", func(t *testing.T) {
 		st := &streamState{}
 		ev := ""
-		if counted := st.captureSSEError(`{"error":{"message":"boom"}}`, &ev, 1, ld); counted {
+		// A FRAGMENT: what P1-B exists for, and the only thing it takes. A
+		// whole frame is the observer's to read, however it starts — routing
+		// one here instead put it in front of parseAccumulatedError's raw
+		// fallback, which records the entire payload as the error message.
+		if counted := st.captureSSEError(`{"error":{"message":"bo`, &ev, 1, ld); counted {
 			t.Error("error-prefixed line should accumulate, not count as Anthropic")
 		}
 		if st.lastErrMsg != "" || len(st.errAccum) == 0 {
 			t.Errorf("after accumulate: lastErrMsg=%q errAccum=%q (want empty msg, non-empty accum)", st.lastErrMsg, st.errAccum)
 		}
-		// A non-error line flushes the accumulated error.
+		// A non-error line flushes the accumulated error. Nothing can parse a
+		// truncated object, so the fragment itself is the best available
+		// message — recovering that is the whole point of the accumulator.
 		st.captureSSEError(`{"id":"x","choices":[]}`, &ev, 2, ld)
-		if st.lastErrMsg != "boom" || st.errorChunkCount != 1 {
-			t.Errorf("after flush: lastErrMsg=%q errorChunkCount=%d, want boom/1", st.lastErrMsg, st.errorChunkCount)
+		if !strings.Contains(st.lastErrMsg, "bo") || st.errorChunkCount != 1 {
+			t.Errorf("after flush: lastErrMsg=%q errorChunkCount=%d, want the fragment/1", st.lastErrMsg, st.errorChunkCount)
 		}
 		if st.errAccum != nil {
 			t.Errorf("errAccum should be cleared, got %q", st.errAccum)
+		}
+	})
+
+	// A complete error frame is not a fragment, whatever it starts with: it
+	// goes to the observer, and the accumulator must not also hold it.
+	t.Run("P1-B ignores a whole frame", func(t *testing.T) {
+		st := &streamState{}
+		ev := ""
+		st.captureSSEError(`{"error":"","choices":[{"delta":{"content":"secret"}}]}`, &ev, 1, ld)
+		if len(st.errAccum) != 0 {
+			t.Errorf("a parseable frame must not accumulate, got %q", st.errAccum)
+		}
+		st.captureSSEError(`{"id":"x","choices":[]}`, &ev, 2, ld)
+		if st.lastErrMsg != "" || st.errorChunkCount != 0 {
+			t.Errorf("nothing to flush, got lastErrMsg=%q count=%d", st.lastErrMsg, st.errorChunkCount)
 		}
 	})
 

--- a/internal/proxy/token_usage_test.go
+++ b/internal/proxy/token_usage_test.go
@@ -37,8 +37,12 @@ func TestTokenUsage_RecordedOnClientDisconnect(t *testing.T) {
 		_ = vkRepo.Delete(ctx, vk.ID)
 	}()
 
-	// Build an upstream that streams tokens, sends usage, then delays
-	// so the client has time to disconnect.
+	// disconnected is closed once the test has cancelled the client context;
+	// the upstream holds the stream open until then.
+	disconnected := make(chan struct{})
+
+	// Build an upstream that streams tokens, sends usage, then waits so the
+	// client disconnects mid-stream.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -55,8 +59,9 @@ func TestTokenUsage_RecordedOnClientDisconnect(t *testing.T) {
 		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-test\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n")
 		flusher.Flush()
 
-		// Delay so the client can disconnect after seeing the usage chunk.
-		time.Sleep(200 * time.Millisecond)
+		// Hold the stream open until the test has disconnected, so the
+		// disconnect always lands mid-stream rather than after [DONE].
+		<-disconnected
 
 		// Send [DONE] — may or may not be received by the client.
 		fmt.Fprint(w, "data: [DONE]\n\n")
@@ -79,7 +84,14 @@ func TestTokenUsage_RecordedOnClientDisconnect(t *testing.T) {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	req = req.WithContext(cancelCtx)
 
-	inner := httptest.NewRecorder()
+	// The usage chunk is the second data frame the proxy forwards, and the
+	// observers run BEFORE the emit — so a write carrying "usage" proves the
+	// token counts are already in streamState. Waiting on that instead of on a
+	// sleep is what makes the disconnect land at a known point: an 80ms guess
+	// was enough locally and not on a loaded runner under -race, where the
+	// stream had not reached the usage chunk yet and the test read tokens=0.
+	usageSeen := make(chan struct{})
+	inner := &notifyOnMatchWriter{inner: httptest.NewRecorder(), match: "usage", seen: usageSeen}
 	logData := &requestLogData{
 		modelID:         "test-model",
 		streaming:       true,
@@ -98,9 +110,14 @@ func TestTokenUsage_RecordedOnClientDisconnect(t *testing.T) {
 		close(done)
 	}()
 
-	// Let the content + usage chunks be processed, then disconnect.
-	time.Sleep(80 * time.Millisecond)
+	// Disconnect once the usage chunk has actually been forwarded.
+	select {
+	case <-usageSeen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the usage chunk was never forwarded")
+	}
 	cancel()
+	close(disconnected)
 
 	// Wait for the handler to finish.
 	select {
@@ -163,3 +180,28 @@ func TestTokenUsage_RecordedOnNonStreamingSuccess(t *testing.T) {
 		t.Errorf("expected tokens_used=75 (50 prompt + 25 completion), got %d", refreshed.TokensUsed)
 	}
 }
+
+// notifyOnMatchWriter closes seen the first time a written chunk contains match.
+// It exists so a streaming test can act at a point in the stream rather than at
+// a point in time.
+type notifyOnMatchWriter struct {
+	inner http.ResponseWriter
+	match string
+	seen  chan struct{}
+	fired bool
+}
+
+func (w *notifyOnMatchWriter) Header() http.Header { return w.inner.Header() }
+
+func (w *notifyOnMatchWriter) Write(p []byte) (int, error) {
+	n, err := w.inner.Write(p)
+	if !w.fired && strings.Contains(string(p), w.match) {
+		w.fired = true
+		close(w.seen)
+	}
+	return n, err
+}
+
+func (w *notifyOnMatchWriter) WriteHeader(statusCode int) { w.inner.WriteHeader(statusCode) }
+
+func (w *notifyOnMatchWriter) Flush() {}

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -320,8 +320,10 @@ func carriesErrorObject(body []byte) bool {
 // check above, the probe that decides a hedged race, and the streaming observer
 // that decides what the request log and the circuit breaker are told. They read
 // the same bytes, so a second opinion is only ever a way for them to disagree.
-// (parseAccumulatedError reads error bytes too, but only ever a truncated
-// fragment, which is a member no reader can judge.)
+// Two readers stand outside it, both by necessity: parseAccumulatedError, whose
+// input is a truncated fragment no reader can judge, and the P1-C Anthropic
+// branch, which is keyed on the preceding "event: error" line rather than on
+// the member at all.
 //
 // The zero value of every JSON type carries nothing — including `false` and `0`,
 // which are not a peculiar error but the C convention for its absence, and
@@ -329,6 +331,12 @@ func carriesErrorObject(body []byte) bool {
 // observer shares this rule. Reading `"error":false` as a failure would mark
 // every request from such a relay failed, suppress its terminal frame, and lose
 // it every hedged race it was in fact winning.
+//
+// A container carries whatever its values carry, because the same convention
+// appears one level down: `{"code":0,"message":""}` and `{"code":null}` are a
+// relay stamping its no-error struct on every frame, and stopping the rule at
+// the top level made every one of those requests a provider_error — which also
+// feeds the retirement machinery — while the provider answered perfectly.
 func errorMemberCarries(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
@@ -337,19 +345,36 @@ func errorMemberCarries(raw json.RawMessage) bool {
 	if err := json.Unmarshal(raw, &content); err != nil {
 		return false
 	}
-	switch v := content.(type) {
+	return valueCarries(content)
+}
+
+// valueCarries is the emptiness rule over a decoded JSON value. Recursion is
+// bounded by the value's own nesting, which encoding/json has already capped
+// while building it.
+func valueCarries(v any) bool {
+	switch v := v.(type) {
 	case nil:
 		return false
 	case string:
 		return strings.TrimSpace(v) != ""
-	case map[string]any:
-		return len(v) > 0
-	case []any:
-		return len(v) > 0
 	case bool:
 		return v
 	case float64:
 		return v != 0
+	case map[string]any:
+		for _, val := range v {
+			if valueCarries(val) {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, val := range v {
+			if valueCarries(val) {
+				return true
+			}
+		}
+		return false
 	default:
 		// Nothing else survives a decode into `any`; a shape that somehow did
 		// is a value the provider put there, and a client can render it.

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -308,8 +308,20 @@ func carriesErrorObject(body []byte) bool {
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return false
 	}
-	raw, present := envelope["error"]
-	if !present {
+	return errorMemberCarries(envelope["error"])
+}
+
+// errorMemberCarries is that emptiness test over the member itself, so a caller
+// already holding the raw "error" value does not re-derive the rule. An absent
+// member (a nil or empty raw) carries nothing, which is what makes the missing
+// key and the null-valued key the same answer.
+//
+// Every reading of an error member goes through here: the whole-body check
+// above, the probe that decides a hedged race, and the streaming observer that
+// decides what the request log and the circuit breaker are told. They read the
+// same bytes, so a second opinion is only ever a way for them to disagree.
+func errorMemberCarries(raw json.RawMessage) bool {
+	if len(raw) == 0 {
 		return false
 	}
 	var content any
@@ -330,4 +342,26 @@ func carriesErrorObject(body []byte) bool {
 		// a client can render it.
 		return true
 	}
+}
+
+// errorMemberMessage renders the provider's own text out of an error member
+// already judged to carry something. The conventional {"message":…} wins; a
+// bare string is the message; anything else is rendered as the JSON the
+// provider sent, because dropping a frame's only explanation to preserve a
+// shape preference helps nobody reading a request log.
+//
+// The result is provider text, not response content, and every caller bounds
+// and masks it before it is stored or forwarded.
+func errorMemberMessage(raw json.RawMessage) string {
+	var obj struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(raw, &obj) == nil && obj.Message != "" {
+		return obj.Message
+	}
+	var bare string
+	if json.Unmarshal(raw, &bare) == nil {
+		return bare
+	}
+	return string(raw)
 }

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 	"slices"
-	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -229,15 +228,6 @@ func (m credentialMasker) maskExact(body []byte) []byte {
 	return body
 }
 
-// maskKeyShapedTokens scrubs credential-looking substrings from upstream error
-// text before it reaches a client or the request log. Auth-class errors never
-// forward at all, and credentialMasker has already removed this gateway's own
-// key by exact value; this is the third layer, for a provider quoting some
-// other credential inside an otherwise forwardable payload error. A match with no
-// digit in it is an identifier or prose ("sk_business_unit_identifier",
-// "Bearer authentication-required") rather than a credential, and stays -
-// real keys carry digits. The replacement carries no JSON metacharacters, so
-// a valid body stays valid.
 // exactMaskWriter applies credentialMasker.maskExact to a byte stream whose
 // writes may split the key: it holds back the last len(key)-1 bytes of each
 // write until the next one arrives, so a key straddling two writes is still
@@ -282,6 +272,15 @@ func (e *exactMaskWriter) Flush() error {
 	return err
 }
 
+// maskKeyShapedTokens scrubs credential-looking substrings from upstream error
+// text before it reaches a client or the request log. Auth-class errors never
+// forward at all, and credentialMasker has already removed this gateway's own
+// key by exact value; this is the third layer, for a provider quoting some
+// other credential inside an otherwise forwardable payload error. A match with no
+// digit in it is an identifier or prose ("sk_business_unit_identifier",
+// "Bearer authentication-required") rather than a credential, and stays -
+// real keys carry digits. The replacement carries no JSON metacharacters, so
+// a valid body stays valid.
 func maskKeyShapedTokens(body []byte) []byte {
 	return keyShapedToken.ReplaceAllFunc(body, func(m []byte) []byte {
 		if !bytes.ContainsAny(m, "0123456789") {
@@ -295,111 +294,14 @@ func maskKeyShapedTokens(body []byte) []byte {
 // "error" member that actually carries something, which is what decides between
 // forwarding that body verbatim and synthesising an envelope over it.
 //
-// The test is emptiness, not shape. What a provider puts inside its error is not
-// this gateway's to judge, so any populated value counts: an object with fields,
-// Ollama's bare string ("model not found"), a list, even a number. What does not
-// count is a member that leaves a client with nothing to read - `null`, `{}`,
-// `""`, `[]` - because a body carrying one of those is, from the caller's side,
-// the same body with no error member at all, which is exactly the case this
-// function exists to catch. A body that is not a JSON object (an array, a bare
-// string, HTML) can carry no member and reports false.
+// util.ErrorMemberCarries holds the rule and documents it: emptiness, not shape,
+// applied at every depth, with `false` and `0` counting as empty like every
+// other zero value. A body that is not a JSON object (an array, a bare string,
+// HTML) can carry no member and reports false.
 func carriesErrorObject(body []byte) bool {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return false
 	}
-	return errorMemberCarries(envelope["error"])
-}
-
-// errorMemberCarries is that emptiness test over the member itself, so a caller
-// already holding the raw "error" value does not re-derive the rule. An absent
-// member (a nil or empty raw) carries nothing, which is what makes the missing
-// key and the null-valued key the same answer.
-//
-// Every reading of an error member's MEANING goes through here: the whole-body
-// check above, the probe that decides a hedged race, and the streaming observer
-// that decides what the request log and the circuit breaker are told. They read
-// the same bytes, so a second opinion is only ever a way for them to disagree.
-// Two readers stand outside it, both by necessity: parseAccumulatedError, whose
-// input is a truncated fragment no reader can judge, and the P1-C Anthropic
-// branch, which is keyed on the preceding "event: error" line rather than on
-// the member at all.
-//
-// The zero value of every JSON type carries nothing — including `false` and `0`,
-// which are not a peculiar error but the C convention for its absence, and
-// which reach here on every frame of every 200 stream now that the streaming
-// observer shares this rule. Reading `"error":false` as a failure would mark
-// every request from such a relay failed, suppress its terminal frame, and lose
-// it every hedged race it was in fact winning.
-//
-// A container carries whatever its values carry, because the same convention
-// appears one level down: `{"code":0,"message":""}` and `{"code":null}` are a
-// relay stamping its no-error struct on every frame, and stopping the rule at
-// the top level made every one of those requests a provider_error — which also
-// feeds the retirement machinery — while the provider answered perfectly.
-func errorMemberCarries(raw json.RawMessage) bool {
-	if len(raw) == 0 {
-		return false
-	}
-	var content any
-	if err := json.Unmarshal(raw, &content); err != nil {
-		return false
-	}
-	return valueCarries(content)
-}
-
-// valueCarries is the emptiness rule over a decoded JSON value. Recursion is
-// bounded by the value's own nesting, which encoding/json has already capped
-// while building it.
-func valueCarries(v any) bool {
-	switch v := v.(type) {
-	case nil:
-		return false
-	case string:
-		return strings.TrimSpace(v) != ""
-	case bool:
-		return v
-	case float64:
-		return v != 0
-	case map[string]any:
-		for _, val := range v {
-			if valueCarries(val) {
-				return true
-			}
-		}
-		return false
-	case []any:
-		for _, val := range v {
-			if valueCarries(val) {
-				return true
-			}
-		}
-		return false
-	default:
-		// Nothing else survives a decode into `any`; a shape that somehow did
-		// is a value the provider put there, and a client can render it.
-		return true
-	}
-}
-
-// errorMemberMessage renders the provider's own text out of an error member
-// already judged to carry something. The conventional {"message":…} wins; a
-// bare string is the message; anything else is rendered as the JSON the
-// provider sent, because dropping a frame's only explanation to preserve a
-// shape preference helps nobody reading a request log.
-//
-// The result is raw provider text: unbounded, and scrubbed by nothing. Every
-// caller masks and bounds it before storing, forwarding or logging it.
-func errorMemberMessage(raw json.RawMessage) string {
-	var obj struct {
-		Message string `json:"message"`
-	}
-	if json.Unmarshal(raw, &obj) == nil && obj.Message != "" {
-		return obj.Message
-	}
-	var bare string
-	if json.Unmarshal(raw, &bare) == nil {
-		return bare
-	}
-	return string(raw)
+	return util.ErrorMemberCarries(envelope["error"])
 }

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -316,10 +316,19 @@ func carriesErrorObject(body []byte) bool {
 // member (a nil or empty raw) carries nothing, which is what makes the missing
 // key and the null-valued key the same answer.
 //
-// Every reading of an error member goes through here: the whole-body check
-// above, the probe that decides a hedged race, and the streaming observer that
-// decides what the request log and the circuit breaker are told. They read the
-// same bytes, so a second opinion is only ever a way for them to disagree.
+// Every reading of an error member's MEANING goes through here: the whole-body
+// check above, the probe that decides a hedged race, and the streaming observer
+// that decides what the request log and the circuit breaker are told. They read
+// the same bytes, so a second opinion is only ever a way for them to disagree.
+// (parseAccumulatedError reads error bytes too, but only ever a truncated
+// fragment, which is a member no reader can judge.)
+//
+// The zero value of every JSON type carries nothing — including `false` and `0`,
+// which are not a peculiar error but the C convention for its absence, and
+// which reach here on every frame of every 200 stream now that the streaming
+// observer shares this rule. Reading `"error":false` as a failure would mark
+// every request from such a relay failed, suppress its terminal frame, and lose
+// it every hedged race it was in fact winning.
 func errorMemberCarries(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
@@ -337,9 +346,13 @@ func errorMemberCarries(raw json.RawMessage) bool {
 		return len(v) > 0
 	case []any:
 		return len(v) > 0
+	case bool:
+		return v
+	case float64:
+		return v != 0
 	default:
-		// A number or a bool: peculiar, but the provider put a value there and
-		// a client can render it.
+		// Nothing else survives a decode into `any`; a shape that somehow did
+		// is a value the provider put there, and a client can render it.
 		return true
 	}
 }
@@ -350,8 +363,8 @@ func errorMemberCarries(raw json.RawMessage) bool {
 // provider sent, because dropping a frame's only explanation to preserve a
 // shape preference helps nobody reading a request log.
 //
-// The result is provider text, not response content, and every caller bounds
-// and masks it before it is stored or forwarded.
+// The result is raw provider text: unbounded, and scrubbed by nothing. Every
+// caller masks and bounds it before storing, forwarding or logging it.
 func errorMemberMessage(raw json.RawMessage) string {
 	var obj struct {
 		Message string `json:"message"`

--- a/internal/util/errormember.go
+++ b/internal/util/errormember.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ErrorMemberCarries reports whether the "error" member of a provider payload
+// leaves a client something to read.
+//
+// The test is emptiness, not shape. What a provider puts inside its error is
+// not a gateway's to judge, so any populated value counts: an object with
+// fields, Ollama's bare string ("model not found"), a list, even a number. What
+// does not count is a member that leaves a caller with nothing — null, {}, "",
+// [] — because a payload carrying one of those is, from the caller's side, the
+// same payload with no error member at all. An absent member (a nil or empty
+// raw) carries nothing, which is what makes the missing key and the
+// null-valued key the same answer.
+//
+// `false` and `0` carry nothing either. They are not a peculiar error but the C
+// convention for its absence, and they arrive on every frame of every 200
+// stream from a relay that uses it. Reading "error":false as a failure marks
+// every one of those requests failed, suppresses its terminal frame, and loses
+// it every hedged race it was in fact winning.
+//
+// A container carries whatever its values carry, because the same convention
+// appears one level down: {"code":0,"message":""} and {"code":null} are a relay
+// stamping its no-error struct on every frame, and a rule that stopped at the
+// top level called every one of those a provider error.
+//
+// This lives in util because more than one package reads an error member — the
+// OpenAI-compatible streaming path, the hedging probe, the buffered non-2xx
+// forwarder, and the native Anthropic passthrough. They read the same bytes, so
+// a second opinion is only ever a way for them to disagree, and the disagreement
+// costs a hedged race to a provider whose failure is then never recorded.
+func ErrorMemberCarries(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var content any
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return false
+	}
+	return valueCarries(content)
+}
+
+// valueCarries is the emptiness rule over a decoded JSON value. Recursion is
+// bounded by the value's own nesting, which encoding/json has already capped
+// while building it.
+func valueCarries(v any) bool {
+	switch v := v.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(v) != ""
+	case bool:
+		return v
+	case float64:
+		return v != 0
+	case map[string]any:
+		for _, val := range v {
+			if valueCarries(val) {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, val := range v {
+			if valueCarries(val) {
+				return true
+			}
+		}
+		return false
+	default:
+		// Nothing else survives a decode into `any`; a shape that somehow did
+		// is a value the provider put there, and a client can render it.
+		return true
+	}
+}
+
+// ErrorMemberMessage renders the provider's own text out of an error member
+// already judged to carry something. The conventional {"message":…} wins; a
+// bare string is the message; anything else is rendered as the JSON the
+// provider sent, because dropping a frame's only explanation to preserve a
+// shape preference helps nobody reading a request log.
+//
+// The result is raw provider text: unbounded, and scrubbed by nothing. Every
+// caller masks and bounds it before storing, forwarding or logging it.
+func ErrorMemberMessage(raw json.RawMessage) string {
+	var obj struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(raw, &obj) == nil && obj.Message != "" {
+		return obj.Message
+	}
+	var bare string
+	if json.Unmarshal(raw, &bare) == nil {
+		return bare
+	}
+	return string(raw)
+}

--- a/internal/util/errormember_test.go
+++ b/internal/util/errormember_test.go
@@ -1,0 +1,87 @@
+package util_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+func TestErrorMemberCarries(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		member string
+		want   bool
+	}{
+		{`{"message":"rate limited"}`, true},
+		{`"model not found"`, true},
+		{`{"code":500}`, true},
+		{`["bad","worse"]`, true},
+		{`503`, true},
+		{`true`, true},
+		{`{"code":404,"message":"","type":"not_found"}`, true},
+		{`[{"reason":"quota"}]`, true},
+
+		{`null`, false},
+		{`{}`, false},
+		{`""`, false},
+		{`"   "`, false},
+		{`[]`, false},
+		// The C convention for the absence of an error, at the top level and
+		// one down: a relay's no-error stamp, arriving on every frame.
+		{`false`, false},
+		{`0`, false},
+		{`{"code":0,"message":"","type":""}`, false},
+		{`{"code":null,"message":null}`, false},
+		{`{"details":[]}`, false},
+		{`{"failed":false}`, false},
+		{`[null,{}]`, false},
+		// Not JSON at all. Every reader hands this function a member that came
+		// out of a successful unmarshal, so this is the contract for a caller
+		// with a raw member of its own: garbage carries nothing.
+		{`{"message":"trunc`, false},
+		{``, false},
+	} {
+		t.Run(tc.member, func(t *testing.T) {
+			t.Parallel()
+			if got := util.ErrorMemberCarries(json.RawMessage(tc.member)); got != tc.want {
+				t.Errorf("ErrorMemberCarries(%s) = %v, want %v", tc.member, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorMemberMessage(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ member, want string }{
+		{`{"message":"rate limited"}`, "rate limited"},
+		{`"model not found"`, "model not found"},
+		{`{"code":500}`, `{"code":500}`},
+		{`["bad","worse"]`, `["bad","worse"]`},
+		{`503`, "503"},
+		{`true`, "true"},
+	} {
+		t.Run(tc.member, func(t *testing.T) {
+			t.Parallel()
+			if got := util.ErrorMemberMessage(json.RawMessage(tc.member)); got != tc.want {
+				t.Errorf("ErrorMemberMessage(%s) = %q, want %q", tc.member, got, tc.want)
+			}
+		})
+	}
+}
+
+// encoding/json caps nesting while decoding, so the recursion is bounded before
+// it is ever entered. This is the depth that cap allows.
+func TestErrorMemberCarries_DeepNesting(t *testing.T) {
+	t.Parallel()
+	const depth = 9000
+	deep := strings.Repeat(`[`, depth) + `"boom"` + strings.Repeat(`]`, depth)
+	if !util.ErrorMemberCarries(json.RawMessage(deep)) {
+		t.Error("a value nested to the decoder's limit must still be read")
+	}
+	empty := strings.Repeat(`[`, depth) + strings.Repeat(`]`, depth)
+	if util.ErrorMemberCarries(json.RawMessage(empty)) {
+		t.Error("nesting alone is not something to read")
+	}
+}


### PR DESCRIPTION
## The bug

`streamChunk` typed the `error` member of a streaming frame as `{"message": string}`. A provider sending any other shape — Ollama's bare `{"error":"model not found"}`, a list, a number — failed the **whole** chunk unmarshal, so the gateway treated the frame as corrupt bytes:

- **it was dropped, not forwarded.** `writeTerminalError` also bails once an error has been counted, so a stream whose only frame was such an error reached the caller as a completely empty body: no error frame, no `[DONE]`, connection closed.
- **no observer ran**, so neither the request log nor the circuit breaker learned anything — and `unparsedChunks` then held back even the empty-stream charge, so a provider erroring on every request never opened its circuit.
- **no masking ran** — the invalid-JSON branch masks nowhere at all.

Whether the error was recorded came down to **key order**. The P1-B accumulator only recognises a payload that literally *starts* with `{"error"`, so Ollama's own frame was caught by that heuristic while `{"model":"llama3","error":"model not found"}` produced, to this gateway and to the caller, a stream that had merely finished.

The hedging probe has accepted all of those shapes since #803, so two readings of the same bytes disagreed exactly where it costs most: a provider lost the race, and its failure was then never recorded.

## The fix

The member becomes `json.RawMessage`, and the two decisions about it each live in one place — `errorMemberCarries` (does it leave a caller anything to read?) and `errorMemberMessage` (render the provider's text) — shared by `carriesErrorObject`, the probe, and the stream observer.

Four defects two review rounds turned up, all in the same seam:

**The accumulator was taking whole frames.** `parseAccumulatedError` returned the entire payload when it could not parse one, so `{"error":"","choices":[{"delta":{"content":…}}]}` wrote **the model's output into `request_logs.error_message`** and failed the request for an error no reader of that member agrees is there. P1-B exists for fragments; a payload that parses is a whole frame and belongs to the observer. And for the fragments that remain, the function now walks the object and reads **only the error member** — no other key's value can be inside it. The same reasoning retires the invalid-JSON warn's `payload_preview`: the commonest reason a frame fails to parse is a stream cut mid-delta, so the preview was the answer, in the app log.

**`"error":false` and `"error":0` are the C convention for the absence of an error** — as are `{"code":0,"message":""}` and an all-null error struct one level down. The rule used to see only buffered non-2xx bodies; sharing it with the observer put it on every frame of every 200 stream, so a relay using that convention would have had every request marked `provider_error`, which also feeds the retirement machinery, while answering perfectly.

**Content must never meet the key-shape regex.** The scrub is gated on the frame being an error because the regex matches prose. Gating on the member's mere *presence* fires on `"error":null`, an ordinary per-frame shape — and an assistant writing out `sk-proj-…`, an `AIza…` or a `Bearer` header had its answer silently rewritten to `[redacted]` mid-stream.

**The native Anthropic passthrough had the same defect one struct away** — and a worse consequence. It typed its own `error` member as an object, so a bare-string error cost the *event* its type; the key-shape scrub is gated on that type, so the frame reached the caller **verbatim, with a relayed credential intact**, the error went uncounted, and the request log recorded "stream truncated" instead of the provider's own words. The rule now lives in `internal/util` where all four readers share it — the OpenAI-compatible streaming path, the hedging probe, the buffered non-2xx forwarder, and the native passthrough. Claiming one rule while keeping a private copy per package is how they drift.

**Four app-log sites logged provider error text raw**, including the stream-end flush — a copy of `flushAccumulatedError` that leaked both a relayed credential and this gateway's own key. That copy is gone; every flush site shares one body, and `errLogAttr` masks and bounds at each.

## Verified on the rebuilt dev stack

Against a mock provider emitting each shape:

| model | client stream | `request_logs` |
|---|---|---|
| `late-err-bare` / `late-err-keyorder` | error frame forwarded | `failed` / `provider_error` / "model not found" |
| `late-err-relaykey` | `{"error":"invalid key [redacted]"}` | "invalid key [redacted]" |
| `late-empty-member` | content streams, clean `[DONE]` | `completed`, empty error_message |
| `null-err-with-key-in-content` | **content intact**, key not rewritten | `completed` |
| `zeroed-err-struct` | content streams | `completed` |
| `ok-falseflag` | content streams | `completed` |
| `truncated-content` (cut mid-delta) | dropped, `[DONE]` injected | `completed`, nothing logged |
| `malformed-err-with-content` (raw tab) | dropped, `[DONE]` injected | `completed`, nothing logged |
| `anthropic-bare-err` | probe rejects it, no frame forwarded | `failed` / "overloaded [redacted]" |

`request_logs` and `app_logs` between them contain zero occurrences of the model's answer, the relayed credential, or the gateway's own key.

## Tests

`internal/proxy/error_frame_shape_test.go` runs one corpus of error-member shapes through the observer, the probe, **and** the whole streaming pipeline — the third is what catches a disagreement the unit level cannot see, which is how the accumulator defect was found. The probe's own table, which duplicated the same rule, now drives off that corpus rather than being maintained beside it.

Every assertion is mutation-verified: reverting the field type kills 8 subtests, restoring `false`/`0` as errors kills 4, flattening the emptiness rule kills 3, reverting the accumulator guard kills 7, widening the masking gate kills 6, restoring the raw payload fallback, the payload preview, or the salvage-on-any-decode-error kills the content-logging tests, reverting the native Anthropic member kills the credential-to-client test, and neutering `errLogAttr` at either site kills the log tests.
