### PR TITLE
fix(proxy): a 200 is a status, not an answer, on the completion path too

### DIFF
--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -87,6 +88,14 @@ type oaiUsage struct {
 	} `json:"completion_tokens_details,omitempty"`
 }
 
+// ErrNoCandidates marks the one translation failure that is NOT the provider
+// malfunctioning: Gemini answered, and its answer carried no candidate — which
+// is what a prompt blocked by its safety filter looks like. The body is a
+// perfectly good Gemini object and the provider is plainly alive, so a caller
+// deciding whether to hold the provider at fault has to be able to tell this
+// apart from bytes that are not a Gemini response at all.
+var ErrNoCandidates = errors.New("gemini: response carried no candidates")
+
 // BuildChatCompletion converts a non-streaming Gemini generateContent response
 // body into an OpenAI chat-completion body. id, model and created are supplied
 // by the caller (the model string the client requested is echoed back).
@@ -100,7 +109,7 @@ func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, 
 		if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
 			reason = "prompt blocked: " + resp.PromptFeedback.BlockReason
 		}
-		return nil, fmt.Errorf("gemini: %s", reason)
+		return nil, fmt.Errorf("gemini: %s: %w", reason, ErrNoCandidates)
 	}
 
 	cand := resp.Candidates[0]

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -88,13 +88,17 @@ type oaiUsage struct {
 	} `json:"completion_tokens_details,omitempty"`
 }
 
-// ErrNoCandidates marks the one translation failure that is NOT the provider
-// malfunctioning: Gemini answered, and its answer carried no candidate — which
-// is what a prompt blocked by its safety filter looks like. The body is a
-// perfectly good Gemini object and the provider is plainly alive, so a caller
-// deciding whether to hold the provider at fault has to be able to tell this
-// apart from bytes that are not a Gemini response at all.
-var ErrNoCandidates = errors.New("gemini: response carried no candidates")
+// ErrPromptBlocked marks the one translation failure that is NOT the provider
+// malfunctioning: Gemini answered, and its answer was a refusal — promptFeedback
+// carries a blockReason and no candidate. The body is a good Gemini object and
+// the provider is plainly alive, so a caller deciding whether to hold it at
+// fault has to be able to tell this apart from bytes that merely lack candidates.
+//
+// Keyed on the stated reason, not on candidate absence: {} , null and an
+// aggregator's 200 {"error":…} all unmarshal into genResponse with no
+// candidates, and exempting those left no non-streaming body a Gemini provider
+// could return that would ever charge its breaker.
+var ErrPromptBlocked = errors.New("gemini: prompt blocked")
 
 // BuildChatCompletion converts a non-streaming Gemini generateContent response
 // body into an OpenAI chat-completion body. id, model and created are supplied
@@ -105,11 +109,14 @@ func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, 
 		return nil, fmt.Errorf("gemini: invalid upstream response: %s", jsonfault.Describe(err, len(body)))
 	}
 	if len(resp.Candidates) == 0 {
-		reason := "no candidates in response"
 		if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
-			reason = "prompt blocked: " + resp.PromptFeedback.BlockReason
+			return nil, fmt.Errorf("gemini: prompt blocked: %s: %w", resp.PromptFeedback.BlockReason, ErrPromptBlocked)
 		}
-		return nil, fmt.Errorf("gemini: %s: %w", reason, ErrNoCandidates)
+		// No candidates and no stated reason. That is not Gemini declining to
+		// answer, it is a body that does not carry one — an aggregator's error
+		// envelope, a bare {}, a null — all of which unmarshal into genResponse
+		// without complaint.
+		return nil, fmt.Errorf("gemini: no candidates in response")
 	}
 
 	cand := resp.Candidates[0]

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -2,6 +2,9 @@ package proxy
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -60,7 +63,7 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
 			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-			h.recordAnswerOutcome(st, candidate, logData)
+			h.recordAnswerOutcome(st, candidate, logData, false)
 
 			charged := h.circuitBreaker.GetState(providerID) == failover.StateOpen
 			if charged != tc.wantCharge {
@@ -83,7 +86,7 @@ func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 	h.circuitBreaker.RecordFailure(providerID, "p")
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"})
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"}, false)
 
 	h.circuitBreaker.RecordFailure(providerID, "p")
 	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
@@ -102,7 +105,7 @@ func TestRecordAnswerOutcome_AFailedAttemptIsCharged(t *testing.T) {
 	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", providerID: providerID, providerName: "p"})
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, false)
 
 	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
 		t.Error("a completion that failed after the headers must be charged")
@@ -116,7 +119,7 @@ func TestRecordAnswerOutcome_NoOpWhenTheBreakerIsDisabled(t *testing.T) {
 	providerID := uuid.New()
 
 	h.recordAnswerOutcome(&requestState{circuitBreakerEnabled: false}, modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}},
-		&requestLogData{state: "failed", providerID: providerID, providerName: "p"})
+		&requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, false)
 
 	if _, seen := cbConsecutiveFails(cb, providerID); seen {
 		t.Error("the disabled breaker was touched")
@@ -143,11 +146,14 @@ func TestChargeBreaker_UntranslatableBodyIsCharged(t *testing.T) {
 	}
 }
 
-// And the charge has to happen at the three sites that produce it, not just in
-// the helper. Driven through attemptCandidate with a Gemini candidate whose 200
-// is not a Gemini answer, which is the shape translateEgressResponseBody
-// rejects — the case each adapter's own comment already calls a provider fault,
-// and the case the old code credited before the translation was attempted.
+// And the charge has to happen where it is produced, not just in the helper.
+// Driven through attemptCandidate with a Gemini candidate whose 200 is not a
+// Gemini answer, which is the shape translateEgressResponseBody rejects — the
+// case each adapter's own comment already calls a provider fault, and the case
+// the old code credited before the translation was attempted.
+//
+// One of the three adapters by fixture; all three by code path, since they share
+// rejectUntranslatableBody.
 func TestAttemptCandidate_UntranslatableBodyChargesTheBreaker(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
@@ -180,5 +186,240 @@ func TestAttemptCandidate_UntranslatableBodyChargesTheBreaker(t *testing.T) {
 	}
 	if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
 		t.Error("a 200 whose body could not be translated was not charged to the provider")
+	}
+}
+
+// A client that hangs up mid-read is not a provider failure. The upstream body
+// is read under the caller's context, so a user pressing stop — or a load
+// balancer's client-side timeout — surfaces here as a failed read, and charging
+// for it opens the circuit for every tenant after five impatient cancels.
+//
+// doUpstream, judgeStreamForBreaker, classifyProbeError and the pass-through
+// first-byte probe all refuse to charge for this. This verdict is the one that
+// did not.
+func TestRecordAnswerOutcome_AClientHangingUpIsNotAProviderFailure(t *testing.T) {
+	cb := failover.NewCircuitBreaker(nil)
+	h := &Handler{circuitBreaker: cb}
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, true)
+
+	if _, seen := cbConsecutiveFails(cb, providerID); seen {
+		t.Error("an abandoned request was charged to the provider")
+	}
+}
+
+// A 2xx this gateway could not decode says nothing about whether the provider is
+// up: it is classified provider_bad_request and, as nonStreamingFailureDetail
+// says, it still holds the model's generated text — a relay quoting its token
+// counts is the named cause. judgeStreamForBreaker calls recording nothing the
+// honest verdict for its own unreadable frames, and it is the honest verdict
+// here.
+func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		kind       ErrorKind
+		wantCharge bool
+	}{
+		{KindProviderError, true},
+		{KindProviderTimeout, true},
+		{KindProviderModelGone, true},
+		{KindProviderBadRequest, false},
+	} {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			t.Parallel()
+			cb := failover.NewCircuitBreaker(nil)
+			h := &Handler{circuitBreaker: cb}
+			providerID := uuid.New()
+			st := &requestState{circuitBreakerEnabled: true}
+			candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+			h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: tc.kind, providerID: providerID, providerName: "p"}, false)
+
+			_, seen := cbConsecutiveFails(cb, providerID)
+			if seen != tc.wantCharge {
+				t.Errorf("charged = %v, want %v", seen, tc.wantCharge)
+			}
+		})
+	}
+}
+
+// The bar for a breaker charge has to be generous, because a false negative
+// darkens a provider for every tenant after five requests while a false positive
+// merely fails to strike a model. These are all the model answering, and all of
+// them read as nothing before: refusal, audio and function_call ride in the
+// unmodelled overflow, and reasoning_details was read only AFTER the
+// normalisation that folds it into reasoning_content — which runs later than the
+// judgement.
+func TestChatAnswerCarriesContent_TheShapesAnAnswerCanTake(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"I can't help with that."}}]}`, true},
+		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"id":"a","data":"UklGRg==","transcript":"hello"}}}]}`, true},
+		{"reasoning_details only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_details":[{"type":"reasoning.text","text":"thinking"}]}}]}`, true},
+		{"a legacy function_call", `{"choices":[{"message":{"role":"assistant","content":null,"function_call":{"name":"f","arguments":"{}"}}}]}`, true},
+		// Still nothing: an unmodelled member that carries nothing is not an
+		// answer, and neither is a choice list with nothing in it.
+		{"no choices at all", `{"choices":[]}`, false},
+		{"an empty message", `{"choices":[{"message":{"role":"assistant","content":""}}]}`, false},
+		{"empty unmodelled members", `{"choices":[{"message":{"role":"assistant","content":"","refusal":null,"annotations":[]}}]}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out ChatCompletionResponse
+			if err := json.Unmarshal([]byte(tc.body), &out); err != nil {
+				t.Fatalf("fixture did not decode: %v", err)
+			}
+			if got := chatAnswerCarriesContent(out); got != tc.want {
+				t.Errorf("chatAnswerCarriesContent = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The pass-through surface had the same defect and the detection function
+// already written for it: passthroughAnswered exists precisely to spot
+// 200 {"data":[]}, and it was consulted for the gone-strike streak only. The
+// breaker success was recorded the moment the buffered read succeeded, so an
+// embeddings provider answering nothing to every request recorded a success
+// every time and its circuit could never open.
+func TestServeBufferedJSONPassthrough_EmptyEmbeddingsChargesTheBreaker(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantCharge bool
+	}{
+		{"no data at all", `{"object":"list","data":[]}`, true},
+		{"a real embedding", `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}]}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			st := &requestState{
+				circuitBreakerEnabled: true,
+				startTime:             time.Now(),
+				logData: &requestLogData{
+					modelID: "text-embedding-3-small", providerID: providerID, providerName: "p",
+					endpointType: endpointTypeEmbeddings, state: "pending",
+					virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+				},
+			}
+			candidate := modelCandidate{
+				model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+				provider: &provider.Provider{ID: providerID, Name: "p"},
+			}
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(tc.body)), Header: make(http.Header)}
+
+			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5)
+
+			charged := h.circuitBreaker.GetState(providerID) == failover.StateOpen
+			if charged != tc.wantCharge {
+				t.Errorf("circuit open = %v, want %v", charged, tc.wantCharge)
+			}
+		})
+	}
+}
+
+// And an abandoned pass-through read is not the provider's doing either. The
+// first-byte probe on the streamed twin has always had this guard; the buffered
+// branch did not.
+func TestServeBufferedJSONPassthrough_AClientHangingUpIsNotCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{
+		circuitBreakerEnabled: true,
+		startTime:             time.Now(),
+		logData: &requestLogData{
+			modelID: "text-embedding-3-small", providerID: providerID, providerName: "p",
+			endpointType: endpointTypeEmbeddings, state: "pending",
+			virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+		},
+	}
+	candidate := modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+		provider: &provider.Provider{ID: providerID, Name: "p"},
+	}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(&errorReader{err: errors.New("connection reset by peer")}), Header: make(http.Header)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody).WithContext(ctx)
+
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5)
+
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("an abandoned pass-through read was charged to the provider")
+	}
+}
+
+// End to end through attemptCandidate, which is what proves the verdict is
+// WIRED and not merely correct. Both call sites could be deleted without a test
+// noticing: the unit tests above compose handleNonStreamingResponse and
+// recordAnswerOutcome by hand, and the pre-existing breaker-sequence tests only
+// ever exercise the credit direction.
+func TestAttemptCandidate_EmptyAnswerChargesTheBreaker(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		native bool
+		body   string
+	}{
+		{"openai shaped", false, `{"id":"x","object":"chat.completion","choices":[]}`},
+		{"native anthropic", true, `{"id":"msg_1","type":"message","role":"assistant","model":"claude-x","content":[],"usage":{"input_tokens":3,"output_tokens":0}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+			h.upstreamTransport = dialToTestServer(t, srv)
+
+			m := &model.Model{ID: uuid.New(), ModelID: "claude-x"}
+			cand := goneCandidateAt(m, "Anthropic", "http://api.anthropic.com")
+
+			st := &requestState{
+				startTime:        time.Now(),
+				reqModel:         "claude-x",
+				bodyBytes:        []byte(`{"model":"claude-x","messages":[{"role":"user","content":"hi"}]}`),
+				anthropicRawBody: []byte(`{"model":"claude-x","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`),
+				// buildCandidateRequest recomputes anthropicNativeAttempt from
+				// anthropicIn and the provider family, so setting the flag
+				// directly is overwritten — as this test found by surviving a
+				// mutation of the native call site.
+				anthropicIn:           tc.native,
+				failoverTimeout:       30 * time.Second,
+				circuitBreakerEnabled: true,
+				vkHash:                "test-hash",
+				logData: &requestLogData{
+					modelID: "claude-x", providerID: cand.provider.ID, providerName: "Anthropic",
+					endpointType: endpointTypeChat, state: "pending",
+					virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+				},
+			}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+			h.attemptCandidate(w, r, st, cand, 0, 1)
+
+			if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+				t.Errorf("a 200 carrying no answer was not charged (state %q, body %q)", st.logData.state, w.Body.String())
+			}
+		})
 	}
 }

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
@@ -203,25 +204,99 @@ func TestAttemptCandidate_UntranslatableBodyChargesTheBreaker(t *testing.T) {
 	}
 }
 
-// A client that hangs up mid-read is not a provider failure. The upstream body
-// is read under the caller's context, so a user pressing stop — or a load
-// balancer's client-side timeout — surfaces here as a failed read, and charging
-// for it opens the circuit for every tenant after five impatient cancels.
+// An interrupted read is not a provider failure, and the KIND is what says so.
+// recordAnswerOutcome no longer carries a second client-gone guard of its own:
+// it reads the kind the handler classified, which is the one place that knows
+// what interrupted the read.
 //
