### PR TITLE
fix(proxy): a frame the gateway cannot type is still the provider's answer

### DIFF
--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -28,12 +29,19 @@ import (
 //
 // errors.As also unwraps, so a nested custom UnmarshalJSON returning a type
 // error of its own reaches here too; the check covers that case for free.
+//
+// The error must NAME a member. A type error with an empty Field is the whole
+// value being the wrong kind of thing — `data: 42`, `data: "[DONE]"`, a usage
+// member that is a number — and that is not "a member this package does not
+// model", it is not the document at all. Relaying such a frame put a quoted
+// sentinel into an OpenAI-shaped stream as a data event, and keeping such a
+// usage block made the gateway emit a zeroed one the provider never sent.
 func shapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
 	if decodeErr == nil {
 		return nil
 	}
 	var typeErr *json.UnmarshalTypeError
-	if !errors.As(decodeErr, &typeErr) || !json.Valid(data) {
+	if !errors.As(decodeErr, &typeErr) || typeErr.Field == "" || !json.Valid(data) {
 		return nil
 	}
 	return typeErr
@@ -241,11 +249,43 @@ func (c ChatCompletionResponse) MarshalJSON() ([]byte, error) {
 func (u *Usage) UnmarshalJSON(data []byte) error {
 	type alias Usage
 	var a alias
-	if err := util.DecodeCounts(data, &a); err != nil && shapeError(data, err) == nil {
-		return err
+	if err := util.DecodeCounts(data, &a); err != nil {
+		if shapeError(data, err) == nil {
+			return err
+		}
+		// encoding/json allocates a breakdown's pointer before it reaches the
+		// value, so a member it could not read leaves a struct full of zeros —
+		// and re-encoding that emits {"cached_tokens":0}, a positive claim that
+		// nothing was cached, in place of whatever the provider wrote. A
+		// breakdown this package could not read is reported as absent, which is
+		// what it is.
+		a.PromptTokensDetails = keepIfObject(data, "prompt_tokens_details", a.PromptTokensDetails)
+		a.CompletionTokensDetails = keepIfObject(data, "completion_tokens_details", a.CompletionTokensDetails)
 	}
 	*u = Usage(a)
 	u.Extra = decodeExtras(data, usageJSONFields)
+	return nil
+}
+
+// keepIfObject returns ptr when the named member of data really is a JSON
+// object, and nil otherwise — the breakdown was allocated by the decoder before
+// it saw the value, so a non-object there leaves a zeroed struct standing for
+// something that was never read.
+func keepIfObject[T any](data []byte, member string, ptr *T) *T {
+	if ptr == nil {
+		return nil
+	}
+	var members map[string]json.RawMessage
+	if json.Unmarshal(data, &members) != nil {
+		return ptr
+	}
+	raw, ok := members[member]
+	if !ok {
+		return ptr
+	}
+	if trimmed := bytes.TrimSpace(raw); len(trimmed) > 0 && trimmed[0] == '{' {
+		return ptr
+	}
 	return nil
 }
 

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -2,10 +2,42 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
+
+// shapeError reports the type error behind a failed decode when the frame
+// is nonetheless well-formed JSON — a shape this gateway has no struct for
+// rather than bytes that are broken — and nil otherwise.
+//
+// It is the difference between "this gateway has no struct for these bytes" and
+// "these bytes are broken", and both the streaming frame handler and Usage's own
+// decoder turn on it: the first keeps the frame, the second keeps the counts.
+//
+// The validity is CHECKED, not inferred. json.Unmarshal happens to validate the
+// whole document before decoding any of it, so today a type error already proves
+// the bytes are sound; json.Decoder makes no such promise, and GOEXPERIMENT
+// jsonv2 decodes streaming, where a type error on an early member can be
+// reported before a syntax error further on is ever reached. The check costs one
+// pass over a small frame on a path that has already failed, and without it a
+// change of build flag would start treating truncated bytes as merely
+// mis-shaped — forwarding half a frame to a caller, or keeping half a usage
+// block — which is the one thing the strictness exists to prevent.
+//
+// errors.As also unwraps, so a nested custom UnmarshalJSON returning a type
+// error of its own reaches here too; the check covers that case for free.
+func shapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
+	if decodeErr == nil {
+		return nil
+	}
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(decodeErr, &typeErr) || !json.Valid(data) {
+		return nil
+	}
+	return typeErr
+}
 
 // Provider-specific fields that this package does not model must survive the
 // decode/re-encode in handleNonStreamingResponse, because some of them are
@@ -189,14 +221,27 @@ func (c ChatCompletionResponse) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON decodes usage and retains the accounting fields this package
 // does not model, above all the per-request cost aggregators report.
+//
+// util.DecodeCounts, not a plain Unmarshal: a count is a count however the
+// provider spelled it, quoted or with a fraction on it.
+//
+// And a member left in a shape this package has no struct for costs that member
+// only. An error here does not merely blank the usage — Usage decodes inside the
+// response object, so returning one stops THAT decode where it stands and the
+// caller is handed "the provider returned a response the gateway could not
+// decode" in place of the answer the model already produced. prompt_tokens_details
+// as [] rather than {} is enough to do it, and an empty object written as an
+// empty array is a routine relay habit.
+//
+// So a type error keeps whatever did decode: encoding/json records it and
+// carries on with the siblings, and the counts that were readable are worth more
+// than the ones that were not. Bytes that are not well-formed JSON still fail —
+// there is nothing to keep — and that is checked rather than inferred, for the
+// reason given on untypeableFrame.
 func (u *Usage) UnmarshalJSON(data []byte) error {
 	type alias Usage
 	var a alias
-	// util.DecodeCounts, not a plain Unmarshal: a count is a count however the
-	// provider spelled it, and an error here does not merely blank the usage —
-	// it stops the decode of the response object around it, so one quoted token
-	// count cost the caller the answer the model had already produced.
-	if err := util.DecodeCounts(data, &a); err != nil {
+	if err := util.DecodeCounts(data, &a); err != nil && shapeError(data, err) == nil {
 		return err
 	}
 	*u = Usage(a)

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -30,21 +30,37 @@ import (
 // errors.As also unwraps, so a nested custom UnmarshalJSON returning a type
 // error of its own reaches here too; the check covers that case for free.
 //
-// The error must NAME a member. A type error with an empty Field is the whole
+// The document must be a JSON OBJECT. A type error on anything else is the whole
 // value being the wrong kind of thing — `data: 42`, `data: "[DONE]"`, a usage
 // member that is a number — and that is not "a member this package does not
 // model", it is not the document at all. Relaying such a frame put a quoted
 // sentinel into an OpenAI-shaped stream as a data event, and keeping such a
-// usage block made the gateway emit a zeroed one the provider never sent.
+// usage member made the gateway emit a zeroed usage block the provider never
+// sent.
+//
+// The object test rather than typeErr.Field != "", which was the first attempt:
+// an error returned by a NESTED custom UnmarshalJSON reaches here with an empty
+// Field too, so requiring a member name threw away a perfectly good chat frame
+// whose usage member happened to be [] instead of {} — the routine relay habit
+// this whole change exists to survive.
 func shapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
 	if decodeErr == nil {
 		return nil
 	}
 	var typeErr *json.UnmarshalTypeError
-	if !errors.As(decodeErr, &typeErr) || typeErr.Field == "" || !json.Valid(data) {
+	if !errors.As(decodeErr, &typeErr) || !isJSONObject(data) {
 		return nil
 	}
 	return typeErr
+}
+
+// isJSONObject reports whether data is a well-formed JSON object. json.Valid is
+// what makes the type error's "these bytes are sound" reading a check rather
+// than an assumption; the leading brace is what separates a document with a
+// member this package cannot read from a value that is not the document.
+func isJSONObject(data []byte) bool {
+	trimmed := bytes.TrimSpace(data)
+	return len(trimmed) > 0 && trimmed[0] == '{' && json.Valid(trimmed)
 }
 
 // Provider-specific fields that this package does not model must survive the

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"encoding/json"
 	"reflect"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // Provider-specific fields that this package does not model must survive the
@@ -190,7 +192,11 @@ func (c ChatCompletionResponse) MarshalJSON() ([]byte, error) {
 func (u *Usage) UnmarshalJSON(data []byte) error {
 	type alias Usage
 	var a alias
-	if err := json.Unmarshal(data, &a); err != nil {
+	// util.DecodeCounts, not a plain Unmarshal: a count is a count however the
+	// provider spelled it, and an error here does not merely blank the usage —
+	// it stops the decode of the response object around it, so one quoted token
+	// count cost the caller the answer the model had already produced.
+	if err := util.DecodeCounts(data, &a); err != nil {
 		return err
 	}
 	*u = Usage(a)

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -275,15 +275,13 @@ func keepIfObject[T any](data []byte, member string, ptr *T) *T {
 	if ptr == nil {
 		return nil
 	}
+	// A non-nil pointer means the decoder reached this member, in a document
+	// shapeError has already found to be valid JSON — so data is an object and
+	// the member is in it. A failure here would leave members nil, and an absent
+	// member reads as a non-object, which is the safe answer anyway.
 	var members map[string]json.RawMessage
-	if json.Unmarshal(data, &members) != nil {
-		return ptr
-	}
-	raw, ok := members[member]
-	if !ok {
-		return ptr
-	}
-	if trimmed := bytes.TrimSpace(raw); len(trimmed) > 0 && trimmed[0] == '{' {
+	_ = json.Unmarshal(data, &members)
+	if trimmed := bytes.TrimSpace(members[member]); len(trimmed) > 0 && trimmed[0] == '{' {
 		return ptr
 	}
 	return nil

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -662,29 +662,42 @@ func (h *Handler) finalizePassthroughLog(st *requestState, statusCode, attempt i
 // usage.total_tokens, used as a last-resort prompt count (Cohere's native
 // rerank bills in search units, not tokens, and meters as zero). Only the
 // usage object is decoded; the response content itself is never inspected.
+// The usage member is lifted out before its counts are read, for two reasons.
+// util.DecodeCounts re-parses the document it is given on each coercion pass,
+// and an embeddings body is large; and reading only those bytes is what makes
+// the sentence above literally true rather than merely intended.
 func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
-	var resp struct {
-		Usage *struct {
-			PromptTokens     int `json:"prompt_tokens"`
-			CompletionTokens int `json:"completion_tokens"`
-			InputTokens      int `json:"input_tokens"`
-			OutputTokens     int `json:"output_tokens"`
-			TotalTokens      int `json:"total_tokens"`
-		} `json:"usage"`
+	var envelope struct {
+		Usage json.RawMessage `json:"usage"`
 	}
-	if json.Unmarshal(body, &resp) != nil || resp.Usage == nil {
+	if json.Unmarshal(body, &envelope) != nil || len(envelope.Usage) == 0 {
 		return 0, 0
 	}
-	promptTokens = resp.Usage.PromptTokens
+	var usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		InputTokens      int `json:"input_tokens"`
+		OutputTokens     int `json:"output_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	}
+	// util.DecodeCounts, and a shape error keeps what did read, for the reason
+	// given on Usage.UnmarshalJSON: a count quoted or written with a fraction on
+	// it is still a count, and one member this gateway cannot read must not cost
+	// the request every count beside it. Metering a served request as zero is a
+	// quota the caller never spends.
+	if err := util.DecodeCounts(envelope.Usage, &usage); err != nil && shapeError(envelope.Usage, err) == nil {
+		return 0, 0
+	}
+	promptTokens = usage.PromptTokens
 	if promptTokens == 0 {
-		promptTokens = resp.Usage.InputTokens
+		promptTokens = usage.InputTokens
 	}
 	if promptTokens == 0 {
-		promptTokens = resp.Usage.TotalTokens
+		promptTokens = usage.TotalTokens
 	}
-	completionTokens = resp.Usage.CompletionTokens
+	completionTokens = usage.CompletionTokens
 	if completionTokens == 0 {
-		completionTokens = resp.Usage.OutputTokens
+		completionTokens = usage.OutputTokens
 	}
 	return promptTokens, completionTokens
 }

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -412,7 +412,16 @@ func liveCandidate(name, baseURL string) modelCandidate {
 // test can observe "was the breaker charged" through GetState.
 func withBreakerThresholdOne(t *testing.T, h *Handler) {
 	t.Helper()
-	if err := h.settingsRepo.Set(context.Background(), "circuit_breaker_threshold", "1"); err != nil {
+	withBreakerThreshold(t, h, "1")
+}
+
+// withBreakerThreshold sets the consecutive-failure threshold for one test. A
+// threshold above one is what makes a recorded SUCCESS observable: it is the
+// only thing that resets the counter, so whether a later failure opens the
+// circuit reports whether the stream credited the provider.
+func withBreakerThreshold(t *testing.T, h *Handler, threshold string) {
+	t.Helper()
+	if err := h.settingsRepo.Set(context.Background(), "circuit_breaker_threshold", threshold); err != nil {
 		t.Fatalf("set circuit_breaker_threshold: %v", err)
 	}
 	h.settingsRepo.InvalidateCache("circuit_breaker_threshold")

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -1110,10 +1110,12 @@ func TestJudgeStreamForBreaker_EmptyNativeStreamIsCharged(t *testing.T) {
 	}
 }
 
-// A frame this gateway could not parse is not evidence the provider sent
-// nothing — it may have answered in a shape our types do not cover (tool-call
-// arguments as an object, content as an array of parts). The contents are
-// unknown, so the verdict is neither a charge nor a credit.
+// A frame this gateway could not read is not evidence the provider sent nothing
+// — it may have answered in a shape our types do not cover, whether that frame
+// was dropped as broken bytes or forwarded verbatim. The contents are unknown,
+// so with nothing else delivered the verdict is neither a charge nor a credit.
+// A stream that DID deliver is credited regardless; see
+// TestJudgeStreamForBreaker_UntypeableFrames.
 func TestJudgeStreamForBreaker_UnparseableFramesWithholdTheVerdict(t *testing.T) {
 	st := &streamState{sawDone: true, unparsedChunks: 1}
 	v := judgeStreamForBreaker(st, &requestLogData{}, "", true)

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -571,28 +571,61 @@ func deltaCarriesReasoning(delta map[string]json.RawMessage) bool {
 	return false
 }
 
-// untypedDeltaBytes approximates what the model produced in a delta this gateway
-// could not type, for the usage estimate that runs when a provider reports no
-// usage at all.
+// untypedDeltaBytes counts what the model produced in a delta this gateway could
+// not type, for the usage estimate that runs when a provider reports no usage at
+// all — which on the streaming API is the common case, because usage there is
+// opt-in.
 //
-// The raw JSON length of the delta's members, which is what deliveredBytes
-// already counts for reasoning_details — the one other member it holds without
-// being able to break down. It overstates: the quoting and the part wrappers
-// around a content array are not text the model produced. Zero understates far
-// worse, and zero is what this was: a provider sending content as parts and no
-// usage chunk delivered a full answer and was metered nothing at all, so the
-// caller's quota and TPM bucket were debited for none of it. Reading the text
-// out of a part array properly belongs with the rest of content-as-parts.
+// The text is read out of the members that carry it rather than measured as raw
+// JSON, because this number debits a customer's quota and TPM bucket. Streaming
+// deltas are a few tokens each, so the part wrapper around them is most of the
+// bytes: [{"type":"text","text":"hello"}] is 32 bytes for 5 characters, and
+// billing the wrapper overcharges by six to eight times on a real stream. A
+// member whose shape is unreadable even here falls back to its raw length, which
+// is what deliveredBytes already does for reasoning_details.
+//
+// Zero is what this was, and it is the worse error in the other direction: a
+// provider sending content as parts and no usage chunk delivered a full answer
+// while the caller was debited for none of it.
 func untypedDeltaBytes(delta map[string]json.RawMessage) int {
 	total := 0
 	for key, raw := range delta {
-		// role and refusal markers are not output.
-		if key == "role" {
+		switch key {
+		// Not output: a role marker, and the ids/indices that address a tool
+		// call rather than carrying its arguments.
+		case "role", "index", "id":
 			continue
+		case "content", "reasoning", "reasoning_content":
+			total += deltaTextBytes(raw)
+		default:
+			total += len(raw)
 		}
-		total += len(raw)
 	}
 	return total
+}
+
+// deltaTextBytes reads the model's text out of a member that carries it, whether
+// the provider wrote a plain string or the array of parts the OpenAI schema now
+// permits. Anything else is measured whole, which is the honest answer for a
+// shape neither reading covers.
+func deltaTextBytes(raw json.RawMessage) int {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return len(text)
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) == nil {
+		total := 0
+		for _, part := range parts {
+			total += len(part.Text)
+		}
+		if total > 0 {
+			return total
+		}
+	}
+	return len(raw)
 }
 
 // jsonShapeName reduces an UnmarshalTypeError's Value to the shape alone.

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -366,6 +366,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// here is what keeps usage/token metering from being silently dropped when a
 		// provider rides `usage` on the same chunk as a reasoning delta. They read
 		// the immutable typed chunk and never emit, so position doesn't affect output.
+		deliveredBefore := st.deliveredBytes
 		st.observeDataChunk(chunk, anthropicErrorCounted, chunkCount, logData)
 
 		// Mask the provider's credential before any emit. Every chunk gets the
@@ -418,7 +419,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 
 		if untypeable {
 			untypedDelta, _ := parseChunkPayload(payload)
-			if stripReasoning && deltaCarriesReasoning(untypedDelta.delta) {
+			if stripReasoning && untypedFrameResistsStripping(untypedDelta.delta) {
 				// strip_reasoning is a promise to the caller, and forwarding a
 				// frame this gateway cannot read is no way to keep it.
 				// computeStripReasoning works over the payload and would run — but
@@ -438,7 +439,16 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 				sink.swallowBlank = true
 				return false
 			}
-			st.deliveredBytes += untypedDeltaBytes(untypedDelta.delta)
+			// Replaces the observer's count rather than adding to it. The
+			// observers ran above, on a chunk that decoded PARTLY — so every
+			// member that did decode has already been added, and adding the raw
+			// delta on top billed the same content twice (and a tool-call frame
+			// many times over).  The raw reading is the complete one for this
+			// frame, so it stands alone.
+			//
+			// choices[0] only, like the transforms: an n>1 stream whose frame is
+			// also untypeable is metered from its first choice.
+			st.deliveredBytes = deliveredBefore + untypedDeltaBytes(untypedDelta.delta)
 			// Counted like any frame this gateway could not read: the end-of-stream
 			// verdict must not conclude the provider sent nothing on the strength
 			// of frames it could not see into (judgeStreamForBreaker reads
@@ -560,11 +570,30 @@ forwardUntypeable:
 	return false
 }
 
-// deltaCarriesReasoning reports whether a delta holds any of the three spellings
-// of reasoning this gateway knows about.
-func deltaCarriesReasoning(delta map[string]json.RawMessage) bool {
+// untypedFrameResistsStripping reports whether a delta this gateway could not
+// type might carry reasoning it cannot remove — in which case the frame is
+// dropped rather than forwarded to a key that asked for reasoning to be hidden.
+//
+// Two ways it can. A reasoning member that CARRIES something, by the same rule
+// the rest of the gateway uses for an error member: gating on presence dropped
+// the answer out of every frame from a relay that stamps "reasoning":"" or
+// "reasoning_details":[] on its non-reasoning deltas, which the OpenRouter
+// family does.
+//
+// Or a content member that is not a plain string. Reasoning arrives inside a
+// part array as {"type":"thinking",…} on exactly the Anthropic-shaped relays
+// that make a frame untypeable in the first place, so a content array cannot be
+// read as text-only — and computeStripReasoning would not have caught it either,
+// since it only removes the three named members.
+func untypedFrameResistsStripping(delta map[string]json.RawMessage) bool {
 	for _, key := range []string{"reasoning_content", "reasoning_details", "reasoning"} {
-		if raw, ok := delta[key]; ok && len(raw) > 0 && string(raw) != "null" {
+		if util.ValueCarries(delta[key]) {
+			return true
+		}
+	}
+	if raw, ok := delta["content"]; ok {
+		var text string
+		if json.Unmarshal(raw, &text) != nil {
 			return true
 		}
 	}
@@ -591,10 +620,21 @@ func untypedDeltaBytes(delta map[string]json.RawMessage) int {
 	total := 0
 	for key, raw := range delta {
 		switch key {
-		// Not output: a role marker, and the ids/indices that address a tool
-		// call rather than carrying its arguments.
-		case "role", "index", "id":
+		// Not output: a role marker, and the ids/indices/types that address a
+		// tool call rather than carrying its arguments.
+		case "role", "index", "id", "type":
 			continue
+		}
+		// A member that carries nothing is not output, by the rule the rest of
+		// the gateway reads an error member with. Measuring raw length instead
+		// made "" two bytes and null four, which is delivery to everything
+		// downstream: the opening {"role":"assistant","content":""} chunk that
+		// almost every stream sends then credited the circuit breaker, and a
+		// provider erroring on every request could never open its circuit.
+		if !util.ValueCarries(raw) {
+			continue
+		}
+		switch key {
 		case "content", "reasoning", "reasoning_content":
 			total += deltaTextBytes(raw)
 		default:

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -450,8 +450,13 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			// diagnosis and the part an operator can act on; the frame itself is
 			// the provider's, and the commonest reason one lands here is that the
 			// model's own output was written in a shape this gateway has no struct
-			// for — so the payload does not go in the log. Field is bounded
-			// because a map key is provider-controlled and lands in it verbatim.
+			// for — so the payload does not go in the log.
+			//
+			// Field is bounded even though streamChunk has no member that could
+			// make it long today: encoding/json writes a MAP KEY into it
+			// verbatim, so the day a map is added to that struct is the day this
+			// line starts carrying provider text, and the bound is cheaper than
+			// remembering.
 			st.untypedChunks++
 			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
 				"model", logData.modelID, "provider", logData.providerName,

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -355,9 +354,10 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	// NOT skipped — it works over the payload as a map of raw members rather than
 	// the struct, so it rewrites the one member it understands and leaves the rest
 	// of the frame exactly as it arrived.
-	decodeErr := json.Unmarshal([]byte(payload), &chunk)
-	var typeErr *json.UnmarshalTypeError
-	untypeable := decodeErr != nil && errors.As(decodeErr, &typeErr)
+	raw := []byte(payload)
+	decodeErr := json.Unmarshal(raw, &chunk)
+	typeErr := shapeError(raw, decodeErr)
+	untypeable := typeErr != nil
 	jsonValid := decodeErr == nil || untypeable
 	if jsonValid {
 		// Side-channel observers (usage, native_finish_reason, repeated content,
@@ -416,21 +416,46 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			_ = json.Unmarshal([]byte(normalized), &chunk)
 		}
 
+		if untypeable && stripReasoning {
+			// strip_reasoning is a promise to the caller, and forwarding a frame
+			// this gateway cannot read is no way to keep it. computeStripReasoning
+			// works over the payload and would run — but its "does this delta still
+			// carry anything" verdict reads content as a plain string, so a
+			// content-as-parts delta looks empty to it and becomes a keep-alive,
+			// taking the answer with it.
+			//
+			// So the frame is dropped, which is what a key with this setting got
+			// before untypeable frames were forwarded at all. The delivery fix is
+			// for the streams where nothing was promised.
+			st.unparsedChunks++
+			debuglog.Warn("proxy: dropping a chunk shape this gateway cannot strip reasoning from",
+				"model", logData.modelID, "provider", logData.providerName,
+				"chunk_number", chunkCount, "json_field", util.SanitizeLogBody(typeErr.Field, 200),
+				"json_got", jsonShapeName(typeErr.Value), "payload_bytes", len(payload))
+			sink.swallowBlank = true
+			return false
+		}
+
 		if untypeable {
-			// Counted the same as a dropped frame: what this gateway managed to
-			// read of it is incomplete, so the end-of-stream verdict must not
-			// conclude the provider sent nothing (see unparsedChunks).
+			// untypedChunks, NOT unparsedChunks. The two say different things to
+			// the end-of-stream verdict: a DROPPED frame's contents are unknown
+			// to the caller as well, so emptiness cannot be pinned on anyone and
+			// no verdict is recorded — while a frame that went out is delivery,
+			// whatever this gateway made of it. Counting a forwarded frame as a
+			// dropped one withheld the breaker's success credit from every stream
+			// a provider sent, and its consecutive-failure count then never reset.
 			//
 			// The mismatch, not the payload: which member, and what shape
 			// arrived. "choices.0.finish_reason arrived as a number" is the whole
 			// diagnosis and the part an operator can act on; the frame itself is
 			// the provider's, and the commonest reason one lands here is that the
 			// model's own output was written in a shape this gateway has no struct
-			// for — so the payload does not go in the log.
-			st.unparsedChunks++
+			// for — so the payload does not go in the log. Field is bounded
+			// because a map key is provider-controlled and lands in it verbatim.
+			st.untypedChunks++
 			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
 				"model", logData.modelID, "provider", logData.providerName,
-				"chunk_number", chunkCount, "json_field", typeErr.Field,
+				"chunk_number", chunkCount, "json_field", util.SanitizeLogBody(typeErr.Field, 200),
 				"json_got", jsonShapeName(typeErr.Value), "payload_bytes", len(payload))
 			goto forwardUntypeable
 		}

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -346,10 +346,15 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	// observers, the masking and the error member all went unread. The frame is
 	// the provider's answer whether or not this gateway has a struct for it.
 	//
-	// What it cannot do is go through the transforms. They rebuild the frame from
-	// that struct, and the member that failed is missing from it — rebuilding a
+	// What it cannot go through are the transforms that rebuild the frame from
+	// that struct: the member that failed is missing from it, so rebuilding a
 	// content-as-parts frame would re-emit it with an empty delta, which is the
-	// same loss by another route. It is observed, masked, and forwarded verbatim.
+	// same loss by another route. It is observed, masked, and forwarded verbatim,
+	// stopping short of strip_reasoning, the reasoning/empty-content transforms
+	// and finish_reason normalisation. Tool-argument normalisation is deliberately
+	// NOT skipped — it works over the payload as a map of raw members rather than
+	// the struct, so it rewrites the one member it understands and leaves the rest
+	// of the frame exactly as it arrived.
 	decodeErr := json.Unmarshal([]byte(payload), &chunk)
 	var typeErr *json.UnmarshalTypeError
 	untypeable := decodeErr != nil && errors.As(decodeErr, &typeErr)

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -427,10 +427,16 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 				// as a plain string, so a content-as-parts delta looks empty to it
 				// and becomes a keep-alive, taking the answer with it.
 				//
-				// Only a frame that actually carries reasoning is dropped. Gating
+				// Only a frame that might be hiding reasoning is dropped. Gating
 				// on untypeable alone deleted the answer out of an ordinary
-				// content delta whose finish_reason happened to be a number, for
-				// no gain: there was nothing there to strip.
+				// content delta whose finish_reason happened to be a number, and
+				// gating on "content is not a plain string" deleted it out of
+				// every content-as-parts frame — which is the loss this whole
+				// change exists to stop, reinstated for one class of key.
+				// The observers ran before this branch and counted whatever
+				// decoded. The caller is not receiving this frame, so it is not
+				// delivery and must not be billed: roll that count back.
+				st.deliveredBytes = deliveredBefore
 				st.unparsedChunks++
 				debuglog.Warn("proxy: dropping a chunk shape this gateway cannot strip reasoning from",
 					"model", logData.modelID, "provider", logData.providerName,
@@ -439,16 +445,25 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 				sink.swallowBlank = true
 				return false
 			}
-			// Replaces the observer's count rather than adding to it. The
-			// observers ran above, on a chunk that decoded PARTLY — so every
-			// member that did decode has already been added, and adding the raw
-			// delta on top billed the same content twice (and a tool-call frame
-			// many times over).  The raw reading is the complete one for this
-			// frame, so it stands alone.
+			// deliveredBytes is deliberately left exactly as the observers set
+			// it: this gateway meters what it could READ and does not guess at
+			// the rest.
 			//
-			// choices[0] only, like the transforms: an n>1 stream whose frame is
-			// also untypeable is metered from its first choice.
-			st.deliveredBytes = deliveredBefore + untypedDeltaBytes(untypedDelta.delta)
+			// Every member of this frame that decoded has already been counted
+			// correctly, across every choice. What is missing is the member that
+			// did not, and four attempts at estimating it were wrong in four
+			// different directions — the raw member length billed a tool-call
+			// frame nine times over, and an empty content-as-parts opener
+			// ({"content":[{"type":"text","text":""}]}) counted as delivery,
+			// which credited the circuit breaker and suppressed the error charge
+			// so a provider failing every request could never open its circuit.
+			//
+			// So an answer delivered ONLY in a shape this gateway cannot read is
+			// currently unbilled when the provider also reports no usage. That is
+			// a revenue gap, and it is the safe direction: the caller receives
+			// content master deleted outright. Reading the text out of a part
+			// array is the job of the content-as-parts work, and it is queued
+			// with it rather than guessed at here.
 			// Counted like any frame this gateway could not read: the end-of-stream
 			// verdict must not conclude the provider sent nothing on the strength
 			// of frames it could not see into (judgeStreamForBreaker reads
@@ -571,7 +586,7 @@ forwardUntypeable:
 }
 
 // untypedFrameResistsStripping reports whether a delta this gateway could not
-// type might carry reasoning it cannot remove — in which case the frame is
+// type might be hiding reasoning it cannot remove — in which case the frame is
 // dropped rather than forwarded to a key that asked for reasoning to be hidden.
 //
 // Two ways it can. A reasoning member that CARRIES something, by the same rule
@@ -580,92 +595,47 @@ forwardUntypeable:
 // "reasoning_details":[] on its non-reasoning deltas, which the OpenRouter
 // family does.
 //
-// Or a content member that is not a plain string. Reasoning arrives inside a
+// Or a content part this gateway cannot vouch for. Reasoning arrives inside a
 // part array as {"type":"thinking",…} on exactly the Anthropic-shaped relays
-// that make a frame untypeable in the first place, so a content array cannot be
-// read as text-only — and computeStripReasoning would not have caught it either,
-// since it only removes the three named members.
+// that make a frame untypeable in the first place, and computeStripReasoning
+// would not catch it either, since it only removes the three named members. But
+// a part array of plain TEXT hides nothing, and rejecting every content that is
+// not a string dropped those too — deleting the whole answer for a
+// strip_reasoning key on any content-as-parts stream, which is the loss this
+// change exists to stop. So the part types are read, and an unrecognised one is
+// what makes a frame unstrippable.
 func untypedFrameResistsStripping(delta map[string]json.RawMessage) bool {
 	for _, key := range []string{"reasoning_content", "reasoning_details", "reasoning"} {
 		if util.ValueCarries(delta[key]) {
 			return true
 		}
 	}
-	if raw, ok := delta["content"]; ok {
-		var text string
-		if json.Unmarshal(raw, &text) != nil {
+	raw, ok := delta["content"]
+	if !ok {
+		return false
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return false
+	}
+	var parts []struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(raw, &parts) != nil {
+		// A content shape that is neither a string nor a list of parts. Nothing
+		// here can say what is in it.
+		return true
+	}
+	for _, part := range parts {
+		switch part.Type {
+		case "text", "output_text", "input_text":
+		default:
+			// Including a part with no type at all: an unnamed part is not one
+			// this gateway can promise carries no reasoning.
 			return true
 		}
 	}
 	return false
-}
-
-// untypedDeltaBytes counts what the model produced in a delta this gateway could
-// not type, for the usage estimate that runs when a provider reports no usage at
-// all — which on the streaming API is the common case, because usage there is
-// opt-in.
-//
-// The text is read out of the members that carry it rather than measured as raw
-// JSON, because this number debits a customer's quota and TPM bucket. Streaming
-// deltas are a few tokens each, so the part wrapper around them is most of the
-// bytes: [{"type":"text","text":"hello"}] is 32 bytes for 5 characters, and
-// billing the wrapper overcharges by six to eight times on a real stream. A
-// member whose shape is unreadable even here falls back to its raw length, which
-// is what deliveredBytes already does for reasoning_details.
-//
-// Zero is what this was, and it is the worse error in the other direction: a
-// provider sending content as parts and no usage chunk delivered a full answer
-// while the caller was debited for none of it.
-func untypedDeltaBytes(delta map[string]json.RawMessage) int {
-	total := 0
-	for key, raw := range delta {
-		switch key {
-		// Not output: a role marker, and the ids/indices/types that address a
-		// tool call rather than carrying its arguments.
-		case "role", "index", "id", "type":
-			continue
-		}
-		// A member that carries nothing is not output, by the rule the rest of
-		// the gateway reads an error member with. Measuring raw length instead
-		// made "" two bytes and null four, which is delivery to everything
-		// downstream: the opening {"role":"assistant","content":""} chunk that
-		// almost every stream sends then credited the circuit breaker, and a
-		// provider erroring on every request could never open its circuit.
-		if !util.ValueCarries(raw) {
-			continue
-		}
-		switch key {
-		case "content", "reasoning", "reasoning_content":
-			total += deltaTextBytes(raw)
-		default:
-			total += len(raw)
-		}
-	}
-	return total
-}
-
-// deltaTextBytes reads the model's text out of a member that carries it, whether
-// the provider wrote a plain string or the array of parts the OpenAI schema now
-// permits. Anything else is measured whole, which is the honest answer for a
-// shape neither reading covers.
-func deltaTextBytes(raw json.RawMessage) int {
-	var text string
-	if json.Unmarshal(raw, &text) == nil {
-		return len(text)
-	}
-	var parts []struct {
-		Text string `json:"text"`
-	}
-	if json.Unmarshal(raw, &parts) == nil {
-		total := 0
-		for _, part := range parts {
-			total += len(part.Text)
-		}
-		if total > 0 {
-			return total
-		}
-	}
-	return len(raw)
 }
 
 // jsonShapeName reduces an UnmarshalTypeError's Value to the shape alone.

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -333,7 +334,26 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 
 	var written bool
 	var chunk streamChunk
-	jsonValid := json.Unmarshal([]byte(payload), &chunk) == nil
+	// A shape this gateway does not model is not broken bytes. encoding/json
+	// checks the whole document for well-formedness BEFORE it decodes any of it,
+	// so an UnmarshalTypeError is proof the frame is valid JSON — and the decoder
+	// records that error and carries on with the siblings, so chunk holds every
+	// member that did fit.
+	//
+	// Read as "were these even JSON", one unmodelled sibling deleted the frame:
+	// a relay numbering its stop reasons, or content as the array of parts the
+	// OpenAI schema now permits, and the caller lost the model's output while the
+	// observers, the masking and the error member all went unread. The frame is
+	// the provider's answer whether or not this gateway has a struct for it.
+	//
+	// What it cannot do is go through the transforms. They rebuild the frame from
+	// that struct, and the member that failed is missing from it — rebuilding a
+	// content-as-parts frame would re-emit it with an empty delta, which is the
+	// same loss by another route. It is observed, masked, and forwarded verbatim.
+	decodeErr := json.Unmarshal([]byte(payload), &chunk)
+	var typeErr *json.UnmarshalTypeError
+	untypeable := decodeErr != nil && errors.As(decodeErr, &typeErr)
+	jsonValid := decodeErr == nil || untypeable
 	if jsonValid {
 		// Side-channel observers (usage, native_finish_reason, repeated content,
 		// chunk.Error) run for EVERY valid chunk — BEFORE the transforms, which may
@@ -391,6 +411,24 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			_ = json.Unmarshal([]byte(normalized), &chunk)
 		}
 
+		if untypeable {
+			// Counted the same as a dropped frame: what this gateway managed to
+			// read of it is incomplete, so the end-of-stream verdict must not
+			// conclude the provider sent nothing (see unparsedChunks).
+			//
+			// The mismatch, not the payload. Field is the member's path and Value
+			// names the JSON shape that arrived — for a number it is the literal,
+			// which is an index or a count and not the model's text. That is the
+			// whole diagnosis ("choices.finish_reason arrived as a number") and it
+			// is what an operator can act on; the frame itself is the provider's.
+			st.unparsedChunks++
+			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
+				"model", logData.modelID, "provider", logData.providerName,
+				"chunk_number", chunkCount, "json_field", typeErr.Field,
+				"json_got", typeErr.Value, "payload_bytes", len(payload))
+			goto forwardUntypeable
+		}
+
 		// strip_reasoning: drop reasoning-only deltas (keep-alive) or forward the
 		// stripped chunk. See computeStripReasoning.
 		if stripReasoning && len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
@@ -439,8 +477,11 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		case finishNone:
 		}
 	}
+forwardUntypeable:
 	if !written && !jsonValid {
-		// Drop invalid/truncated JSON instead of forwarding broken bytes.
+		// Drop JSON that is not well-formed instead of forwarding broken bytes.
+		// A frame this gateway merely has no struct for does NOT come here — it
+		// is valid JSON, and it is forwarded verbatim below.
 		//
 		// The size, not the bytes. This used to log an 80-rune preview of the
 		// payload, and the commonest reason a frame fails to parse is that the

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -421,16 +421,17 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			// read of it is incomplete, so the end-of-stream verdict must not
 			// conclude the provider sent nothing (see unparsedChunks).
 			//
-			// The mismatch, not the payload. Field is the member's path and Value
-			// names the JSON shape that arrived — for a number it is the literal,
-			// which is an index or a count and not the model's text. That is the
-			// whole diagnosis ("choices.finish_reason arrived as a number") and it
-			// is what an operator can act on; the frame itself is the provider's.
+			// The mismatch, not the payload: which member, and what shape
+			// arrived. "choices.0.finish_reason arrived as a number" is the whole
+			// diagnosis and the part an operator can act on; the frame itself is
+			// the provider's, and the commonest reason one lands here is that the
+			// model's own output was written in a shape this gateway has no struct
+			// for — so the payload does not go in the log.
 			st.unparsedChunks++
 			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
 				"model", logData.modelID, "provider", logData.providerName,
 				"chunk_number", chunkCount, "json_field", typeErr.Field,
-				"json_got", typeErr.Value, "payload_bytes", len(payload))
+				"json_got", jsonShapeName(typeErr.Value), "payload_bytes", len(payload))
 			goto forwardUntypeable
 		}
 
@@ -536,6 +537,17 @@ forwardUntypeable:
 // It works on the raw map rather than the typed chunk because the frame is
 // forwarded as bytes: rebuilding it from streamChunk would drop every field
 // this gateway does not model.
+// jsonShapeName reduces an UnmarshalTypeError's Value to the shape alone.
+//
+// encoding/json writes a number's LITERAL into that field ("number 42"), and a
+// relay that sends the model's numeric answer where the schema wants a string is
+// exactly how a frame reaches the untypeable path — so logging Value whole put
+// response content in the app log. The shape is the diagnosis; the value is not.
+func jsonShapeName(v string) string {
+	shape, _, _ := strings.Cut(v, " ")
+	return shape
+}
+
 func normalizeToolArguments(payload string) (string, bool) {
 	// Cheap reject first. Without it every frame of every stream paid for three
 	// json.Unmarshal calls (~5us and ~1.8KB of garbage each) to discover it has

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -416,34 +416,36 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			_ = json.Unmarshal([]byte(normalized), &chunk)
 		}
 
-		if untypeable && stripReasoning {
-			// strip_reasoning is a promise to the caller, and forwarding a frame
-			// this gateway cannot read is no way to keep it. computeStripReasoning
-			// works over the payload and would run — but its "does this delta still
-			// carry anything" verdict reads content as a plain string, so a
-			// content-as-parts delta looks empty to it and becomes a keep-alive,
-			// taking the answer with it.
-			//
-			// So the frame is dropped, which is what a key with this setting got
-			// before untypeable frames were forwarded at all. The delivery fix is
-			// for the streams where nothing was promised.
-			st.unparsedChunks++
-			debuglog.Warn("proxy: dropping a chunk shape this gateway cannot strip reasoning from",
-				"model", logData.modelID, "provider", logData.providerName,
-				"chunk_number", chunkCount, "json_field", util.SanitizeLogBody(typeErr.Field, 200),
-				"json_got", jsonShapeName(typeErr.Value), "payload_bytes", len(payload))
-			sink.swallowBlank = true
-			return false
-		}
-
 		if untypeable {
-			// untypedChunks, NOT unparsedChunks. The two say different things to
-			// the end-of-stream verdict: a DROPPED frame's contents are unknown
-			// to the caller as well, so emptiness cannot be pinned on anyone and
-			// no verdict is recorded — while a frame that went out is delivery,
-			// whatever this gateway made of it. Counting a forwarded frame as a
-			// dropped one withheld the breaker's success credit from every stream
-			// a provider sent, and its consecutive-failure count then never reset.
+			untypedDelta, _ := parseChunkPayload(payload)
+			if stripReasoning && deltaCarriesReasoning(untypedDelta.delta) {
+				// strip_reasoning is a promise to the caller, and forwarding a
+				// frame this gateway cannot read is no way to keep it.
+				// computeStripReasoning works over the payload and would run — but
+				// its "does this delta still carry anything" verdict reads content
+				// as a plain string, so a content-as-parts delta looks empty to it
+				// and becomes a keep-alive, taking the answer with it.
+				//
+				// Only a frame that actually carries reasoning is dropped. Gating
+				// on untypeable alone deleted the answer out of an ordinary
+				// content delta whose finish_reason happened to be a number, for
+				// no gain: there was nothing there to strip.
+				st.unparsedChunks++
+				debuglog.Warn("proxy: dropping a chunk shape this gateway cannot strip reasoning from",
+					"model", logData.modelID, "provider", logData.providerName,
+					"chunk_number", chunkCount, "json_field", util.SanitizeLogBody(typeErr.Field, 200),
+					"json_got", jsonShapeName(typeErr.Value), "payload_bytes", len(payload))
+				sink.swallowBlank = true
+				return false
+			}
+			st.deliveredBytes += untypedDeltaBytes(untypedDelta.delta)
+			// Counted like any frame this gateway could not read: the end-of-stream
+			// verdict must not conclude the provider sent nothing on the strength
+			// of frames it could not see into (judgeStreamForBreaker reads
+			// delivery first, so a stream that plainly answered is still
+			// credited). Calling a forwarded frame delivery in its own right was
+			// worse: the terminal chunk is exactly where a relay numbers its stop
+			// reason, and that frame carries no output at all.
 			//
 			// The mismatch, not the payload: which member, and what shape
 			// arrived. "choices.0.finish_reason arrived as a number" is the whole
@@ -457,7 +459,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			// verbatim, so the day a map is added to that struct is the day this
 			// line starts carrying provider text, and the bound is cheaper than
 			// remembering.
-			st.untypedChunks++
+			st.unparsedChunks++
 			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
 				"model", logData.modelID, "provider", logData.providerName,
 				"chunk_number", chunkCount, "json_field", util.SanitizeLogBody(typeErr.Field, 200),
@@ -555,6 +557,58 @@ forwardUntypeable:
 	return false
 }
 
+// deltaCarriesReasoning reports whether a delta holds any of the three spellings
+// of reasoning this gateway knows about.
+func deltaCarriesReasoning(delta map[string]json.RawMessage) bool {
+	for _, key := range []string{"reasoning_content", "reasoning_details", "reasoning"} {
+		if raw, ok := delta[key]; ok && len(raw) > 0 && string(raw) != "null" {
+			return true
+		}
+	}
+	return false
+}
+
+// untypedDeltaBytes approximates what the model produced in a delta this gateway
+// could not type, for the usage estimate that runs when a provider reports no
+// usage at all.
+//
+// The raw JSON length of the delta's members, which is what deliveredBytes
+// already counts for reasoning_details — the one other member it holds without
+// being able to break down. It overstates: the quoting and the part wrappers
+// around a content array are not text the model produced. Zero understates far
+// worse, and zero is what this was: a provider sending content as parts and no
+// usage chunk delivered a full answer and was metered nothing at all, so the
+// caller's quota and TPM bucket were debited for none of it. Reading the text
+// out of a part array properly belongs with the rest of content-as-parts.
+func untypedDeltaBytes(delta map[string]json.RawMessage) int {
+	total := 0
+	for key, raw := range delta {
+		// role and refusal markers are not output.
+		if key == "role" {
+			continue
+		}
+		total += len(raw)
+	}
+	return total
+}
+
+// jsonShapeName reduces an UnmarshalTypeError's Value to the shape alone.
+//
+// encoding/json writes a number's LITERAL into that field, but only when the
+// number lands on a NUMERIC field: {"content":8675309} into a *string reports
+// "number", while {"n":3.5} into an int reports "number 3.5". No integer field
+// under streamChunk is reachable from here — the only ones live inside Usage,
+// whose own decoder keeps what it can read rather than returning a type error —
+// so today the value is always a bare shape word.
+//
+// It is kept anyway, and cheaply: the shape is the whole diagnosis, the literal
+// is provider data, and one integer field added to that struct is all it would
+// take for this line to start carrying it. TestJSONShapeName is what holds it.
+func jsonShapeName(v string) string {
+	shape, _, _ := strings.Cut(v, " ")
+	return shape
+}
+
 // normalizeToolArguments rewrites any tool-call arguments the provider sent as
 // an object (or array, or number) into the spec's JSON string, and reports
 // whether anything changed. The spec form is left untouched, so an ordinary
@@ -567,17 +621,6 @@ forwardUntypeable:
 // It works on the raw map rather than the typed chunk because the frame is
 // forwarded as bytes: rebuilding it from streamChunk would drop every field
 // this gateway does not model.
-// jsonShapeName reduces an UnmarshalTypeError's Value to the shape alone.
-//
-// encoding/json writes a number's LITERAL into that field ("number 42"), and a
-// relay that sends the model's numeric answer where the schema wants a string is
-// exactly how a frame reaches the untypeable path — so logging Value whole put
-// response content in the app log. The shape is the diagnosis; the value is not.
-func jsonShapeName(v string) string {
-	shape, _, _ := strings.Cut(v, " ")
-	return shape
-}
-
 func normalizeToolArguments(payload string) (string, bool) {
 	// Cheap reject first. Without it every frame of every stream paid for three
 	// json.Unmarshal calls (~5us and ~1.8KB of garbage each) to discover it has

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -517,9 +517,12 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	}
 forwardUntypeable:
 	if !written && !jsonValid {
-		// Drop JSON that is not well-formed instead of forwarding broken bytes.
-		// A frame this gateway merely has no struct for does NOT come here — it
-		// is valid JSON, and it is forwarded verbatim below.
+		// Drop what is not a frame instead of forwarding it: bytes that are not
+		// well-formed JSON, and a top-level value that is not an object at all —
+		// a bare number, a list, or the quoted sentinel "[DONE]", none of which a
+		// client can read as a chunk. A frame this gateway merely has no struct
+		// for does NOT come here; it is valid JSON and is forwarded verbatim
+		// below.
 		//
 		// The size, not the bytes. This used to log an 80-rune preview of the
 		// payload, and the commonest reason a frame fails to parse is that the
@@ -532,7 +535,7 @@ forwardUntypeable:
 		// delivered is incomplete, and does not charge the provider for an
 		// emptiness it cannot actually vouch for.
 		st.unparsedChunks++
-		debuglog.Warn("proxy: skipping invalid JSON chunk from upstream",
+		debuglog.Warn("proxy: skipping a data line that is not a chunk",
 			"model", logData.modelID, "provider", logData.providerName,
 			"chunk_number", chunkCount, "payload_bytes", len(payload))
 		sink.swallowBlank = true

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -39,20 +39,14 @@ type streamState struct {
 	promptCacheMissTokens int
 	chunkCount            int
 	errorChunkCount       int
-	// unparsedChunks counts data frames the gateway could not read AND did not
-	// forward: bytes that are not well-formed JSON, and the frames dropped
-	// because strip_reasoning could not be applied to a shape this gateway
-	// cannot read. The caller lost them too, so whether the provider answered is
-	// unknowable from here — the delivery accounting must neither conclude the
-	// response was empty nor credit one.
+	// unparsedChunks counts data frames this gateway could not read: bytes that
+	// are not well-formed JSON (dropped), a shape its types do not cover
+	// (forwarded verbatim), and the frames dropped because strip_reasoning could
+	// not be applied to one. Whether the provider actually answered in them is
+	// unknowable from here, so they are neither evidence of emptiness nor
+	// evidence against it — see judgeStreamForBreaker, which reads delivery
+	// FIRST and falls back to this only when nothing typed reached the caller.
 	unparsedChunks int
-	// untypedChunks counts data frames that were forwarded verbatim because they
-	// are well-formed JSON in a shape this gateway's types do not cover
-	// (content as an array of parts, a numeric finish_reason). The delivery
-	// accounting cannot see into them either — but the caller received them, so
-	// they are delivery, and a provider whose every frame is one of these must
-	// still be able to clear its failure count.
-	untypedChunks  int
 	lastErrMsg     string
 	sawDone        bool
 	sawMessageStop bool // native Anthropic passthrough: terminal message_stop event seen
@@ -134,10 +128,7 @@ func providerAtFault(kind ErrorKind) bool {
 // charge against a provider that answered correctly, which after five requests
 // takes it out of rotation for every tenant — so this errs toward "delivered".
 func streamDeliveredOutput(st *streamState) bool {
-	// untypedChunks is delivery for the same reason: the frame went out. Its
-	// contents are opaque to the accounting above, so without this a provider
-	// whose shapes this gateway does not model reads as having answered nothing.
-	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0 || st.untypedChunks > 0
+	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0
 }
 
 // judgeStreamForBreaker decides what a finished stream tells the circuit
@@ -180,19 +171,29 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		// sibling, the one that produced frames carrying no output and was
 		// already committed to by the time that became clear.
 		//
-		// unparsedChunks holds the charge back: those frames were dropped by
-		// THIS gateway's parser, not left out by the provider, so their contents
-		// are unknown and emptiness cannot be pinned on the upstream. Recording
-		// nothing is the honest verdict — neither a charge nor a credit.
+		// Delivery is read FIRST, and unparsedChunks only decides what to do
+		// when nothing typed arrived. Read the other way round, one frame this
+		// gateway could not parse withheld the CREDIT from a stream that plainly
+		// answered — so a provider whose shapes it does not model never cleared
+		// its consecutive-failure count, and old failures accumulated until an
+		// unrelated one opened the circuit.
+		if streamDeliveredOutput(st) {
+			// Includes the stream whose absent [DONE] was injected above: the
+			// sentinel was missing, the answer was not.
+			return streamBreakerVerdict{success: true}
+		}
+		// Nothing typed reached the caller, and frames went unread. Those were
+		// unreadable to THIS gateway's parser, not left out by the provider, so
+		// emptiness cannot be pinned on the upstream. Recording nothing is the
+		// honest verdict — neither a charge nor a credit. Calling them delivery
+		// instead was worse than either: a relay that numbers its stop reasons
+		// emits one untypeable frame per stream, on the terminal chunk, which
+		// carries no output at all — so every empty response it gave would have
+		// cleared its failure streak, and its circuit could never open.
 		if st.unparsedChunks > 0 {
 			return streamBreakerVerdict{}
 		}
-		if !streamDeliveredOutput(st) {
-			return streamBreakerVerdict{failureReason: "stream completed without delivering content"}
-		}
-		// Includes the stream whose absent [DONE] was injected above: the
-		// sentinel was missing, the answer was not.
-		return streamBreakerVerdict{success: true}
+		return streamBreakerVerdict{failureReason: "stream completed without delivering content"}
 	}
 	// Reached only with a non-empty errMsg, so errorKind is always set:
 	// deriveStreamError writes the two together. The clean-finish charge above
@@ -300,7 +301,16 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	// Carried for the retirement verdict, which has to decide whether the model
 	// answered. On the native Anthropic passthrough the chunks are never parsed
 	// into deltas, so its terminal message_stop stands in for the same fact.
-	logData.deliveredContent = st.sawContent || st.sawMessageStop
+	//
+	// deliveredBytes, not sawContent alone: sawContent watches content and
+	// reasoning on choices[0], so a stream whose whole answer is a tool call, or
+	// one delivered in a shape this gateway forwarded without being able to
+	// type, read as having produced nothing — and the streak a real answer
+	// should have cleared stayed on the model. It is the same bar the breaker
+	// uses (streamDeliveredOutput), and it can only ever turn an inconclusive
+	// verdict into a served one: verdictForStream decides gone from the error
+	// kind, before it looks at this at all.
+	logData.deliveredContent = st.sawContent || st.sawMessageStop || st.deliveredBytes > 0
 	if errMsg != "" {
 		h.writeTerminalError(sink, st, opts, logData, errMsg)
 	}

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -39,13 +39,20 @@ type streamState struct {
 	promptCacheMissTokens int
 	chunkCount            int
 	errorChunkCount       int
-	// unparsedChunks counts data frames the gateway could not unmarshal into a
-	// streamChunk. They are dropped rather than forwarded, so the caller does
-	// lose them — but the provider may have answered perfectly well in a shape
-	// this gateway's types do not cover (tool-call arguments as an object,
-	// content as an array of parts). The delivery accounting cannot see into
-	// such a frame, so it must not conclude the response was empty.
+	// unparsedChunks counts data frames the gateway could not read AND did not
+	// forward: bytes that are not well-formed JSON, and the frames dropped
+	// because strip_reasoning could not be applied to a shape this gateway
+	// cannot read. The caller lost them too, so whether the provider answered is
+	// unknowable from here — the delivery accounting must neither conclude the
+	// response was empty nor credit one.
 	unparsedChunks int
+	// untypedChunks counts data frames that were forwarded verbatim because they
+	// are well-formed JSON in a shape this gateway's types do not cover
+	// (content as an array of parts, a numeric finish_reason). The delivery
+	// accounting cannot see into them either — but the caller received them, so
+	// they are delivery, and a provider whose every frame is one of these must
+	// still be able to clear its failure count.
+	untypedChunks  int
 	lastErrMsg     string
 	sawDone        bool
 	sawMessageStop bool // native Anthropic passthrough: terminal message_stop event seen
@@ -127,7 +134,10 @@ func providerAtFault(kind ErrorKind) bool {
 // charge against a provider that answered correctly, which after five requests
 // takes it out of rotation for every tenant — so this errs toward "delivered".
 func streamDeliveredOutput(st *streamState) bool {
-	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0
+	// untypedChunks is delivery for the same reason: the frame went out. Its
+	// contents are opaque to the accounting above, so without this a provider
+	// whose shapes this gateway does not model reads as having answered nothing.
+	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0 || st.untypedChunks > 0
 }
 
 // judgeStreamForBreaker decides what a finished stream tells the circuit

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -42,21 +42,39 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 	// P1-C: a data line after "event: error" is an Anthropic error payload,
 	// wrapped as {"type":"error","error":{...}} even when it doesn't start with
 	// {"error". Extract the message regardless.
+	//
+	// The member is read with the rule the rest of the gateway shares, not with a
+	// private object type one struct away from it. Typed as an object, any other
+	// shape failed the whole decode and this branch fell silent — the observer
+	// below still caught the member, but the event's own type went unlogged.
+	//
+	// Emptiness matters more here than anywhere else it is read. errorChunkCount
+	// is what tells writeTerminalError the client has already seen the provider's
+	// error, and counting a member that carries nothing spent that on nothing: it
+	// left lastErrMsg blank, so no error was derived from it, and it suppressed
+	// the terminal frame for whatever really did end the stream afterwards. The
+	// caller got a cut connection in place of a reason.
 	anthropicErrorCounted := false
 	if *lastAnthropicEvent == "error" {
 		*lastAnthropicEvent = ""
+		// Only the member: the wrapper's own "type":"error" is what the
+		// preceding event line already said.
 		var anthErr struct {
-			Type  string `json:"type"`
-			Error *struct {
-				Type    string `json:"type"`
-				Message string `json:"message"`
-			} `json:"error"`
+			Error json.RawMessage `json:"error"`
 		}
-		if json.Unmarshal([]byte(payload), &anthErr) == nil && anthErr.Error != nil {
-			st.lastErrMsg = anthErr.Error.Message
+		if json.Unmarshal([]byte(payload), &anthErr) == nil && util.ErrorMemberCarries(anthErr.Error) {
+			msg := util.ErrorMemberMessage(anthErr.Error)
+			st.lastErrMsg = msg
 			anthropicErrorCounted = true
 			st.errorChunkCount++
-			debuglog.Warn("proxy: Anthropic SSE error event", "error_type", anthErr.Error.Type, "error_message", st.errLogAttr(anthErr.Error.Message), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
+			// The error's own type, when the member is the object that has one.
+			// Provider text like any other, so it goes through the same masking
+			// and bounding as the message beside it.
+			var typed struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(anthErr.Error, &typed)
+			debuglog.Warn("proxy: Anthropic SSE error event", "error_type", st.errLogAttr(typed.Type), "error_message", st.errLogAttr(msg), "model", logData.modelID, "provider", logData.providerName, "chunk_number", chunkCount)
 		}
 	}
 	return anthropicErrorCounted

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -169,6 +169,35 @@ type streamChunk struct {
 	Error json.RawMessage `json:"error"`
 }
 
+// observeUsage records the counts a usage block reports.
+//
+// Each count is guarded on its own, the way the cache split already was. Two
+// providers make that necessary: one that rides a usage block on EVERY chunk,
+// and one whose usage block this gateway could only partly read —
+// encoding/json allocates the pointer before it calls the custom unmarshaler, so
+// a usage member in an unmodelled shape leaves a valid pointer to an all-zero
+// Usage, and a bare assignment then wrote zeros over counts an earlier chunk had
+// already reported. A usage chunk saying zero says nothing; only a count carries
+// a reading.
+func (st *streamState) observeUsage(usage *Usage) {
+	if usage == nil {
+		return
+	}
+	if usage.PromptTokens > 0 {
+		st.promptTokens = usage.PromptTokens
+	}
+	if usage.CompletionTokens > 0 {
+		st.completionTokens = usage.CompletionTokens
+	}
+	if usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.ReasoningTokens > 0 {
+		st.reasoningTokens = usage.CompletionTokensDetails.ReasoningTokens
+	}
+	if hit, miss := extractCacheTokens(*usage); hit > 0 || miss > 0 {
+		st.promptCacheHitTokens = hit
+		st.promptCacheMissTokens = miss
+	}
+}
+
 // observeDataChunk applies the four non-emitting, side-channel observers over a
 // parsed data chunk, updating streamState in place (Phase 4 — the first pipeline
 // stage extracted from handleStreamingResponse). It never writes to the client
@@ -182,17 +211,7 @@ type streamChunk struct {
 //   - P2-5 repeated-content detection (and the first-thinking log)
 //   - chunk.Error capture (clears errAccum so P1-B won't re-count)
 func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted bool, chunkCount int, logData *requestLogData) {
-	if chunk.Usage != nil {
-		st.promptTokens = chunk.Usage.PromptTokens
-		st.completionTokens = chunk.Usage.CompletionTokens
-		if chunk.Usage.CompletionTokensDetails != nil && chunk.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
-			st.reasoningTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
-		}
-		if hit, miss := extractCacheTokens(*chunk.Usage); hit > 0 || miss > 0 {
-			st.promptCacheHitTokens = hit
-			st.promptCacheMissTokens = miss
-		}
-	}
+	st.observeUsage(chunk.Usage)
 	// P2-7: Log native_finish_reason from OpenRouter for debugging.
 	// OpenRouter includes this field alongside the normalized finish_reason,
 	// preserving the original provider's value (e.g. "STOP" instead of "stop").

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -37,12 +37,45 @@ var untypeableFrames = []struct {
 	{"reasoning as a list", `{"choices":[{"delta":{"content":"CONTENTMARKER","reasoning":["step one"]}}]}`},
 	// choices as an object rather than the array of choices.
 	{"choices as an object", `{"choices":{"0":{"delta":{"content":"CONTENTMARKER"}}}}`},
-	// Not an object at all. The type error carries no member path, so the log
-	// line has nothing to name — but the same rule applies: the bytes are the
-	// provider's answer, and this gateway having no struct for them is not a
-	// reason to delete them from the caller's stream.
-	{"a bare list", `["CONTENTMARKER"]`},
-	{"a bare string", `"CONTENTMARKER"`},
+}
+
+// Not an object at all. The type error names no member, because the whole value
+// is the wrong kind of thing rather than one part of it — that is not a frame
+// this gateway has no struct for, it is not a chat-completion frame. Relaying
+// them put a quoted sentinel into an OpenAI-shaped stream as a data event.
+var notFrames = []string{
+	`["CONTENTMARKER"]`,
+	`"CONTENTMARKER"`,
+	`42`,
+	`"[DONE]"`,
+}
+
+func TestHandleStreamingResponse_TopLevelNonObjectIsNotAFrame(t *testing.T) {
+	for _, payload := range notFrames {
+		t.Run(payload, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			body := w.Body.String()
+			if strings.Contains(body, "CONTENTMARKER") || strings.Contains(body, "42") {
+				t.Errorf("a non-frame was relayed to the caller: %q", body)
+			}
+			// One [DONE], the gateway's own, not the provider's quoted one.
+			if n := strings.Count(body, "[DONE]"); n != 1 {
+				t.Errorf("[DONE] appears %d times: %q", n, body)
+			}
+		})
+	}
 }
 
 // A frame the gateway cannot type is still the provider's answer. encoding/json
@@ -149,8 +182,21 @@ func TestHandleStreamingResponse_UntypeableErrorFrameIsMasked(t *testing.T) {
 
 	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
 
-	if strings.Contains(w.Body.String(), "sk-proj-1234") {
-		t.Errorf("a credential quoted in an untypeable error frame reached the caller: %q", w.Body.String())
+	body := w.Body.String()
+	// The positive half first. Both assertions below are satisfied by a frame
+	// that never went out at all, and a dropped frame runs no observers either —
+	// so without this the test passes with the whole forward reverted.
+	if !strings.Contains(body, "rejected by") {
+		t.Fatalf("the error frame never reached the caller, so nothing was masked: %q", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Errorf("the credential was not redacted for the caller: %q", body)
+	}
+	if strings.Contains(body, "sk-proj-1234") {
+		t.Errorf("a credential quoted in an untypeable error frame reached the caller: %q", body)
+	}
+	if !strings.Contains(logData.errorMessage, "rejected by") {
+		t.Fatalf("the observer never read the error member: %q", logData.errorMessage)
 	}
 	if strings.Contains(logData.errorMessage, "sk-proj-1234") {
 		t.Errorf("a credential reached the request log: %q", logData.errorMessage)
@@ -250,11 +296,12 @@ var anthropicErrorEvents = []struct {
 	{"no error member", `{"type":"error"}`, "", false, ""},
 }
 
+// Not parallel: it reads the shared default logger, which captureProxyLogs
+// swaps out for the duration of each case.
 func TestCaptureSSEError_AnthropicErrorEventShapes(t *testing.T) {
-	t.Parallel()
 	for _, tc := range anthropicErrorEvents {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			capture := captureProxyLogs(t)
 			st := &streamState{lastAnthropicEvent: "error"}
 			counted := st.captureSSEError(tc.payload, &st.lastAnthropicEvent, 1, &requestLogData{modelID: "m", providerName: "p"})
 
@@ -269,6 +316,18 @@ func TestCaptureSSEError_AnthropicErrorEventShapes(t *testing.T) {
 			}
 			if st.lastAnthropicEvent != "" {
 				t.Errorf("the event carry was not consumed: %q", st.lastAnthropicEvent)
+			}
+			// The event's own type is the thing the old private struct lost on
+			// every shape but one, and it is logged rather than stored — so the
+			// log is where it has to be read.
+			var loggedType string
+			for _, rec := range capture.all() {
+				if strings.Contains(rec.msg, "Anthropic SSE error event") {
+					loggedType = rec.attrs["error_type"]
+				}
+			}
+			if loggedType != tc.wantType {
+				t.Errorf("logged error_type = %q, want %q", loggedType, tc.wantType)
 			}
 		})
 	}
@@ -546,5 +605,124 @@ func TestHandleStreamingResponse_UntypeableWarnCarriesNoneOfTheFrame(t *testing.
 	}
 	if !sawWarn {
 		t.Fatal("the untypeable warn never fired, so nothing was asserted")
+	}
+}
+
+// Forwarding a frame is not the same as knowing it carried anything. The
+// terminal chunk is exactly where a relay numbers its stop reason, and that
+// frame carries no output at all — so treating a forwarded frame as delivery in
+// its own right meant every empty response from such a provider cleared its
+// failure streak and its circuit could never open.
+//
+// What the counter is for is the other direction: it must not let an unreadable
+// frame CHARGE the provider either. Silence is the verdict when nothing typed
+// arrived; a stream that plainly answered is still credited.
+func TestJudgeStreamForBreaker_UntypeableFrames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		st          *streamState
+		wantSuccess bool
+		wantCharge  bool
+	}{
+		{"nothing but an unreadable frame", &streamState{sawDone: true, unparsedChunks: 1}, false, false},
+		{"an unreadable frame beside a real answer", &streamState{sawDone: true, unparsedChunks: 1, sawContent: true}, true, false},
+		{"an unreadable frame beside counted output", &streamState{sawDone: true, unparsedChunks: 1, deliveredBytes: 40}, true, false},
+		{"a genuinely empty stream", &streamState{sawDone: true}, false, true},
+		{"an ordinary answered stream", &streamState{sawDone: true, sawContent: true}, true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := judgeStreamForBreaker(tc.st, &requestLogData{}, "", true)
+			if got.success != tc.wantSuccess {
+				t.Errorf("success = %v, want %v", got.success, tc.wantSuccess)
+			}
+			if (got.failureReason != "") != tc.wantCharge {
+				t.Errorf("failureReason = %q, want a charge = %v", got.failureReason, tc.wantCharge)
+			}
+		})
+	}
+}
+
+// A frame this gateway forwarded but could not read still carried the model's
+// answer, and the estimator is what bills a stream whose provider reported no
+// usage — streaming usage is opt-in, so that is the common case, not the rare
+// one. Counting nothing for it delivered a full answer and debited the caller's
+// quota and TPM bucket for none of it.
+func TestHandleStreamingResponse_UntypeableContentIsStillMetered(t *testing.T) {
+	vkRepo := &mockVirtualKeyRepo{}
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = vkRepo
+
+	body := `data: {"choices":[{"delta":{"content":[{"type":"text","text":"a reasonably long answer from the model"}]}}]}` + "\n\ndata: [DONE]\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	logData := newErrorFrameLog()
+	logData.promptTextBytes = 40
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+	h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout", vkHash: "test-hash"})
+
+	if got := singleAddTokens(t, vkRepo); got == 0 {
+		t.Error("an answer the caller received was metered as nothing")
+	}
+}
+
+// The strip is owed only where there is reasoning to strip. Dropping every
+// untypeable frame deleted the answer out of an ordinary content delta whose
+// finish_reason happened to be a number, for no gain at all.
+func TestHandleStreamingResponse_StripReasoningKeepsFramesWithNoneOfIt(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	payload := `{"choices":[{"delta":{"content":"CONTENTMARKER"},"finish_reason":0}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
+		t.Errorf("an answer with no reasoning in it was dropped: %q", w.Body.String())
+	}
+}
+
+// The retirement verdict asks the same question the breaker does and used a
+// narrower signal to answer it. sawContent watches content and reasoning on
+// choices[0], so a stream whose whole answer is a tool call — or one delivered
+// in a shape this gateway forwarded without being able to type — read as having
+// produced nothing, and the gone-strike streak a real answer should have
+// cleared stayed on the model.
+func TestFinalizeStream_DeliveredContentCountsEveryShapeOfOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"a tool call and no text", `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup","arguments":"{}"}}]}}]}`},
+		{"content this gateway cannot type", `{"choices":[{"delta":{"content":[{"type":"text","text":"an answer"}]}}]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + tc.body + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			logData := newErrorFrameLog()
+
+			h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !logData.deliveredContent {
+				t.Error("the model answered and the retirement verdict was told it did not")
+			}
+		})
 	}
 }

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -10,7 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 )
 
 // untypeableFrames are well-formed JSON frames carrying a member in a shape
@@ -33,6 +37,12 @@ var untypeableFrames = []struct {
 	{"reasoning as a list", `{"choices":[{"delta":{"content":"CONTENTMARKER","reasoning":["step one"]}}]}`},
 	// choices as an object rather than the array of choices.
 	{"choices as an object", `{"choices":{"0":{"delta":{"content":"CONTENTMARKER"}}}}`},
+	// Not an object at all. The type error carries no member path, so the log
+	// line has nothing to name — but the same rule applies: the bytes are the
+	// provider's answer, and this gateway having no struct for them is not a
+	// reason to delete them from the caller's stream.
+	{"a bare list", `["CONTENTMARKER"]`},
+	{"a bare string", `"CONTENTMARKER"`},
 }
 
 // A frame the gateway cannot type is still the provider's answer. encoding/json
@@ -73,8 +83,6 @@ func TestHandleStreamingResponse_UntypeableFrameIsForwardedVerbatim(t *testing.T
 	h := newUnitHandler()
 	defer stopUnitHandler(h)
 
-	// strip_reasoning on and a reasoning member present: the transform this
-	// frame would otherwise be rebuilt by.
 	payload := `{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"}],"reasoning_content":"thinking"}}]}`
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -83,7 +91,6 @@ func TestHandleStreamingResponse_UntypeableFrameIsForwardedVerbatim(t *testing.T
 	}
 	w := httptest.NewRecorder()
 	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
 
 	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
 
@@ -153,23 +160,32 @@ func TestHandleStreamingResponse_UntypeableErrorFrameIsMasked(t *testing.T) {
 // The content of an untypeable frame is not an error, and the key-shape regex
 // matches prose. It must not run over a frame whose error member carries
 // nothing, whatever else about the frame failed to type.
+//
+// Every case here has an error member PRESENT. Without one the gate is never
+// read at all — a json.RawMessage for an absent member is nil, so the correct
+// gate and the presence gate that once rewrote model output both answer no, and
+// the test passes whichever is in the code.
 func TestHandleStreamingResponse_UntypeableFrameContentIsNotKeyShapeMasked(t *testing.T) {
-	h := newUnitHandler()
-	defer stopUnitHandler(h)
+	for _, member := range []string{`null`, `{}`, `""`, `false`, `{"code":0,"message":""}`} {
+		t.Run(member, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
 
-	payload := `{"choices":[{"delta":{"content":"use sk-proj-1234567890abcdefghij in the header"},"finish_reason":0}]}`
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
-		Header:     make(http.Header),
-	}
-	w := httptest.NewRecorder()
-	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			payload := `{"error":` + member + `,"choices":[{"delta":{"content":"use sk-proj-1234567890abcdefghij in the header"},"finish_reason":0}]}`
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
 
-	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
 
-	if !strings.Contains(w.Body.String(), "sk-proj-1234567890abcdefghij") {
-		t.Errorf("the model's answer was rewritten mid-stream: %q", w.Body.String())
+			if !strings.Contains(w.Body.String(), "sk-proj-1234567890abcdefghij") {
+				t.Errorf("the model's answer was rewritten mid-stream: %q", w.Body.String())
+			}
+		})
 	}
 }
 
@@ -365,5 +381,131 @@ func TestJSONShapeName(t *testing.T) {
 		if got := jsonShapeName(tc.value); got != tc.want {
 			t.Errorf("jsonShapeName(%q) = %q, want %q", tc.value, got, tc.want)
 		}
+	}
+}
+
+// strip_reasoning is a promise to the caller, and forwarding a frame this
+// gateway cannot read is no way to keep it. computeStripReasoning works over the
+// payload, so it would run — but its "does this delta still carry anything"
+// verdict reads content as a plain string, so a content-as-parts delta looks
+// empty to it and becomes a keep-alive, and the answer is gone.
+//
+// So a key that asked for reasoning to be stripped gets the frame dropped, which
+// is what it got before an untypeable frame was forwarded at all. The delivery
+// fix is for the streams where nothing was promised.
+func TestHandleStreamingResponse_StripReasoningDropsUntypeableFrames(t *testing.T) {
+	for _, payload := range []string{
+		`{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"}],"reasoning_content":"THINKINGMARKER"}}]}`,
+		`{"choices":[{"delta":{"content":"CONTENTMARKER","reasoning":["THINKINGMARKER"]}}]}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if strings.Contains(w.Body.String(), "THINKINGMARKER") {
+				t.Errorf("reasoning reached a caller that asked for it stripped: %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// The inference the forward path rests on — a type error proves the bytes are
+// well-formed — is a property of json.Unmarshal, which validates the whole
+// document before decoding any of it. json.Decoder does not promise it, and
+// GOEXPERIMENT=jsonv2 decodes streaming and so can report a type error on an
+// early member before reaching a syntax error later on.
+//
+// The predicate therefore checks rather than infers. If that guarantee ever goes
+// away this branch keeps dropping truncated bytes instead of forwarding them to
+// callers, which is the whole point of the drop branch existing.
+func TestShapeError_ChecksValidityRatherThanInferringIt(t *testing.T) {
+	t.Parallel()
+	typeErr := &json.UnmarshalTypeError{Value: "number", Field: "choices.0.finish_reason"}
+	if shapeError([]byte(`{"choices":[{"finish_reason":0}]}`), typeErr) == nil {
+		t.Error("a type error on well-formed JSON is an untypeable frame")
+	}
+	if got := shapeError([]byte(`{"choices":[{"finish_reason":0`), typeErr); got != nil {
+		t.Errorf("a type error on truncated bytes must not be forwarded, got %v", got)
+	}
+	if got := shapeError([]byte(`{"choices":[]}`), nil); got != nil {
+		t.Errorf("a clean decode is not an untypeable frame, got %v", got)
+	}
+	if got := shapeError([]byte(`{"choices":[`), &json.SyntaxError{}); got != nil {
+		t.Errorf("a syntax error is not an untypeable frame, got %v", got)
+	}
+}
+
+// A stream whose frames this gateway forwarded but could not read is not an
+// empty stream: the caller received them. Holding back the breaker's success
+// credit for every such stream leaves the provider's consecutive-failure count
+// never resetting, so old failures accumulate until an unrelated one opens the
+// circuit.
+func TestHandleStreamingResponse_UntypeableFramesStillCreditTheProvider(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThreshold(t, h, "2")
+
+	providerID := uuid.New()
+	logData := streamingLog()
+	logData.providerName = "wide-shape-provider"
+	h.insertRequestLogAsync(logData)
+	// A threshold of two with one failure already on the clock. Only a recorded
+	// SUCCESS clears it, so whether the second failure below opens the circuit
+	// is exactly the question of whether this stream credited the provider.
+	h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
+
+	body := "data: {\"choices\":[{\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}]}\n\ndata: [DONE]\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       providerID,
+		providerName:     "wide-shape-provider",
+		circuitBreakerOn: true,
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Fatal("a frame the gateway forwarded must not be charged to the provider")
+	}
+	h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
+	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+		t.Error("the stream recorded no success, so an old failure was still on the clock")
+	}
+}
+
+// A frame whose usage member could not be read leaves chunk.Usage a valid
+// pointer to an all-zero Usage: encoding/json allocates it before it calls the
+// custom unmarshaler. The observer gated on the pointer alone, so such a frame
+// wrote zeros over the counts an earlier usage chunk had already reported --
+// and a provider that rides usage on EVERY chunk gives it that chance on every
+// frame it sends.
+func TestHandleStreamingResponse_UnreadableUsageDoesNotZeroWhatWasCounted(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	body := `data: {"choices":[{"delta":{"content":"hi"}}],"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}` + "\n\n" +
+		`data: {"choices":[{"delta":{"content":"there"}}],"usage":{"completion_tokens_details":["reasoning"]}}` + "\n\n" +
+		"data: [DONE]\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if logData.tokensPrompt != 100 || logData.tokensCompletion != 50 {
+		t.Errorf("got prompt=%d completion=%d, want the counts the provider reported (100/50)", logData.tokensPrompt, logData.tokensCompletion)
 	}
 }

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -791,3 +791,214 @@ func TestUntypedDeltaBytes_SkipsToolCallScaffolding(t *testing.T) {
 		t.Errorf("counted %d bytes, want the 2 the model produced", got)
 	}
 }
+
+// A member that carries nothing is not output. Measuring the raw member instead
+// made "" two bytes and null four, and two bytes is delivery to everything
+// downstream — so the opening {"role":"assistant","content":""} chunk that
+// almost every OpenAI-shaped stream sends was enough on its own.
+func TestUntypedDeltaBytes_EmptyMembersAreNotOutput(t *testing.T) {
+	t.Parallel()
+	for _, payload := range []string{
+		`{"choices":[{"delta":{"role":"assistant","content":""}}]}`,
+		`{"choices":[{"delta":{"content":null}}]}`,
+		`{"choices":[{"delta":{"content":"","reasoning":"","reasoning_details":[]}}]}`,
+		`{"choices":[{"delta":{"refusal":"","annotations":[]}}]}`,
+		`{"choices":[{"delta":{}}]}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			t.Parallel()
+			p, ok := parseChunkPayload(payload)
+			if !ok {
+				t.Fatal("fixture did not parse")
+			}
+			if got := untypedDeltaBytes(p.delta); got != 0 {
+				t.Errorf("counted %d bytes of output in a delta that carries none", got)
+			}
+		})
+	}
+}
+
+// The consequence that made it a blocker rather than a rounding error: a
+// provider failing every single request must still open its circuit. The empty
+// opening delta credited delivery, delivery suppressed the error charge, and the
+// breaker never counted a failure.
+func TestHandleStreamingResponse_EmptyUntypeableDeltaDoesNotShieldAFailingProvider(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	// An untypeable opening delta that carries nothing, then the provider's error.
+	body := `data: {"choices":[{"delta":{"role":"assistant","content":""},"finish_reason":0}]}` + "\n\n" +
+		`data: {"error":{"message":"model not found"}}` + "\n\ndata: [DONE]\n\n"
+
+	logData := streamingLog()
+	logData.providerName = "failing-provider"
+	h.insertRequestLogAsync(logData)
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
+	h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), streamOptions{
+		responseHeaderMs: 10,
+		providerID:       providerID,
+		providerName:     "failing-provider",
+		circuitBreakerOn: true,
+		vkHash:           "test-hash",
+		attempt:          1,
+	})
+
+	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
+		t.Errorf("circuit = %v, want open: an empty delta must not shield a provider that failed", got)
+	}
+}
+
+// The observers run before this branch on a chunk that decoded PARTLY, so every
+// member that did decode has already been counted. Adding the raw delta on top
+// billed the same content twice, and a tool-call frame many times over.
+//
+// Read by comparison rather than against a number: the same answer, once in a
+// frame that types cleanly and once in a frame that does not, must cost the
+// caller the same.
+func TestHandleStreamingResponse_UntypeableFrameIsMeteredOnce(t *testing.T) {
+	const answer = "0123456789012345678901234567890123456789"
+	meter := func(t *testing.T, payload string) int {
+		t.Helper()
+		vkRepo := &mockVirtualKeyRepo{}
+		h := newIntegrationHandler()
+		t.Cleanup(func() { stopUnitHandler(h) })
+		h.virtualKeyRepo = vkRepo
+
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")), Header: make(http.Header)}
+		logData := newErrorFrameLog()
+		logData.promptTextBytes = 40
+		req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout", vkHash: "test-hash"})
+		return singleAddTokens(t, vkRepo)
+	}
+
+	typed := meter(t, `{"choices":[{"delta":{"content":"`+answer+`"}}]}`)
+	untypeable := meter(t, `{"choices":[{"delta":{"content":"`+answer+`"},"finish_reason":0}]}`)
+
+	if typed == 0 {
+		t.Fatal("the typed control metered nothing, so there is nothing to compare against")
+	}
+	if untypeable != typed {
+		t.Errorf("the same answer cost %d tokens typed and %d untypeable", typed, untypeable)
+	}
+}
+
+// Reasoning markers a relay stamps on every NON-reasoning delta carry nothing,
+// and gating the drop on their presence deleted the answer beside them. The
+// OpenRouter family stamps exactly these.
+func TestHandleStreamingResponse_StripReasoningKeepsFramesWithEmptyMarkers(t *testing.T) {
+	for _, member := range []string{`"reasoning":""`, `"reasoning_details":[]`, `"reasoning_content":""`, `"reasoning":null`, `"reasoning_details":{}`} {
+		t.Run(member, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			payload := `{"choices":[{"delta":{"content":"CONTENTMARKER",` + member + `},"finish_reason":0}]}`
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
+				t.Errorf("an empty reasoning marker deleted the answer beside it: %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// Reasoning arrives inside a part array on exactly the relays that make a frame
+// untypeable in the first place, so a content array cannot be read as text-only.
+// A key that asked for reasoning to be hidden must not be handed a thinking part.
+func TestHandleStreamingResponse_StripReasoningDropsThinkingParts(t *testing.T) {
+	for _, payload := range []string{
+		`{"choices":[{"delta":{"content":[{"type":"thinking","thinking":"THINKINGMARKER"},{"type":"text","text":"answer"}]}}]}`,
+		`{"choices":[{"delta":{"content":[{"type":"text","text":"answer"}],"reasoning_content":"THINKINGMARKER"}}]}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if strings.Contains(w.Body.String(), "THINKINGMARKER") {
+				t.Errorf("reasoning reached a caller that asked for it stripped: %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// A frame whose usage member is not an object is still a frame, and the answer
+// in it is still the answer. Requiring the type error to NAME a member threw
+// these away whole: an error from a nested custom unmarshaler reaches the caller
+// with an empty Field, so the rule could not tell them from `data: 42`.
+func TestHandleStreamingResponse_UnreadableUsageDoesNotCostTheFrame(t *testing.T) {
+	for _, usage := range []string{`[]`, `""`, `0`, `"none"`, `{"prompt_tokens":[]}`} {
+		t.Run(usage, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			payload := `{"choices":[{"delta":{"content":"CONTENTMARKER"}}],"usage":` + usage + `}`
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
+				t.Errorf("a usage member the gateway could not read cost the caller the answer: %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// The object rule, read directly. A nested custom UnmarshalJSON returns its
+// error with an empty Field, so "does the type error name a member" could not
+// tell a chat frame with an unreadable usage member from a bare number.
+func TestShapeError_RequiresAJSONObject(t *testing.T) {
+	t.Parallel()
+	typeErr := &json.UnmarshalTypeError{Value: "number", Field: "choices.0.finish_reason"}
+	fieldless := &json.UnmarshalTypeError{Value: "array"}
+	for _, tc := range []struct {
+		data string
+		err  error
+		want bool
+	}{
+		{`{"choices":[{"finish_reason":0}]}`, typeErr, true},
+		// An object whose type error names nothing: a nested unmarshaler's.
+		{`{"choices":[{"delta":{"content":"hi"}}],"usage":[]}`, fieldless, true},
+		// Not the document at all.
+		{`[1,2,3]`, fieldless, false},
+		{`"[DONE]"`, fieldless, false},
+		{`42`, fieldless, false},
+		{`null`, fieldless, false},
+		// An object, but not sound bytes.
+		{`{"choices":[`, typeErr, false},
+	} {
+		t.Run(tc.data, func(t *testing.T) {
+			t.Parallel()
+			if got := shapeError([]byte(tc.data), tc.err) != nil; got != tc.want {
+				t.Errorf("shapeError(%s) non-nil = %v, want %v", tc.data, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -1,0 +1,203 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+)
+
+// untypeableFrames are well-formed JSON frames carrying a member in a shape
+// streamChunk does not model. Every one of them was DROPPED — not forwarded, not
+// observed, not masked — because the pipeline read "did this fit my structs" as
+// "were these bytes even JSON".
+//
+// The shapes are deliberately ones no leniency in this package covers, so the
+// test reads the safety net rather than a typed field's own tolerance.
+var untypeableFrames = []struct {
+	name    string
+	payload string
+}{
+	// A relay that numbers its stop reasons. finish_reason is *string.
+	{"numeric finish_reason", `{"choices":[{"delta":{"content":"CONTENTMARKER"},"finish_reason":0}]}`},
+	// Content as an array of parts, which is what an Anthropic-shaped relay
+	// emits and what the OpenAI schema itself now permits. content is *string.
+	{"content as parts", `{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"}]}}]}`},
+	// Reasoning as a list of blocks. reasoning is *string.
+	{"reasoning as a list", `{"choices":[{"delta":{"content":"CONTENTMARKER","reasoning":["step one"]}}]}`},
+	// choices as an object rather than the array of choices.
+	{"choices as an object", `{"choices":{"0":{"delta":{"content":"CONTENTMARKER"}}}}`},
+}
+
+// A frame the gateway cannot type is still the provider's answer. encoding/json
+// validates the whole document before it decodes anything, so a type error
+// proves the bytes are well-formed JSON — the opposite of the truncated frame
+// the drop branch exists for. Dropping it silently deletes model output from the
+// caller's stream.
+func TestHandleStreamingResponse_UntypeableFrameIsForwarded(t *testing.T) {
+	for _, tc := range untypeableFrames {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			body := "data: " + tc.payload + "\n\ndata: [DONE]\n\n"
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
+				t.Errorf("the frame never reached the caller, body = %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// The transforms rebuild the frame from the typed chunk. On a frame that only
+// partly decoded, the field that failed is missing from that struct — so
+// rebuilding is how the content in a content-as-parts frame would be forwarded
+// as an empty delta. Forwarding the original bytes is the only honest answer
+// when the gateway does not understand them.
+func TestHandleStreamingResponse_UntypeableFrameIsForwardedVerbatim(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	// strip_reasoning on and a reasoning member present: the transform this
+	// frame would otherwise be rebuilt by.
+	payload := `{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"}],"reasoning_content":"thinking"}}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if !strings.Contains(w.Body.String(), payload) {
+		t.Errorf("the frame was rewritten rather than forwarded, body = %q", w.Body.String())
+	}
+}
+
+// The observers only read, and encoding/json keeps decoding the siblings after
+// it records a type error, so everything that did fit is there to be read. A
+// frame whose error member is intact and whose finish_reason is not must still
+// fail the request: it is the provider saying why it stopped.
+func TestHandleStreamingResponse_UntypeableFrameIsStillObserved(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	payload := `{"choices":[{"finish_reason":0}],"error":{"message":"upstream capacity"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed", logData.state)
+	}
+	if !strings.Contains(logData.errorMessage, "upstream capacity") {
+		t.Errorf("errorMessage = %q, want the provider's error", logData.errorMessage)
+	}
+}
+
+// Masking is on the emit path, and the drop branch masked nothing because
+// nothing was emitted. Now that the frame goes out, it goes out scrubbed: the
+// exact key on every frame, and the key-shape regex on the ones whose error
+// member carries something. The token here is not the configured credential, so
+// only the shape scrub can catch it — and it carries a digit, without which the
+// regex drops the match as prose and the assertion reads nothing at all.
+func TestHandleStreamingResponse_UntypeableErrorFrameIsMasked(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	payload := `{"choices":[{"finish_reason":0}],"error":{"message":"rejected by sk-proj-1234567890abcdefghij"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if strings.Contains(w.Body.String(), "sk-proj-1234") {
+		t.Errorf("a credential quoted in an untypeable error frame reached the caller: %q", w.Body.String())
+	}
+	if strings.Contains(logData.errorMessage, "sk-proj-1234") {
+		t.Errorf("a credential reached the request log: %q", logData.errorMessage)
+	}
+}
+
+// The content of an untypeable frame is not an error, and the key-shape regex
+// matches prose. It must not run over a frame whose error member carries
+// nothing, whatever else about the frame failed to type.
+func TestHandleStreamingResponse_UntypeableFrameContentIsNotKeyShapeMasked(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	payload := `{"choices":[{"delta":{"content":"use sk-proj-1234567890abcdefghij in the header"},"finish_reason":0}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if !strings.Contains(w.Body.String(), "sk-proj-1234567890abcdefghij") {
+		t.Errorf("the model's answer was rewritten mid-stream: %q", w.Body.String())
+	}
+}
+
+// The drop branch still exists, and this is what it is for: bytes that are not
+// JSON at all. Forwarding a frame cut in half hands the caller a parse error in
+// place of a clean end.
+func TestHandleStreamingResponse_MalformedFrameIsStillDropped(t *testing.T) {
+	for _, payload := range []string{
+		`{"choices":[{"delta":{"content":"CONTENTMARKER"`,
+		`{"choices":[{"delta":{"content":"CONTENTMARKER"}}],}`,
+		`not json at all CONTENTMARKER`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if strings.Contains(w.Body.String(), "CONTENTMARKER") {
+				t.Errorf("broken bytes were forwarded to the caller: %q", w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -313,3 +313,37 @@ func TestHandleStreamingResponse_AnthropicErrorIsCountedOnce(t *testing.T) {
 		t.Errorf("state = %q, errorMessage = %q, want the provider's error", logData.state, logData.errorMessage)
 	}
 }
+
+// The transforms are skipped for an untypeable frame because they rebuild it
+// from the struct. normalizeToolArguments does not — it works over the payload
+// as a map of raw members, so everything it does not rewrite survives verbatim,
+// and it is the one rewrite an untypeable frame still needs.
+//
+// Forwarding the object form is not a smaller loss than dropping the frame, it
+// is a different one: the caller echoes the assistant turn into its next
+// request, and a failover group whose next turn lands on an Anthropic or Gemini
+// member 400s on it for the life of the conversation.
+func TestHandleStreamingResponse_UntypeableFrameStillNormalisesToolArguments(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	payload := `{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"lookup","arguments":{"city":"Oslo"}}}]},"finish_reason":0}]}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+
+	h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	body := w.Body.String()
+	if !strings.Contains(body, `"arguments":"{\"city\":\"Oslo\"}"`) {
+		t.Errorf("tool-call arguments left in the object form: %q", body)
+	}
+	// The member that could not be typed still rides through untouched.
+	if !strings.Contains(body, `"finish_reason":0`) {
+		t.Errorf("the untypeable member was not preserved: %q", body)
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -199,5 +200,116 @@ func TestHandleStreamingResponse_MalformedFrameIsStillDropped(t *testing.T) {
 				t.Errorf("broken bytes were forwarded to the caller: %q", w.Body.String())
 			}
 		})
+	}
+}
+
+// P1-C reads the Anthropic error event with its own decoder, one struct away
+// from the member the rest of the gateway now shares a rule for. Two defects
+// followed from that.
+//
+// It typed the member as an object, so any other shape failed the whole decode
+// and the branch recorded nothing — the event's TYPE went with it, and the
+// observer beneath had to catch what it could from a member it reads correctly.
+//
+// Worse, it counted an error whose message is empty. errorChunkCount>0 is what
+// tells writeTerminalError the client has already seen the provider's error, so
+// an empty one suppressed the terminal frame while leaving lastErrMsg blank: the
+// caller's stream simply stopped, with no error frame and no [DONE].
+var anthropicErrorEvents = []struct {
+	name     string
+	payload  string
+	wantMsg  string
+	isError  bool
+	wantType string
+}{
+	{"object with a message", `{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}`, "overloaded", true, "overloaded_error"},
+	{"bare string", `{"type":"error","error":"overloaded"}`, "overloaded", true, ""},
+	{"list", `{"type":"error","error":["overloaded"]}`, `["overloaded"]`, true, ""},
+	// A type and no message: something to report, and the caller must still be
+	// told the stream ended because of it.
+	{"type only", `{"type":"error","error":{"type":"overloaded_error"}}`, `{"type":"overloaded_error"}`, true, "overloaded_error"},
+	// Nothing to report. Counting it suppressed the terminal frame.
+	{"empty object", `{"type":"error","error":{}}`, "", false, ""},
+	{"null", `{"type":"error","error":null}`, "", false, ""},
+	{"no error member", `{"type":"error"}`, "", false, ""},
+}
+
+func TestCaptureSSEError_AnthropicErrorEventShapes(t *testing.T) {
+	t.Parallel()
+	for _, tc := range anthropicErrorEvents {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := &streamState{lastAnthropicEvent: "error"}
+			counted := st.captureSSEError(tc.payload, &st.lastAnthropicEvent, 1, &requestLogData{modelID: "m", providerName: "p"})
+
+			if counted != tc.isError {
+				t.Errorf("counted an Anthropic error = %v, want %v", counted, tc.isError)
+			}
+			if (st.errorChunkCount > 0) != tc.isError {
+				t.Errorf("errorChunkCount = %d, want an error = %v", st.errorChunkCount, tc.isError)
+			}
+			if st.lastErrMsg != tc.wantMsg {
+				t.Errorf("lastErrMsg = %q, want %q", st.lastErrMsg, tc.wantMsg)
+			}
+			if st.lastAnthropicEvent != "" {
+				t.Errorf("the event carry was not consumed: %q", st.lastAnthropicEvent)
+			}
+		})
+	}
+}
+
+// The consequence, end to end. errorChunkCount is what tells writeTerminalError
+// the client has already seen the provider's error, so counting an error with no
+// message spends that budget on nothing: when the stream then really does fail,
+// the frame that would have told the caller why is suppressed, and the caller is
+// left holding a cut connection.
+func TestHandleStreamingResponse_EmptyAnthropicErrorDoesNotEatTheTerminalFrame(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	// A delta, an error event carrying nothing, then the upstream connection
+	// breaks. The broken read is the error the caller has to be told about.
+	body := io.MultiReader(
+		strings.NewReader("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\nevent: error\ndata: {\"type\":\"error\",\"error\":{}}\n\n"),
+		&errorReader{err: errors.New("connection reset by peer")},
+	)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(body),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if logData.state != "failed" {
+		t.Fatalf("state = %q, want failed", logData.state)
+	}
+	if !strings.Contains(w.Body.String(), `"server_error"`) {
+		t.Errorf("the caller got no terminal error frame: %q", w.Body.String())
+	}
+}
+
+// An error the P1-C branch does record must not be counted twice by the observer
+// reading the same member off the same line.
+func TestHandleStreamingResponse_AnthropicErrorIsCountedOnce(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("event: error\ndata: {\"type\":\"error\",\"error\":\"overloaded\"}\n\n")),
+		Header:     make(http.Header),
+	}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	if logData.state != "failed" || !strings.Contains(logData.errorMessage, "overloaded") {
+		t.Errorf("state = %q, errorMessage = %q, want the provider's error", logData.state, logData.errorMessage)
 	}
 }

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -347,3 +347,23 @@ func TestHandleStreamingResponse_UntypeableFrameStillNormalisesToolArguments(t *
 		t.Errorf("the untypeable member was not preserved: %q", body)
 	}
 }
+
+// encoding/json writes a number's literal into UnmarshalTypeError.Value, and a
+// relay sending the model's numeric answer where the schema wants a string is
+// exactly how a frame reaches the untypeable path. Only the shape is loggable.
+func TestJSONShapeName(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ value, want string }{
+		{"array", "array"},
+		{"object", "object"},
+		{"string", "string"},
+		{"bool", "bool"},
+		{"number 42", "number"},
+		{"number -3.5e10", "number"},
+		{"", ""},
+	} {
+		if got := jsonShapeName(tc.value); got != tc.want {
+			t.Errorf("jsonShapeName(%q) = %q, want %q", tc.value, got, tc.want)
+		}
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -509,3 +509,42 @@ func TestHandleStreamingResponse_UnreadableUsageDoesNotZeroWhatWasCounted(t *tes
 		t.Errorf("got prompt=%d completion=%d, want the counts the provider reported (100/50)", logData.tokensPrompt, logData.tokensCompletion)
 	}
 }
+
+// The warn that reports an untypeable frame must name the mismatch and nothing
+// else. The commonest reason a frame lands there is that the model's own output
+// was written in a shape this gateway has no struct for, so the payload is
+// response content and the app log, the live viewer and the OTLP export are the
+// three places it must never reach.
+//
+// Asserted over every attribute rather than the two known ones, because the next
+// attribute added here is the one that would leak.
+func TestHandleStreamingResponse_UntypeableWarnCarriesNoneOfTheFrame(t *testing.T) {
+	capture := captureProxyLogs(t)
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	const secret = "MODELANSWERTHATMUSTNOTBELOGGED"
+	payload := `{"choices":[{"delta":{"content":"` + secret + `"},"finish_reason":0}],"note":8675309}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+		Header:     make(http.Header),
+	}
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	h.handleStreamingResponse(httptest.NewRecorder(), req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	var sawWarn bool
+	for _, rec := range capture.all() {
+		if strings.Contains(rec.msg, "does not model") {
+			sawWarn = true
+		}
+		for k, text := range rec.attrs {
+			if strings.Contains(text, secret) || strings.Contains(text, "8675309") {
+				t.Errorf("attribute %q carried the frame: %q", k, text)
+			}
+		}
+	}
+	if !sawWarn {
+		t.Fatal("the untypeable warn never fired, so nothing was asserted")
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -505,45 +505,6 @@ func TestShapeError_ChecksValidityRatherThanInferringIt(t *testing.T) {
 	}
 }
 
-// A stream whose frames this gateway forwarded but could not read is not an
-// empty stream: the caller received them. Holding back the breaker's success
-// credit for every such stream leaves the provider's consecutive-failure count
-// never resetting, so old failures accumulate until an unrelated one opens the
-// circuit.
-func TestHandleStreamingResponse_UntypeableFramesStillCreditTheProvider(t *testing.T) {
-	h := newIntegrationHandler()
-	defer stopUnitHandlerIntegration(h)
-	withBreakerThreshold(t, h, "2")
-
-	providerID := uuid.New()
-	logData := streamingLog()
-	logData.providerName = "wide-shape-provider"
-	h.insertRequestLogAsync(logData)
-	// A threshold of two with one failure already on the clock. Only a recorded
-	// SUCCESS clears it, so whether the second failure below opens the circuit
-	// is exactly the question of whether this stream credited the provider.
-	h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
-
-	body := "data: {\"choices\":[{\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}]}\n\ndata: [DONE]\n\n"
-	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}
-	h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), streamOptions{
-		responseHeaderMs: 10,
-		providerID:       providerID,
-		providerName:     "wide-shape-provider",
-		circuitBreakerOn: true,
-		vkHash:           "test-hash",
-		attempt:          1,
-	})
-
-	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
-		t.Fatal("a frame the gateway forwarded must not be charged to the provider")
-	}
-	h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
-	if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
-		t.Error("the stream recorded no success, so an old failure was still on the clock")
-	}
-}
-
 // A frame whose usage member could not be read leaves chunk.Usage a valid
 // pointer to an all-zero Usage: encoding/json allocates it before it calls the
 // custom unmarshaler. The observer gated on the pointer alone, so such a frame
@@ -608,6 +569,64 @@ func TestHandleStreamingResponse_UntypeableWarnCarriesNoneOfTheFrame(t *testing.
 	}
 }
 
+// A stream whose frames this gateway forwarded but could not read tells the
+// breaker nothing, in either direction. It is not emptiness — the caller
+// received them — and it is not health either, because what was in them is
+// unknown here.
+//
+// Both wrong answers have been tried. Crediting such a stream meant a relay that
+// numbers its stop reasons cleared its failure streak on every empty response,
+// so its circuit could never open; charging it would penalise a provider that
+// answered perfectly well in a shape this gateway has no struct for. Silence is
+// the honest verdict, and a stream that delivered anything READABLE alongside is
+// credited on the strength of that.
+func TestHandleStreamingResponse_UnreadableFramesTellTheBreakerNothing(t *testing.T) {
+	partsOnly := "data: {\"choices\":[{\"delta\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}]}\n\ndata: [DONE]\n\n"
+	alsoReadable := "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n" + partsOnly
+
+	for _, tc := range []struct {
+		name        string
+		body        string
+		wantCleared bool
+	}{
+		{"nothing this gateway could read", partsOnly, false},
+		{"a readable answer beside it", alsoReadable, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			defer stopUnitHandlerIntegration(h)
+			withBreakerThreshold(t, h, "2")
+
+			providerID := uuid.New()
+			logData := streamingLog()
+			logData.providerName = "wide-shape-provider"
+			h.insertRequestLogAsync(logData)
+			// One failure on the clock. Only a recorded SUCCESS clears it, so
+			// whether the second failure opens the circuit reports the verdict.
+			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
+
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(tc.body))}
+			h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), streamOptions{
+				responseHeaderMs: 10,
+				providerID:       providerID,
+				providerName:     "wide-shape-provider",
+				circuitBreakerOn: true,
+				vkHash:           "test-hash",
+				attempt:          1,
+			})
+
+			if got := h.circuitBreaker.GetState(providerID); got == failover.StateOpen {
+				t.Fatal("a frame the gateway forwarded must never be charged to the provider")
+			}
+			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider")
+			cleared := h.circuitBreaker.GetState(providerID) != failover.StateOpen
+			if cleared != tc.wantCleared {
+				t.Errorf("failure streak cleared = %v, want %v", cleared, tc.wantCleared)
+			}
+		})
+	}
+}
+
 // Forwarding a frame is not the same as knowing it carried anything. The
 // terminal chunk is exactly where a relay numbers its stop reason, and that
 // frame carries no output at all — so treating a forwarded frame as delivery in
@@ -644,30 +663,6 @@ func TestJudgeStreamForBreaker_UntypeableFrames(t *testing.T) {
 	}
 }
 
-// A frame this gateway forwarded but could not read still carried the model's
-// answer, and the estimator is what bills a stream whose provider reported no
-// usage — streaming usage is opt-in, so that is the common case, not the rare
-// one. Counting nothing for it delivered a full answer and debited the caller's
-// quota and TPM bucket for none of it.
-func TestHandleStreamingResponse_UntypeableContentIsStillMetered(t *testing.T) {
-	vkRepo := &mockVirtualKeyRepo{}
-	h := newIntegrationHandler()
-	t.Cleanup(func() { stopUnitHandler(h) })
-	h.virtualKeyRepo = vkRepo
-
-	body := `data: {"choices":[{"delta":{"content":[{"type":"text","text":"a reasonably long answer from the model"}]}}]}` + "\n\ndata: [DONE]\n\n"
-	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
-	logData := newErrorFrameLog()
-	logData.promptTextBytes = 40
-	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
-
-	h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout", vkHash: "test-hash"})
-
-	if got := singleAddTokens(t, vkRepo); got == 0 {
-		t.Error("an answer the caller received was metered as nothing")
-	}
-}
-
 // The strip is owed only where there is reasoning to strip. Dropping every
 // untypeable frame deleted the answer out of an ordinary content delta whose
 // finish_reason happened to be a number, for no gain at all.
@@ -694,17 +689,21 @@ func TestHandleStreamingResponse_StripReasoningKeepsFramesWithNoneOfIt(t *testin
 
 // The retirement verdict asks the same question the breaker does and used a
 // narrower signal to answer it. sawContent watches content and reasoning on
-// choices[0], so a stream whose whole answer is a tool call — or one delivered
-// in a shape this gateway forwarded without being able to type — read as having
+// choices[0], so a stream whose whole answer is a tool call read as having
 // produced nothing, and the gone-strike streak a real answer should have
 // cleared stayed on the model.
+//
+// A stream delivered ONLY in a shape this gateway cannot read still reads as
+// nothing, because nothing here can say otherwise — the TTFT probe covers it
+// wherever it is on, and it is listed with the rest of what content-as-parts
+// owes.
 func TestFinalizeStream_DeliveredContentCountsEveryShapeOfOutput(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		body string
 	}{
 		{"a tool call and no text", `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup","arguments":"{}"}}]}}]}`},
-		{"content this gateway cannot type", `{"choices":[{"delta":{"content":[{"type":"text","text":"an answer"}]}}]}`},
+		{"reasoning and no text", `{"choices":[{"delta":{"reasoning":"working on it"}}]}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newUnitHandler()
@@ -722,97 +721,6 @@ func TestFinalizeStream_DeliveredContentCountsEveryShapeOfOutput(t *testing.T) {
 
 			if !logData.deliveredContent {
 				t.Error("the model answered and the retirement verdict was told it did not")
-			}
-		})
-	}
-}
-
-// The role marker is not output. It rides on the first delta of most streams,
-// and counting it would put a few bytes of estimate on a frame that carried the
-// model nothing at all.
-func TestUntypedDeltaBytes_SkipsTheRoleMarker(t *testing.T) {
-	t.Parallel()
-	withRole, ok := parseChunkPayload(`{"choices":[{"delta":{"role":"assistant","content":"hello"}}]}`)
-	if !ok {
-		t.Fatal("fixture did not parse")
-	}
-	withoutRole, ok := parseChunkPayload(`{"choices":[{"delta":{"content":"hello"}}]}`)
-	if !ok {
-		t.Fatal("fixture did not parse")
-	}
-	if got, want := untypedDeltaBytes(withRole.delta), untypedDeltaBytes(withoutRole.delta); got != want {
-		t.Errorf("role added %d bytes to the estimate (%d vs %d)", got-want, got, want)
-	}
-	if untypedDeltaBytes(withoutRole.delta) == 0 {
-		t.Error("content counted as nothing")
-	}
-}
-
-// The number debits a customer's quota, so it counts the model's text and not
-// the JSON around it. Streaming deltas are a few tokens each, which is exactly
-// where the part wrapper dominates: measuring the raw member bills six to eight
-// times what the model produced.
-func TestUntypedDeltaBytes_CountsTextNotItsWrapper(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		name    string
-		payload string
-		want    int
-	}{
-		{"content as parts", `{"choices":[{"delta":{"content":[{"type":"text","text":"hello"}]}}]}`, 5},
-		{"several parts", `{"choices":[{"delta":{"content":[{"type":"text","text":"hel"},{"type":"text","text":"lo"}]}}]}`, 5},
-		{"a plain string beside an untypeable sibling", `{"choices":[{"delta":{"content":"hello"}}]}`, 5},
-		{"reasoning as parts", `{"choices":[{"delta":{"reasoning":[{"type":"text","text":"hello"}]}}]}`, 5},
-		// A shape neither reading covers is measured whole rather than dropped.
-		{"content as a number", `{"choices":[{"delta":{"content":8675309}}]}`, 7},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			p, ok := parseChunkPayload(tc.payload)
-			if !ok {
-				t.Fatal("fixture did not parse")
-			}
-			if got := untypedDeltaBytes(p.delta); got != tc.want {
-				t.Errorf("counted %d bytes, want %d", got, tc.want)
-			}
-		})
-	}
-}
-
-// The scaffolding that addresses a tool call is not what the model produced;
-// the arguments are.
-func TestUntypedDeltaBytes_SkipsToolCallScaffolding(t *testing.T) {
-	t.Parallel()
-	p, ok := parseChunkPayload(`{"choices":[{"delta":{"index":0,"id":"call_abcdefghijklmnop","content":"hi"}}]}`)
-	if !ok {
-		t.Fatal("fixture did not parse")
-	}
-	if got := untypedDeltaBytes(p.delta); got != 2 {
-		t.Errorf("counted %d bytes, want the 2 the model produced", got)
-	}
-}
-
-// A member that carries nothing is not output. Measuring the raw member instead
-// made "" two bytes and null four, and two bytes is delivery to everything
-// downstream — so the opening {"role":"assistant","content":""} chunk that
-// almost every OpenAI-shaped stream sends was enough on its own.
-func TestUntypedDeltaBytes_EmptyMembersAreNotOutput(t *testing.T) {
-	t.Parallel()
-	for _, payload := range []string{
-		`{"choices":[{"delta":{"role":"assistant","content":""}}]}`,
-		`{"choices":[{"delta":{"content":null}}]}`,
-		`{"choices":[{"delta":{"content":"","reasoning":"","reasoning_details":[]}}]}`,
-		`{"choices":[{"delta":{"refusal":"","annotations":[]}}]}`,
-		`{"choices":[{"delta":{}}]}`,
-	} {
-		t.Run(payload, func(t *testing.T) {
-			t.Parallel()
-			p, ok := parseChunkPayload(payload)
-			if !ok {
-				t.Fatal("fixture did not parse")
-			}
-			if got := untypedDeltaBytes(p.delta); got != 0 {
-				t.Errorf("counted %d bytes of output in a delta that carries none", got)
 			}
 		})
 	}
@@ -847,41 +755,6 @@ func TestHandleStreamingResponse_EmptyUntypeableDeltaDoesNotShieldAFailingProvid
 
 	if got := h.circuitBreaker.GetState(providerID); got != failover.StateOpen {
 		t.Errorf("circuit = %v, want open: an empty delta must not shield a provider that failed", got)
-	}
-}
-
-// The observers run before this branch on a chunk that decoded PARTLY, so every
-// member that did decode has already been counted. Adding the raw delta on top
-// billed the same content twice, and a tool-call frame many times over.
-//
-// Read by comparison rather than against a number: the same answer, once in a
-// frame that types cleanly and once in a frame that does not, must cost the
-// caller the same.
-func TestHandleStreamingResponse_UntypeableFrameIsMeteredOnce(t *testing.T) {
-	const answer = "0123456789012345678901234567890123456789"
-	meter := func(t *testing.T, payload string) int {
-		t.Helper()
-		vkRepo := &mockVirtualKeyRepo{}
-		h := newIntegrationHandler()
-		t.Cleanup(func() { stopUnitHandler(h) })
-		h.virtualKeyRepo = vkRepo
-
-		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")), Header: make(http.Header)}
-		logData := newErrorFrameLog()
-		logData.promptTextBytes = 40
-		req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
-		h.handleStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout", vkHash: "test-hash"})
-		return singleAddTokens(t, vkRepo)
-	}
-
-	typed := meter(t, `{"choices":[{"delta":{"content":"`+answer+`"}}]}`)
-	untypeable := meter(t, `{"choices":[{"delta":{"content":"`+answer+`"},"finish_reason":0}]}`)
-
-	if typed == 0 {
-		t.Fatal("the typed control metered nothing, so there is nothing to compare against")
-	}
-	if untypeable != typed {
-		t.Errorf("the same answer cost %d tokens typed and %d untypeable", typed, untypeable)
 	}
 }
 
@@ -1000,5 +873,66 @@ func TestShapeError_RequiresAJSONObject(t *testing.T) {
 				t.Errorf("shapeError(%s) non-nil = %v, want %v", tc.data, got, tc.want)
 			}
 		})
+	}
+}
+
+// A part array of plain TEXT hides nothing, so a strip_reasoning key still gets
+// it. Rejecting every content that is not a string deleted the whole answer for
+// those keys on any content-as-parts stream — reinstating, for one class of key,
+// the exact loss this change exists to stop.
+func TestHandleStreamingResponse_StripReasoningKeepsPlainTextParts(t *testing.T) {
+	for _, payload := range []string{
+		`{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"}]}}]}`,
+		`{"choices":[{"delta":{"content":[{"type":"text","text":"CONTENTMARKER"},{"type":"text","text":" and more"}]}}]}`,
+		`{"choices":[{"delta":{"content":[{"type":"output_text","text":"CONTENTMARKER"}]},"finish_reason":0}]}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			h := newUnitHandler()
+			defer stopUnitHandler(h)
+
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")),
+				Header:     make(http.Header),
+			}
+			w := httptest.NewRecorder()
+			req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+			req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+			h.handleStreamingResponse(w, req, newErrorFrameLog(), resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+			if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
+				t.Errorf("a text-only part array was deleted for a strip_reasoning key: %q", w.Body.String())
+			}
+		})
+	}
+}
+
+// And a frame it withheld is not one the caller can be billed for. The
+// observers run before the drop and counted whatever decoded, so without
+// rolling that back a strip_reasoning caller paid for a stream it never saw.
+func TestHandleStreamingResponse_ADroppedFrameIsNotBilled(t *testing.T) {
+	vkRepo := &mockVirtualKeyRepo{}
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = vkRepo
+
+	// Readable content plus reasoning, on a frame that cannot be typed: the
+	// content is counted by the observers, then the frame is withheld.
+	payload := `{"choices":[{"delta":{"content":"` + strings.Repeat("x", 200) + `","reasoning":"THINKING"},"finish_reason":0}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: " + payload + "\n\ndata: [DONE]\n\n")), Header: make(http.Header)}
+	logData := newErrorFrameLog()
+	logData.promptTextBytes = 40
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyStripReasoningKey, true))
+
+	w := httptest.NewRecorder()
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout", vkHash: "test-hash"})
+
+	if strings.Contains(w.Body.String(), "THINKING") {
+		t.Fatalf("the frame was not withheld, so there is nothing to assert: %q", w.Body.String())
+	}
+	if got := singleAddTokens(t, vkRepo); got != 0 {
+		t.Errorf("billed %d tokens for a frame the caller never received", got)
 	}
 }

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -726,3 +726,24 @@ func TestFinalizeStream_DeliveredContentCountsEveryShapeOfOutput(t *testing.T) {
 		})
 	}
 }
+
+// The role marker is not output. It rides on the first delta of most streams,
+// and counting it would put a few bytes of estimate on a frame that carried the
+// model nothing at all.
+func TestUntypedDeltaBytes_SkipsTheRoleMarker(t *testing.T) {
+	t.Parallel()
+	withRole, ok := parseChunkPayload(`{"choices":[{"delta":{"role":"assistant","content":"hello"}}]}`)
+	if !ok {
+		t.Fatal("fixture did not parse")
+	}
+	withoutRole, ok := parseChunkPayload(`{"choices":[{"delta":{"content":"hello"}}]}`)
+	if !ok {
+		t.Fatal("fixture did not parse")
+	}
+	if got, want := untypedDeltaBytes(withRole.delta), untypedDeltaBytes(withoutRole.delta); got != want {
+		t.Errorf("role added %d bytes to the estimate (%d vs %d)", got-want, got, want)
+	}
+	if untypedDeltaBytes(withoutRole.delta) == 0 {
+		t.Error("content counted as nothing")
+	}
+}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -747,3 +747,47 @@ func TestUntypedDeltaBytes_SkipsTheRoleMarker(t *testing.T) {
 		t.Error("content counted as nothing")
 	}
 }
+
+// The number debits a customer's quota, so it counts the model's text and not
+// the JSON around it. Streaming deltas are a few tokens each, which is exactly
+// where the part wrapper dominates: measuring the raw member bills six to eight
+// times what the model produced.
+func TestUntypedDeltaBytes_CountsTextNotItsWrapper(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		payload string
+		want    int
+	}{
+		{"content as parts", `{"choices":[{"delta":{"content":[{"type":"text","text":"hello"}]}}]}`, 5},
+		{"several parts", `{"choices":[{"delta":{"content":[{"type":"text","text":"hel"},{"type":"text","text":"lo"}]}}]}`, 5},
+		{"a plain string beside an untypeable sibling", `{"choices":[{"delta":{"content":"hello"}}]}`, 5},
+		{"reasoning as parts", `{"choices":[{"delta":{"reasoning":[{"type":"text","text":"hello"}]}}]}`, 5},
+		// A shape neither reading covers is measured whole rather than dropped.
+		{"content as a number", `{"choices":[{"delta":{"content":8675309}}]}`, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p, ok := parseChunkPayload(tc.payload)
+			if !ok {
+				t.Fatal("fixture did not parse")
+			}
+			if got := untypedDeltaBytes(p.delta); got != tc.want {
+				t.Errorf("counted %d bytes, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The scaffolding that addresses a tool call is not what the model produced;
+// the arguments are.
+func TestUntypedDeltaBytes_SkipsToolCallScaffolding(t *testing.T) {
+	t.Parallel()
+	p, ok := parseChunkPayload(`{"choices":[{"delta":{"index":0,"id":"call_abcdefghijklmnop","content":"hi"}}]}`)
+	if !ok {
+		t.Fatal("fixture did not parse")
+	}
+	if got := untypedDeltaBytes(p.delta); got != 2 {
+		t.Errorf("counted %d bytes, want the 2 the model produced", got)
+	}
+}

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -62,22 +62,29 @@ func TestUsage_NestedCountSpellings(t *testing.T) {
 	assert.Equal(t, 2, u.CompletionTokensDetails.ReasoningTokens)
 }
 
-// A member that is not a count in any spelling is still a decode failure. The
-// tolerance is for how a number is written, not for a field holding something
-// else entirely.
-func TestUsage_NonNumericCountIsStillAnError(t *testing.T) {
+// A member that is not a count in any spelling reads as nothing. The tolerance
+// is for how a number is written, not for a field holding something else — and
+// no reading is invented for it, so the count stays zero and the estimator picks
+// the request up. What it must not do is take the rest of the response with it.
+func TestUsage_NonNumericCountReadsAsNothing(t *testing.T) {
 	t.Parallel()
 	for _, raw := range []string{
-		`{"prompt_tokens":"lots"}`,
-		`{"prompt_tokens":{"value":12}}`,
-		`{"prompt_tokens":[12]}`,
-		`{"prompt_tokens":true}`,
+		`{"completion_tokens":3,"prompt_tokens":"lots"}`,
+		`{"completion_tokens":3,"prompt_tokens":{"value":12}}`,
+		`{"completion_tokens":3,"prompt_tokens":[12]}`,
+		`{"completion_tokens":3,"prompt_tokens":true}`,
 	} {
 		t.Run(raw, func(t *testing.T) {
 			t.Parallel()
 			var u Usage
-			if err := json.Unmarshal([]byte(raw), &u); err == nil {
-				t.Errorf("decoded %s as a count: %d", raw, u.PromptTokens)
+			if err := json.Unmarshal([]byte(raw), &u); err != nil {
+				t.Fatalf("usage did not decode: %v", err)
+			}
+			if u.PromptTokens != 0 {
+				t.Errorf("invented a count of %d from %s", u.PromptTokens, raw)
+			}
+			if u.CompletionTokens != 3 {
+				t.Errorf("the count beside it was lost: %d", u.CompletionTokens)
 			}
 		})
 	}
@@ -148,4 +155,90 @@ func TestHandleStreamingResponse_QuotedUsageIsMetered(t *testing.T) {
 
 	assert.Equal(t, 12, logData.tokensPrompt)
 	assert.Equal(t, 3, logData.tokensCompletion)
+}
+
+// The retry bound has to clear the struct it exists for. Usage carries nine
+// integer members and each pass fixes exactly one, and a relay that quotes one
+// count quotes all of them -- so a bound of eight failed on the archetypal
+// caller, which is the case the whole helper was written for.
+func TestUsage_EveryCountQuoted(t *testing.T) {
+	t.Parallel()
+	raw := `{"prompt_tokens":"1","completion_tokens":"2","total_tokens":"3",` +
+		`"prompt_cache_hit_tokens":"4","prompt_cache_miss_tokens":"5",` +
+		`"cache_read_input_tokens":"6","cache_creation_input_tokens":"7",` +
+		`"prompt_tokens_details":{"cached_tokens":"8"},` +
+		`"completion_tokens_details":{"reasoning_tokens":"9"}}`
+	var u Usage
+	require.NoError(t, json.Unmarshal([]byte(raw), &u))
+	assert.Equal(t, 1, u.PromptTokens)
+	assert.Equal(t, 2, u.CompletionTokens)
+	assert.Equal(t, 3, u.TotalTokens)
+	assert.Equal(t, 4, u.PromptCacheHitTokens)
+	assert.Equal(t, 5, u.PromptCacheMissTokens)
+	assert.Equal(t, 6, u.CacheReadInputTokens)
+	assert.Equal(t, 7, u.CacheCreationInputTokens)
+	require.NotNil(t, u.PromptTokensDetails)
+	require.NotNil(t, u.CompletionTokensDetails)
+	assert.Equal(t, 8, u.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 9, u.CompletionTokensDetails.ReasoningTokens)
+}
+
+// A usage member in a shape this gateway has no struct for is the same defect
+// the streaming path fixes one level out, and it had the same cost: Usage
+// returned before assigning, so counts that decoded perfectly were thrown away
+// with it -- and on the non-streaming path that error stops the decode of the
+// response object and the caller loses the answer.
+//
+// [] where an object belongs is a routine relay habit, not an exotic one.
+func TestUsage_KeepsWhatItCouldRead(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		`{"prompt_tokens":12,"completion_tokens":3,"prompt_tokens_details":[]}`,
+		`{"prompt_tokens":12,"completion_tokens":3,"completion_tokens_details":""}`,
+		`{"prompt_tokens":12,"completion_tokens":3,"total_tokens":"lots"}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			var u Usage
+			if err := json.Unmarshal([]byte(raw), &u); err != nil {
+				t.Fatalf("usage did not decode: %v", err)
+			}
+			assert.Equal(t, 12, u.PromptTokens)
+			assert.Equal(t, 3, u.CompletionTokens)
+		})
+	}
+}
+
+// Bytes that are not JSON are still an error: there is nothing to keep.
+func TestUsage_MalformedIsStillAnError(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{`{"prompt_tokens":12`, `{"prompt_tokens":}`} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			var u Usage
+			if err := json.Unmarshal([]byte(raw), &u); err == nil {
+				t.Errorf("decoded malformed usage as %+v", u)
+			}
+		})
+	}
+}
+
+// The whole point, end to end: a usage member the gateway cannot type must not
+// cost the caller the answer the model already produced.
+func TestHandleNonStreamingResponse_UnreadableUsageStillAnswers(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = &mockVirtualKeyRepo{}
+
+	upstreamBody := `{"id":"x","object":"chat.completion","usage":{"prompt_tokens":12,"completion_tokens":3,"prompt_tokens_details":[]},"choices":[{"index":0,"message":{"role":"assistant","content":"Hello, world!"}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(upstreamBody)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := &requestLogData{modelID: "gpt-test", providerID: uuid.New(), virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "pending"}
+
+	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Hello, world!")
+	assert.Equal(t, 12, logData.tokensPrompt)
 }

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -241,4 +241,10 @@ func TestHandleNonStreamingResponse_UnreadableUsageStillAnswers(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Hello, world!")
 	assert.Equal(t, 12, logData.tokensPrompt)
+	// What the re-encoded body says about the member it could not read: its zero
+	// value, because encoding/json allocated the struct before it hit the type
+	// error. A cached count of zero is what an absent breakdown already means to
+	// every consumer, and it is the honest report — the gateway could not read
+	// what the provider put there.
+	assert.Contains(t, w.Body.String(), `"prompt_tokens_details":{"cached_tokens":0}`)
 }

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -241,10 +241,40 @@ func TestHandleNonStreamingResponse_UnreadableUsageStillAnswers(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Hello, world!")
 	assert.Equal(t, 12, logData.tokensPrompt)
-	// What the re-encoded body says about the member it could not read: its zero
-	// value, because encoding/json allocated the struct before it hit the type
-	// error. A cached count of zero is what an absent breakdown already means to
-	// every consumer, and it is the honest report — the gateway could not read
-	// what the provider put there.
-	assert.Contains(t, w.Body.String(), `"prompt_tokens_details":{"cached_tokens":0}`)
+	// And what it says about the member it could NOT read: nothing. The decoder
+	// allocated that struct before it reached the value, so keeping it would
+	// have the gateway emit {"cached_tokens":0} — a positive claim that nothing
+	// was cached, which a cost calculator acts on — in place of whatever the
+	// provider actually wrote. Absent is the honest report.
+	assert.NotContains(t, w.Body.String(), "prompt_tokens_details")
+}
+
+// The pass-through surfaces (/v1/embeddings, /v1/images/*, /v1/audio/*, rerank)
+// read usage with a decoder of their own, and it had the same defect: a count
+// quoted or written with a fraction on it failed the whole decode and the
+// request metered as zero. Same package, same fix.
+func TestExtractPassthroughUsage_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		body            string
+		wantIn, wantOut int
+	}{
+		{"plain", `{"usage":{"prompt_tokens":12,"completion_tokens":3}}`, 12, 3},
+		{"quoted", `{"usage":{"prompt_tokens":"12","completion_tokens":"3"}}`, 12, 3},
+		{"fractional", `{"usage":{"input_tokens":12.0,"output_tokens":3.0}}`, 12, 3},
+		{"quoted total only", `{"usage":{"total_tokens":"15"}}`, 15, 0},
+		// One member unreadable must not cost the counts beside it.
+		{"partly unreadable", `{"usage":{"prompt_tokens":12,"completion_tokens":3,"detail":{"x":1},"total_tokens":["nope"]}}`, 12, 3},
+		{"no usage", `{"data":[]}`, 0, 0},
+		{"not json", `{`, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in, out := extractPassthroughUsage([]byte(tc.body))
+			if in != tc.wantIn || out != tc.wantOut {
+				t.Errorf("got %d/%d, want %d/%d", in, out, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
 }

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -278,3 +278,20 @@ func TestExtractPassthroughUsage_CountSpellings(t *testing.T) {
 		})
 	}
 }
+
+// One breakdown unreadable must not take the readable one with it, and a usage
+// block with no breakdown at all must come through untouched.
+func TestUsage_KeepsTheBreakdownItCouldRead(t *testing.T) {
+	t.Parallel()
+	var both Usage
+	require.NoError(t, json.Unmarshal([]byte(`{"prompt_tokens":12,"prompt_tokens_details":{"cached_tokens":8},"completion_tokens_details":[]}`), &both))
+	require.NotNil(t, both.PromptTokensDetails, "the breakdown that decoded was dropped with the one that did not")
+	assert.Equal(t, 8, both.PromptTokensDetails.CachedTokens)
+	assert.Nil(t, both.CompletionTokensDetails, "a breakdown that did not decode must be reported absent")
+
+	// A shape error with no breakdown present at all.
+	var neither Usage
+	require.NoError(t, json.Unmarshal([]byte(`{"prompt_tokens":12,"total_tokens":[1]}`), &neither))
+	assert.Equal(t, 12, neither.PromptTokens)
+	assert.Nil(t, neither.PromptTokensDetails)
+}

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -1,0 +1,151 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// usageSpellings are the ways a count arrives that are not the plain integer the
+// schema asks for. A relay that did its arithmetic in floating point emits 12.0;
+// several emit the count quoted. A plain int field rejects both, and Usage has
+// its own UnmarshalJSON — so the error does not merely blank the usage, it stops
+// the surrounding decode where it stands.
+var usageSpellings = []struct {
+	name  string
+	usage string
+}{
+	{"plain integers", `{"prompt_tokens":12,"completion_tokens":3,"total_tokens":15}`},
+	{"floating point", `{"prompt_tokens":12.0,"completion_tokens":3.0,"total_tokens":15.0}`},
+	{"quoted", `{"prompt_tokens":"12","completion_tokens":"3","total_tokens":"15"}`},
+	{"quoted floats", `{"prompt_tokens":"12.0","completion_tokens":"3.0","total_tokens":"15.0"}`},
+	{"mixed", `{"prompt_tokens":"12","completion_tokens":3.0,"total_tokens":15}`},
+}
+
+func TestUsage_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range usageSpellings {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var u Usage
+			if err := json.Unmarshal([]byte(tc.usage), &u); err != nil {
+				t.Fatalf("usage did not decode: %v", err)
+			}
+			if u.PromptTokens != 12 || u.CompletionTokens != 3 || u.TotalTokens != 15 {
+				t.Errorf("got prompt=%d completion=%d total=%d, want 12/3/15", u.PromptTokens, u.CompletionTokens, u.TotalTokens)
+			}
+		})
+	}
+}
+
+// The nested breakdowns are counts too, and the cache split is what keeps a
+// cached prompt from being priced at the full input rate.
+func TestUsage_NestedCountSpellings(t *testing.T) {
+	t.Parallel()
+	var u Usage
+	raw := `{"prompt_tokens":"12","prompt_tokens_details":{"cached_tokens":"8"},"completion_tokens_details":{"reasoning_tokens":2.0}}`
+	if err := json.Unmarshal([]byte(raw), &u); err != nil {
+		t.Fatalf("usage did not decode: %v", err)
+	}
+	require.NotNil(t, u.PromptTokensDetails)
+	require.NotNil(t, u.CompletionTokensDetails)
+	assert.Equal(t, 8, u.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 2, u.CompletionTokensDetails.ReasoningTokens)
+}
+
+// A member that is not a count in any spelling is still a decode failure. The
+// tolerance is for how a number is written, not for a field holding something
+// else entirely.
+func TestUsage_NonNumericCountIsStillAnError(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		`{"prompt_tokens":"lots"}`,
+		`{"prompt_tokens":{"value":12}}`,
+		`{"prompt_tokens":[12]}`,
+		`{"prompt_tokens":true}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			var u Usage
+			if err := json.Unmarshal([]byte(raw), &u); err == nil {
+				t.Errorf("decoded %s as a count: %d", raw, u.PromptTokens)
+			}
+		})
+	}
+}
+
+// Counts are re-encoded as the integers the schema asks for, whatever spelling
+// arrived — the non-streaming path decodes and re-emits the whole body, and the
+// caller is entitled to the shape it asked this gateway for.
+func TestUsage_ReencodesAsIntegers(t *testing.T) {
+	t.Parallel()
+	var u Usage
+	require.NoError(t, json.Unmarshal([]byte(`{"prompt_tokens":"12","completion_tokens":3.0,"cost":0.004}`), &u))
+	out, err := json.Marshal(u)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"prompt_tokens":12`)
+	assert.Contains(t, string(out), `"completion_tokens":3`)
+	// The unmodelled members still ride through untouched.
+	assert.Contains(t, string(out), `"cost":0.004`)
+}
+
+// End to end on the non-streaming path, which is where the damage is worst:
+// Usage.UnmarshalJSON returning an error aborts the decode of the response
+// object around it, so a quoted count cost the caller its answer.
+func TestHandleNonStreamingResponse_QuotedUsageStillAnswers(t *testing.T) {
+	vkRepo := &mockVirtualKeyRepo{}
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.virtualKeyRepo = vkRepo
+
+	upstreamBody := `{"id":"x","object":"chat.completion","usage":{"prompt_tokens":"12","completion_tokens":"3"},"choices":[{"index":0,"message":{"role":"assistant","content":"Hello, world!"}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(upstreamBody)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	logData := &requestLogData{
+		modelID:        "gpt-test",
+		providerID:     uuid.New(),
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "pending",
+	}
+	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Hello, world!")
+	assert.Equal(t, 12, logData.tokensPrompt)
+	assert.Equal(t, 3, logData.tokensCompletion)
+	// Measured usage, so nothing is estimated: 12+3 reaches the meter.
+	assert.Equal(t, 15, singleAddTokens(t, vkRepo))
+}
+
+// The streaming path meters from the usage chunk. A count it could not read was
+// no longer costing the caller the frame (an untypeable frame is forwarded now),
+// but it still put the request on an estimate when the provider had said exactly
+// what it billed.
+func TestHandleStreamingResponse_QuotedUsageIsMetered(t *testing.T) {
+	h := newUnitHandler()
+	defer stopUnitHandler(h)
+
+	body := `data: {"choices":[{"delta":{"content":"hi"}}]}` + "\n\n" +
+		`data: {"choices":[],"usage":{"prompt_tokens":"12","completion_tokens":3.0}}` + "\n\n" +
+		"data: [DONE]\n\n"
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+	req := withAuthContext(httptest.NewRequest("GET", "/", http.NoBody))
+	logData := newErrorFrameLog()
+
+	h.handleStreamingResponse(w, req, logData, resp, time.Now(), streamOptions{cancelOrigin: "failover_timeout"})
+
+	assert.Equal(t, 12, logData.tokensPrompt)
+	assert.Equal(t, 3, logData.tokensCompletion)
+}

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -1,0 +1,169 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// maxCountCoercions bounds the retry loop. Each pass fixes exactly one member,
+// so this is the number of differently-spelled counts one object may carry
+// before the decode is allowed to fail — comfortably more than any usage block
+// has fields, and a hard stop on a document that keeps producing type errors.
+const maxCountCoercions = 8
+
+// maxCount is the largest value a count is accepted as. A token count is bounded
+// by a context window; a value past this is not a count in another spelling, it
+// is a different kind of wrong, and rounding it into an int would report a
+// number the provider never sent.
+const maxCount = math.MaxInt32
+
+// DecodeCounts unmarshals data into dst, tolerating a count written in a
+// spelling other than the plain JSON integer the schema asks for: quoted
+// ("12"), or carrying a fraction (12.0), which is what a relay that did its
+// arithmetic in floating point emits.
+//
+// This is not leniency applied across the document. The strict decode runs
+// first, and a body that decodes cleanly never reaches the rest of this
+// function. When it does not, only the member encoding/json NAMED in its
+// UnmarshalTypeError is rewritten, and only when the struct declared that member
+// as an integer and the value really is a number written differently. A field
+// holding something that is not a count at all ("lots", an object, a list) still
+// fails, and it fails with the original error rather than a second-hand one.
+//
+// The rewrite is fed to the decoder, not returned: the caller keeps its original
+// bytes, so anything it reads from them separately — an overflow map of
+// unmodelled members, say — still sees exactly what the provider sent.
+//
+// Why it is worth doing at all: a count is metering, and metering is billing,
+// but the decode that fails takes far more than the count with it. Usage decodes
+// through an UnmarshalJSON of its own, and an error there stops the decode of
+// the response object around it, so one quoted token count returned the caller
+// "the provider returned a response the gateway could not decode" in place of
+// the answer the model had already produced.
+func DecodeCounts(data []byte, dst any) error {
+	err := json.Unmarshal(data, dst)
+	for range maxCountCoercions {
+		if err == nil {
+			return nil
+		}
+		var typeErr *json.UnmarshalTypeError
+		if !errors.As(err, &typeErr) || typeErr.Field == "" || !isIntegerKind(typeErr.Type) {
+			return err
+		}
+		coerced, ok := coerceCount(data, typeErr.Field)
+		if !ok {
+			return err
+		}
+		data = coerced
+		// Cleared between passes so a member that decoded on an earlier one
+		// cannot survive into a document it is no longer in.
+		zero(dst)
+		err = json.Unmarshal(data, dst)
+	}
+	return err
+}
+
+func isIntegerKind(t reflect.Type) bool {
+	if t == nil {
+		return false
+	}
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	default:
+		return false
+	}
+}
+
+func zero(dst any) {
+	v := reflect.ValueOf(dst)
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
+		v.Elem().Set(reflect.Zero(v.Elem().Type()))
+	}
+}
+
+// coerceCount rewrites the member at path into a plain JSON integer, reporting
+// whether it could. Numbers are re-read with UseNumber so every value the
+// rewrite does not touch keeps the literal the provider wrote.
+func coerceCount(data []byte, path string) ([]byte, bool) {
+	var root any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if dec.Decode(&root) != nil {
+		return nil, false
+	}
+	obj, key, ok := locate(root, path)
+	if !ok {
+		return nil, false
+	}
+	n, ok := asCount(obj[key])
+	if !ok {
+		return nil, false
+	}
+	obj[key] = n
+	out, err := json.Marshal(root)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// locate walks the dotted member path encoding/json reports and returns the
+// object holding the leaf. A key containing a dot is matched whole before the
+// path is split, which covers it at the level it appears on.
+func locate(v any, path string) (map[string]any, string, bool) {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, "", false
+	}
+	if _, exists := obj[path]; exists {
+		return obj, path, true
+	}
+	head, rest, found := strings.Cut(path, ".")
+	if !found {
+		return nil, "", false
+	}
+	return locate(obj[head], rest)
+}
+
+// asCount reads a count out of the two spellings that are not a JSON integer.
+// A value that already IS one is refused: it was not what the decoder tripped
+// over, and rewriting it would be a change with no reason behind it.
+func asCount(v any) (json.Number, bool) {
+	switch v := v.(type) {
+	case json.Number:
+		if _, err := v.Int64(); err == nil {
+			return "", false
+		}
+		f, err := v.Float64()
+		if err != nil {
+			return "", false
+		}
+		return roundToCount(f)
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return "", false
+		}
+		return roundToCount(f)
+	default:
+		return "", false
+	}
+}
+
+func roundToCount(f float64) (json.Number, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return "", false
+	}
+	r := math.Round(f)
+	if r > maxCount || r < -maxCount {
+		return "", false
+	}
+	return json.Number(strconv.FormatInt(int64(r), 10)), true
+}

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -88,6 +88,9 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 	var root any
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
+	// Unreachable if the caller's reasoning holds — a type error means the
+	// document parsed — and kept as the guard for the case where it does not.
+	// Refusing to rewrite leaves the decoder's own error to come back.
 	if dec.Decode(&root) != nil {
 		return nil, false
 	}

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -10,11 +10,18 @@ import (
 	"strings"
 )
 
-// maxCountCoercions bounds the retry loop. Each pass fixes exactly one member,
-// so this is the number of differently-spelled counts one object may carry
-// before the decode is allowed to fail — comfortably more than any usage block
-// has fields, and a hard stop on a document that keeps producing type errors.
-const maxCountCoercions = 8
+// maxCountCoercions bounds the retry loop.
+//
+// A runaway guard, not a schema limit. Each pass fixes exactly one member, and
+// asCount refuses a value that already reads as an integer, so the loop cannot
+// re-fire on a member it has fixed and terminates on its own. The bound is here
+// only so a document nobody anticipated cannot spin.
+//
+// It was 8, with a comment calling that "comfortably more than any usage block
+// has fields". The usage block it was written for has NINE integer members, and
+// a relay that quotes one count quotes all of them — so the archetypal caller
+// was one member past the bound and lost the whole response.
+const maxCountCoercions = 64
 
 // maxCount is the largest value a count is accepted as. A token count is bounded
 // by a context window; a value past this is not a count in another spelling, it

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -91,15 +91,15 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 	if dec.Decode(&root) != nil {
 		return nil, false
 	}
-	obj, key, ok := locate(root, path)
+	holder, key, ok := locate(root, path)
 	if !ok {
 		return nil, false
 	}
-	n, ok := asCount(obj[key])
+	n, ok := asCount(holder.get(key))
 	if !ok {
 		return nil, false
 	}
-	obj[key] = n
+	holder.set(key, n)
 	out, err := json.Marshal(root)
 	if err != nil {
 		return nil, false
@@ -108,21 +108,64 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 }
 
 // locate walks the dotted member path encoding/json reports and returns the
-// object holding the leaf. A key containing a dot is matched whole before the
-// path is split, which covers it at the level it appears on.
-func locate(v any, path string) (map[string]any, string, bool) {
-	obj, ok := v.(map[string]any)
-	if !ok {
+// container holding the leaf, addressed by a key or an index.
+//
+// The path steps through arrays as well as objects: the decoder writes the index
+// into it, so a count inside a list reads as rows.1.count. A key containing a
+// dot is matched whole before the path is split, which covers it at the level it
+// appears on. A path that does not resolve simply yields no rewrite, and the
+// caller returns the decoder's original error.
+func locate(v any, path string) (container, string, bool) {
+	head, rest, nested := strings.Cut(path, ".")
+	switch v := v.(type) {
+	case map[string]any:
+		if _, exists := v[path]; exists {
+			return objectContainer(v), path, true
+		}
+		if !nested {
+			return nil, "", false
+		}
+		return locate(v[head], rest)
+	case []any:
+		i, err := strconv.Atoi(head)
+		if err != nil || i < 0 || i >= len(v) {
+			return nil, "", false
+		}
+		if !nested {
+			return sliceContainer(v), head, true
+		}
+		return locate(v[i], rest)
+	default:
 		return nil, "", false
 	}
-	if _, exists := obj[path]; exists {
-		return obj, path, true
+}
+
+// container is the object or array a located member sits in, read and written
+// by the key or index the path named.
+type container interface {
+	get(key string) any
+	set(key string, v json.Number)
+}
+
+type objectContainer map[string]any
+
+func (c objectContainer) get(key string) any            { return c[key] }
+func (c objectContainer) set(key string, v json.Number) { c[key] = v }
+
+type sliceContainer []any
+
+func (c sliceContainer) get(key string) any {
+	i, err := strconv.Atoi(key)
+	if err != nil || i < 0 || i >= len(c) {
+		return nil
 	}
-	head, rest, found := strings.Cut(path, ".")
-	if !found {
-		return nil, "", false
+	return c[i]
+}
+
+func (c sliceContainer) set(key string, v json.Number) {
+	if i, err := strconv.Atoi(key); err == nil && i >= 0 && i < len(c) {
+		c[i] = v
 	}
-	return locate(obj[head], rest)
 }
 
 // asCount reads a count out of the two spellings that are not a JSON integer.

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -59,10 +59,10 @@ func DecodeCounts(data []byte, dst any) error {
 		if !ok {
 			return err
 		}
+		// dst is not cleared between passes: every pass decodes the same
+		// document with one member rewritten, so each sets the same fields to the
+		// same values, and encoding/json never clears a field it does not visit.
 		data = coerced
-		// Cleared between passes so a member that decoded on an earlier one
-		// cannot survive into a document it is no longer in.
-		zero(dst)
 		err = json.Unmarshal(data, dst)
 	}
 	return err
@@ -78,13 +78,6 @@ func isIntegerKind(t reflect.Type) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-func zero(dst any) {
-	v := reflect.ValueOf(dst)
-	if v.Kind() == reflect.Pointer && !v.IsNil() {
-		v.Elem().Set(reflect.Zero(v.Elem().Type()))
 	}
 }
 
@@ -133,8 +126,13 @@ func locate(v any, path string) (map[string]any, string, bool) {
 }
 
 // asCount reads a count out of the two spellings that are not a JSON integer.
-// A value that already IS one is refused: it was not what the decoder tripped
-// over, and rewriting it would be a change with no reason behind it.
+//
+// A value that already IS one is refused. It is not what this function is for,
+// and rewriting it would produce a document identical to the one that just
+// failed — so the loop above would spend its whole budget re-running a decode
+// that cannot start succeeding. That is reachable: an integer too large for the
+// field it lands in (300 into an int8) is a type error on a value already
+// written as an integer.
 func asCount(v any) (json.Number, bool) {
 	switch v := v.(type) {
 	case json.Number:

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -1,0 +1,191 @@
+package util_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+type countBlock struct {
+	Prompt     int          `json:"prompt_tokens"`
+	Completion int          `json:"completion_tokens"`
+	Label      string       `json:"label"`
+	Details    *countDetail `json:"details"`
+}
+
+type countDetail struct {
+	Cached int `json:"cached_tokens"`
+}
+
+func TestDecodeCounts_Spellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"plain integer", `{"prompt_tokens":12}`, 12},
+		{"quoted", `{"prompt_tokens":"12"}`, 12},
+		{"quoted with space", `{"prompt_tokens":" 12 "}`, 12},
+		{"fractional", `{"prompt_tokens":12.0}`, 12},
+		{"quoted fractional", `{"prompt_tokens":"12.0"}`, 12},
+		{"exponent", `{"prompt_tokens":1.2e1}`, 12},
+		// Rounded rather than truncated: a fractional count is floating-point
+		// residue, and 11.999999 is a report of 12.
+		{"rounds to nearest", `{"prompt_tokens":11.9999999}`, 12},
+		{"negative", `{"prompt_tokens":"-1"}`, -1},
+		{"zero", `{"prompt_tokens":"0"}`, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got countBlock
+			if err := util.DecodeCounts([]byte(tc.raw), &got); err != nil {
+				t.Fatalf("DecodeCounts(%s): %v", tc.raw, err)
+			}
+			if got.Prompt != tc.want {
+				t.Errorf("prompt = %d, want %d", got.Prompt, tc.want)
+			}
+		})
+	}
+}
+
+// The tolerance is for how a number is written. Anything else is a member
+// holding something that is not a count, and it must still fail — with the
+// decoder's own error, not one invented on the way past.
+func TestDecodeCounts_RefusesWhatIsNotACount(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		`{"prompt_tokens":"lots"}`,
+		`{"prompt_tokens":""}`,
+		`{"prompt_tokens":{"value":12}}`,
+		`{"prompt_tokens":[12]}`,
+		`{"prompt_tokens":true}`,
+		// Past any context window. Rounding this into an int would report a
+		// number the provider never sent.
+		`{"prompt_tokens":1e30}`,
+		`{"prompt_tokens":"1e30"}`,
+		// Not a number at all, however it is spelled.
+		`{"prompt_tokens":"NaN"}`,
+		`{"prompt_tokens":"Inf"}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			var got countBlock
+			if err := util.DecodeCounts([]byte(raw), &got); err == nil {
+				t.Errorf("decoded as a count: %d", got.Prompt)
+			}
+		})
+	}
+}
+
+// A string field that happens to hold digits is not touched. Only the member the
+// decoder named, and only when the struct wants an integer there.
+func TestDecodeCounts_LeavesNonCountFieldsAlone(t *testing.T) {
+	t.Parallel()
+	var got countBlock
+	if err := util.DecodeCounts([]byte(`{"label":"12","prompt_tokens":"7"}`), &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if got.Label != "12" {
+		t.Errorf("label = %q, want the string it arrived as", got.Label)
+	}
+	if got.Prompt != 7 {
+		t.Errorf("prompt = %d, want 7", got.Prompt)
+	}
+}
+
+// Every differently-spelled count in one object, including a nested one, and
+// each fixed on its own pass.
+func TestDecodeCounts_SeveralMembersAndNesting(t *testing.T) {
+	t.Parallel()
+	var got countBlock
+	raw := `{"prompt_tokens":"12","completion_tokens":3.0,"details":{"cached_tokens":"8"}}`
+	if err := util.DecodeCounts([]byte(raw), &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if got.Prompt != 12 || got.Completion != 3 {
+		t.Errorf("got prompt=%d completion=%d, want 12/3", got.Prompt, got.Completion)
+	}
+	if got.Details == nil || got.Details.Cached != 8 {
+		t.Errorf("nested count = %+v, want 8", got.Details)
+	}
+}
+
+// The caller's bytes are its own: the rewrite is fed to the decoder and never
+// handed back, because callers read those same bytes for what this struct does
+// not model.
+func TestDecodeCounts_DoesNotMutateTheCallersBytes(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"prompt_tokens":"12"}`)
+	original := string(raw)
+	var got countBlock
+	if err := util.DecodeCounts(raw, &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if string(raw) != original {
+		t.Errorf("input was rewritten in place: %q, want %q", raw, original)
+	}
+}
+
+// A document that is not JSON, or not an object, never reaches the rewrite: the
+// decoder's error is not an UnmarshalTypeError and comes straight back.
+func TestDecodeCounts_PassesThroughOtherErrors(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{`{"prompt_tokens":`, `[1,2]`, `"nope"`} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			var got countBlock
+			if err := util.DecodeCounts([]byte(raw), &got); err == nil {
+				t.Error("want an error")
+			}
+		})
+	}
+}
+
+// The retry is bounded. A document with more differently-spelled counts than the
+// bound fails rather than looping, and one within it succeeds — which is what
+// makes the bound a limit rather than a number nothing ever reaches.
+func TestDecodeCounts_RetryIsBounded(t *testing.T) {
+	t.Parallel()
+	type wide struct {
+		A, B, C, D, E, F, G, H, I, J int
+	}
+	build := func(n int) string {
+		names := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
+		parts := make([]string, 0, len(names))
+		for i, name := range names {
+			if i < n {
+				parts = append(parts, `"`+name+`":"1"`)
+			} else {
+				parts = append(parts, `"`+name+`":1`)
+			}
+		}
+		return "{" + strings.Join(parts, ",") + "}"
+	}
+	var within wide
+	if err := util.DecodeCounts([]byte(build(8)), &within); err != nil {
+		t.Errorf("eight quoted counts must decode: %v", err)
+	}
+	var beyond wide
+	if err := util.DecodeCounts([]byte(build(10)), &beyond); err == nil {
+		t.Error("ten quoted counts must exhaust the retry bound rather than loop")
+	}
+}
+
+// json.Number round-trips as the literal that was written, so a value the
+// rewrite does not touch is not reformatted on its way to the decoder.
+func TestDecodeCounts_LeavesOtherNumbersLiteral(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		Prompt int             `json:"prompt_tokens"`
+		Cost   json.RawMessage `json:"cost"`
+	}
+	if err := util.DecodeCounts([]byte(`{"prompt_tokens":"12","cost":0.00000004}`), &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if string(got.Cost) != "0.00000004" {
+		t.Errorf("cost = %s, want the literal the provider wrote", got.Cost)
+	}
+}

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -66,6 +66,8 @@ func TestDecodeCounts_RefusesWhatIsNotACount(t *testing.T) {
 		// number the provider never sent.
 		`{"prompt_tokens":1e30}`,
 		`{"prompt_tokens":"1e30"}`,
+		// Past float64 itself, so it does not even reach the ceiling check.
+		`{"prompt_tokens":1e999}`,
 		// Not a number at all, however it is spelled.
 		`{"prompt_tokens":"NaN"}`,
 		`{"prompt_tokens":"Inf"}`,
@@ -220,5 +222,52 @@ func TestDecodeCounts_WalksArrayIndices(t *testing.T) {
 	}
 	if len(got.Rows) != 2 || got.Rows[1].Count != 2 {
 		t.Errorf("rows = %+v, want the second count read as 2", got.Rows)
+	}
+}
+
+// A count that IS the array element, rather than a member of an object inside
+// one: the path ends at the index, so the rewrite addresses the slice directly.
+func TestDecodeCounts_CoercesAnArrayElement(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		Counts []int `json:"counts"`
+	}
+	if err := util.DecodeCounts([]byte(`{"counts":[1,"2",3.0]}`), &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if len(got.Counts) != 3 || got.Counts[1] != 2 || got.Counts[2] != 3 {
+		t.Errorf("counts = %v, want [1 2 3]", got.Counts)
+	}
+}
+
+// The tolerance is for counts, and a count is an integer. A field the struct
+// declared as a float is not one, so a quoted value there is left to fail rather
+// than quietly given a second reading this function never argued for.
+func TestDecodeCounts_OnlyIntegerFields(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		raw  string
+		dst  any
+	}{
+		{"float", `{"v":"1"}`, &struct {
+			V float64 `json:"v"`
+		}{}},
+		{"bool", `{"v":"1"}`, &struct {
+			V bool `json:"v"`
+		}{}},
+		// The other direction, and the one that matters most: a number arriving
+		// where a string is wanted is the model's own output written as one.
+		// Rewriting it would be this function inventing a reading of content.
+		{"string", `{"v":1}`, &struct {
+			V string `json:"v"`
+		}{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := util.DecodeCounts([]byte(tc.raw), tc.dst); err == nil {
+				t.Errorf("coerced into a %s field: %+v", tc.name, tc.dst)
+			}
+		})
 	}
 }

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -35,6 +35,11 @@ func TestDecodeCounts_Spellings(t *testing.T) {
 		// Rounded rather than truncated: a fractional count is floating-point
 		// residue, and 11.999999 is a report of 12.
 		{"rounds to nearest", `{"prompt_tokens":11.9999999}`, 12},
+		// Deliberately not floored. This helper changes the spelling of a
+		// number, and an unquoted -1 has always decoded to -1 — refusing the
+		// quoted one would put a validation rule in the one place that cannot
+		// enforce it. A count that must be non-negative belongs where it is
+		// metered, not where it is read.
 		{"negative", `{"prompt_tokens":"-1"}`, -1},
 		{"zero", `{"prompt_tokens":"0"}`, 0},
 	} {
@@ -146,33 +151,33 @@ func TestDecodeCounts_PassesThroughOtherErrors(t *testing.T) {
 	}
 }
 
-// The retry is bounded. A document with more differently-spelled counts than the
-// bound fails rather than looping, and one within it succeeds — which is what
-// makes the bound a limit rather than a number nothing ever reaches.
+// The retry is a runaway guard, and a guard has to actually stop. Each pass
+// fixes one member, so a document with more differently-spelled counts than the
+// bound must come back with an error rather than spin — and one within it must
+// decode, which is what keeps the bound from being a number nothing reaches.
 func TestDecodeCounts_RetryIsBounded(t *testing.T) {
 	t.Parallel()
-	type wide struct {
-		A, B, C, D, E, F, G, H, I, J int
+	var quoted struct {
+		Counts []int `json:"counts"`
 	}
-	build := func(n int) string {
-		names := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
-		parts := make([]string, 0, len(names))
-		for i, name := range names {
-			if i < n {
-				parts = append(parts, `"`+name+`":"1"`)
-			} else {
-				parts = append(parts, `"`+name+`":1`)
-			}
+	build := func(n int) []byte {
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = `"1"`
 		}
-		return "{" + strings.Join(parts, ",") + "}"
+		return []byte(`{"counts":[` + strings.Join(parts, ",") + `]}`)
 	}
-	var within wide
-	if err := util.DecodeCounts([]byte(build(8)), &within); err != nil {
-		t.Errorf("eight quoted counts must decode: %v", err)
+	if err := util.DecodeCounts(build(60), &quoted); err != nil {
+		t.Errorf("sixty quoted counts are within the bound: %v", err)
 	}
-	var beyond wide
-	if err := util.DecodeCounts([]byte(build(10)), &beyond); err == nil {
-		t.Error("ten quoted counts must exhaust the retry bound rather than loop")
+	if len(quoted.Counts) != 60 {
+		t.Errorf("read %d counts, want 60", len(quoted.Counts))
+	}
+	var beyond struct {
+		Counts []int `json:"counts"`
+	}
+	if err := util.DecodeCounts(build(100), &beyond); err == nil {
+		t.Error("a hundred must exhaust the bound rather than loop")
 	}
 }
 

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -202,3 +202,23 @@ func TestDecodeCounts_IntegerTooLargeForItsFieldStillFails(t *testing.T) {
 		t.Errorf("300 decoded into an int8 as %d", got.Small)
 	}
 }
+
+// encoding/json puts array indices in the member path (choices.0.finish_reason
+// is what the streaming warn logs), so the walk has to step through slices as
+// well as objects. Usage carries no arrays today; a caller that does must not
+// silently lose the coercion.
+func TestDecodeCounts_WalksArrayIndices(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		Rows []struct {
+			Count int `json:"count"`
+		} `json:"rows"`
+	}
+	raw := `{"rows":[{"count":1},{"count":"2"}]}`
+	if err := util.DecodeCounts([]byte(raw), &got); err != nil {
+		t.Fatalf("DecodeCounts: %v", err)
+	}
+	if len(got.Rows) != 2 || got.Rows[1].Count != 2 {
+		t.Errorf("rows = %+v, want the second count read as 2", got.Rows)
+	}
+}

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -189,3 +189,16 @@ func TestDecodeCounts_LeavesOtherNumbersLiteral(t *testing.T) {
 		t.Errorf("cost = %s, want the literal the provider wrote", got.Cost)
 	}
 }
+
+// An integer too large for the field it lands in is a type error on a value that
+// is already written as an integer. There is no other spelling to try, and
+// rewriting it would hand the loop the document that just failed.
+func TestDecodeCounts_IntegerTooLargeForItsFieldStillFails(t *testing.T) {
+	t.Parallel()
+	var got struct {
+		Small int8 `json:"prompt_tokens"`
+	}
+	if err := util.DecodeCounts([]byte(`{"prompt_tokens":300}`), &got); err == nil {
+		t.Errorf("300 decoded into an int8 as %d", got.Small)
+	}
+}

--- a/internal/util/errormember.go
+++ b/internal/util/errormember.go
@@ -34,6 +34,21 @@ import (
 // a second opinion is only ever a way for them to disagree, and the disagreement
 // costs a hedged race to a provider whose failure is then never recorded.
 func ErrorMemberCarries(raw json.RawMessage) bool {
+	return ValueCarries(raw)
+}
+
+// ValueCarries is the emptiness rule above, without the error-member framing:
+// does this JSON value leave a reader anything at all?
+//
+// The streaming path asks it of a delta's members too. A reasoning marker a
+// relay stamps on every non-reasoning frame ("reasoning":"" or
+// "reasoning_details":[]) is present without carrying anything, and a rule that
+// read presence dropped the answer beside it on every frame; and a member that
+// carries nothing is not output, so it must not be metered as delivery.
+//
+// Same rule, deliberately: a second reading of "is there anything here" is only
+// ever a way for two callers to disagree.
+func ValueCarries(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
 	}


### PR DESCRIPTION
`handleDataChunk` read "did this fit my structs" as "were these bytes even JSON" and dropped the frame on either. One unmodelled sibling therefore deleted a whole frame from the caller's stream, and the same reading, one struct away, cost a usage block and an Anthropic error event.

## A frame the gateway cannot type is still the provider's answer

`json.Unmarshal` checks the whole document for well-formedness before it decodes any of it, so an `UnmarshalTypeError` proves the bytes are valid JSON, and the decoder records that error and carries on with the siblings. A relay numbering its stop reasons, content as the array of parts the OpenAI schema now permits, reasoning as a list of blocks: each of those deleted the frame, and with it the observers, the masking, and the error member.

Such a frame is now observed, masked and forwarded verbatim. It skips the transforms that rebuild it from the typed chunk (the member that failed is missing from that struct, so rebuilding a content-as-parts frame re-emits it with an empty delta) but not tool-argument normalisation, which works over the payload as a map of raw members. Bytes that are not JSON at all are still dropped.

The validity is **checked**, not inferred: `shapeError` runs `json.Valid`. `json.Decoder` makes no such promise and `GOEXPERIMENT=jsonv2` decodes streaming, where a type error can be reported before a later syntax error is reached — one pass over a small frame on a path that has already failed, against a build flag silently turning truncated bytes into merely mis-shaped ones.

## The Anthropic error event, read with the rule the gateway shares

P1-C kept a private object type for the error member and had both defects the shared rule exists to prevent. Any other shape failed the whole decode and the branch fell silent. And it counted an error whose message is empty — `errorChunkCount` is what tells `writeTerminalError` the client has already been shown the provider's error, so an empty member spent that on nothing and then suppressed the terminal frame for whatever really did end the stream. A delta, an empty error event and a reset connection left the caller with a cut stream and no reason for it.

## A count is a count however the provider spelled it

`Usage` has an `UnmarshalJSON` of its own, so an error there stops the decode of the response object around it. One quoted token count returned the caller `"the provider returned a response the gateway could not decode"` in place of the answer the model had already produced.

`util.DecodeCounts` tolerates the two spellings that are not the schema's plain integer — quoted, and fractional (what a relay that did its arithmetic in floating point emits). Nothing is coerced speculatively: the strict decode runs first, and only the member `encoding/json` named is rewritten, and only when the struct declared it as an integer and the value really is a number written differently. `"lots"`, an object, a list, or a magnitude past any context window still fail. `Usage` also keeps whatever did decode when one member is unmodelled — `prompt_tokens_details` as `[]` rather than `{}` used to cost the caller the whole answer.

## strip_reasoning

A frame this gateway cannot type cannot be stripped by `computeStripReasoning` either — its "does this delta still carry anything" verdict reads content as a plain string, so a content-as-parts delta looks empty to it and becomes a keep-alive, taking the answer with it. So a key with the flag set gets such a frame dropped, but only when it might be hiding something: a reasoning member that *carries* (`"reasoning":""` is what the OpenRouter family stamps on every non-reasoning delta, and gating on presence deleted the answer beside it), or a content part whose type this gateway does not recognise. A part array of plain text hides nothing and is forwarded. A frame that is withheld is not billed to the caller.

## Verified live

Rebuilt dev stack against a mock provider emitting each shape. Content as parts, a numeric finish_reason and a numeric answer all reach the caller (all four were dropped before); a credential relayed inside an untypeable error frame comes back `[redacted]`; a key-shaped token in *content* is left alone; malformed bytes and top-level non-objects stay dropped; a quoted usage block meters 12/3 on both the streaming and non-streaming paths; a partly-readable usage block no longer zeroes the counts an earlier chunk reported; an empty Anthropic error event no longer eats the terminal frame; and a `strip_reasoning` key gets plain text parts but not a thinking part.

`request_logs` and the app log were scanned after each run: zero occurrences of the model's answer, the relayed credential, the gateway's own key, or the virtual key.

## Review

Four independent subagent rounds. Every round found real defects in the previous round's fixes, twice at blocker severity — the fixes written under review pressure were consistently the least-reviewed code in the branch. The two that mattered most, both introduced mid-review and both caught before merge: a forwarded frame counted as delivery credited the circuit breaker on an *empty* stream, so a provider failing every request could never open its circuit; and `deltaCarriesReasoning` gated on presence rather than meaning, which is the same mistake #810 spent three rounds on, made again one function away.

Round 4 is why the byte estimate for an unreadable frame is gone rather than fixed. Four rounds produced four wrong answers to "how many bytes of output are in a frame I cannot parse" — raw length billed a tool-call frame nine times over; skipping empty members missed that `[{"type":"text","text":""}]` carries a non-empty *type* string; reading text out of parts billed a whole base64 data URI and metered whitespace-only output as zero while erasing what the observers had got right. The question was the mistake. The observers already count every member that decoded, correctly, across every choice, and that count now simply stands.

Twenty mutations across the branch, every one killed by a named test. Three survivors were removed rather than papered over: a reset the retry loop never needed, a bound nothing was asserting, and — found by mutation, not by review — the part-type rule with no test behind it.

## Not in this PR

- **An answer delivered only in a shape this gateway cannot read is unbilled** when the provider also reports no usage. That is a revenue gap, in the safe direction: the caller receives content master deleted outright. Reading text out of a part array is the content-as-parts work and is queued with it.
- The retirement verdict reads such a stream as having produced nothing where the TTFT probe is switched off. Same cause, same queue entry.
- Counts are not floored at zero. This changes how a number is *spelled*; an unquoted `-1` has always decoded to `-1`, and a non-negative rule belongs where counts are metered.
- `internal/anthropic`, `internal/openairesponses` and `internal/gemini` have usage structs with the same exposure; queued separately.
- A `400 invalid model format`, and any burst of concurrent requests, still strands a `request_logs` row in `pending`. Reproduced again here; strands before model resolution, upstream of everything this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