-// doUpstream, judgeStreamForBreaker, classifyProbeError and the pass-through
-// first-byte probe all refuse to charge for this. This verdict is the one that
-// did not.
-func TestRecordAnswerOutcome_AClientHangingUpIsNotAProviderFailure(t *testing.T) {
-	cb := failover.NewCircuitBreaker(nil)
-	h := &Handler{circuitBreaker: cb}
-	providerID := uuid.New()
-	st := &requestState{circuitBreakerEnabled: true}
-	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+// Both interruptions matter. A caller hanging up is the obvious one; this
+// gateway's OWN request_timeout is the one that got missed, because it produces
+// context.DeadlineExceeded — which a check for context.Canceled does not match —
+// while the client's context stays perfectly healthy. Five slow-but-alive
+// answers would have taken the provider out of rotation for every tenant.
+func TestCancelKind_ClassifiesEveryWayAnAttemptIsInterrupted(t *testing.T) {
+	t.Parallel()
+	withOrigin := func(origin string) context.Context {
+		return context.WithValue(context.Background(), ctxkeys.CancelOriginKey, origin)
+	}
+	for _, tc := range []struct {
+		name    string
+		ctx     context.Context
+		err     error
+		want    ErrorKind
+		aborted bool
+	}{
+		{"the caller hung up", context.Background(), context.Canceled, KindClientDisconnect, true},
+		{"this gateway's request_timeout", withOrigin("failover_timeout"), context.DeadlineExceeded, KindFailoverTimeout, true},
+		{"a retry's own timeout", withOrigin("retry_timeout"), context.DeadlineExceeded, KindRetryTimeout, true},
+		// The context went down underneath a read that reported something else.
+		{"a cancelled context under another error", cancelledContext(), errors.New("connection reset by peer"), KindClientDisconnect, true},
+		// A real provider failure, with the attempt still live.
+		{"the provider broke", context.Background(), errors.New("connection reset by peer"), "", false},
+		{"nothing went wrong", context.Background(), nil, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			kind, aborted := cancelKind(tc.ctx, tc.err)
+			if aborted != tc.aborted || kind != tc.want {
+				t.Errorf("cancelKind = (%q, %v), want (%q, %v)", kind, aborted, tc.want, tc.aborted)
+			}
+			if aborted && providerAtFault(kind) {
+				t.Errorf("kind %q is an interruption and must never be the provider's fault", kind)
+			}
+		})
+	}
+}
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, cancelledRequest())
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
 
-	if _, seen := cbConsecutiveFails(cb, providerID); seen {
-		t.Error("an abandoned request was charged to the provider")
+// End to end: an interrupted body read must classify as the interruption and
+// must not charge, whichever context went down.
+func TestHandleNonStreamingResponse_AnInterruptedReadIsNotCharged(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		origin   string
+		readErr  error
+		wantKind ErrorKind
+	}{
+		{"the caller hung up", "", context.Canceled, KindClientDisconnect},
+		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindFailoverTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+			candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+			logData := &requestLogData{
+				modelID: "m", providerID: providerID, providerName: "p", state: "pending",
+				virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+			}
+			body := io.MultiReader(bytes.NewBufferString(`{"id":"x","choices":[{"messa`), &errorReader{err: tc.readErr})
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body), Header: make(http.Header)}
+
+			ctx := context.Background()
+			if tc.origin != "" {
+				ctx = context.WithValue(ctx, ctxkeys.CancelOriginKey, tc.origin)
+			}
+			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)).WithContext(ctx)
+
+			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+			h.recordAnswerOutcome(st, candidate, logData, req)
+
+			if logData.errorKind != tc.wantKind {
+				t.Errorf("errorKind = %q, want %q", logData.errorKind, tc.wantKind)
+			}
+			if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+				t.Error("an interrupted read was charged to the provider")
+			}
+		})
 	}
 }
 
@@ -294,6 +369,16 @@ func TestEmptyCompletion_IsOnlyACompletionWithNothingInIt(t *testing.T) {
 		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"no"}}]}`, false},
 		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"data":"UklGRg=="}}}]}`, false},
 		{"a legacy function_call", `{"choices":[{"message":{"role":"assistant","content":null,"function_call":{"name":"f"}}}]}`, false},
+		{"annotations", `{"choices":[{"message":{"role":"assistant","content":"","annotations":[{"type":"url_citation"}]}}]}`, false},
+		// The WHOLE answer for these models, and charged before the allowlist
+		// covered them.
+		{"an OpenRouter generated image", `{"choices":[{"message":{"role":"assistant","content":"","images":[{"image_url":{"url":"data:image/png;base64,AA"}}]}}]}`, false},
+		{"Perplexity citations", `{"choices":[{"message":{"role":"assistant","content":"","citations":["http://x"]}}]}`, false},
+		{"thinking blocks", `{"choices":[{"message":{"role":"assistant","content":"","thinking_blocks":[{"thinking":"x"}]}}]}`, false},
+		{"ollama style reasoning", `{"choices":[{"message":{"role":"assistant","content":"","reasoning":"thinking"}}]}`, false},
+		// Present but carrying nothing is not an answer: OpenAI stamps
+		// "refusal": null and "annotations": [] on ordinary completions.
+		{"the empty forms of those members", `{"choices":[{"message":{"role":"assistant","content":"","refusal":null,"annotations":[],"images":[]}}]}`, true},
 		// A stop reason about the provider's own output. Gemini's SAFETY maps here.
 		{"a content filter block", `{"choices":[{"finish_reason":"content_filter","message":{"role":"assistant","content":null}}]}`, false},
 		{"a length cut", `{"choices":[{"finish_reason":"length","message":{"role":"assistant","content":null}}]}`, false},
@@ -314,17 +399,69 @@ func TestEmptyCompletion_IsOnlyACompletionWithNothingInIt(t *testing.T) {
 	}
 }
 
-// And the retirement bar stays where it was: a refusal envelope must not clear a
-// model's gone-strike streak.
-func TestChatAnswerCarriesContent_StaysStrictForRetirement(t *testing.T) {
+// And the retirement bar stays narrow, which is a different bar from the one
+// above. It gained exactly one thing on this branch: it reads ReasoningDetails,
+// which it had been judging BEFORE the normalisation that folds them into
+// ReasoningContent, so a reasoning-only answer read as nothing at all.
+func TestChatAnswerCarriesContent_StaysNarrowForRetirement(t *testing.T) {
 	t.Parallel()
-	var out ChatCompletionResponse
-	body := `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"this model is no longer available"}}]}`
-	if err := json.Unmarshal([]byte(body), &out); err != nil {
-		t.Fatalf("fixture did not decode: %v", err)
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		// An aggregator writes its gone-marker into refusal. Counting it would
+		// clear the streak that is meant to retire the model.
+		{"a refusal envelope", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"this model is no longer available"}}]}`, false},
+		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"data":"AA"}}}]}`, false},
+		{"generated images", `{"choices":[{"message":{"role":"assistant","content":"","images":[{"image_url":{"url":"data:x"}}]}}]}`, false},
+		// The one addition, and why.
+		{"reasoning_details only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_details":[{"type":"reasoning.text","text":"t"}]}}]}`, true},
+		{"real text", `{"choices":[{"message":{"role":"assistant","content":"hello"}}]}`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out ChatCompletionResponse
+			if err := json.Unmarshal([]byte(tc.body), &out); err != nil {
+				t.Fatalf("fixture did not decode: %v", err)
+			}
+			if got := chatAnswerCarriesContent(out); got != tc.want {
+				t.Errorf("chatAnswerCarriesContent = %v, want %v", got, tc.want)
+			}
+		})
 	}
-	if chatAnswerCarriesContent(out) {
-		t.Error("a refusal envelope cleared the retirement streak: an aggregator writes its gone-marker there")
+}
+
+// The oversized-body refusal is THIS gateway's policy, not the provider dying.
+// Folded into the read error it reported "the provider stopped sending its
+// response" for a provider that sent too much, and charged its circuit.
+func TestHandleNonStreamingResponse_AnOversizedBodyIsNotTheProvidersFault(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+	logData := &requestLogData{
+		modelID: "m", providerID: providerID, providerName: "p", state: "pending",
+		virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+	}
+	huge := `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"` +
+		strings.Repeat("x", nonStreamingBodyCap) + `"}}]}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(huge)), Header: make(http.Header)}
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.recordAnswerOutcome(st, candidate, logData, nil)
+
+	if logData.errorKind != KindProviderBadRequest {
+		t.Errorf("errorKind = %q, want provider_bad_request: refusing a body is this gateway's policy", logData.errorKind)
+	}
+	if !strings.Contains(logData.errorMessage, "body cap") {
+		t.Errorf("errorMessage = %q, want the cap named", logData.errorMessage)
+	}
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("a provider was charged for sending too much")
 	}
 }
 
@@ -722,7 +859,7 @@ func TestNonStreamingFailureDetail_ClassifiesTheReadFailure(t *testing.T) {
 			if decodeErr == nil {
 				decodeErr = errors.New("invalid character")
 			}
-			_, _, kind, _ := nonStreamingFailureDetail(resp, []byte("{"), tc.readErr, decodeErr, "m")
+			_, _, kind, _ := nonStreamingFailureDetail(context.Background(), resp, []byte("{"), tc.readErr, decodeErr, "m")
 			if kind != tc.want {
 				t.Errorf("kind = %q, want %q", kind, tc.want)
 			}
@@ -759,5 +896,47 @@ func TestHandleNonStreamingResponse_ACompleteBodyBehindAnUncleanCloseIsServed(t 
 	}
 	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
 		t.Error("a provider that delivered a complete answer was charged")
+	}
+}
+
+// The native Anthropic path hard-coded provider_error for any body-read
+// failure, so the identical event — a caller hanging up, or this gateway's own
+// request_timeout, mid-read — logged provider_error on /v1/messages and the
+// interruption on /v1/chat/completions, decided by nothing but which dialect the
+// request came in on.
+func TestHandleNativeNonStreaming_AnInterruptedReadIsClassified(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		origin   string
+		readErr  error
+		wantKind ErrorKind
+	}{
+		{"the caller hung up", "", context.Canceled, KindClientDisconnect},
+		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindFailoverTimeout},
+		{"the provider broke", "", errors.New("connection reset by peer"), KindProviderError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+
+			logData := &requestLogData{
+				modelID: "claude-x", providerID: uuid.New(), providerName: "p", state: "pending",
+				virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+			}
+			st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(&errorReader{err: tc.readErr}), Header: make(http.Header)}
+
+			ctx := context.Background()
+			if tc.origin != "" {
+				ctx = context.WithValue(ctx, ctxkeys.CancelOriginKey, tc.origin)
+			}
+			req := httptest.NewRequest("POST", "/v1/messages", http.NoBody).WithContext(ctx)
+
+			h.handleNativeNonStreaming(httptest.NewRecorder(), req, st, resp, 1, 5)
+
+			if logData.errorKind != tc.wantKind {
+				t.Errorf("errorKind = %q, want %q", logData.errorKind, tc.wantKind)
+			}
+		})
 	}
 }

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -33,9 +33,19 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 		body       string
 		wantCharge bool
 	}{
+		// The only shape charged: nothing came back at all. This is what an
+		// aggregator in front of a retired model returns between its refusals.
 		{"no choices at all", `{"id":"x","object":"chat.completion","choices":[]}`, true},
-		{"a choice with empty content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`, true},
-		{"a null content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}`, true},
+		// A choice that EXISTS is the provider answering, even when this gateway
+		// cannot find content in it. Charging these darkens a provider for every
+		// tenant after five requests; not charging them merely leaves the breaker
+		// blind to one shape.
+		{"a choice with empty content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`, false},
+		{"a null content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}`, false},
+		{"a safety refusal", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null,"refusal":"I can't help with that."}}]}`, false},
+		{"an audio answer", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null,"audio":{"id":"a","data":"UklGRg==","transcript":"hi"}}}]}`, false},
+		{"an azure content filter block", `{"id":"x","object":"chat.completion","choices":[{"index":0,"finish_reason":"content_filter","content_filter_results":{"hate":{"filtered":true}},"message":{"role":"assistant","content":null}}]}`, false},
+		{"a legacy function_call", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null,"function_call":{"name":"f","arguments":"{}"}}}]}`, false},
 		// Anything the model actually produced clears it.
 		{"text", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello"}}]}`, false},
 		{"content as parts", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}]}`, false},
@@ -63,7 +73,7 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
 			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-			h.recordAnswerOutcome(st, candidate, logData, false)
+			h.recordAnswerOutcome(st, candidate, logData, nil)
 
 			charged := h.circuitBreaker.GetState(providerID) == failover.StateOpen
 			if charged != tc.wantCharge {
@@ -86,7 +96,7 @@ func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 	h.circuitBreaker.RecordFailure(providerID, "p")
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"}, false)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"}, nil)
 
 	h.circuitBreaker.RecordFailure(providerID, "p")
 	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
@@ -105,7 +115,7 @@ func TestRecordAnswerOutcome_AFailedAttemptIsCharged(t *testing.T) {
 	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, false)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, nil)
 
 	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
 		t.Error("a completion that failed after the headers must be charged")
@@ -119,7 +129,7 @@ func TestRecordAnswerOutcome_NoOpWhenTheBreakerIsDisabled(t *testing.T) {
 	providerID := uuid.New()
 
 	h.recordAnswerOutcome(&requestState{circuitBreakerEnabled: false}, modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}},
-		&requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, false)
+		&requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, nil)
 
 	if _, seen := cbConsecutiveFails(cb, providerID); seen {
 		t.Error("the disabled breaker was touched")
@@ -204,7 +214,7 @@ func TestRecordAnswerOutcome_AClientHangingUpIsNotAProviderFailure(t *testing.T)
 	st := &requestState{circuitBreakerEnabled: true}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, true)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, cancelledRequest())
 
 	if _, seen := cbConsecutiveFails(cb, providerID); seen {
 		t.Error("an abandoned request was charged to the provider")
@@ -227,6 +237,10 @@ func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
 		{KindProviderTimeout, true},
 		{KindProviderModelGone, true},
 		{KindProviderBadRequest, false},
+		// An unclassified failure escapes too. Documented rather than changed:
+		// every path into this branch sets a kind, and inventing a charge for
+		// one that did not would be guessing at whose fault it was.
+		{"", false},
 	} {
 		t.Run(string(tc.kind), func(t *testing.T) {
 			t.Parallel()
@@ -236,7 +250,7 @@ func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
 			st := &requestState{circuitBreakerEnabled: true}
 			candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-			h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: tc.kind, providerID: providerID, providerName: "p"}, false)
+			h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: tc.kind, providerID: providerID, providerName: "p"}, nil)
 
 			_, seen := cbConsecutiveFails(cb, providerID)
 			if seen != tc.wantCharge {
@@ -246,29 +260,27 @@ func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
 	}
 }
 
-// The bar for a breaker charge has to be generous, because a false negative
-// darkens a provider for every tenant after five requests while a false positive
-// merely fails to strike a model. These are all the model answering, and all of
-// them read as nothing before: refusal, audio and function_call ride in the
-// unmodelled overflow, and reasoning_details was read only AFTER the
-// normalisation that folds it into reasoning_content — which runs later than the
-// judgement.
-func TestChatAnswerCarriesContent_TheShapesAnAnswerCanTake(t *testing.T) {
+// The bar the BREAKER reads is narrower than !deliveredContent on purpose, and
+// the two questions are not the same question.
+//
+// deliveredContent backs the retirement verdict, where missing an answer merely
+// fails to clear a streak — and `refusal` is the single likeliest field for an
+// aggregator to write "this model is gone" into behind a 200, so widening THAT
+// would let such a provider clear its gone-strikes forever. A breaker charge
+// costs the opposite way round: five of them take a provider out of rotation for
+// every tenant. So the breaker charges only a completion with nothing in it.
+func TestEmptyCompletion_IsOnlyACompletionWithNothingInIt(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		body string
 		want bool
 	}{
-		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"I can't help with that."}}]}`, true},
-		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"id":"a","data":"UklGRg==","transcript":"hello"}}}]}`, true},
-		{"reasoning_details only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_details":[{"type":"reasoning.text","text":"thinking"}]}}]}`, true},
-		{"a legacy function_call", `{"choices":[{"message":{"role":"assistant","content":null,"function_call":{"name":"f","arguments":"{}"}}}]}`, true},
-		// Still nothing: an unmodelled member that carries nothing is not an
-		// answer, and neither is a choice list with nothing in it.
-		{"no choices at all", `{"choices":[]}`, false},
-		{"an empty message", `{"choices":[{"message":{"role":"assistant","content":""}}]}`, false},
-		{"empty unmodelled members", `{"choices":[{"message":{"role":"assistant","content":"","refusal":null,"annotations":[]}}]}`, false},
+		{"no choices at all", `{"choices":[]}`, true},
+		{"no choices but usage", `{"choices":[],"usage":{"completion_tokens":7}}`, false},
+		{"an empty message is still an answer", `{"choices":[{"message":{"role":"assistant","content":""}}]}`, false},
+		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"no"}}]}`, false},
+		{"real text", `{"choices":[{"message":{"role":"assistant","content":"hello"}}]}`, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -276,10 +288,25 @@ func TestChatAnswerCarriesContent_TheShapesAnAnswerCanTake(t *testing.T) {
 			if err := json.Unmarshal([]byte(tc.body), &out); err != nil {
 				t.Fatalf("fixture did not decode: %v", err)
 			}
-			if got := chatAnswerCarriesContent(out); got != tc.want {
-				t.Errorf("chatAnswerCarriesContent = %v, want %v", got, tc.want)
+			got := len(out.Choices) == 0 && out.Usage.CompletionTokens == 0
+			if got != tc.want {
+				t.Errorf("emptyCompletion = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// And the retirement bar stays where it was: a refusal envelope must not clear a
+// model's gone-strike streak.
+func TestChatAnswerCarriesContent_StaysStrictForRetirement(t *testing.T) {
+	t.Parallel()
+	var out ChatCompletionResponse
+	body := `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"this model is no longer available"}}]}`
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("fixture did not decode: %v", err)
+	}
+	if chatAnswerCarriesContent(out) {
+		t.Error("a refusal envelope cleared the retirement streak: an aggregator writes its gone-marker there")
 	}
 }
 
@@ -421,5 +448,176 @@ func TestAttemptCandidate_EmptyAnswerChargesTheBreaker(t *testing.T) {
 				t.Errorf("a 200 carrying no answer was not charged (state %q, body %q)", st.logData.state, w.Body.String())
 			}
 		})
+	}
+}
+
+// A Gemini prompt blocked by its safety filter comes back 200 with an empty
+// candidate list. BuildChatCompletion cannot turn that into a completion, but
+// the body is a perfectly good Gemini object and the provider is plainly alive —
+// so charging for it took a healthy provider out of rotation for every tenant
+// after five blocked prompts, which is exactly what a client retries.
+func TestAttemptCandidate_AGeminiSafetyBlockIsNotAProviderFault(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantCharge bool
+	}{
+		{"prompt blocked by the safety filter", `{"promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}`, false},
+		{"no candidates and no reason", `{"candidates":[]}`, false},
+		// Still a fault: these bytes are not a Gemini response at all.
+		{"not a gemini object", `<html>502 Bad Gateway</html>`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+			h.upstreamTransport = dialToTestServer(t, srv)
+
+			m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+			cand := goneCandidateAt(m, "Vertex Express", "http://us-central1-aiplatform.googleapis.com/v1")
+
+			st := &requestState{
+				startTime:             time.Now(),
+				reqModel:              "gemini-2.0-flash",
+				bodyBytes:             []byte(`{"model":"gemini-2.0-flash","messages":[{"role":"user","content":"hi"}]}`),
+				failoverTimeout:       30 * time.Second,
+				circuitBreakerEnabled: true,
+				logData:               &requestLogData{modelID: "gemini-2.0-flash", endpointType: endpointTypeChat},
+			}
+			r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+			h.attemptCandidate(httptest.NewRecorder(), r, st, cand, 0, 2)
+
+			charged := h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen
+			if charged != tc.wantCharge {
+				t.Errorf("charged = %v, want %v", charged, tc.wantCharge)
+			}
+		})
+	}
+}
+
+// The third charge site created by this change needed the client-gone guard the
+// other two got. Both translators read the body with an unbounded ReadAll under
+// the caller's context, so an abandoned request arrives as a translation
+// failure.
+func TestRejectUntranslatableBody_AClientHangingUpIsNotCharged(t *testing.T) {
+	cb := failover.NewCircuitBreaker(nil)
+	h := &Handler{circuitBreaker: cb}
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+	h.rejectUntranslatableBody(st, candidate, &requestLogData{modelID: "m", providerName: "p"}, "gemini", errors.New("read: connection reset"), 0, cancelledRequest())
+
+	if _, seen := cbConsecutiveFails(cb, providerID); seen {
+		t.Error("an abandoned request was charged to the provider")
+	}
+}
+
+// A body that died on the wire is not a body this gateway could not parse, and
+// the two were collapsed into one error kind — so the transport failure carried
+// the parse failure's classification, which providerAtFault excludes, and it was
+// never charged.
+func TestHandleNonStreamingResponse_ABodyThatDiedOnTheWireIsCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+	logData := &requestLogData{
+		modelID: "gpt-test", providerID: providerID, providerName: "p", state: "pending",
+		virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+	}
+	body := io.MultiReader(bytes.NewBufferString(`{"id":"x","choices":[{"message":{"content":"par`), &errorReader{err: errors.New("connection reset by peer")})
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body), Header: make(http.Header)}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.recordAnswerOutcome(st, candidate, logData, nil)
+
+	if logData.errorKind != KindProviderError {
+		t.Errorf("errorKind = %q, want provider_error: a dead read is not a parse failure", logData.errorKind)
+	}
+	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
+		t.Error("a provider that broke after committing its status was not charged")
+	}
+}
+
+// cancelledRequest is a request whose caller has already gone.
+func cancelledRequest() *http.Request {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx)
+}
+
+// A 204 or 202 legitimately carries an empty body and the provider is plainly
+// alive. The streamed pass-through twin says exactly that and credits it, so
+// charging here would have the two disagree about one response.
+func TestServeBufferedJSONPassthrough_AnEmptyNon200IsCredited(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThreshold(t, h, "2")
+
+	providerID := uuid.New()
+	h.circuitBreaker.RecordFailure(providerID, "p")
+	st := passthroughState(providerID)
+	candidate := modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+		provider: &provider.Provider{ID: providerID, Name: "p"},
+	}
+	resp := &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(bytes.NewBufferString("")), Header: make(http.Header)}
+
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5)
+
+	h.circuitBreaker.RecordFailure(providerID, "p")
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("an empty 204 recorded no success, so an old failure was still on the clock")
+	}
+}
+
+// And a body that READ fine under a caller who has gone is not the provider's
+// doing either. The existing abandoned-read test exits at the read-error guard
+// and never reaches this arm.
+func TestServeBufferedJSONPassthrough_AnAbandonedRequestIsNotCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := passthroughState(providerID)
+	candidate := modelCandidate{
+		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+		provider: &provider.Provider{ID: providerID, Name: "p"},
+	}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(`{"object":"list","data":[]}`)), Header: make(http.Header)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody).WithContext(ctx)
+
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5)
+
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("an abandoned pass-through request was charged to the provider")
+	}
+}
+
+func passthroughState(providerID uuid.UUID) *requestState {
+	return &requestState{
+		circuitBreakerEnabled: true,
+		startTime:             time.Now(),
+		logData: &requestLogData{
+			modelID: "text-embedding-3-small", providerID: providerID, providerName: "p",
+			endpointType: endpointTypeEmbeddings, state: "pending",
+			virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+		},
 	}
 }

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
@@ -139,5 +140,45 @@ func TestChargeBreaker_UntranslatableBodyIsCharged(t *testing.T) {
 
 	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
 		t.Error("a body the gateway could not translate must be charged to the provider")
+	}
+}
+
+// And the charge has to happen at the three sites that produce it, not just in
+// the helper. Driven through attemptCandidate with a Gemini candidate whose 200
+// is not a Gemini answer, which is the shape translateEgressResponseBody
+// rejects — the case each adapter's own comment already calls a provider fault,
+// and the case the old code credited before the translation was attempted.
+func TestAttemptCandidate_UntranslatableBodyChargesTheBreaker(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `<html>502 Bad Gateway</html>`)
+	}))
+	defer srv.Close()
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	m := &model.Model{ID: uuid.New(), ModelID: "gemini-2.0-flash"}
+	// The hostname decides the dialect; the transport dials the test server.
+	cand := goneCandidateAt(m, "Vertex Express", "http://us-central1-aiplatform.googleapis.com/v1")
+
+	st := &requestState{
+		startTime:             time.Now(),
+		reqModel:              "gemini-2.0-flash",
+		bodyBytes:             []byte(`{"model":"gemini-2.0-flash","messages":[{"role":"user","content":"hi"}]}`),
+		failoverTimeout:       30 * time.Second,
+		circuitBreakerEnabled: true,
+		logData:               &requestLogData{modelID: "gemini-2.0-flash", endpointType: endpointTypeChat},
+	}
+	r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+	// Two candidates, so the attempt is free to reject this one.
+	if got := h.attemptCandidate(httptest.NewRecorder(), r, st, cand, 0, 2); got != outcomeFailover {
+		t.Fatalf("outcome = %v, want a failover on an untranslatable 200", got)
+	}
+	if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+		t.Error("a 200 whose body could not be translated was not charged to the provider")
 	}
 }

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,12 +37,15 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 		// The only shape charged: nothing came back at all. This is what an
 		// aggregator in front of a retired model returns between its refusals.
 		{"no choices at all", `{"id":"x","object":"chat.completion","choices":[]}`, true},
-		// A choice that EXISTS is the provider answering, even when this gateway
-		// cannot find content in it. Charging these darkens a provider for every
-		// tenant after five requests; not charging them merely leaves the breaker
-		// blind to one shape.
-		{"a choice with empty content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`, false},
-		{"a null content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}`, false},
+		// A choice whose message holds literally nothing is an empty answer too,
+		// and it has to be: every egress translator synthesises exactly this
+		// shape for an emptied Gemini, Anthropic or Responses answer, so a rule
+		// that stopped at "a choice exists" could never charge any of them.
+		{"a choice with empty content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`, true},
+		{"a null content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}`, true},
+		// What that rule must NOT catch is a choice carrying something this
+		// gateway does not model, or a stop reason about the provider's own
+		// output. Those follow.
 		{"a safety refusal", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null,"refusal":"I can't help with that."}}]}`, false},
 		{"an audio answer", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null,"audio":{"id":"a","data":"UklGRg==","transcript":"hi"}}}]}`, false},
 		{"an azure content filter block", `{"id":"x","object":"chat.completion","choices":[{"index":0,"finish_reason":"content_filter","content_filter_results":{"hate":{"filtered":true}},"message":{"role":"assistant","content":null}}]}`, false},
@@ -96,7 +100,7 @@ func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 	h.circuitBreaker.RecordFailure(providerID, "p")
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"}, nil)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", emptyCompletion: false, providerID: providerID, providerName: "p"}, nil)
 
 	h.circuitBreaker.RecordFailure(providerID, "p")
 	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
@@ -277,10 +281,25 @@ func TestEmptyCompletion_IsOnlyACompletionWithNothingInIt(t *testing.T) {
 		want bool
 	}{
 		{"no choices at all", `{"choices":[]}`, true},
+		// What every egress translator synthesises for an emptied answer.
+		{"a synthesised empty message", `{"choices":[{"index":0,"message":{"role":"assistant","content":""},"finish_reason":"stop"}]}`, true},
+		{"a null content", `{"choices":[{"message":{"role":"assistant","content":null}}]}`, true},
 		{"no choices but usage", `{"choices":[],"usage":{"completion_tokens":7}}`, false},
-		{"an empty message is still an answer", `{"choices":[{"message":{"role":"assistant","content":""}}]}`, false},
-		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"no"}}]}`, false},
 		{"real text", `{"choices":[{"message":{"role":"assistant","content":"hello"}}]}`, false},
+		{"content as parts", `{"choices":[{"message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}]}`, false},
+		{"reasoning only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_content":"thinking"}}]}`, false},
+		{"reasoning_details only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_details":[{"type":"reasoning.text","text":"t"}]}}]}`, false},
+		{"a tool call", `{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"c","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`, false},
+		// Unmodelled, and unmistakably the answer.
+		{"a safety refusal", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"no"}}]}`, false},
+		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"data":"UklGRg=="}}}]}`, false},
+		{"a legacy function_call", `{"choices":[{"message":{"role":"assistant","content":null,"function_call":{"name":"f"}}}]}`, false},
+		// A stop reason about the provider's own output. Gemini's SAFETY maps here.
+		{"a content filter block", `{"choices":[{"finish_reason":"content_filter","message":{"role":"assistant","content":null}}]}`, false},
+		{"a length cut", `{"choices":[{"finish_reason":"length","message":{"role":"assistant","content":null}}]}`, false},
+		// An allowlist, not "any member that carries": a relay stamping a
+		// bookkeeping field must not silently make the breaker inert.
+		{"a bookkeeping field only", `{"choices":[{"message":{"role":"assistant","content":"","name":"assistant","provider":"acme"}}]}`, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -288,8 +307,7 @@ func TestEmptyCompletion_IsOnlyACompletionWithNothingInIt(t *testing.T) {
 			if err := json.Unmarshal([]byte(tc.body), &out); err != nil {
 				t.Fatalf("fixture did not decode: %v", err)
 			}
-			got := len(out.Choices) == 0 && out.Usage.CompletionTokens == 0
-			if got != tc.want {
+			if got := !answerCarriesSomething(out); got != tc.want {
 				t.Errorf("emptyCompletion = %v, want %v", got, tc.want)
 			}
 		})
@@ -463,7 +481,14 @@ func TestAttemptCandidate_AGeminiSafetyBlockIsNotAProviderFault(t *testing.T) {
 		wantCharge bool
 	}{
 		{"prompt blocked by the safety filter", `{"promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}`, false},
-		{"no candidates and no reason", `{"candidates":[]}`, false},
+		// No candidates and no stated reason is not Gemini declining to answer,
+		// it is a body that does not carry one — {} , null and an aggregator's
+		// 200 {"error":…} all unmarshal into the Gemini shape without complaint,
+		// so exempting candidate-absence left no body a Gemini provider could
+		// return that would ever charge its breaker.
+		{"no candidates and no reason", `{"candidates":[]}`, true},
+		{"an aggregator error envelope", `{"error":{"code":404,"message":"model gone"}}`, true},
+		{"a bare null", `null`, true},
 		// Still a fault: these bytes are not a Gemini response at all.
 		{"not a gemini object", `<html>502 Bad Gateway</html>`, true},
 	} {
@@ -619,5 +644,120 @@ func passthroughState(providerID uuid.UUID) *requestState {
 			endpointType: endpointTypeEmbeddings, state: "pending",
 			virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
 		},
+	}
+}
+
+// The hole the narrow bar left, driven end to end. Every egress translator
+// synthesises a one-element Choices literal on success, so an emptied Gemini,
+// Anthropic-egress or Responses answer always arrives with a choice — and a rule
+// that charged only `len(Choices) == 0` could never fire for any of them. The
+// same upstream emptiness charged on the native path and credited here, chosen
+// by nothing but which dialect the request came in on.
+func TestAttemptCandidate_AnEmptiedEgressAnswerIsCharged(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURL string
+		body    string
+	}{
+		{"gemini egress", "http://us-central1-aiplatform.googleapis.com/v1", `{"candidates":[{"content":{"parts":[],"role":"model"},"finishReason":"STOP"}]}`},
+		{"anthropic egress", "http://api.anthropic.com", `{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"usage":{"input_tokens":3,"output_tokens":0}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+			h.upstreamTransport = dialToTestServer(t, srv)
+
+			m := &model.Model{ID: uuid.New(), ModelID: "m"}
+			cand := goneCandidateAt(m, "egress", tc.baseURL)
+
+			st := &requestState{
+				startTime:             time.Now(),
+				reqModel:              "m",
+				bodyBytes:             []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`),
+				failoverTimeout:       30 * time.Second,
+				circuitBreakerEnabled: true,
+				vkHash:                "test-hash",
+				logData: &requestLogData{
+					modelID: "m", providerID: cand.provider.ID, providerName: "egress",
+					endpointType: endpointTypeChat, state: "pending",
+					virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+				},
+			}
+			r := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+
+			h.attemptCandidate(httptest.NewRecorder(), r, st, cand, 0, 1)
+
+			if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+				t.Errorf("an emptied %s answer was credited (state %q)", tc.name, st.logData.state)
+			}
+		})
+	}
+}
+
+// A caller that hangs up is not the provider failing, and the row has to say so:
+// the body is read under the request context, so a client cancel arrives as a
+// read error and was being reported as the provider dying.
+func TestNonStreamingFailureDetail_ClassifiesTheReadFailure(t *testing.T) {
+	t.Parallel()
+	resp := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+	for _, tc := range []struct {
+		name    string
+		readErr error
+		want    ErrorKind
+	}{
+		{"the client cancelled", context.Canceled, KindClientDisconnect},
+		{"the provider stopped sending", errors.New("connection reset by peer"), KindProviderError},
+		{"a body this gateway could not parse", nil, KindProviderBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			decodeErr := tc.readErr
+			if decodeErr == nil {
+				decodeErr = errors.New("invalid character")
+			}
+			_, _, kind, _ := nonStreamingFailureDetail(resp, []byte("{"), tc.readErr, decodeErr, "m")
+			if kind != tc.want {
+				t.Errorf("kind = %q, want %q", kind, tc.want)
+			}
+		})
+	}
+}
+
+// JSON is self-delimiting, so a provider that sent the whole document and then
+// dropped the connection without its terminal chunk yields ErrUnexpectedEOF from
+// a body that parses perfectly. Discarding it threw away a complete answer, and
+// once the breaker started reading the outcome it charged for one too.
+func TestHandleNonStreamingResponse_ACompleteBodyBehindAnUncleanCloseIsServed(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+	logData := &requestLogData{
+		modelID: "m", providerID: providerID, providerName: "p", state: "pending",
+		virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+	}
+	complete := `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello"}}]}`
+	body := io.MultiReader(bytes.NewBufferString(complete), &errorReader{err: io.ErrUnexpectedEOF})
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body), Header: make(http.Header)}
+	w := httptest.NewRecorder()
+
+	h.handleNonStreamingResponse(w, withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	h.recordAnswerOutcome(st, candidate, logData, nil)
+
+	if !strings.Contains(w.Body.String(), "hello") {
+		t.Errorf("a complete answer was discarded: %q", w.Body.String())
+	}
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("a provider that delivered a complete answer was charged")
 	}
 }

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -1,0 +1,143 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// A 200 is a status, not an answer. recordBreakerOutcome credited the provider
+// the moment the response headers arrived, before a byte of the body was read —
+// so a provider answering {"choices":[]} to every request recorded a success
+// every time, and RecordSuccess resets consecutiveFails, so its circuit could
+// never open however long it went on returning nothing.
+//
+// That is #805's charge, on the path #805 did not cover: it fixed the streaming
+// side, where finalizeStream judges the stream after it ends, and left the
+// completion side crediting on headers.
+func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantCharge bool
+	}{
+		{"no choices at all", `{"id":"x","object":"chat.completion","choices":[]}`, true},
+		{"a choice with empty content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":""}}]}`, true},
+		{"a null content", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":null}}]}`, true},
+		// Anything the model actually produced clears it.
+		{"text", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello"}}]}`, false},
+		{"content as parts", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}]}`, false},
+		{"reasoning only", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"","reasoning_content":"thinking"}}]}`, false},
+		{"a tool call and no text", `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"","tool_calls":[{"id":"c","type":"function","function":{"name":"f","arguments":"{}"}}]}}]}`, false},
+		{"usage reporting completion tokens", `{"id":"x","object":"chat.completion","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":7}}`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThresholdOne(t, h)
+
+			providerID := uuid.New()
+			st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+			candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "empty-answer-provider"}}
+			logData := &requestLogData{
+				modelID:        "gpt-test",
+				providerID:     providerID,
+				providerName:   "empty-answer-provider",
+				virtualKeyName: "k",
+				virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+				state:          "pending",
+			}
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(tc.body)), Header: make(http.Header)}
+			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+
+			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+			h.recordAnswerOutcome(st, candidate, logData)
+
+			charged := h.circuitBreaker.GetState(providerID) == failover.StateOpen
+			if charged != tc.wantCharge {
+				t.Errorf("circuit open = %v, want %v (state %q)", charged, tc.wantCharge, logData.state)
+			}
+		})
+	}
+}
+
+// The credit has to keep working, or every completion stops clearing the
+// provider's failure history and old failures accumulate until an unrelated one
+// opens the circuit.
+func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThreshold(t, h, "2")
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+	h.circuitBreaker.RecordFailure(providerID, "p")
+
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", deliveredContent: true, providerID: providerID, providerName: "p"})
+
+	h.circuitBreaker.RecordFailure(providerID, "p")
+	if h.circuitBreaker.GetState(providerID) == failover.StateOpen {
+		t.Error("an answered completion recorded no success, so an old failure was still on the clock")
+	}
+}
+
+// A completion the gateway could not read is the provider's fault, not a
+// success: the old code had already credited it at header time.
+func TestRecordAnswerOutcome_AFailedAttemptIsCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", providerID: providerID, providerName: "p"})
+
+	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
+		t.Error("a completion that failed after the headers must be charged")
+	}
+}
+
+// And it stays a no-op when the breaker is off.
+func TestRecordAnswerOutcome_NoOpWhenTheBreakerIsDisabled(t *testing.T) {
+	cb := failover.NewCircuitBreaker(nil)
+	h := &Handler{circuitBreaker: cb}
+	providerID := uuid.New()
+
+	h.recordAnswerOutcome(&requestState{circuitBreakerEnabled: false}, modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}},
+		&requestLogData{state: "failed", providerID: providerID, providerName: "p"})
+
+	if _, seen := cbConsecutiveFails(cb, providerID); seen {
+		t.Error("the disabled breaker was touched")
+	}
+}
+
+// A 200 whose body this gateway cannot turn into a completion is a provider
+// fault — the comment at each of those three sites already says so — and the
+// old code credited every one of them at header time, because the credit
+// happened before the translation was even attempted.
+func TestChargeBreaker_UntranslatableBodyIsCharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+	h.chargeBreaker(st, candidate, "upstream body could not be translated")
+
+	if h.circuitBreaker.GetState(providerID) != failover.StateOpen {
+		t.Error("a body the gateway could not translate must be charged to the provider")
+	}
+}

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -48,12 +48,20 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		debuglog.Warn("proxy: native anthropic read failed", "error", err, "provider", logData.providerName)
 		// Finalize the log row so it does not orphan in the in-flight state: a
-		// read failure on a 200 body is a provider/transport fault.
+		// read failure on a 200 body is a provider/transport fault — unless it
+		// was interrupted rather than broken, which the translated path already
+		// classifies and this one hard-coded past. The identical event logged
+		// provider_error here and client_disconnect there, decided by nothing but
+		// which dialect the request came in on.
+		kind := KindProviderError
+		if cancelled, aborted := cancelKind(r.Context(), err); aborted {
+			kind = cancelled
+		}
 		logData.statusCode = http.StatusBadGateway
 		logData.durationMs = float64(time.Since(st.startTime).Microseconds()) / 1000.0
 		logData.responseHeaderMs = responseHeaderMs
 		logData.failoverAttempt = attempt
-		logData.errorKind = KindProviderError
+		logData.errorKind = kind
 		logData.errorMessage = "failed to read upstream response: " + err.Error()
 		logData.state = "failed"
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -95,6 +95,9 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// corroborate, for a provider that answers without reporting usage. Same
 	// judgement the OpenAI-shaped path makes with chatAnswerCarriesContent.
 	logData.deliveredContent = outputTokens > 0 || anthropic.ResponseCarriesContent(body)
+	// The narrower question the breaker asks of the same body, mirroring the
+	// translated path: nothing at all came back. See requestLogData.emptyCompletion.
+	logData.emptyCompletion = outputTokens == 0 && !anthropic.ResponseCarriesContent(body)
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 	inputTokens, outputTokens, _ = estimateMissingUsage(inputTokens, outputTokens, 0, logData, anthropic.ResponseTextBytes(body))

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -95,8 +95,10 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// corroborate, for a provider that answers without reporting usage. Same
 	// judgement the OpenAI-shaped path makes with chatAnswerCarriesContent.
 	logData.deliveredContent = outputTokens > 0 || anthropic.ResponseCarriesContent(body)
-	// The narrower question the breaker asks of the same body, mirroring the
-	// translated path: nothing at all came back. See requestLogData.emptyCompletion.
+	// The question the breaker asks of the same body: did anything come back.
+	// ResponseCarriesContent reads block PRESENCE, which is the native analogue
+	// of the translated path's "any choice carrying something" — so on this path
+	// the two bars do coincide, and the negation is exact.
 	logData.emptyCompletion = outputTokens == 0 && !anthropic.ResponseCarriesContent(body)
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // The circuit-breaker verdict for a non-streaming attempt lives here, beside
@@ -68,11 +69,10 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 // non-streaming attempt, and is the completion-side sibling of
 // judgeStreamForBreaker.
 //
-// The bar is producedOutput, the same one the retirement verdict uses two lines
-// from each call site — text, content parts, reasoning, a tool call, or usage
-// reporting completion tokens. `200 {"choices":[]}` is what an aggregator in
-// front of a retired model returns between its refusals, and it is not an
-// answer whichever question is being asked of it.
+// The bar is emptyCompletion — did ANYTHING come back — and deliberately not the
+// retirement verdict's bar two lines from each call site. See
+// answerCarriesSomething for why the two questions differ and why the answer to
+// this one cannot be `len(Choices) == 0`.
 //
 // A state other than "completed" means the attempt failed after the headers: a
 // body read that died, a body the gateway could not decode, an upstream that
@@ -85,7 +85,7 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 	// Read here rather than at the call sites: two copies of the same expression
 	// is how one of them comes to be missing it, which is what happened to the
 	// third charge site this change added.
-	clientGone := r != nil && r.Context().Err() != nil
+	gone := clientGone(r)
 	if logData.state != "completed" {
 		// The attempt failed after the headers.
 		//
@@ -102,7 +102,7 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 		// relay quoting its token counts is the named cause), so it says nothing
 		// about whether the provider is up. A body that died on the wire is a
 		// different kind now, and does charge.
-		if clientGone || !providerAtFault(logData.errorKind) {
+		if gone || !providerAtFault(logData.errorKind) {
 			return
 		}
 		h.chargeBreaker(st, candidate, "response failed after headers")
@@ -145,7 +145,7 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	// caller's context, so an abandoned request arrives here as a translation
 	// failure — the same false charge the two sibling verdicts guard against,
 	// and this third charge site was created in the same change without it.
-	if (r == nil || r.Context().Err() == nil) && translationIsProviderFault(err) {
+	if !clientGone(r) && translationIsProviderFault(err) {
 		h.chargeBreaker(st, candidate, "upstream body could not be translated")
 	}
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
@@ -162,5 +162,76 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 // Charging for it took a healthy provider out of rotation for every tenant after
 // five blocked prompts, which is exactly what a client retries.
 func translationIsProviderFault(err error) bool {
-	return !errors.Is(err, gemini.ErrNoCandidates)
+	return !errors.Is(err, gemini.ErrPromptBlocked)
+}
+
+// answerCarriesSomething reports whether a completion carries anything at all
+// from the provider. Its negation is requestLogData.emptyCompletion, the one
+// shape a 200 is charged for.
+//
+// Deliberately NOT chatAnswerCarriesContent, which backs the retirement verdict
+// and stays strict: `refusal` is the likeliest field for an aggregator to write
+// "this model is gone" into behind a 200, and widening the retirement bar to
+// count it would let such a provider clear its gone-strikes forever.
+//
+// And deliberately not `len(Choices) == 0` either, which is what this was first
+// narrowed to. Every egress translator synthesises a one-element Choices literal
+// on success, so an emptied Gemini, Anthropic-egress or Responses answer always
+// had a choice and the charge could never fire for any of them — the fix was a
+// no-op for three whole dialects.
+//
+// The bar is therefore: did any choice come back with SOMETHING in it. An
+// allowlist for the unmodelled shapes rather than "any member that carries",
+// because a relay stamping a bookkeeping field on the assistant message would
+// otherwise make the breaker inert with no signal anywhere.
+func answerCarriesSomething(out ChatCompletionResponse) bool {
+	if out.Usage.CompletionTokens > 0 {
+		return true
+	}
+	for _, choice := range out.Choices {
+		if choiceCarriesSomething(choice) {
+			return true
+		}
+	}
+	return false
+}
+
+func choiceCarriesSomething(choice Choice) bool {
+	// A stop reason the provider reported about its own output. A filtered
+	// answer is the provider answering — Gemini's SAFETY maps here too — and a
+	// length cut means there was output to cut.
+	if choice.FinishReason != nil {
+		switch *choice.FinishReason {
+		case "content_filter", "length":
+			return true
+		}
+	}
+	msg := choice.Message
+	if text, ok := msg.Content.(string); ok && text != "" {
+		return true
+	}
+	if parts, ok := msg.Content.([]any); ok && len(parts) > 0 {
+		return true
+	}
+	if msg.ReasoningContent != "" || msg.Reasoning != "" || len(msg.ReasoningDetails) > 0 {
+		return true
+	}
+	if len(msg.ToolCalls) > 0 {
+		return true
+	}
+	// The unmodelled shapes that ARE the answer: a safety refusal, the audio
+	// object on a speech completion, a legacy function_call, a citation set.
+	for _, key := range []string{"refusal", "audio", "function_call", "annotations"} {
+		if util.ValueCarries(msg.Extra[key]) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientGone reports whether the caller has already hung up. One spelling,
+// because the two hand-written copies this replaced were mutually inverted and
+// sixty lines apart — the shape that let the third charge site ship without one.
+func clientGone(r *http.Request) bool {
+	return r != nil && r.Context().Err() != nil
 }

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/gemini"
 )
 
 // The circuit-breaker verdict for a non-streaming attempt lives here, beside
@@ -76,38 +78,44 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 // body read that died, a body the gateway could not decode, an upstream that
 // sent a success shape behind a failure status. The old code had already
 // credited every one of those before the read was even attempted.
-func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData, clientGone bool) {
+func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData, r *http.Request) {
 	if !st.circuitBreakerEnabled {
 		return
 	}
-	// A client that hangs up mid-read is not a provider failure. The upstream
-	// body is read under the caller's context, so a user pressing stop, or a
-	// load balancer's client-side timeout, surfaces here as a failed read — and
-	// charging for it would open the circuit for every tenant after N impatient
-	// cancels. doUpstream, judgeStreamForBreaker, classifyProbeError and the
-	// pass-through first-byte probe all refuse to charge for this; this was the
-	// one verdict that did not.
-	if clientGone {
-		return
-	}
+	// Read here rather than at the call sites: two copies of the same expression
+	// is how one of them comes to be missing it, which is what happened to the
+	// third charge site this change added.
+	clientGone := r != nil && r.Context().Err() != nil
 	if logData.state != "completed" {
-		// The attempt failed after the headers. Only a fault that is the
-		// PROVIDER'S counts — the same predicate judgeStreamForBreaker uses, and
-		// for the same reason it uses it. A 2xx this gateway could not decode is
+		// The attempt failed after the headers.
+		//
+		// Not when the CLIENT hung up: the upstream body is read under the
+		// caller's context, so a user pressing stop, or a load balancer's
+		// client-side timeout, surfaces here as a failed read — and charging for
+		// it would open the circuit for every tenant after five impatient
+		// cancels. doUpstream, judgeStreamForBreaker, classifyProbeError and the
+		// pass-through first-byte probe all refuse to charge for this.
+		//
+		// And only a fault that is the PROVIDER'S counts, by the same predicate
+		// judgeStreamForBreaker uses. A 2xx this gateway could not decode is
 		// classified provider_bad_request and still holds the model's text (a
 		// relay quoting its token counts is the named cause), so it says nothing
-		// about whether the provider is up; the streaming side calls recording
-		// nothing the honest verdict there, and it is the honest verdict here.
-		if providerAtFault(logData.errorKind) {
-			h.chargeBreaker(st, candidate, "response failed after headers")
+		// about whether the provider is up. A body that died on the wire is a
+		// different kind now, and does charge.
+		if clientGone || !providerAtFault(logData.errorKind) {
+			return
 		}
+		h.chargeBreaker(st, candidate, "response failed after headers")
 		return
 	}
-	if producedOutput(logData) {
-		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+	// A completed answer is credited even if the caller has since gone: the body
+	// was read, the provider answered, and withholding the credit leaves older
+	// failures on the clock to open a healthy circuit later.
+	if logData.emptyCompletion {
+		h.chargeBreaker(st, candidate, "response completed without delivering content")
 		return
 	}
-	h.chargeBreaker(st, candidate, "response completed without delivering content")
+	h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 }
 
 // chargeBreaker records one breaker failure with its cause in the log. The
@@ -131,10 +139,28 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, reas
 // any translation was attempted, and each adapter's own comment already called
 // this a provider fault. Mutation testing then showed two of the three copies
 // had no test behind them.
-func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, err error, attempt int) candidateOutcome {
+func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
-	h.chargeBreaker(st, candidate, "upstream body could not be translated")
+	// Both translators read the body with an unbounded ReadAll under the
+	// caller's context, so an abandoned request arrives here as a translation
+	// failure — the same false charge the two sibling verdicts guard against,
+	// and this third charge site was created in the same change without it.
+	if (r == nil || r.Context().Err() == nil) && translationIsProviderFault(err) {
+		h.chargeBreaker(st, candidate, "upstream body could not be translated")
+	}
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt
 	return outcomeFailover
+}
+
+// translationIsProviderFault separates "these bytes are not the object this
+// adapter expects" from "the provider answered, and its answer was a refusal".
+//
+// A Gemini prompt blocked by its safety filter returns 200 with an empty
+// candidate list, which BuildChatCompletion cannot turn into a completion — but
+// the body is a perfectly good Gemini object and the provider is plainly alive.
+// Charging for it took a healthy provider out of rotation for every tenant after
+// five blocked prompts, which is exactly what a client retries.
+func translationIsProviderFault(err error) bool {
+	return !errors.Is(err, gemini.ErrNoCandidates)
 }

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -102,3 +102,20 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, reas
 	debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
 	h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
 }
+
+// rejectUntranslatableBody is the single outcome all three egress adapters have
+// for a 200 whose body they cannot turn into a completion.
+//
+// One place because the outcome has four parts — the log, the breaker charge,
+// the request error and the failover — and three copies of it is how the charge
+// came to be missing from all three: a 200 was credited at header time, before
+// any translation was attempted, and each adapter's own comment already called
+// this a provider fault. Mutation testing then showed two of the three copies
+// had no test behind them.
+func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, err error, attempt int) candidateOutcome {
+	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
+	h.chargeBreaker(st, candidate, "upstream body could not be translated")
+	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
+	logData.failoverAttempt = attempt
+	return outcomeFailover
+}

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -76,19 +76,38 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 // body read that died, a body the gateway could not decode, an upstream that
 // sent a success shape behind a failure status. The old code had already
 // credited every one of those before the read was even attempted.
-func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData) {
+func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData, clientGone bool) {
 	if !st.circuitBreakerEnabled {
 		return
 	}
-	if logData.state == "completed" && producedOutput(logData) {
+	// A client that hangs up mid-read is not a provider failure. The upstream
+	// body is read under the caller's context, so a user pressing stop, or a
+	// load balancer's client-side timeout, surfaces here as a failed read — and
+	// charging for it would open the circuit for every tenant after N impatient
+	// cancels. doUpstream, judgeStreamForBreaker, classifyProbeError and the
+	// pass-through first-byte probe all refuse to charge for this; this was the
+	// one verdict that did not.
+	if clientGone {
+		return
+	}
+	if logData.state != "completed" {
+		// The attempt failed after the headers. Only a fault that is the
+		// PROVIDER'S counts — the same predicate judgeStreamForBreaker uses, and
+		// for the same reason it uses it. A 2xx this gateway could not decode is
+		// classified provider_bad_request and still holds the model's text (a
+		// relay quoting its token counts is the named cause), so it says nothing
+		// about whether the provider is up; the streaming side calls recording
+		// nothing the honest verdict there, and it is the honest verdict here.
+		if providerAtFault(logData.errorKind) {
+			h.chargeBreaker(st, candidate, "response failed after headers")
+		}
+		return
+	}
+	if producedOutput(logData) {
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 		return
 	}
-	reason := "response completed without delivering content"
-	if logData.state != "completed" {
-		reason = "response failed after headers"
-	}
-	h.chargeBreaker(st, candidate, reason)
+	h.chargeBreaker(st, candidate, "response completed without delivering content")
 }
 
 // chargeBreaker records one breaker failure with its cause in the log. The

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -85,24 +85,20 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 	// Read here rather than at the call sites: two copies of the same expression
 	// is how one of them comes to be missing it, which is what happened to the
 	// third charge site this change added.
-	gone := clientGone(r)
 	if logData.state != "completed" {
 		// The attempt failed after the headers.
 		//
-		// Not when the CLIENT hung up: the upstream body is read under the
-		// caller's context, so a user pressing stop, or a load balancer's
-		// client-side timeout, surfaces here as a failed read — and charging for
-		// it would open the circuit for every tenant after five impatient
-		// cancels. doUpstream, judgeStreamForBreaker, classifyProbeError and the
-		// pass-through first-byte probe all refuse to charge for this.
+		// The KIND decides, and nothing else. Every way an attempt can fail after
+		// the headers already has one: a caller hanging up, this gateway's own
+		// request_timeout, a body it could not decode, a body that died on the
+		// wire. providerAtFault excludes all but the last, which is the same
+		// predicate judgeStreamForBreaker uses.
 		//
-		// And only a fault that is the PROVIDER'S counts, by the same predicate
-		// judgeStreamForBreaker uses. A 2xx this gateway could not decode is
-		// classified provider_bad_request and still holds the model's text (a
-		// relay quoting its token counts is the named cause), so it says nothing
-		// about whether the provider is up. A body that died on the wire is a
-		// different kind now, and does charge.
-		if gone || !providerAtFault(logData.errorKind) {
+		// A separate client-gone guard used to sit here as well. It read the
+		// CLIENT's context, so it was blind to a failover-timeout cancel, and it
+		// was a second rule that had to agree with the first — the shape three
+		// review rounds kept finding a hole in.
+		if !providerAtFault(logData.errorKind) {
 			return
 		}
 		h.chargeBreaker(st, candidate, "response failed after headers")
@@ -142,10 +138,10 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, reas
 func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
 	// Both translators read the body with an unbounded ReadAll under the
-	// caller's context, so an abandoned request arrives here as a translation
-	// failure — the same false charge the two sibling verdicts guard against,
-	// and this third charge site was created in the same change without it.
-	if !clientGone(r) && translationIsProviderFault(err) {
+	// attempt's context, so an interrupted request arrives here as a translation
+	// failure — a caller hanging up or this gateway's own request_timeout, and
+	// neither is the provider's doing.
+	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
 		h.chargeBreaker(st, candidate, "upstream body could not be translated")
 	}
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
@@ -170,9 +166,12 @@ func translationIsProviderFault(err error) bool {
 // shape a 200 is charged for.
 //
 // Deliberately NOT chatAnswerCarriesContent, which backs the retirement verdict
-// and stays strict: `refusal` is the likeliest field for an aggregator to write
-// "this model is gone" into behind a 200, and widening the retirement bar to
-// count it would let such a provider clear its gone-strikes forever.
+// and stays narrow: `refusal` is the likeliest field for an aggregator to write
+// "this model is gone" into behind a 200, and letting the retirement bar count
+// it would clear such a provider's gone-strikes forever. That bar gained exactly
+// one thing on this branch — it reads ReasoningDetails, which it had been
+// judging BEFORE the normalisation that folds them into ReasoningContent, so a
+// reasoning-only answer read as nothing at all.
 //
 // And deliberately not `len(Choices) == 0` either, which is what this was first
 // narrowed to. Every egress translator synthesises a one-element Choices literal
@@ -220,18 +219,19 @@ func choiceCarriesSomething(choice Choice) bool {
 		return true
 	}
 	// The unmodelled shapes that ARE the answer: a safety refusal, the audio
-	// object on a speech completion, a legacy function_call, a citation set.
-	for _, key := range []string{"refusal", "audio", "function_call", "annotations"} {
+	// object on a speech completion, a legacy function_call, OpenRouter's
+	// generated `images`, Perplexity's `citations`, an Anthropic-shaped relay's
+	// `thinking_blocks`. For the image and citation models those members are the
+	// WHOLE answer, so a relay forwarding one without a usage block would have
+	// had a correct answer charged against it.
+	//
+	// An allowlist rather than "any member that carries", because a relay
+	// stamping a bookkeeping field on the assistant message would otherwise make
+	// the breaker inert with nothing to show for it.
+	for _, key := range []string{"refusal", "audio", "function_call", "annotations", "images", "citations", "thinking_blocks"} {
 		if util.ValueCarries(msg.Extra[key]) {
 			return true
 		}
 	}
 	return false
-}
-
-// clientGone reports whether the caller has already hung up. One spelling,
-// because the two hand-written copies this replaced were mutually inverted and
-// sixty lines apart — the shape that let the third charge site ship without one.
-func clientGone(r *http.Request) bool {
-	return r != nil && r.Context().Err() != nil
 }

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -1,0 +1,104 @@
+package proxy
+
+import (
+	"net/http"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// The circuit-breaker verdict for a non-streaming attempt lives here, beside
+// the failover loop that produces it rather than inside it — the streaming
+// verdict has the same arrangement in stream_finalize.go, and keeping the two
+// policies in named places is what stops a second opinion growing at a call
+// site. Split out of proxy_failover.go when that file hit the size ceiling.
+
+// recordBreakerOutcome records the circuit-breaker result for a completed
+// upstream attempt (phase D8). It is a no-op when the breaker is disabled.
+//
+// For a failover-eligible status it applies the breakerRecordAction mapping
+// (failure / no-op / success). For a non-eligible status it records a success,
+// except for a 200 — on either path.
+//
+// A 200 is a status, not an answer, and these headers arrive before a byte of
+// the body has been read. The verdict is deferred to whoever reads it:
+// judgeStreamForBreaker once the stream ends, recordAnswerOutcome once the
+// completion is decoded. Crediting here meant a provider answering
+// {"choices":[]} to every request recorded a success every time — and
+// RecordSuccess resets consecutiveFails, so its circuit could never open. #805
+// made that argument for streams and this is the same argument for completions.
+func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidate, statusCode int, isFailoverEligible bool) {
+	if !st.circuitBreakerEnabled {
+		return
+	}
+	if isFailoverEligible {
+		// Determine breaker action from status code.
+		// See breakerRecordAction for the full status→action mapping.
+		switch breakerRecordAction(statusCode) {
+		case breakerActionFailure:
+			// The hedged probe path reaches this with no other log of the
+			// upstream status, so without this line a breaker opening on
+			// repeated 5xx has no recorded cause anywhere.
+			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "upstream status", "status", statusCode, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
+			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
+		case breakerActionNoOp:
+			// Model-specific client error (404/499): provider is alive
+			// but rejecting this request. No-op for the breaker — neither
+			// failure nor success. Recording success would erase real 5xx
+			// failure history (resetting consecutiveFails in Closed state)
+			// and could prematurely close a half-open circuit based on a
+			// model-specific error that says nothing about provider health.
+		case breakerActionSuccess:
+			// Not reached for failover-eligible codes: shouldFailover only
+			// returns true for {5xx,429,401,403,402,404,499}, all of which map
+			// to failure or no-op above. Retained so the switch stays exhaustive
+			// over breakerAction — if the shouldFailover/breakerRecordAction
+			// mappings ever diverge, a success is recorded rather than dropped.
+			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+		}
+		return
+	}
+	if statusCode != http.StatusOK {
+		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+	}
+}
+
+// recordAnswerOutcome records the circuit-breaker verdict for a finished
+// non-streaming attempt, and is the completion-side sibling of
+// judgeStreamForBreaker.
+//
+// The bar is producedOutput, the same one the retirement verdict uses two lines
+// from each call site — text, content parts, reasoning, a tool call, or usage
+// reporting completion tokens. `200 {"choices":[]}` is what an aggregator in
+// front of a retired model returns between its refusals, and it is not an
+// answer whichever question is being asked of it.
+//
+// A state other than "completed" means the attempt failed after the headers: a
+// body read that died, a body the gateway could not decode, an upstream that
+// sent a success shape behind a failure status. The old code had already
+// credited every one of those before the read was even attempted.
+func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData) {
+	if !st.circuitBreakerEnabled {
+		return
+	}
+	if logData.state == "completed" && producedOutput(logData) {
+		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+		return
+	}
+	reason := "response completed without delivering content"
+	if logData.state != "completed" {
+		reason = "response failed after headers"
+	}
+	h.chargeBreaker(st, candidate, reason)
+}
+
+// chargeBreaker records one breaker failure with its cause in the log. The
+// cause is worth the line: a breaker that opens on anything other than an
+// upstream status has no other record of why, which is the gap the
+// "recording circuit breaker failure" warn was added to close.
+func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, reason string) {
+	if !st.circuitBreakerEnabled {
+		return
+	}
+	debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
+	h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
+}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -553,8 +553,30 @@ func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 		if choice.Message.ReasoningContent != "" || choice.Message.Reasoning != "" {
 			return true
 		}
+		// Read here rather than after the reasoning normalisation that folds it
+		// into ReasoningContent: that runs several statements LATER than the
+		// caller which judges this, so a reasoning-only OpenRouter answer read as
+		// nothing at all.
+		if len(choice.Message.ReasoningDetails) > 0 {
+			return true
+		}
 		if len(choice.Message.ToolCalls) > 0 {
 			return true
+		}
+		// Everything this package does not model rides in Extra, and some of it
+		// is unmistakably the model answering: a safety `refusal`, the `audio`
+		// object that IS the answer on a speech completion, a legacy
+		// `function_call`. Judged by the shared emptiness rule so a member that
+		// is present but carries nothing does not count.
+		//
+		// The generosity is deliberate and asymmetric. A false negative here
+		// charges the circuit breaker against a provider that answered
+		// correctly, which after five requests takes it out of rotation for
+		// every tenant; a false positive merely fails to strike a model.
+		for _, raw := range choice.Message.Extra {
+			if util.ValueCarries(raw) {
+				return true
+			}
 		}
 	}
 	return out.Usage.CompletionTokens > 0

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -553,10 +553,12 @@ func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 		if choice.Message.ReasoningContent != "" || choice.Message.Reasoning != "" {
 			return true
 		}
-		// Read here rather than after the reasoning normalisation that folds it
-		// into ReasoningContent: that runs several statements LATER than the
-		// caller which judges this, so a reasoning-only OpenRouter answer read as
-		// nothing at all.
+		// The one thing this bar gained: read here rather than after the
+		// reasoning normalisation that folds it into ReasoningContent, which
+		// runs several statements LATER than the caller judging this — so a
+		// reasoning-only OpenRouter answer read as nothing at all. A modelled
+		// field the model plainly produced, unlike the overflow members that
+		// belong to the breaker's bar alone (see answerCarriesSomething).
 		if len(choice.Message.ReasoningDetails) > 0 {
 			return true
 		}

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -563,21 +563,6 @@ func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 		if len(choice.Message.ToolCalls) > 0 {
 			return true
 		}
-		// Everything this package does not model rides in Extra, and some of it
-		// is unmistakably the model answering: a safety `refusal`, the `audio`
-		// object that IS the answer on a speech completion, a legacy
-		// `function_call`. Judged by the shared emptiness rule so a member that
-		// is present but carries nothing does not count.
-		//
-		// The generosity is deliberate and asymmetric. A false negative here
-		// charges the circuit breaker against a provider that answered
-		// correctly, which after five requests takes it out of rotation for
-		// every tenant; a false positive merely fails to strike a model.
-		for _, raw := range choice.Message.Extra {
-			if util.ValueCarries(raw) {
-				return true
-			}
-		}
 	}
 	return out.Usage.CompletionTokens > 0
 }

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -393,6 +393,13 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		if st.circuitBreakerEnabled {
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 		}
+	case resp.StatusCode != http.StatusOK:
+		// A 204 or 202 legitimately carries an empty body and the provider is
+		// plainly alive — the streamed twin says exactly this and credits it, so
+		// charging here would have the two disagree about one response.
+		if st.circuitBreakerEnabled {
+			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+		}
 	default:
 		h.chargeBreaker(st, candidate, "response completed without delivering content")
 	}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -346,10 +346,11 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
 	if err != nil {
-		// Not when the CLIENT hung up: this read runs under the caller's
-		// context, so an abandoned request surfaces here as a failed read. The
-		// first-byte probe below has always had this guard; this branch did not.
-		if r.Context().Err() == nil {
+		// Not when the read was interrupted rather than broken: it runs under
+		// the attempt's context, so a caller hanging up or this gateway's own
+		// request_timeout both surface here as a failed read, and neither is the
+		// provider's doing. cancelKind is the package's classifier for that.
+		if _, aborted := cancelKind(r.Context(), err); !aborted {
 			h.chargeBreaker(st, candidate, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough body read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", err)
@@ -388,7 +389,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	// written and used for the streak alone.
 	switch {
 	case r.Context().Err() != nil:
-		// The client is gone; nothing here is the provider's doing.
+		// The request was interrupted; nothing here is the provider's doing.
 	case answered:
 		if st.circuitBreakerEnabled {
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -329,7 +329,7 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
 
 	if isJSON {
-		h.serveBufferedJSONPassthrough(w, st, candidate, resp, contentType, attempt, responseHeaderMs)
+		h.serveBufferedJSONPassthrough(w, r, st, candidate, resp, contentType, attempt, responseHeaderMs)
 		return
 	}
 	h.serveStreamedPassthrough(w, r, st, candidate, resp, contentType, isSSE, attempt, responseHeaderMs)
@@ -341,21 +341,21 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 // whose body dies mid-read records a failure, not a success — and response
 // headers are only written after that point, so the read-error path emits a
 // clean OpenAI error response.
-func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64) {
+func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64) {
 	logData := st.logData
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
 	if err != nil {
-		if st.circuitBreakerEnabled {
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
+		// Not when the CLIENT hung up: this read runs under the caller's
+		// context, so an abandoned request surfaces here as a failed read. The
+		// first-byte probe below has always had this guard; this branch did not.
+		if r.Context().Err() == nil {
+			h.chargeBreaker(st, candidate, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough body read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", err)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", err))
 		writeOpenAIError(w, "failed to read upstream response", http.StatusBadGateway)
 		return
-	}
-	if st.circuitBreakerEnabled {
-		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
 	// The commit point is where the model has proved it is alive, so it is where
 	// its gone-strike streak stops being current. Without it "three CONSECUTIVE
@@ -379,6 +379,22 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, st *reques
 	answered := passthroughAnswered(logData.endpointType, body)
 	if answered {
 		h.noteModelServed(candidate.model, logData.endpointType)
+	}
+	// The breaker verdict reads the same answer, and until now it did not: the
+	// success was recorded the moment the read succeeded, so an embeddings
+	// provider replying 200 {"data":[]} to every request recorded a success
+	// every time and its circuit could never open. That is the chat-path bug
+	// this change fixes, on the surface whose detection function was already
+	// written and used for the streak alone.
+	switch {
+	case r.Context().Err() != nil:
+		// The client is gone; nothing here is the provider's doing.
+	case answered:
+		if st.circuitBreakerEnabled {
+			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
+		}
+	default:
+		h.chargeBreaker(st, candidate, "response completed without delivering content")
 	}
 	// Oversized is judged on the bytes read, before masking can shrink a
 	// cap+1 read under the cap and drop the streamed remainder.

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -161,7 +161,7 @@ func TestPassthrough_OversizedJSONChargesTheEstimate(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(`{"data":"` + strings.Repeat("a", passthroughJSONBufferCap) + `"}`)),
 	}
 	rec := httptest.NewRecorder()
-	h.serveBufferedJSONPassthrough(rec, st, modelCandidate{
+	h.serveBufferedJSONPassthrough(rec, httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -218,7 +218,7 @@ func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"created":1,"data":[{"b64":"AAAA"}]}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-3"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -259,7 +259,7 @@ func TestPassthrough_ReportedUsageWinsOverEstimate(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"usage":{"prompt_tokens":7,"total_tokens":7}}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -352,7 +352,7 @@ func TestPassthrough_EmptyAnswerIsNotCharged(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -457,7 +457,7 @@ func TestMultipartPassthrough_NoPromptFieldStillMeters(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"text":"hello there"}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -510,7 +510,7 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body:       io.NopCloser(strings.NewReader(`{"text":"ok"}`)),
 		}
-		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 		}, resp, "application/json", 1, 10.0)
@@ -537,7 +537,7 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 			Body: io.NopCloser(strings.NewReader(
 				`{"text":"ok","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`)),
 		}
-		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 		}, resp, "application/json", 1, 10.0)
@@ -584,7 +584,7 @@ func TestPassthroughFloor_StaysBehindTheDeliveryGate(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)
@@ -630,7 +630,7 @@ func TestOversizedPassthrough_ZeroPromptStillMeters(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(huge)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-2"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -42,17 +41,20 @@ var newRequestWithContext = http.NewRequestWithContext
 //   - A non-2xx carries no completion. Its body is the provider's error
 //     document, and that text is the whole reason such a row is worth reading,
 //     so it is sanitized and kept.
-func nonStreamingFailureDetail(resp *http.Response, body []byte, readErr, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
+func nonStreamingFailureDetail(ctx context.Context, resp *http.Response, body []byte, readErr, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if readErr != nil {
-			// A caller that hung up is not the provider failing. The body is read
-			// under the request context, so a client cancel arrives here as a
-			// read error — and reporting it as a provider fault put the tenant's
-			// own cancel on the provider's row in the dashboard. The streaming
-			// side already records KindClientDisconnect for this.
-			if errors.Is(readErr, context.Canceled) {
-				detail = "client disconnected before the response was read"
-				return detail, detail, KindClientDisconnect, "the request was cancelled"
+			// A read the provider did not break is not the provider failing. The
+			// body is read under the attempt's context, so a caller hanging up
+			// AND this gateway's own request_timeout both arrive here as read
+			// errors — and reporting either as a provider fault put someone
+			// else's cancellation on the provider's row and, once the breaker
+			// started reading these, its circuit. cancelKind is the package's own
+			// classifier; hand-rolling a narrower one here is what dropped the
+			// deadline case.
+			if kind, aborted := cancelKind(ctx, readErr); aborted {
+				detail = "the request was interrupted before the response was read"
+				return detail, detail, kind, "the request was interrupted"
 			}
 			// A body that died on the wire is not a body this gateway could not
 			// parse, and the two were collapsed into one kind. The parse failure
@@ -231,7 +233,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.dialMs = dialMs
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
-		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, readErr, decodeErr, logData.modelID)
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(r.Context(), resp, body, readErr, decodeErr, logData.modelID)
 		// body is already exact-masked; the log row also gets the key-shape
 		// layer, like every other stored error message.
 		logData.errorMessage = string(maskKeyShapedTokens([]byte(logMsg)))
@@ -285,8 +287,11 @@ func readNonStreamingBody(resp *http.Response, masker credentialMasker) (body []
 		}
 		return body, chatResp, readErr, err
 	}
-	// It decoded, so whatever the wire did afterwards cost nothing.
-	return body, chatResp, nil, nil
+	// readErr is returned as it was rather than cleared. It is only ever
+	// consulted alongside a decode failure — a clean decode means the 2xx branch
+	// serves the answer and never looks at it — so clearing it claimed a
+	// meaning it did not have.
+	return body, chatResp, readErr, nil
 }
 
 // failRequest populates logData with failure details and updates the request log.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -41,8 +41,18 @@ var newRequestWithContext = http.NewRequestWithContext
 //   - A non-2xx carries no completion. Its body is the provider's error
 //     document, and that text is the whole reason such a row is worth reading,
 //     so it is sanitized and kept.
-func nonStreamingFailureDetail(resp *http.Response, body []byte, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
+func nonStreamingFailureDetail(resp *http.Response, body []byte, readErr, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if readErr != nil {
+			// A body that died on the wire is not a body this gateway could not
+			// parse, and the two were collapsed into one kind. The parse failure
+			// is provider_bad_request because the answer is probably still in
+			// there; a transport failure is the provider breaking after it
+			// committed the status, which is what the breaker exists to catch —
+			// and classifying it as the parse failure left it uncharged.
+			detail = fmt.Sprintf("upstream body read error: %s (body_bytes=%d)", errString(readErr), len(body))
+			return detail, detail, KindProviderError, "the provider stopped sending its response"
+		}
 		detail = fmt.Sprintf("response decode error: %s (body_bytes=%d, content_type=%q)",
 			errString(decodeErr), len(body), resp.Header.Get("Content-Type"))
 		// Not "upstream provider returned HTTP 200": reporting the status as the
@@ -160,6 +170,9 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// completion is what an aggregator in front of a retired model returns,
 		// resetting the count so the model is never nominated.
 		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
+		// And the narrower question the breaker asks of the same body: see
+		// requestLogData.emptyCompletion.
+		logData.emptyCompletion = len(chatResp.Choices) == 0 && chatResp.Usage.CompletionTokens == 0
 		// Fire-and-forget: skip WaitForInsert to avoid blocking TTFB.
 		// The async INSERT is very likely complete by now; if not, the
 		// UPDATE simply affects 0 rows (harmless, logged as warning).
@@ -220,7 +233,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.dialMs = dialMs
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
-		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, decodeErr, logData.modelID)
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, readErr, decodeErr, logData.modelID)
 		// body is already exact-masked; the log row also gets the key-shape
 		// layer, like every other stored error message.
 		logData.errorMessage = string(maskKeyShapedTokens([]byte(logMsg)))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -44,6 +45,15 @@ var newRequestWithContext = http.NewRequestWithContext
 func nonStreamingFailureDetail(resp *http.Response, body []byte, readErr, decodeErr error, modelID string) (logMsg, detail string, kind ErrorKind, reason string) {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		if readErr != nil {
+			// A caller that hung up is not the provider failing. The body is read
+			// under the request context, so a client cancel arrives here as a
+			// read error — and reporting it as a provider fault put the tenant's
+			// own cancel on the provider's row in the dashboard. The streaming
+			// side already records KindClientDisconnect for this.
+			if errors.Is(readErr, context.Canceled) {
+				detail = "client disconnected before the response was read"
+				return detail, detail, KindClientDisconnect, "the request was cancelled"
+			}
 			// A body that died on the wire is not a body this gateway could not
 			// parse, and the two were collapsed into one kind. The parse failure
 			// is provider_bad_request because the answer is probably still in
@@ -108,19 +118,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 	// cap+1 is refused as oversized rather than decoded, because a truncated
 	// completion re-encoded as a valid one would hand the client silently
 	// mutilated content.
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
-	if readErr == nil && len(body) > nonStreamingBodyCap {
-		readErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap", nonStreamingBodyCap)
-	}
-	// Exact-key scrub on the whole body: the client answer and the failure
-	// log message both derive from it, and a success body is content where
-	// the key-shape regex must not run.
-	body = logData.masker.maskExact(body)
-	var chatResp ChatCompletionResponse
-	decodeErr := readErr
-	if decodeErr == nil {
-		decodeErr = json.NewDecoder(bytes.NewReader(body)).Decode(&chatResp)
-	}
+	body, chatResp, readErr, decodeErr := readNonStreamingBody(resp, logData.masker)
 
 	// Only a 2xx that decodes is a completion. Some upstreams (OpenCode Zen and
 	// OpenCode Go both do this) answer a failed request with a non-2xx carrying a
@@ -170,9 +168,9 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// completion is what an aggregator in front of a retired model returns,
 		// resetting the count so the model is never nominated.
 		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
-		// And the narrower question the breaker asks of the same body: see
-		// requestLogData.emptyCompletion.
-		logData.emptyCompletion = len(chatResp.Choices) == 0 && chatResp.Usage.CompletionTokens == 0
+		// And the different question the breaker asks of the same body: see
+		// answerCarriesSomething.
+		logData.emptyCompletion = !answerCarriesSomething(chatResp)
 		// Fire-and-forget: skip WaitForInsert to avoid blocking TTFB.
 		// The async INSERT is very likely complete by now; if not, the
 		// UPDATE simply affects 0 rows (harmless, logged as warning).
@@ -245,6 +243,50 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		debuglog.Debug("proxy: non-streaming error details", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "error", detail, "duration_ms", totalDuration)
 		writeOpenAIError(w, upstreamClientMessage(logData.providerName, resp.StatusCode, reason), resp.StatusCode)
 	}
+}
+
+// readNonStreamingBody reads the upstream body once and decodes it, returning
+// the bytes both branches below need, the decoded completion, and the two
+// failures kept apart: what went wrong on the wire, and what went wrong parsing.
+//
+// The read is bounded (nonStreamingBodyCap) so one upstream cannot make the
+// gateway buffer an arbitrary amount: cap+1 is read, and a body that reaches
+// cap+1 is refused rather than decoded, because a truncated completion
+// re-encoded as a valid one would hand the client silently mutilated content.
+// That refusal is THIS gateway's policy and not the provider failing, so it is
+// reported as a decode failure — folding it into readErr had an oversized answer
+// reported as "the provider stopped sending its response" and its provider's
+// circuit breaker charged for sending too much.
+//
+// json.Decoder, not json.Unmarshal: a decoder stops at the end of the first JSON
+// value, so a completion with trailing bytes after it still decodes.
+//
+// The decode is attempted even when the read errored, because JSON is
+// self-delimiting: a provider that sent the whole document and then dropped the
+// connection without its terminal chunk yields ErrUnexpectedEOF from a body that
+// parses perfectly. Discarding that threw away a complete answer and charged the
+// provider for it. If the bytes really were cut short the decode fails too, and
+// the read error is what gets reported. Same salvage rule as #810.
+func readNonStreamingBody(resp *http.Response, masker credentialMasker) (body []byte, chatResp ChatCompletionResponse, readErr, decodeErr error) {
+	body, readErr = io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
+	if readErr == nil && len(body) > nonStreamingBodyCap {
+		decodeErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap", nonStreamingBodyCap)
+	}
+	// Exact-key scrub on the whole body: the client answer and the failure log
+	// message both derive from it, and a success body is content where the
+	// key-shape regex must not run.
+	body = masker.maskExact(body)
+	if decodeErr != nil {
+		return body, chatResp, readErr, decodeErr
+	}
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&chatResp); err != nil {
+		if readErr != nil {
+			return body, chatResp, readErr, readErr
+		}
+		return body, chatResp, readErr, err
+	}
+	// It decoded, so whatever the wire did afterwards cost nothing.
+	return body, chatResp, nil, nil
 }
 
 // failRequest populates logData with failure details and updates the request log.

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -232,7 +232,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
-		h.recordAnswerOutcome(st, candidate, logData)
+		h.recordAnswerOutcome(st, candidate, logData, r.Context().Err() != nil)
 		if producedOutput(logData) {
 			h.noteModelServed(candidate.model, logData.endpointType)
 		}
@@ -240,7 +240,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
-	h.recordAnswerOutcome(st, candidate, logData)
+	h.recordAnswerOutcome(st, candidate, logData, r.Context().Err() != nil)
 	if producedOutput(logData) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -190,6 +190,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			// A 200 whose body cannot be read or is not a Responses object is
 			// a provider fault; fail over like any other malformed upstream.
 			debuglog.Warn("proxy: responses api translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
+			h.chargeBreaker(st, candidate, "upstream body could not be translated")
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt
 			return outcomeFailover
@@ -201,6 +202,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
 			debuglog.Warn("proxy: gemini translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
+			h.chargeBreaker(st, candidate, "upstream body could not be translated")
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt
 			return outcomeFailover
@@ -212,6 +214,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
 			debuglog.Warn("proxy: anthropic egress translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
+			h.chargeBreaker(st, candidate, "upstream body could not be translated")
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 			logData.failoverAttempt = attempt
 			return outcomeFailover
@@ -241,6 +244,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
+		h.recordAnswerOutcome(st, candidate, logData)
 		if producedOutput(logData) {
 			h.noteModelServed(candidate.model, logData.endpointType)
 		}
@@ -248,6 +252,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
+	h.recordAnswerOutcome(st, candidate, logData)
 	if producedOutput(logData) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
@@ -728,47 +733,4 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	// Log upstream response metadata for debugging.
 	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"), "x_request_id", resp.Header.Get("X-Request-Id"), "x_ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"), "attempt", attempt+1)
 	return resp, true
-}
-
-// recordBreakerOutcome records the circuit-breaker result for a completed
-// upstream attempt (phase D8). It is a no-op when the breaker is disabled.
-//
-// For a failover-eligible status it applies the breakerRecordAction mapping
-// (failure / no-op / success). For a non-eligible status it records a success,
-// except for a streaming 200 — there the success is deferred until the TTFT
-// probe confirms a first token, so it must not be recorded here.
-func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidate, statusCode int, isFailoverEligible bool) {
-	if !st.circuitBreakerEnabled {
-		return
-	}
-	if isFailoverEligible {
-		// Determine breaker action from status code.
-		// See breakerRecordAction for the full status→action mapping.
-		switch breakerRecordAction(statusCode) {
-		case breakerActionFailure:
-			// The hedged probe path reaches this with no other log of the
-			// upstream status, so without this line a breaker opening on
-			// repeated 5xx has no recorded cause anywhere.
-			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "upstream status", "status", statusCode, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name)
-		case breakerActionNoOp:
-			// Model-specific client error (404/499): provider is alive
-			// but rejecting this request. No-op for the breaker — neither
-			// failure nor success. Recording success would erase real 5xx
-			// failure history (resetting consecutiveFails in Closed state)
-			// and could prematurely close a half-open circuit based on a
-			// model-specific error that says nothing about provider health.
-		case breakerActionSuccess:
-			// Not reached for failover-eligible codes: shouldFailover only
-			// returns true for {5xx,429,401,403,402,404,499}, all of which map
-			// to failure or no-op above. Retained so the switch stays exhaustive
-			// over breakerAction — if the shouldFailover/breakerRecordAction
-			// mappings ever diverge, a success is recorded rather than dropped.
-			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-		}
-		return
-	}
-	if !st.isStreaming || statusCode != http.StatusOK {
-		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
-	}
 }

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -189,11 +189,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		} else if err := translateResponsesResponseBody(resp, st.reqModel); err != nil {
 			// A 200 whose body cannot be read or is not a Responses object is
 			// a provider fault; fail over like any other malformed upstream.
-			debuglog.Warn("proxy: responses api translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
-			h.chargeBreaker(st, candidate, "upstream body could not be translated")
-			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
-			logData.failoverAttempt = attempt
-			return outcomeFailover
+			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", err, attempt)
 		}
 	}
 	if st.geminiAttempt {
@@ -201,11 +197,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
-			debuglog.Warn("proxy: gemini translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
-			h.chargeBreaker(st, candidate, "upstream body could not be translated")
-			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
-			logData.failoverAttempt = attempt
-			return outcomeFailover
+			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", err, attempt)
 		}
 	}
 	if st.anthropicEgressAttempt {
@@ -213,11 +205,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
-			debuglog.Warn("proxy: anthropic egress translation failed", "error", err, "model", logData.modelID, "provider", logData.providerName)
-			h.chargeBreaker(st, candidate, "upstream body could not be translated")
-			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
-			logData.failoverAttempt = attempt
-			return outcomeFailover
+			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", err, attempt)
 		}
 	}
 	if st.isStreaming {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -189,7 +189,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		} else if err := translateResponsesResponseBody(resp, st.reqModel); err != nil {
 			// A 200 whose body cannot be read or is not a Responses object is
 			// a provider fault; fail over like any other malformed upstream.
-			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", err, attempt)
+			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", err, attempt, r)
 		}
 	}
 	if st.geminiAttempt {
@@ -197,7 +197,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", err, attempt)
+			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", err, attempt, r)
 		}
 	}
 	if st.anthropicEgressAttempt {
@@ -205,7 +205,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", err, attempt)
+			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", err, attempt, r)
 		}
 	}
 	if st.isStreaming {
@@ -232,7 +232,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
-		h.recordAnswerOutcome(st, candidate, logData, r.Context().Err() != nil)
+		h.recordAnswerOutcome(st, candidate, logData, r)
 		if producedOutput(logData) {
 			h.noteModelServed(candidate.model, logData.endpointType)
 		}
@@ -240,7 +240,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
-	h.recordAnswerOutcome(st, candidate, logData, r.Context().Err() != nil)
+	h.recordAnswerOutcome(st, candidate, logData, r)
 	if producedOutput(logData) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -231,7 +231,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	//
 	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
-		outcome := h.handleNativeNonStreaming(w, r, st, resp, attempt, responseHeaderMs)
+		outcome := h.handleNativeNonStreaming(w, r.WithContext(failoverCtx), st, resp, attempt, responseHeaderMs)
 		h.recordAnswerOutcome(st, candidate, logData, r)
 		if producedOutput(logData) {
 			h.noteModelServed(candidate.model, logData.endpointType)
@@ -239,7 +239,11 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return outcome
 	}
 
-	h.handleNonStreamingResponse(w, r, logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
+	// The handler reads the upstream body, and that read runs under failoverCtx —
+	// so that is the context it must judge an interrupted read by. Handing it the
+	// bare client request made this gateway's own request_timeout look like the
+	// provider dying.
+	h.handleNonStreamingResponse(w, r.WithContext(failoverCtx), logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
 	h.recordAnswerOutcome(st, candidate, logData, r)
 	if producedOutput(logData) {
 		h.noteModelServed(candidate.model, logData.endpointType)

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -66,7 +66,7 @@ func resp400(body string) *http.Response {
 // breakerOutcome describes the observable effect of recordBreakerOutcome on a
 // fresh circuit: failure creates a circuit with one consecutive fail, success
 // creates a circuit with zero, and "untouched" means no circuit was created
-// (no-op / disabled / deferred streaming-200).
+// (no-op / disabled / a 200 whose verdict is deferred until the body is read).
 type breakerOutcome int
 
 const (
@@ -93,7 +93,10 @@ func TestRecordBreakerOutcome(t *testing.T) {
 		{"eligible 200 -> success (exhaustive switch)", true, false, 200, true, breakerSuccessRecorded},
 		{"eligible 502 -> failure", true, false, 502, true, breakerFailureRecorded},
 		{"eligible 503 -> failure", true, false, 503, true, breakerFailureRecorded},
-		{"non-eligible 200 non-streaming -> success", true, false, 200, false, breakerSuccessRecorded},
+		// A 200 is a status, not an answer, on BOTH paths: the verdict waits for
+		// the body — judgeStreamForBreaker for a stream, recordAnswerOutcome for
+		// a completion.
+		{"non-eligible 200 non-streaming -> deferred (untouched)", true, false, 200, false, breakerUntouched},
 		{"non-eligible 200 streaming -> deferred (untouched)", true, true, 200, false, breakerUntouched},
 		{"non-eligible non-200 streaming -> success", true, true, 204, false, breakerSuccessRecorded},
 		{"non-eligible 204 non-streaming -> success", true, false, 204, false, breakerSuccessRecorded},

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -687,7 +688,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`{"choices":[{"message":{"role":"assistant","content":"private answer"}}],"created":"1"}`)
 		resp := &http.Response{StatusCode: http.StatusOK, Header: jsonHeader}
 
-		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, nil, decodeErr, "m")
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(context.Background(), resp, body, nil, decodeErr, "m")
 
 		for _, s := range []string{logMsg, detail} {
 			if strings.Contains(s, "private answer") || strings.Contains(s, "choices") {
@@ -710,7 +711,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`{"error":{"message":"rate limit reached for gpt-4o"}}`)
 		resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: jsonHeader}
 
-		logMsg, detail, kind, _ := nonStreamingFailureDetail(resp, body, nil, nil, "gpt-4o")
+		logMsg, detail, kind, _ := nonStreamingFailureDetail(context.Background(), resp, body, nil, nil, "gpt-4o")
 
 		if !strings.Contains(logMsg, "upstream HTTP 429") || !strings.Contains(logMsg, "rate limit reached") {
 			t.Errorf("logMsg = %q", logMsg)
@@ -728,7 +729,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`<html>502 Bad Gateway</html>`)
 		resp := &http.Response{StatusCode: http.StatusBadGateway, Header: http.Header{"Content-Type": []string{"text/html"}}}
 
-		logMsg, _, _, _ := nonStreamingFailureDetail(resp, body, nil, decodeErr, "m")
+		logMsg, _, _, _ := nonStreamingFailureDetail(context.Background(), resp, body, nil, decodeErr, "m")
 
 		if !strings.Contains(logMsg, "response decode error") || !strings.Contains(logMsg, "502 Bad Gateway") {
 			t.Errorf("logMsg = %q", logMsg)

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -687,7 +687,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`{"choices":[{"message":{"role":"assistant","content":"private answer"}}],"created":"1"}`)
 		resp := &http.Response{StatusCode: http.StatusOK, Header: jsonHeader}
 
-		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, decodeErr, "m")
+		logMsg, detail, kind, reason := nonStreamingFailureDetail(resp, body, nil, decodeErr, "m")
 
 		for _, s := range []string{logMsg, detail} {
 			if strings.Contains(s, "private answer") || strings.Contains(s, "choices") {
@@ -710,7 +710,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`{"error":{"message":"rate limit reached for gpt-4o"}}`)
 		resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: jsonHeader}
 
-		logMsg, detail, kind, _ := nonStreamingFailureDetail(resp, body, nil, "gpt-4o")
+		logMsg, detail, kind, _ := nonStreamingFailureDetail(resp, body, nil, nil, "gpt-4o")
 
 		if !strings.Contains(logMsg, "upstream HTTP 429") || !strings.Contains(logMsg, "rate limit reached") {
 			t.Errorf("logMsg = %q", logMsg)
@@ -728,7 +728,7 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 		body := []byte(`<html>502 Bad Gateway</html>`)
 		resp := &http.Response{StatusCode: http.StatusBadGateway, Header: http.Header{"Content-Type": []string{"text/html"}}}
 
-		logMsg, _, _, _ := nonStreamingFailureDetail(resp, body, decodeErr, "m")
+		logMsg, _, _, _ := nonStreamingFailureDetail(resp, body, nil, decodeErr, "m")
 
 		if !strings.Contains(logMsg, "response decode error") || !strings.Contains(logMsg, "502 Bad Gateway") {
 			t.Errorf("logMsg = %q", logMsg)

--- a/internal/proxy/reqerror.go
+++ b/internal/proxy/reqerror.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -80,6 +82,37 @@ type reqError struct {
 // cancelOriginToKind maps an internal cancel-origin identifier (the value
 // stored under ctxkeys.CancelOriginKey, also fed to humanReadableCancelOrigin)
 // to its error kind.
+// cancelKind classifies a failure that is a context error rather than the
+// provider misbehaving, and reports whether it was one.
+//
+// It exists because a second, narrower spelling of this rule kept being
+// hand-rolled at each new site and kept dropping a case. The one that cost most:
+// checking only errors.Is(err, context.Canceled) missed context.DeadlineExceeded,
+// which is what this gateway's own request_timeout produces mid-body-read — so a
+// slow but healthy provider was charged with a breaker failure, five of them
+// taking it out of rotation for every tenant.
+//
+// Two inputs, one question: the error itself, and the attempt's context going
+// down underneath a read that reported something else. Keeping those as two
+// separate guards at each site is what let one of them ship without the other.
+//
+// Whoever cancelled, it was not the provider: every kind this returns is
+// excluded by providerAtFault, so a caller that classifies with this and then
+// gates on providerAtFault needs no separate client-gone guard at all.
+func cancelKind(ctx context.Context, err error) (ErrorKind, bool) {
+	interrupted := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	if !interrupted && ctx.Err() == nil {
+		return "", false
+	}
+	if !interrupted {
+		// The context went down underneath a read that reported something else.
+		// The cancellation is still the reason there is no answer, and it is
+		// still not the provider's doing.
+		err = ctx.Err()
+	}
+	return cancelOriginToKind(resolveCancelOrigin(ctx, err)), true
+}
+
 func cancelOriginToKind(origin string) ErrorKind {
 	switch origin {
 	case "client_disconnect":

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -159,6 +159,18 @@ type requestLogData struct {
 	// can be switched off — and a real success that reports neither would
 	// otherwise look indistinguishable from a stream that emitted nothing.
 	deliveredContent bool
+	// emptyCompletion records that the upstream answered with nothing at all --
+	// no choices and no completion tokens -- which is the only shape the circuit
+	// breaker charges a 200 for.
+	//
+	// Deliberately narrower than !deliveredContent. That flag backs the
+	// RETIREMENT verdict, where missing an answer merely fails to clear a
+	// streak; here a false positive takes the provider out of rotation for every
+	// tenant after five requests. So a choice that exists but whose content this
+	// gateway does not recognise -- a safety refusal, an audio answer, an Azure
+	// content_filter block, a legacy function_call -- is the provider answering,
+	// and only a completion with no choices in it is not.
+	emptyCompletion bool
 	// promptTextBytes is the size of the prompt text in the client's request
 	// (message text and tool definitions, never inline media), recorded at
 	// ingest so every response path can estimate the prompt when the provider

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -163,13 +163,13 @@ type requestLogData struct {
 	// no choices and no completion tokens -- which is the only shape the circuit
 	// breaker charges a 200 for.
 	//
-	// Deliberately narrower than !deliveredContent. That flag backs the
-	// RETIREMENT verdict, where missing an answer merely fails to clear a
-	// streak; here a false positive takes the provider out of rotation for every
-	// tenant after five requests. So a choice that exists but whose content this
-	// gateway does not recognise -- a safety refusal, an audio answer, an Azure
-	// content_filter block, a legacy function_call -- is the provider answering,
-	// and only a completion with no choices in it is not.
+	// A different question from !deliveredContent, not a narrower one. That flag
+	// backs the RETIREMENT verdict and stays strict, because `refusal` is the
+	// likeliest field for an aggregator to write "this model is gone" into
+	// behind a 200 and it must not clear a gone-strike streak. This one asks
+	// only whether ANYTHING came back, so a safety refusal, an audio answer, an
+	// Azure content_filter block or a legacy function_call all count as the
+	// provider answering. See answerCarriesSomething.
 	emptyCompletion bool
 	// promptTextBytes is the size of the prompt text in the client's request
 	// (message text and tool definitions, never inline media), recorded at


### PR DESCRIPTION
`recordBreakerOutcome` credited the provider with a success the moment the response **headers** arrived, before a byte of the body was read. So a provider answering `{"choices":[]}` to every request recorded a success every time — and `RecordSuccess` resets `consecutiveFails`, so its circuit could never open however long it went on returning nothing. `200 {"choices":[]}` is exactly what an aggregator in front of a retired model returns between its refusals.

That is #805's charge on the path #805 did not cover: it fixed the streaming side, where `finalizeStream` judges the stream after it ends, and left the completion side crediting on headers. The rule is the same on both now — **a 200 defers, and whoever reads the body records the verdict.**

## What decides it

`recordAnswerOutcome` is the completion-side sibling of `judgeStreamForBreaker`, and it has the same gates the sibling does, because three review rounds found this branch charging a healthy provider in five different ways:

- **An interrupted read is not a provider failure, and there is now one classifier for it.** The body is read under `failoverCtx`, so a caller hanging up *and* this gateway's own `request_timeout` both arrive as read errors. Checking only `errors.Is(err, context.Canceled)` missed the timeout's `context.DeadlineExceeded`, and the client-gone guard read the *client's* context, which is healthy at that moment — so five slow-but-alive answers took a provider out of rotation for every tenant. `cancelKind` is the package's existing rule (`resolveCancelOrigin` + `cancelOriginToKind`) applied at all four charge sites, instead of four hand-rolled spellings each dropping a different case.
- **A Gemini safety block is Gemini answering.** Every vertex-express chat request goes through `BuildChatCompletion`, which errors on an empty candidate list — exactly what a blocked prompt returns behind a good 200. `gemini.ErrPromptBlocked` marks it, keyed on the stated `blockReason`: exempting mere candidate-absence left `{}`, `null` and an aggregator's `200 {"error":…}` all exempt too, so no Gemini body could ever charge.
- **A complete answer behind an unclean close is served, not charged.** JSON is self-delimiting, so a provider that sent the whole document and then dropped the connection yields `ErrUnexpectedEOF` from parseable bytes. Same salvage rule as #810.
- **An oversized body is this gateway's policy, not the provider dying.** Folded into the read error it reported "the provider stopped sending its response" for a provider that sent too much.

## The bar, and why it is not the retirement bar

`answerCarriesSomething` asks whether **any choice came back with anything in it**. That question had to survive the egress translators: all three synthesise a one-element `Choices` literal on success, so a rule of `len(Choices) == 0` — which this branch briefly used — could never charge an emptied Gemini, Anthropic-egress or Responses answer. The identical upstream body charged on the native Anthropic path and credited through anthropic-egress, decided by nothing but which dialect the request arrived in.

It is deliberately **not** `chatAnswerCarriesContent`, which backs the retirement verdict and stays strict: `refusal` is the likeliest field for an aggregator to write *"this model is gone"* into behind a 200, and widening the retirement bar to count it would let such a provider clear its gone-strikes forever. The unmodelled shapes are an allowlist (`refusal`, `audio`, `function_call`, `annotations`) rather than "any member that carries", so a relay stamping a bookkeeping field cannot make the breaker inert with nothing to show for it.

## Two more of the same bug, found on the way

**The three egress adapters** (responses, gemini, anthropic-egress) each say in their own comment that a 200 whose body cannot be translated is a provider fault — and each one was crediting it. Their four identical lines are now one `rejectUntranslatableBody`, because mutation testing showed that even after adding the charge to all three, two of the three copies had no test behind them.

**The pass-through surface** had the original bug with its detection function already written: `passthroughAnswered` exists precisely to spot `200 {"data":[]}`, and was consulted for the gone-strike streak only while the breaker success was recorded the moment the buffered read succeeded. An embeddings provider answering nothing to every request could never open its circuit. Its buffered read-failure branch also lacked the client-gone guard its streamed twin has.

`proxy_failover.go` crossed the 800-line ceiling, so the breaker verdict moved to `breaker_outcome.go` — the arrangement the streaming verdict already has in `stream_finalize.go`.

## Verified live

Rebuilt dev stack against a mock provider:

- five empty 200s → `circuit-breaker: provider state=closed→open consecutive_failures=5`
- four empty, one real, four empty → no open at all; the real answer reset the streak
- six safety-refusal answers → no charge at all
- six `200 {"data":[]}` embeddings → six `response completed without delivering content` charges

App log and `request_logs` scanned after each run: zero occurrences of any response content or credential.

## Review

Four independent subagent rounds. Every round found real defects in the previous round's fixes, twice at HIGH severity — the fixes written under review pressure were consistently the least-reviewed code. Thirty mutations across the branch, all killed; several of them found tests that could not detect the change they were named after, including one that re-implemented the predicate under test instead of calling it.

## Not in this PR

- `anthropicegress` returns `upstream error: <kind>` for a well-formed Anthropic error envelope behind a 200. For `invalid_request_error` and friends that is the caller's fault and the provider is alive, so it deserves the same exemption Gemini got. Anthropic does not normally do this; relays might.
- A hedged loser still gets no breaker verdict. Pre-existing; `runHedgedStreaming` is streaming-only so this branch does not touch it.
- An interrupted non-streaming row carries HTTP 200 rather than 499, so status-based analytics count it as a success. Fixing the row alone would disagree with what the client is written; changing both is a caller-visible decision worth taking on its own.
- `internal/anthropic`, `internal/openairesponses` and `internal/gemini` decode token counts as plain ints. On the latter two that is inside the whole-response decode, so a quoted count loses the answer — and now charges the provider for it. Next up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
