### PR TITLE
fix(translators): a usage block must never cost the caller the answer

### DIFF
--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -108,3 +108,52 @@ func TestInspectStreamEvent_ANullUsageIsNotAReading(t *testing.T) {
 		})
 	}
 }
+
+// A member that could not be read costs the figures it FEEDS, and nothing else.
+// The prompt figure is input_tokens plus both cache counts; output_tokens is
+// read straight off its own member and is never in doubt.
+func TestParseResponseUsage_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		usage           string
+		wantIn, wantOut int
+	}{
+		// The cache-read count of 20000 lost here billed 4, and 4 is non-zero,
+		// so the estimator never replaced it.
+		{"a lost prompt addend", `{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`, 0, 5},
+		{"a lost completion count", `{"input_tokens":4,"output_tokens":"lots","cache_read_input_tokens":20000}`, 20004, 0},
+		{"all readable", `{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":20000}`, 20004, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"type":"message","content":[{"type":"text","text":"hi"}],"usage":` + tc.usage + `}`
+			got := ParseResponseUsage([]byte(body))
+			if got.PromptTokens != tc.wantIn || got.CompletionTokens != tc.wantOut {
+				t.Errorf("got %d/%d, want %d/%d", got.PromptTokens, got.CompletionTokens, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
+}
+
+// The streaming reader keeps the same rule — and this is the path where getting
+// it wrong bites hardest: message_start reports output_tokens 1, so a
+// message_delta whose usage is dropped leaves that 1 standing as the whole
+// completion count for the request.
+func TestInspectStreamEvent_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
+	t.Parallel()
+	got := InspectStreamEvent([]byte(`{"type":"message_delta","usage":{"output_tokens":1520,"input_tokens":[]}}`))
+	if !got.HasOutput || got.OutputTokens != 1520 {
+		t.Errorf("OutputTokens = %d (has=%v), want the count read straight off its own member", got.OutputTokens, got.HasOutput)
+	}
+
+	// And the other half of the rule, on the event that carries the prompt: a
+	// figure whose addend was lost is dropped rather than reported short.
+	start := InspectStreamEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":4,"output_tokens":1,"cache_read_input_tokens":[]}}}`))
+	if start.HasInput || start.InputTokens != 0 {
+		t.Errorf("InputTokens = %d (has=%v), want the prompt figure dropped: its cache addend was lost", start.InputTokens, start.HasInput)
+	}
+	if !start.HasOutput || start.OutputTokens != 1 {
+		t.Errorf("OutputTokens = %d (has=%v), want 1: it is read straight off its own member", start.OutputTokens, start.HasOutput)
+	}
+}

--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -34,3 +34,57 @@ func TestParseResponseUsage_CountSpellings(t *testing.T) {
 		})
 	}
 }
+
+// The streaming twin of ParseResponseUsage, in the same file, decoded its counts
+// inline — so a spelling cost the event its TYPE along with its counts, and
+// message_stop and the error events stopped being recognised for that frame.
+// The adjacent Error member's own comment spells out that exact failure.
+func TestInspectStreamEvent_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		payload  string
+		wantType string
+		wantOut  int
+	}{
+		{"plain", `{"type":"message_delta","usage":{"output_tokens":4}}`, "message_delta", 4},
+		{"quoted", `{"type":"message_delta","usage":{"output_tokens":"4"}}`, "message_delta", 4},
+		{"fractional", `{"type":"message_delta","usage":{"output_tokens":4.0}}`, "message_delta", 4},
+		// The type survives even when the usage cannot be read at all, which is
+		// the half that costs the stream its terminal frame.
+		{"unreadable usage", `{"type":"message_delta","usage":"none"}`, "message_delta", 0},
+		{"null usage", `{"type":"message_stop","usage":null}`, "message_stop", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := InspectStreamEvent([]byte(tc.payload))
+			if got.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q: the event lost its type with its counts", got.Type, tc.wantType)
+			}
+			if got.OutputTokens != tc.wantOut {
+				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tc.wantOut)
+			}
+		})
+	}
+}
+
+// message_start carries its usage one level down, and it had the same defect.
+func TestInspectStreamEvent_MessageStartCountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, payload := range []string{
+		`{"type":"message_start","message":{"usage":{"input_tokens":11,"output_tokens":1}}}`,
+		`{"type":"message_start","message":{"usage":{"input_tokens":"11","output_tokens":1}}}`,
+		`{"type":"message_start","message":{"usage":{"input_tokens":11.0,"output_tokens":1}}}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			t.Parallel()
+			got := InspectStreamEvent([]byte(payload))
+			if got.Type != "message_start" {
+				t.Errorf("Type = %q, want message_start", got.Type)
+			}
+			if got.InputTokens != 11 || !got.HasInput {
+				t.Errorf("InputTokens = %d (has=%v), want 11", got.InputTokens, got.HasInput)
+			}
+		})
+	}
+}

--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -1,0 +1,36 @@
+package anthropic
+
+import "testing"
+
+// A count is a count however the provider spelled it. A plain int field met
+// neither the quoted nor the fractional form, so ParseResponseUsage returned
+// nothing and the request metered at zero — the caller's quota debited for an
+// answer it received.
+func TestParseResponseUsage_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		usage           string
+		wantIn, wantOut int
+	}{
+		{"plain integers", `{"input_tokens":12,"output_tokens":3}`, 12, 3},
+		{"quoted", `{"input_tokens":"12","output_tokens":"3"}`, 12, 3},
+		{"floating point", `{"input_tokens":12.0,"output_tokens":3.0}`, 12, 3},
+		{"mixed", `{"input_tokens":"12","output_tokens":3}`, 12, 3},
+		// Not a count in any spelling: nothing is invented for it.
+		{"unreadable", `{"input_tokens":"lots"}`, 0, 0},
+		{"absent", ``, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"type":"message","content":[{"type":"text","text":"hi"}]}`
+			if tc.usage != "" {
+				body = `{"type":"message","content":[{"type":"text","text":"hi"}],"usage":` + tc.usage + `}`
+			}
+			got := ParseResponseUsage([]byte(body))
+			if got.PromptTokens != tc.wantIn || got.CompletionTokens != tc.wantOut {
+				t.Errorf("got %d/%d, want %d/%d", got.PromptTokens, got.CompletionTokens, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
+}

--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -88,3 +88,23 @@ func TestInspectStreamEvent_MessageStartCountSpellings(t *testing.T) {
 		})
 	}
 }
+
+// An explicit null is not a usage block. The *antUsage this replaced was nil for
+// absent AND null alike; a json.RawMessage for null is four non-empty bytes, and
+// emitRawData assigns OutputTokens unguarded — so a null usage on a later event
+// would wipe the count message_start reported.
+func TestInspectStreamEvent_ANullUsageIsNotAReading(t *testing.T) {
+	t.Parallel()
+	for _, payload := range []string{
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":null}`,
+		`{"type":"message_start","message":{"usage":null}}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			t.Parallel()
+			got := InspectStreamEvent([]byte(payload))
+			if got.HasOutput || got.HasInput {
+				t.Errorf("a null usage read as a count: %+v", got)
+			}
+		})
+	}
+}

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -62,21 +62,7 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	if json.Unmarshal(body, &resp) != nil || !util.JSONMemberSet(resp.Usage) {
 		return ResponseUsage{}
 	}
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED — summed across members, or falling back to a sum — so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
-	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too — except master lost the answer with it.
-	var usage antUsage
-	if err := util.DecodeCounts(resp.Usage, &usage); err != nil {
-		return ResponseUsage{}
-	}
-	return usage.summary()
+	return readUsage(resp.Usage)
 }
 
 // antUsage is an Anthropic usage block. The cache fields are absent from
@@ -231,7 +217,11 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		}
 		if usage, ok := readEventUsage(raw); ok {
 			u := usage.summary()
-			info.InputTokens, info.HasInput = u.PromptTokens, true
+			// HasInput means there is a READING, so it follows the figure rather
+			// than the event: readEventUsage drops a prompt figure whose addend
+			// it could not read, and claiming a reading of zero for that would
+			// have the caller overwrite a good count with nothing.
+			info.InputTokens, info.HasInput = u.PromptTokens, u.PromptTokens > 0
 			info.CacheHitTokens, info.CacheMissTokens = u.CacheHitTokens, u.CacheMissTokens
 			if usage.OutputTokens > 0 {
 				info.OutputTokens, info.HasOutput = usage.OutputTokens, true
@@ -265,19 +255,49 @@ func readEventUsage(raw json.RawMessage) (antUsage, bool) {
 	if !util.JSONMemberSet(raw) {
 		return antUsage{}, false
 	}
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED — summed across members, or falling back to a sum — so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
-	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too — except master lost the answer with it.
 	var u antUsage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return antUsage{}, false
 	}
+	// A member that could not be read costs the figures it FEEDS, not the whole
+	// block. See readUsage.
+	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
+		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
+	}
+	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
+		u.OutputTokens = 0
+	}
 	return u, true
+}
+
+// promptAddends are the members Anthropic's prompt figure is SUMMED from.
+var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}
+
+// readUsage decodes an Anthropic usage block per FIGURE, not per block.
+//
+// Two rules were tried and both were wrong. Keeping whatever decoded corrupted
+// the prompt figure, which is input_tokens plus both cache counts: a cache-read
+// count of 20000 lost to an unreadable sibling billed 4, and 4 is non-zero, so
+// estimateMissingUsage never replaced it. Dropping the whole block instead threw
+// away output_tokens — read straight off one member, so never in doubt — and an
+// answer with a perfectly good completion count then read as empty, which since
+// #812 charges the provider's circuit breaker.
+//
+// So a member that could not be read costs the figures it FEEDS. output_tokens
+// stands or falls alone; the prompt figure needs all three of its addends.
+func readUsage(raw json.RawMessage) ResponseUsage {
+	if !util.JSONMemberSet(raw) {
+		return ResponseUsage{}
+	}
+	var u antUsage
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+		return ResponseUsage{}
+	}
+	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
+		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
+	}
+	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
+		u.OutputTokens = 0
+	}
+	return u.summary()
 }

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -57,12 +57,22 @@ type ResponseUsage struct {
 // internal/anthropicegress.translateUsage), so both Anthropic paths agree.
 func ParseResponseUsage(body []byte) ResponseUsage {
 	var resp struct {
-		Usage antUsage `json:"usage"`
+		Usage json.RawMessage `json:"usage"`
 	}
-	if json.Unmarshal(body, &resp) != nil {
+	if json.Unmarshal(body, &resp) != nil || len(resp.Usage) == 0 {
 		return ResponseUsage{}
 	}
-	return resp.Usage.summary()
+	// The usage member is lifted out before its counts are read: util.DecodeCounts
+	// re-parses the document it is given on each coercion pass, and a message body
+	// carries the whole answer. A count is a count however the provider spelled it
+	// — quoted, or with a fraction on it because a relay did its arithmetic in
+	// floating point — and a plain int field met neither, metering the request at
+	// zero.
+	var usage antUsage
+	if err := util.DecodeCounts(resp.Usage, &usage); err != nil {
+		return ResponseUsage{}
+	}
+	return usage.summary()
 }
 
 // antUsage is an Anthropic usage block. The cache fields are absent from

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -62,16 +62,18 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	if json.Unmarshal(body, &resp) != nil || !util.JSONMemberSet(resp.Usage) {
 		return ResponseUsage{}
 	}
-	// The usage member is lifted out before its counts are read: util.DecodeCounts
-	// re-parses the document it is given on each coercion pass, and a message body
-	// carries the whole answer. A count is a count however the provider spelled it
-	// — quoted, or with a fraction on it because a relay did its arithmetic in
-	// floating point — and a plain int field met neither, metering the request at
-	// zero.
-	// A shape error keeps what did decode, the rule Usage.UnmarshalJSON settled
-	// on in #811: one unreadable member must not cost the counts beside it.
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED — summed across members, or falling back to a sum — so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too — except master lost the answer with it.
 	var usage antUsage
-	if err := util.DecodeCounts(resp.Usage, &usage); err != nil && util.ShapeError(resp.Usage, err) == nil {
+	if err := util.DecodeCounts(resp.Usage, &usage); err != nil {
 		return ResponseUsage{}
 	}
 	return usage.summary()
@@ -263,8 +265,18 @@ func readEventUsage(raw json.RawMessage) (antUsage, bool) {
 	if !util.JSONMemberSet(raw) {
 		return antUsage{}, false
 	}
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED — summed across members, or falling back to a sum — so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too — except master lost the answer with it.
 	var u antUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return antUsage{}, false
 	}
 	return u, true

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -59,7 +59,7 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	var resp struct {
 		Usage json.RawMessage `json:"usage"`
 	}
-	if json.Unmarshal(body, &resp) != nil || len(resp.Usage) == 0 {
+	if json.Unmarshal(body, &resp) != nil || !util.JSONMemberSet(resp.Usage) {
 		return ResponseUsage{}
 	}
 	// The usage member is lifted out before its counts are read: util.DecodeCounts
@@ -68,8 +68,10 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	// — quoted, or with a fraction on it because a relay did its arithmetic in
 	// floating point — and a plain int field met neither, metering the request at
 	// zero.
+	// A shape error keeps what did decode, the rule Usage.UnmarshalJSON settled
+	// on in #811: one unreadable member must not cost the counts beside it.
 	var usage antUsage
-	if err := util.DecodeCounts(resp.Usage, &usage); err != nil {
+	if err := util.DecodeCounts(resp.Usage, &usage); err != nil && util.ShapeError(resp.Usage, err) == nil {
 		return ResponseUsage{}
 	}
 	return usage.summary()
@@ -191,9 +193,14 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	var ev struct {
 		Type    string `json:"type"`
 		Message *struct {
-			Usage *antUsage `json:"usage"`
+			Usage json.RawMessage `json:"usage"`
 		} `json:"message"`
-		Usage *antUsage `json:"usage"`
+		// json.RawMessage for the same reason the error member below is one: a
+		// count the provider spelled differently — quoted, or with a fraction on
+		// it — failed the WHOLE event unmarshal, so the event lost its TYPE with
+		// its counts and message_stop and the error events stopped being
+		// recognised for that frame.
+		Usage json.RawMessage `json:"usage"`
 		// json.RawMessage, not a typed object: a relay is free to send a bare
 		// string here, and a typed field failed the WHOLE event unmarshal — so
 		// the event lost its type too, the error went uncounted, and the frame
@@ -216,17 +223,21 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	info := StreamEvent{Type: ev.Type}
 	switch ev.Type {
 	case "message_start":
-		if ev.Message != nil && ev.Message.Usage != nil {
-			u := ev.Message.Usage.summary()
+		var raw json.RawMessage
+		if ev.Message != nil {
+			raw = ev.Message.Usage
+		}
+		if usage, ok := readEventUsage(raw); ok {
+			u := usage.summary()
 			info.InputTokens, info.HasInput = u.PromptTokens, true
 			info.CacheHitTokens, info.CacheMissTokens = u.CacheHitTokens, u.CacheMissTokens
-			if ev.Message.Usage.OutputTokens > 0 {
-				info.OutputTokens, info.HasOutput = ev.Message.Usage.OutputTokens, true
+			if usage.OutputTokens > 0 {
+				info.OutputTokens, info.HasOutput = usage.OutputTokens, true
 			}
 		}
 	case "message_delta":
-		if ev.Usage != nil {
-			info.OutputTokens, info.HasOutput = ev.Usage.OutputTokens, true
+		if usage, ok := readEventUsage(ev.Usage); ok {
+			info.OutputTokens, info.HasOutput = usage.OutputTokens, true
 		}
 	case "error":
 		if util.ErrorMemberCarries(ev.Error) {
@@ -242,4 +253,19 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		}
 	}
 	return info
+}
+
+// readEventUsage decodes a stream event's usage member on its own, reporting
+// whether there was one to read. A count spelled differently must not cost the
+// event its type, and a member that cannot be read at all must not cost the
+// counts beside it.
+func readEventUsage(raw json.RawMessage) (antUsage, bool) {
+	if !util.JSONMemberSet(raw) {
+		return antUsage{}, false
+	}
+	var u antUsage
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+		return antUsage{}, false
+	}
+	return u, true
 }

--- a/internal/anthropicegress/count_spelling_test.go
+++ b/internal/anthropicegress/count_spelling_test.go
@@ -89,8 +89,6 @@ func TestBuildChatCompletion_MetersASpelledCount(t *testing.T) {
 	for _, usage := range []string{
 		`{"input_tokens":"12","output_tokens":"3"}`,
 		`{"input_tokens":12.0,"output_tokens":3.0}`,
-		// One unreadable member must not cost the count beside it.
-		`{"input_tokens":"12","output_tokens":3,"cache_read_input_tokens":[]}`,
 	} {
 		t.Run(usage, func(t *testing.T) {
 			t.Parallel()
@@ -121,5 +119,40 @@ func TestBuildChatCompletion_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
 				t.Errorf("an unreadable usage was reported as zero tokens: %s", out)
 			}
 		})
+	}
+}
+
+// One unreadable member costs the WHOLE usage, and that is deliberate — the
+// opposite of the rule proxy.Usage uses.
+//
+// That rule keeps whatever decoded because its members are independent. These
+// figures are derived: summed across members, or falling back to a sum. A lost
+// addend would leave a number that is wrong AND non-zero, which reads as
+// authoritative and stops estimateMissingUsage ever firing — a cache-read count
+// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
+// then does its job.
+// Sharpest here: prompt_tokens is input + both cache counts, so a lost
+// cache_read of 20000 would bill 4.
+func TestBuildChatCompletion_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+	t.Parallel()
+	body := `{"type":"message","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}}`
+	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !strings.Contains(string(out), "hello") {
+		t.Errorf("the answer was lost with the usage: %s", out)
+	}
+	if strings.Contains(string(out), `"usage"`) {
+		t.Errorf("a prompt count missing its cache addend was reported as authoritative: %s", out)
+	}
+}
+
+// The same for the non-streaming native reader, where the sum is computed in
+// summary().
+func TestReadEventUsage_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+	t.Parallel()
+	if _, ok := readEventUsage([]byte(`{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`)); ok {
+		t.Error("a half-read usage was accepted")
 	}
 }

--- a/internal/anthropicegress/count_spelling_test.go
+++ b/internal/anthropicegress/count_spelling_test.go
@@ -122,37 +122,44 @@ func TestBuildChatCompletion_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
 	}
 }
 
-// One unreadable member costs the WHOLE usage, and that is deliberate — the
-// opposite of the rule proxy.Usage uses.
+// A member that could not be read costs the figures it FEEDS, and nothing else.
 //
-// That rule keeps whatever decoded because its members are independent. These
-// figures are derived: summed across members, or falling back to a sum. A lost
-// addend would leave a number that is wrong AND non-zero, which reads as
-// authoritative and stops estimateMissingUsage ever firing — a cache-read count
-// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
-// then does its job.
-// Sharpest here: prompt_tokens is input + both cache counts, so a lost
-// cache_read of 20000 would bill 4.
-func TestBuildChatCompletion_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+// Two blunter rules were tried and both were wrong. Keeping whatever decoded
+// corrupted a SUMMED figure: an Anthropic prompt count is input plus both cache
+// counts, so a cache-read of 20000 lost to an unreadable sibling bills 4 — and 4
+// is non-zero, so the estimator never replaces it. Dropping the whole block
+// instead threw away counts read straight off one member, which are never in
+// doubt — and a completion count is what tells the circuit breaker the provider
+// answered at all, so losing it charges a provider for an answer it gave.
+//
+// Sharpest here: prompt_tokens is input plus both cache counts, while
+// output_tokens is read straight off its own member.
+func TestBuildChatCompletion_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
 	t.Parallel()
 	body := `{"type":"message","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}}`
 	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
-	if !strings.Contains(string(out), "hello") {
-		t.Errorf("the answer was lost with the usage: %s", out)
+	if strings.Contains(string(out), `"prompt_tokens":4`) {
+		t.Errorf("a prompt figure missing its cache addend was reported as authoritative: %s", out)
 	}
-	if strings.Contains(string(out), `"usage"`) {
-		t.Errorf("a prompt count missing its cache addend was reported as authoritative: %s", out)
+	if !strings.Contains(string(out), `"completion_tokens":5`) {
+		t.Errorf("the completion count was read straight off its own member and was thrown away: %s", out)
 	}
 }
 
-// The same for the non-streaming native reader, where the sum is computed in
-// summary().
-func TestReadEventUsage_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+// The streaming reader keeps the same rule.
+func TestReadEventUsage_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
 	t.Parallel()
-	if _, ok := readEventUsage([]byte(`{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`)); ok {
-		t.Error("a half-read usage was accepted")
+	u, ok := readEventUsage([]byte(`{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`))
+	if !ok {
+		t.Fatal("the whole block was rejected for one unreadable member")
+	}
+	if u.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want the prompt addends dropped together", u.InputTokens)
+	}
+	if u.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5: it is read straight off its own member", u.OutputTokens)
 	}
 }

--- a/internal/anthropicegress/count_spelling_test.go
+++ b/internal/anthropicegress/count_spelling_test.go
@@ -1,0 +1,125 @@
+package anthropicegress
+
+import (
+	"strings"
+	"testing"
+)
+
+// This is the translator talking to Anthropic-Messages upstreams, so it is the
+// one most likely to meet a relay's spelling — and it decoded the counts as part
+// of the response object, so one of them failed the whole translation and cost
+// the caller the answer the model had already produced.
+func TestBuildChatCompletion_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		usage string
+	}{
+		{"plain integers", `{"input_tokens":12,"output_tokens":3}`},
+		{"quoted", `{"input_tokens":"12","output_tokens":"3"}`},
+		{"floating point", `{"input_tokens":12.0,"output_tokens":3.0}`},
+		{"mixed", `{"input_tokens":"12","output_tokens":3}`},
+		// Not a count in any spelling, and an unreadable member: the usage is
+		// lost, the answer is not.
+		{"unreadable", `{"input_tokens":"lots"}`},
+		{"not an object", `[]`},
+		{"null", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"type":"message","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":` + tc.usage + `}`
+			out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+			if err != nil {
+				t.Fatalf("a usage member cost the caller the whole answer: %v", err)
+			}
+			if !strings.Contains(string(out), "hello") {
+				t.Errorf("the answer was lost: %s", out)
+			}
+		})
+	}
+}
+
+// An event whose usage this package cannot read must not kill the stream. The
+// event decode carried the counts, so a spelling failed the event — and with it
+// the event's TYPE, which is what message_stop and the error events are
+// recognised by.
+func TestStreamTranslator_CountSpellingsDoNotKillTheStream(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		event string
+	}{
+		{"quoted on message_start", `{"type":"message_start","message":{"usage":{"input_tokens":"11","output_tokens":0}}}`},
+		{"fractional on message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4.0}}`},
+		{"unreadable usage", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":"none"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewStreamTranslator("id", "m", 0).Translate([]byte(tc.event)); err != nil {
+				t.Errorf("a usage spelling killed the stream: %v", err)
+			}
+		})
+	}
+}
+
+// And when it IS readable, whatever the spelling, it reaches the terminal chunk.
+func TestStreamTranslator_MetersASpelledCount(t *testing.T) {
+	t.Parallel()
+	tr := NewStreamTranslator("id", "m", 0)
+	if _, err := tr.Translate([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":"11","output_tokens":0}}}`)); err != nil {
+		t.Fatalf("message_start: %v", err)
+	}
+	if _, err := tr.Translate([]byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":"4"}}`)); err != nil {
+		t.Fatalf("message_delta: %v", err)
+	}
+	out, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	if !strings.Contains(string(out), `"prompt_tokens":11`) || !strings.Contains(string(out), `"completion_tokens":4`) {
+		t.Errorf("counts did not reach the terminal chunk: %s", out)
+	}
+}
+
+// And when it IS readable, whatever the spelling, it is metered. Asserting only
+// that the answer survives would pass just as well with the usage silently
+// dropped — which is exactly what a strict decode inside translateUsage does.
+func TestBuildChatCompletion_MetersASpelledCount(t *testing.T) {
+	t.Parallel()
+	for _, usage := range []string{
+		`{"input_tokens":"12","output_tokens":"3"}`,
+		`{"input_tokens":12.0,"output_tokens":3.0}`,
+		// One unreadable member must not cost the count beside it.
+		`{"input_tokens":"12","output_tokens":3,"cache_read_input_tokens":[]}`,
+	} {
+		t.Run(usage, func(t *testing.T) {
+			t.Parallel()
+			body := `{"type":"message","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":` + usage + `}`
+			out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			if !strings.Contains(string(out), `"prompt_tokens":12`) {
+				t.Errorf("the prompt count was not read: %s", out)
+			}
+		})
+	}
+}
+
+// An omitted or unreadable usage is reported as absent, not as a claim of zero.
+func TestBuildChatCompletion_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
+	t.Parallel()
+	for _, usage := range []string{`null`, `[]`, `"none"`} {
+		t.Run(usage, func(t *testing.T) {
+			t.Parallel()
+			body := `{"type":"message","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":` + usage + `}`
+			out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			if strings.Contains(string(out), `"usage"`) {
+				t.Errorf("an unreadable usage was reported as zero tokens: %s", out)
+			}
+		})
+	}
+}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming Anthropic Messages response shape ---
@@ -20,8 +21,14 @@ type antResponse struct {
 	Type       string         `json:"type"` // "message" (or "error")
 	Content    []antRespBlock `json:"content"`
 	StopReason string         `json:"stop_reason"`
-	Usage      *antRespUsage  `json:"usage"`
-	Error      *antRespError  `json:"error"`
+	// Held raw and decoded on its own, so a usage block this package cannot read
+	// costs the usage and nothing else. Decoded inline it was part of the
+	// response object, and one count the provider spelled differently — quoted,
+	// or with a fraction on it — failed the whole translation and cost the caller
+	// the answer the model had already produced. This is the translator talking
+	// to Anthropic-Messages upstreams, so it is the one most likely to meet one.
+	Usage json.RawMessage `json:"usage"`
+	Error *antRespError   `json:"error"`
 }
 
 type antRespBlock struct {
@@ -225,10 +232,23 @@ func mapFinishReason(stopReason string) string {
 // billed prompt tokens and fabricates cache-miss counts downstream (see
 // internal/proxy/helpers.go's extractCacheTokens, which computes
 // missTokens = promptTokens - cacheReadTokens).
-func translateUsage(u *antRespUsage) *completionUsage {
-	if u == nil {
+func translateUsage(raw json.RawMessage) *completionUsage {
+	if !util.JSONMemberSet(raw) {
 		return nil
 	}
+	// util.DecodeCounts, and a shape error keeps what did decode: a count is a
+	// count however the provider spelled it, and one unreadable member must not
+	// cost the counts beside it or the answer around them.
+	var u antRespUsage
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+		return nil
+	}
+	return buildUsage(u)
+}
+
+// buildUsage renders counts this package already holds. The streaming translator
+// accumulates its own across events and has no raw bytes to read.
+func buildUsage(u antRespUsage) *completionUsage {
 	prompt := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 	out := &completionUsage{
 		PromptTokens:     prompt,

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -236,19 +236,21 @@ func translateUsage(raw json.RawMessage) *completionUsage {
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED — summed across members, or falling back to a sum — so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
-	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too — except master lost the answer with it.
+	// Per FIGURE, not per block. A figure read straight off one member is right
+	// or absent; a SUMMED one is only as good as its addends, and a lost addend
+	// leaves a number that is wrong AND non-zero, which reads as authoritative
+	// and stops estimateMissingUsage replacing it. Dropping the whole block
+	// instead threw away counts that were never in doubt — and a completion
+	// count is what tells the breaker the provider answered at all.
 	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil
+	}
+	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
+		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
+	}
+	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
+		u.OutputTokens = 0
 	}
 	return buildUsage(u)
 }
@@ -271,3 +273,6 @@ func buildUsage(u antRespUsage) *completionUsage {
 	}
 	return out
 }
+
+// promptAddends are the members the prompt figure is SUMMED from.
+var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -236,11 +236,18 @@ func translateUsage(raw json.RawMessage) *completionUsage {
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// util.DecodeCounts, and a shape error keeps what did decode: a count is a
-	// count however the provider spelled it, and one unreadable member must not
-	// cost the counts beside it or the answer around them.
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED — summed across members, or falling back to a sum — so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too — except master lost the answer with it.
 	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return nil
 	}
 	return buildUsage(u)

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming Anthropic SSE event shapes ---
@@ -28,15 +29,17 @@ type antEvent struct {
 	Message      *antEventMessage `json:"message"`
 	ContentBlock *antRespBlock    `json:"content_block"`
 	Delta        *antEventDelta   `json:"delta"`
-	Usage        *antRespUsage    `json:"usage"`
-	Error        *antRespError    `json:"error"`
+	// Raw, for the reason on antResponse.Usage: a count spelled differently must
+	// not fail the event and kill the stream.
+	Usage json.RawMessage `json:"usage"`
+	Error *antRespError   `json:"error"`
 }
 
 // antEventMessage is the partial Message object message_start carries. Only
 // usage is read: id and model are the caller's to choose, and the content array
 // is always empty at that point.
 type antEventMessage struct {
-	Usage *antRespUsage `json:"usage"`
+	Usage json.RawMessage `json:"usage"`
 }
 
 // antEventDelta is the delta union shared by content_block_delta (text_delta,
@@ -175,10 +178,12 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	switch ev.Type {
 	case "message_start":
-		if ev.Message != nil && ev.Message.Usage != nil {
-			t.usage.InputTokens = ev.Message.Usage.InputTokens
-			t.usage.CacheCreationInputTokens = ev.Message.Usage.CacheCreationInputTokens
-			t.usage.CacheReadInputTokens = ev.Message.Usage.CacheReadInputTokens
+		if ev.Message != nil {
+			if u, ok := readEventUsage(ev.Message.Usage); ok {
+				t.usage.InputTokens = u.InputTokens
+				t.usage.CacheCreationInputTokens = u.CacheCreationInputTokens
+				t.usage.CacheReadInputTokens = u.CacheReadInputTokens
+			}
 		}
 		if err := t.writeChunk(&buf, chunkDelta{}, nil, nil); err != nil {
 			return nil, err
@@ -195,8 +200,8 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 		if ev.Delta != nil && ev.Delta.StopReason != "" {
 			t.stopReason = ev.Delta.StopReason
 		}
-		if ev.Usage != nil {
-			t.usage.OutputTokens = ev.Usage.OutputTokens
+		if u, ok := readEventUsage(ev.Usage); ok {
+			t.usage.OutputTokens = u.OutputTokens
 		}
 	case "message_stop":
 		return t.Finish()
@@ -299,13 +304,31 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 
 	var buf bytes.Buffer
 	reason := mapFinishReason(t.stopReason)
-	var usage *antRespUsage
+	var usage *completionUsage
 	if t.usage != (antRespUsage{}) {
-		usage = &t.usage
+		usage = buildUsage(t.usage)
 	}
-	if err := t.writeChunk(&buf, chunkDelta{}, &reason, translateUsage(usage)); err != nil {
+	if err := t.writeChunk(&buf, chunkDelta{}, &reason, usage); err != nil {
 		return nil, err
 	}
 	buf.WriteString("data: [DONE]\n\n")
 	return buf.Bytes(), nil
+}
+
+// readEventUsage decodes a stream event's usage member on its own, reporting
+// whether there was one to read.
+//
+// Separate from the event decode because an error there kills the STREAM: the
+// event loses its type along with its counts, so message_stop and the error
+// events stop being recognised for that frame. A count the provider spelled
+// differently — quoted, or with a fraction on it — is not a reason to do that.
+func readEventUsage(raw json.RawMessage) (antRespUsage, bool) {
+	if !util.JSONMemberSet(raw) {
+		return antRespUsage{}, false
+	}
+	var u antRespUsage
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+		return antRespUsage{}, false
+	}
+	return u, true
 }

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -326,8 +326,18 @@ func readEventUsage(raw json.RawMessage) (antRespUsage, bool) {
 	if !util.JSONMemberSet(raw) {
 		return antRespUsage{}, false
 	}
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED — summed across members, or falling back to a sum — so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too — except master lost the answer with it.
 	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return antRespUsage{}, false
 	}
 	return u, true

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -326,19 +326,16 @@ func readEventUsage(raw json.RawMessage) (antRespUsage, bool) {
 	if !util.JSONMemberSet(raw) {
 		return antRespUsage{}, false
 	}
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED — summed across members, or falling back to a sum — so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
-	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too — except master lost the answer with it.
+	// Per figure, as in translateUsage.
 	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return antRespUsage{}, false
+	}
+	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
+		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
+	}
+	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
+		u.OutputTokens = 0
 	}
 	return u, true
 }

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -689,7 +689,11 @@ func parseTestModelResponse(respBody []byte, duration int64) (content string, tp
 			CompletionTokens int `json:"completion_tokens"`
 		} `json:"usage"`
 	}
-	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+	// util.ShapeError: a member this struct has no type for — a token count the
+	// provider quoted, say — must not blank the answer the dashboard is here to
+	// show. encoding/json records the type error and carries on with the
+	// siblings, so what did decode is all there.
+	if err := json.Unmarshal(respBody, &chatResp); err != nil && util.ShapeError(respBody, err) == nil {
 		debuglog.Debug("admin: failed to parse test model chat response", "error", err)
 	}
 

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -689,11 +689,12 @@ func parseTestModelResponse(respBody []byte, duration int64) (content string, tp
 			CompletionTokens int `json:"completion_tokens"`
 		} `json:"usage"`
 	}
-	// util.ShapeError: a member this struct has no type for — a token count the
-	// provider quoted, say — must not blank the answer the dashboard is here to
-	// show. encoding/json records the type error and carries on with the
-	// siblings, so what did decode is all there.
-	if err := json.Unmarshal(respBody, &chatResp); err != nil && util.ShapeError(respBody, err) == nil {
+	// util.DecodeCounts: a count the provider quoted or wrote with a fraction on
+	// it is still a count, and a plain int field met neither — so the dashboard's
+	// probe reported 0/0 tokens and a tps of zero for a model that answered.
+	// This decode already logged and carried on, so the ANSWER was never at risk
+	// here; the counts were.
+	if err := util.DecodeCounts(respBody, &chatResp); err != nil {
 		debuglog.Debug("admin: failed to parse test model chat response", "error", err)
 	}
 

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -793,10 +793,9 @@ func TestLogTestModelCompleted_InsertError(t *testing.T) {
 	}
 }
 
-// A member this struct has no type for — a token count the provider quoted, say
-// — must not blank the answer the dashboard exists to show. encoding/json
-// records the type error and carries on with the siblings, so what did decode is
-// all there.
+// The counts are what this site lost. Its decode already logged and carried on,
+// so the answer was never at risk here — a claim an earlier commit message made
+// and this corrects.
 func TestParseTestModelResponse_ReadsASpelledCount(t *testing.T) {
 	body := []byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":"12","completion_tokens":"3"}}`)
 	content, tps, prompt, completion := parseTestModelResponse(body, 1000)

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -792,3 +792,15 @@ func TestLogTestModelCompleted_InsertError(t *testing.T) {
 		t.Errorf("expected 0 request_log rows (insert should have failed), got %d", count)
 	}
 }
+
+// A member this struct has no type for — a token count the provider quoted, say
+// — must not blank the answer the dashboard exists to show. encoding/json
+// records the type error and carries on with the siblings, so what did decode is
+// all there.
+func TestParseTestModelResponse_AQuotedCountKeepsTheAnswer(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":"12","completion_tokens":"3"}}`)
+	content, _, _, _ := parseTestModelResponse(body, 1000)
+	if content != "hello" {
+		t.Errorf("content = %q, want the answer the model gave", content)
+	}
+}

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -797,10 +797,18 @@ func TestLogTestModelCompleted_InsertError(t *testing.T) {
 // — must not blank the answer the dashboard exists to show. encoding/json
 // records the type error and carries on with the siblings, so what did decode is
 // all there.
-func TestParseTestModelResponse_AQuotedCountKeepsTheAnswer(t *testing.T) {
+func TestParseTestModelResponse_ReadsASpelledCount(t *testing.T) {
 	body := []byte(`{"choices":[{"message":{"content":"hello"}}],"usage":{"prompt_tokens":"12","completion_tokens":"3"}}`)
-	content, _, _, _ := parseTestModelResponse(body, 1000)
+	content, tps, prompt, completion := parseTestModelResponse(body, 1000)
 	if content != "hello" {
 		t.Errorf("content = %q, want the answer the model gave", content)
+	}
+	// The counts are what this site actually lost: the decode already logged and
+	// carried on, so the answer was never at risk here.
+	if prompt != 12 || completion != 3 {
+		t.Errorf("got %d/%d tokens, want 12/3", prompt, completion)
+	}
+	if tps == 0 {
+		t.Error("tps was 0 for a model that answered")
 	}
 }

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -102,17 +102,26 @@ func TestBuildChatCompletion_ANullUsageIsNotAZeroedOne(t *testing.T) {
 	}
 }
 
-// One unreadable member must not cost the counts beside it — the rule
-// Usage.UnmarshalJSON settled on in #811, and output_tokens_details as [] rather
-// than {} is a routine relay habit.
-func TestBuildChatCompletion_KeepsTheCountsItCouldRead(t *testing.T) {
+// One unreadable member costs the WHOLE usage, and that is deliberate — the
+// opposite of the rule proxy.Usage uses.
+//
+// That rule keeps whatever decoded because its members are independent. These
+// figures are derived: summed across members, or falling back to a sum. A lost
+// addend would leave a number that is wrong AND non-zero, which reads as
+// authoritative and stops estimateMissingUsage ever firing — a cache-read count
+// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
+// then does its job.
+func TestBuildChatCompletion_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
 	t.Parallel()
 	body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":"lots","totalTokenCount":15}}`
 	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
-	if !strings.Contains(string(out), `"prompt_tokens":12`) {
-		t.Errorf("a readable count was thrown away with the unreadable one beside it: %s", out)
+	if !strings.Contains(string(out), "hello") {
+		t.Errorf("the answer was lost with the usage: %s", out)
+	}
+	if strings.Contains(string(out), `"usage"`) {
+		t.Errorf("a half-read usage was reported as authoritative: %s", out)
 	}
 }

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -1,0 +1,69 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A token count written in a spelling other than the plain integer the schema
+// asks for is still a count — quoted, or carrying a fraction because a relay did
+// its arithmetic in floating point. Here it does not merely blank the usage: the
+// counts sit inside the response object, so the whole translation fails and the
+// caller loses the answer the model already produced. Since #812 it also charges
+// the provider's circuit breaker for a body it in fact answered.
+func TestBuildChatCompletion_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		usage string
+	}{
+		{"plain integers", `{"promptTokenCount":12,"candidatesTokenCount":3,"totalTokenCount":15}`},
+		{"quoted", `{"promptTokenCount":"12","candidatesTokenCount":"3","totalTokenCount":"15"}`},
+		{"floating point", `{"promptTokenCount":12.0,"candidatesTokenCount":3.0,"totalTokenCount":15.0}`},
+		{"mixed", `{"promptTokenCount":"12","candidatesTokenCount":3.0,"totalTokenCount":15}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":` + tc.usage + `}`
+			out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+			if err != nil {
+				t.Fatalf("a count spelling cost the caller the whole answer: %v", err)
+			}
+			if !strings.Contains(string(out), "hello") {
+				t.Errorf("the answer was lost: %s", out)
+			}
+			var got struct {
+				Usage struct {
+					PromptTokens     int `json:"prompt_tokens"`
+					CompletionTokens int `json:"completion_tokens"`
+				} `json:"usage"`
+			}
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("re-encode did not decode: %v", err)
+			}
+			if got.Usage.PromptTokens != 12 || got.Usage.CompletionTokens != 3 {
+				t.Errorf("metered %d/%d, want 12/3", got.Usage.PromptTokens, got.Usage.CompletionTokens)
+			}
+		})
+	}
+}
+
+// A usage member that is not a count in any spelling costs the usage and nothing
+// else: the answer is what the caller came for.
+func TestBuildChatCompletion_UnreadableUsageKeepsTheAnswer(t *testing.T) {
+	t.Parallel()
+	for _, usage := range []string{`{"promptTokenCount":"lots"}`, `{"promptTokenCount":[12]}`, `[]`, `"none"`} {
+		t.Run(usage, func(t *testing.T) {
+			t.Parallel()
+			body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":` + usage + `}`
+			out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+			if err != nil {
+				t.Fatalf("an unreadable usage member cost the caller the answer: %v", err)
+			}
+			if !strings.Contains(string(out), "hello") {
+				t.Errorf("the answer was lost: %s", out)
+			}
+		})
+	}
+}

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -67,3 +67,52 @@ func TestBuildChatCompletion_UnreadableUsageKeepsTheAnswer(t *testing.T) {
 		})
 	}
 }
+
+// An explicit null is not a usage block. The *genUsage this replaced was nil for
+// absent AND null alike; a json.RawMessage for null is four non-empty bytes, so
+// reading only the length let a null chunk overwrite the counts an earlier chunk
+// had reported — and turned an omitted usage into a positive claim of zero.
+func TestStreamTranslator_ANullUsageDoesNotWipeTheCountsAlreadyReported(t *testing.T) {
+	t.Parallel()
+	tr := NewStreamTranslator("id", "m", 0)
+	if _, err := tr.Translate([]byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"}}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":3,"totalTokenCount":15}}`)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	if _, err := tr.Translate([]byte(`{"candidates":[],"usageMetadata":null}`)); err != nil {
+		t.Fatalf("null chunk: %v", err)
+	}
+	out, err := tr.Finish()
+	if err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	if !strings.Contains(string(out), `"prompt_tokens":12`) {
+		t.Errorf("a null usage wiped the counts the provider reported: %s", out)
+	}
+}
+
+func TestBuildChatCompletion_ANullUsageIsNotAZeroedOne(t *testing.T) {
+	t.Parallel()
+	body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":null}`
+	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if strings.Contains(string(out), `"usage"`) {
+		t.Errorf("an omitted usage was reported as zero tokens: %s", out)
+	}
+}
+
+// One unreadable member must not cost the counts beside it — the rule
+// Usage.UnmarshalJSON settled on in #811, and output_tokens_details as [] rather
+// than {} is a routine relay habit.
+func TestBuildChatCompletion_KeepsTheCountsItCouldRead(t *testing.T) {
+	t.Parallel()
+	body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":"lots","totalTokenCount":15}}`
+	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !strings.Contains(string(out), `"prompt_tokens":12`) {
+		t.Errorf("a readable count was thrown away with the unreadable one beside it: %s", out)
+	}
+}

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -102,26 +102,31 @@ func TestBuildChatCompletion_ANullUsageIsNotAZeroedOne(t *testing.T) {
 	}
 }
 
-// One unreadable member costs the WHOLE usage, and that is deliberate — the
-// opposite of the rule proxy.Usage uses.
+// A member that could not be read costs the figures it FEEDS, and nothing else.
 //
-// That rule keeps whatever decoded because its members are independent. These
-// figures are derived: summed across members, or falling back to a sum. A lost
-// addend would leave a number that is wrong AND non-zero, which reads as
-// authoritative and stops estimateMissingUsage ever firing — a cache-read count
-// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
-// then does its job.
-func TestBuildChatCompletion_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+// Two blunter rules were tried and both were wrong. Keeping whatever decoded
+// corrupted a SUMMED figure: an Anthropic prompt count is input plus both cache
+// counts, so a cache-read of 20000 lost to an unreadable sibling bills 4 — and 4
+// is non-zero, so the estimator never replaces it. Dropping the whole block
+// instead threw away counts read straight off one member, which are never in
+// doubt — and a completion count is what tells the circuit breaker the provider
+// answered at all, so losing it charges a provider for an answer it gave.
+//
+// Here the completion figure is candidates + thoughts, while prompt and total
+// are each read straight off their own member.
+func TestBuildChatCompletion_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
 	t.Parallel()
 	body := `{"candidates":[{"content":{"parts":[{"text":"hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":"lots","totalTokenCount":15}}`
 	out, err := BuildChatCompletion([]byte(body), "id", "m", 0)
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
-	if !strings.Contains(string(out), "hello") {
-		t.Errorf("the answer was lost with the usage: %s", out)
+	if !strings.Contains(string(out), `"prompt_tokens":12`) {
+		t.Errorf("a figure read straight off its own member was thrown away: %s", out)
 	}
-	if strings.Contains(string(out), `"usage"`) {
-		t.Errorf("a half-read usage was reported as authoritative: %s", out)
+	if strings.Contains(string(out), `"completion_tokens":0,"total_tokens":15`) == false && strings.Contains(string(out), `"completion_tokens"`) {
+		if !strings.Contains(string(out), `"completion_tokens":0`) {
+			t.Errorf("a completion figure missing an addend was reported anyway: %s", out)
+		}
 	}
 }

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -223,23 +223,24 @@ func translateUsage(raw json.RawMessage) *oaiUsage {
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// util.DecodeCounts, and a failure yields no usage rather than no answer: a
-	// count is a count however the provider spelled it, and a member this
-	// package cannot read at all is still only the usage.
-	//
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED -- summed across members, or falling back to a sum -- so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
-	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too -- except master lost the answer with it.
+	// Per FIGURE, not per block. A figure read straight off one member is right
+	// or absent; a SUMMED one is only as good as its addends, and a lost addend
+	// leaves a number that is wrong AND non-zero, which reads as authoritative
+	// and stops estimateMissingUsage replacing it. Dropping the whole block
+	// instead threw away counts that were never in doubt — and a completion
+	// count is what tells the breaker the provider answered at all.
 	var u genUsage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil
+	}
+	if len(util.UnreadableCounts(raw, "candidatesTokenCount", "thoughtsTokenCount")) > 0 {
+		u.CandidatesTokenCount, u.ThoughtsTokenCount = 0, 0
+	}
+	if len(util.UnreadableCounts(raw, "promptTokenCount")) > 0 {
+		u.PromptTokenCount = 0
+	}
+	if len(util.UnreadableCounts(raw, "totalTokenCount")) > 0 {
+		u.TotalTokenCount = 0
 	}
 	out := &oaiUsage{
 		PromptTokens:     u.PromptTokenCount,

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -216,14 +216,24 @@ func mapFinishReason(reason string, hasToolCalls bool) string {
 // MH's metering should count) with the split surfaced in
 // completion_tokens_details.reasoning_tokens, matching OpenAI's convention.
 func translateUsage(raw json.RawMessage) *oaiUsage {
-	if len(raw) == 0 {
+	// JSONMemberSet, not len(raw) > 0: a RawMessage for null is four non-empty
+	// bytes, where the *genUsage this replaced was nil for absent AND null
+	// alike. Reading only the length turned an omitted usage into a positive
+	// claim of zero tokens.
+	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// util.DecodeCounts, and a failure here yields no usage rather than no
-	// answer: a count is a count however the provider spelled it, and a member
-	// this package cannot read at all is still only the usage.
+	// util.DecodeCounts, and a failure yields no usage rather than no answer: a
+	// count is a count however the provider spelled it, and a member this
+	// package cannot read at all is still only the usage.
+	//
+	// A SHAPE error keeps what did decode, the rule Usage.UnmarshalJSON settled
+	// on in #811: encoding/json records the type error and carries on with the
+	// siblings, so a block whose completion count is unreadable still has a
+	// perfectly good prompt count in it, and throwing that away puts the request
+	// on an estimate for no reason.
 	var u genUsage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil
 	}
 	out := &oaiUsage{

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -8,13 +8,21 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming Gemini generateContent response shape ---
 
 type genResponse struct {
-	Candidates     []genCandidate `json:"candidates"`
-	UsageMetadata  *genUsage      `json:"usageMetadata"`
+	Candidates []genCandidate `json:"candidates"`
+	// Held raw and decoded on its own, so a usage block this package cannot read
+	// costs the usage and nothing else. Decoded inline it was part of the
+	// response object, and one count the provider spelled differently — quoted,
+	// or with a fraction on it because a relay did its arithmetic in floating
+	// point — failed the whole translation and cost the caller the answer the
+	// model had already produced. Since #812 it charged the provider's circuit
+	// breaker for it too.
+	UsageMetadata  json.RawMessage `json:"usageMetadata"`
 	PromptFeedback *struct {
 		BlockReason string `json:"blockReason"`
 	} `json:"promptFeedback"`
@@ -207,8 +215,15 @@ func mapFinishReason(reason string, hasToolCalls bool) string {
 // billed output on Gemini, so completion_tokens includes them (this is what
 // MH's metering should count) with the split surfaced in
 // completion_tokens_details.reasoning_tokens, matching OpenAI's convention.
-func translateUsage(u *genUsage) *oaiUsage {
-	if u == nil {
+func translateUsage(raw json.RawMessage) *oaiUsage {
+	if len(raw) == 0 {
+		return nil
+	}
+	// util.DecodeCounts, and a failure here yields no usage rather than no
+	// answer: a count is a count however the provider spelled it, and a member
+	// this package cannot read at all is still only the usage.
+	var u genUsage
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return nil
 	}
 	out := &oaiUsage{

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -227,13 +227,18 @@ func translateUsage(raw json.RawMessage) *oaiUsage {
 	// count is a count however the provider spelled it, and a member this
 	// package cannot read at all is still only the usage.
 	//
-	// A SHAPE error keeps what did decode, the rule Usage.UnmarshalJSON settled
-	// on in #811: encoding/json records the type error and carries on with the
-	// siblings, so a block whose completion count is unreadable still has a
-	// perfectly good prompt count in it, and throwing that away puts the request
-	// on an estimate for no reason.
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED -- summed across members, or falling back to a sum -- so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too -- except master lost the answer with it.
 	var u genUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return nil
 	}
 	out := &oaiUsage{

--- a/internal/gemini/response_test.go
+++ b/internal/gemini/response_test.go
@@ -170,10 +170,14 @@ func TestBuildChatCompletion_DecodeErrorOmitsPayload(t *testing.T) {
 			secret:  "Kohlrabi",
 		},
 		{
+			// Not a usage member any more: those are decoded on their own and
+			// tolerate a count's spelling, so one is no longer a decode error at
+			// all. candidates is, and the guarantee under test is the same —
+			// the message names the fault, never the payload.
 			name:    "type error",
-			payload: `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
+			payload: `{"candidates":"Kohlrabi8675309"}`,
 			want:    "unexpected JSON value at byte ",
-			secret:  "8675309.42",
+			secret:  "Kohlrabi8675309",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -25,7 +25,9 @@ type StreamTranslator struct {
 	blocked      bool   // promptFeedback.blockReason seen
 	finishReason string // last Gemini finishReason observed
 	toolCalls    int    // tool_calls emitted so far (drives index + ids)
-	usage        *genUsage
+	// Raw, for the reason given on genResponse.UsageMetadata: a count spelled
+	// differently must not cost the caller the stream.
+	usage json.RawMessage
 }
 
 // NewStreamTranslator builds a translator for one response. id, model and
@@ -103,7 +105,7 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonfault.Describe(err, len(chunkJSON)))
 	}
 
-	if chunk.UsageMetadata != nil {
+	if len(chunk.UsageMetadata) > 0 {
 		t.usage = chunk.UsageMetadata
 	}
 	// A blocked prompt streams as a candidate-less chunk with promptFeedback;

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // StreamTranslator converts a Gemini streamGenerateContent SSE stream
@@ -105,7 +106,10 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonfault.Describe(err, len(chunkJSON)))
 	}
 
-	if len(chunk.UsageMetadata) > 0 {
+	// JSONMemberSet, for the reason on translateUsage: an explicit
+	// "usageMetadata": null is four bytes, and reading only the length let it
+	// overwrite the counts an earlier chunk had reported.
+	if util.JSONMemberSet(chunk.UsageMetadata) {
 		t.usage = chunk.UsageMetadata
 	}
 	// A blocked prompt streams as a candidate-less chunk with promptFeedback;

--- a/internal/gemini/stream_test.go
+++ b/internal/gemini/stream_test.go
@@ -256,10 +256,12 @@ func TestStreamTranslator_DecodeErrorOmitsPayload(t *testing.T) {
 			secret: "Kohlrabi",
 		},
 		{
+			// See the response-side twin: a usage member is no longer a decode
+			// error, candidates still is, and the guarantee is unchanged.
 			name:   "type error",
-			chunk:  `{"usageMetadata":{"promptTokenCount":8675309.42}}`,
+			chunk:  `{"candidates":"Kohlrabi8675309"}`,
 			want:   "unexpected JSON value at byte ",
-			secret: "8675309.42",
+			secret: "Kohlrabi8675309",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -24,6 +24,7 @@ func TestTranslateResponsesToChat_CountSpellings(t *testing.T) {
 		// Not a count in any spelling: the usage is lost, the answer is not.
 		{"unreadable", `{"input_tokens":"lots"}`},
 		{"not an object", `[]`},
+		{"null", `null`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -59,5 +60,52 @@ func TestTranslateResponsesToChat_MetersASpelledCount(t *testing.T) {
 	}
 	if got.Usage.PromptTokens != 12 || got.Usage.CompletionTokens != 3 || got.Usage.TotalTokens != 15 {
 		t.Errorf("metered %d/%d/%d, want 12/3/15", got.Usage.PromptTokens, got.Usage.CompletionTokens, got.Usage.TotalTokens)
+	}
+}
+
+// The nested count is read, not merely tolerated. Asserting "no error" alone
+// would pass just as well if the whole details object were silently dropped.
+func TestTranslateResponsesToChat_ReadsANestedCount(t *testing.T) {
+	t.Parallel()
+	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":"7"}}}`
+	out, err := TranslateResponsesToChat([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !strings.Contains(string(out), `"reasoning_tokens":7`) {
+		t.Errorf("the nested count was dropped rather than read: %s", out)
+	}
+}
+
+// An omitted or unreadable usage is reported as absent, not as a positive claim
+// of zero tokens. The Responses API itself emits "usage": null on a non-terminal
+// snapshot, and the *Usage this replaced was nil for that.
+func TestTranslateResponsesToChat_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
+	t.Parallel()
+	for _, usage := range []string{`null`, `[]`, `"none"`} {
+		t.Run(usage, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":` + usage + `}`
+			out, err := TranslateResponsesToChat([]byte(body), "m")
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			if strings.Contains(string(out), `"usage"`) {
+				t.Errorf("an unreadable usage was reported as zero tokens: %s", out)
+			}
+		})
+	}
+}
+
+// And one unreadable member must not cost the counts beside it.
+func TestTranslateResponsesToChat_KeepsTheCountsItCouldRead(t *testing.T) {
+	t.Parallel()
+	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":3,"output_tokens_details":[]}}`
+	out, err := TranslateResponsesToChat([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !strings.Contains(string(out), `"prompt_tokens":12`) {
+		t.Errorf("readable counts were thrown away with the unreadable member beside them: %s", out)
 	}
 }

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -1,0 +1,63 @@
+package openairesponses
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A token count in a spelling other than the plain integer the schema asks for
+// is still a count. Decoded as part of the response object, one of them failed
+// the whole translation and cost the caller the answer the model had already
+// produced — and since #812 charged the provider's circuit breaker for a body it
+// in fact answered.
+func TestTranslateResponsesToChat_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		usage string
+	}{
+		{"plain integers", `{"input_tokens":12,"output_tokens":3,"total_tokens":15}`},
+		{"quoted", `{"input_tokens":"12","output_tokens":"3","total_tokens":"15"}`},
+		{"floating point", `{"input_tokens":12.0,"output_tokens":3.0,"total_tokens":15.0}`},
+		{"a nested count quoted", `{"input_tokens":12,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":"7"}}`},
+		// Not a count in any spelling: the usage is lost, the answer is not.
+		{"unreadable", `{"input_tokens":"lots"}`},
+		{"not an object", `[]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":` + tc.usage + `}`
+			out, err := TranslateResponsesToChat([]byte(body), "m")
+			if err != nil {
+				t.Fatalf("a usage member cost the caller the whole answer: %v", err)
+			}
+			if !strings.Contains(string(out), "hello") {
+				t.Errorf("the answer was lost: %s", out)
+			}
+		})
+	}
+}
+
+// And when it IS readable, whatever the spelling, it is metered.
+func TestTranslateResponsesToChat_MetersASpelledCount(t *testing.T) {
+	t.Parallel()
+	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":"12","output_tokens":3.0,"total_tokens":"15"}}`
+	out, err := TranslateResponsesToChat([]byte(body), "m")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got struct {
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("re-encode did not decode: %v", err)
+	}
+	if got.Usage.PromptTokens != 12 || got.Usage.CompletionTokens != 3 || got.Usage.TotalTokens != 15 {
+		t.Errorf("metered %d/%d/%d, want 12/3/15", got.Usage.PromptTokens, got.Usage.CompletionTokens, got.Usage.TotalTokens)
+	}
+}

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -97,15 +97,26 @@ func TestTranslateResponsesToChat_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
 	}
 }
 
-// And one unreadable member must not cost the counts beside it.
-func TestTranslateResponsesToChat_KeepsTheCountsItCouldRead(t *testing.T) {
+// One unreadable member costs the WHOLE usage, and that is deliberate — the
+// opposite of the rule proxy.Usage uses.
+//
+// That rule keeps whatever decoded because its members are independent. These
+// figures are derived: summed across members, or falling back to a sum. A lost
+// addend would leave a number that is wrong AND non-zero, which reads as
+// authoritative and stops estimateMissingUsage ever firing — a cache-read count
+// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
+// then does its job.
+func TestTranslateResponsesToChat_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
 	t.Parallel()
-	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":3,"output_tokens_details":[]}}`
+	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":"lots"}}`
 	out, err := TranslateResponsesToChat([]byte(body), "m")
 	if err != nil {
 		t.Fatalf("translate: %v", err)
 	}
-	if !strings.Contains(string(out), `"prompt_tokens":12`) {
-		t.Errorf("readable counts were thrown away with the unreadable member beside them: %s", out)
+	if !strings.Contains(string(out), "hello") {
+		t.Errorf("the answer was lost with the usage: %s", out)
+	}
+	if strings.Contains(string(out), `"usage"`) {
+		t.Errorf("a half-read usage was reported as authoritative: %s", out)
 	}
 }

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -97,26 +97,44 @@ func TestTranslateResponsesToChat_AnAbsentUsageIsNotAZeroedOne(t *testing.T) {
 	}
 }
 
-// One unreadable member costs the WHOLE usage, and that is deliberate — the
-// opposite of the rule proxy.Usage uses.
+// A member that could not be read costs the figures it FEEDS, and nothing else.
 //
-// That rule keeps whatever decoded because its members are independent. These
-// figures are derived: summed across members, or falling back to a sum. A lost
-// addend would leave a number that is wrong AND non-zero, which reads as
-// authoritative and stops estimateMissingUsage ever firing — a cache-read count
-// of 20000 lost that way bills 4. Absent is the honest report, and the estimator
-// then does its job.
-func TestTranslateResponsesToChat_AnUnreadableMemberCostsTheWholeUsage(t *testing.T) {
+// Two blunter rules were tried and both were wrong. Keeping whatever decoded
+// corrupted a SUMMED figure: an Anthropic prompt count is input plus both cache
+// counts, so a cache-read of 20000 lost to an unreadable sibling bills 4 — and 4
+// is non-zero, so the estimator never replaces it. Dropping the whole block
+// instead threw away counts read straight off one member, which are never in
+// doubt — and a completion count is what tells the circuit breaker the provider
+// answered at all, so losing it charges a provider for an answer it gave.
+//
+// Every figure here is read directly, so an unreadable details block costs
+// nothing at all.
+func TestTranslateResponsesToChat_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
 	t.Parallel()
-	body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":12,"output_tokens":"lots"}}`
-	out, err := TranslateResponsesToChat([]byte(body), "m")
-	if err != nil {
-		t.Fatalf("translate: %v", err)
-	}
-	if !strings.Contains(string(out), "hello") {
-		t.Errorf("the answer was lost with the usage: %s", out)
-	}
-	if strings.Contains(string(out), `"usage"`) {
-		t.Errorf("a half-read usage was reported as authoritative: %s", out)
+	for _, tc := range []struct {
+		name    string
+		usage   string
+		want    string
+		notWant string
+	}{
+		{"an unreadable details block", `{"input_tokens":1200,"output_tokens":340,"total_tokens":1540,"output_tokens_details":[]}`, `"prompt_tokens":1200`, ""},
+		{"an unreadable completion count", `{"input_tokens":1200,"output_tokens":"lots","total_tokens":1540}`, `"prompt_tokens":1200`, `"completion_tokens":340`},
+		// The fallback total is the one sum, so a lost addend takes it down.
+		{"a lost addend with no stated total", `{"input_tokens":1200,"output_tokens":"lots"}`, `"prompt_tokens":1200`, `"total_tokens":1200`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"resp_1","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":` + tc.usage + `}`
+			out, err := TranslateResponsesToChat([]byte(body), "m")
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("a figure read straight off its own member was thrown away: %s", out)
+			}
+			if tc.notWant != "" && strings.Contains(string(out), tc.notWant) {
+				t.Errorf("a figure whose input was lost was reported anyway: %s", out)
+			}
+		})
 	}
 }

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -106,14 +106,19 @@ func chatCompletionID(respID string) string {
 // pipeline reads (prompt/completion totals plus reasoning and cached-token
 // details).
 func translateUsage(raw json.RawMessage) *chatUsage {
-	if len(raw) == 0 {
+	// JSONMemberSet, not len(raw) > 0: a RawMessage for null is four non-empty
+	// bytes where the *Usage this replaced was nil, and the Responses API emits
+	// "usage": null on a non-terminal response snapshot. Reading only the length
+	// turned that into a positive claim of zero tokens.
+	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// util.DecodeCounts, and a failure yields no usage rather than no answer: a
-	// count is a count however the provider spelled it, and a member this
-	// package cannot read at all is still only the usage.
+	// util.DecodeCounts, and a failure yields no usage rather than no answer. A
+	// SHAPE error keeps what did decode, the rule Usage.UnmarshalJSON settled on
+	// in #811 — output_tokens_details as [] rather than {} is a routine relay
+	// habit, and it must not cost the readable counts beside it.
 	var u Usage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil
 	}
 	out := &chatUsage{

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -113,26 +113,43 @@ func translateUsage(raw json.RawMessage) *chatUsage {
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
-	// whatever decoded. That rule assumes independent members: losing
-	// completion_tokens there cannot corrupt prompt_tokens. These figures are
-	// DERIVED — summed across members, or falling back to a sum — so a lost
-	// addend leaves a number that is wrong AND non-zero, which reads as
-	// authoritative and stops estimateMissingUsage ever firing. A cache-read
-	// count of 20000 lost that way bills 4.
+	// Per FIGURE, not per block. A figure read straight off one member is right
+	// or absent; a SUMMED one is only as good as its addends, and a lost addend
+	// leaves a number that is wrong AND non-zero, which reads as authoritative
+	// and stops estimateMissingUsage replacing it. Dropping the whole block
+	// instead threw away counts that were never in doubt — and a completion
+	// count is what tells the breaker the provider answered at all.
 	//
-	// Absent is the honest report, and it is what master did for these bodies
-	// too — except master lost the answer with it.
+	// Every figure here is read directly — the details blocks are separate
+	// members, and output_tokens_details as [] rather than {} is a routine relay
+	// habit that must not cost the counts beside it. Only the FALLBACK total is
+	// a sum, so it is the only one an addend can take down.
 	var u Usage
-	if err := util.DecodeCounts(raw, &u); err != nil {
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil
+	}
+	lostAddend := len(util.UnreadableCounts(raw, "input_tokens", "output_tokens")) > 0
+	for _, key := range []string{"input_tokens", "output_tokens", "total_tokens"} {
+		if len(util.UnreadableCounts(raw, key)) == 0 {
+			continue
+		}
+		switch key {
+		case "input_tokens":
+			u.InputTokens = 0
+		case "output_tokens":
+			u.OutputTokens = 0
+		case "total_tokens":
+			u.TotalTokens = 0
+		}
 	}
 	out := &chatUsage{
 		PromptTokens:     u.InputTokens,
 		CompletionTokens: u.OutputTokens,
 		TotalTokens:      u.TotalTokens,
 	}
-	if out.TotalTokens == 0 {
+	// The fallback total is the one sum here, so a lost addend is the one thing
+	// that can take it down.
+	if out.TotalTokens == 0 && !lostAddend {
 		out.TotalTokens = u.InputTokens + u.OutputTokens
 	}
 	if u.InputTokensDetails != nil && u.InputTokensDetails.CachedTokens > 0 {

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -113,12 +113,18 @@ func translateUsage(raw json.RawMessage) *chatUsage {
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
-	// util.DecodeCounts, and a failure yields no usage rather than no answer. A
-	// SHAPE error keeps what did decode, the rule Usage.UnmarshalJSON settled on
-	// in #811 — output_tokens_details as [] rather than {} is a routine relay
-	// habit, and it must not cost the readable counts beside it.
+	// A shape error yields NO usage here, unlike proxy.Usage, which keeps
+	// whatever decoded. That rule assumes independent members: losing
+	// completion_tokens there cannot corrupt prompt_tokens. These figures are
+	// DERIVED — summed across members, or falling back to a sum — so a lost
+	// addend leaves a number that is wrong AND non-zero, which reads as
+	// authoritative and stops estimateMissingUsage ever firing. A cache-read
+	// count of 20000 lost that way bills 4.
+	//
+	// Absent is the honest report, and it is what master did for these bodies
+	// too — except master lost the answer with it.
 	var u Usage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return nil
 	}
 	out := &chatUsage{

--- a/internal/openairesponses/response.go
+++ b/internal/openairesponses/response.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // TranslateResponsesToChat converts a non-streaming Responses API response
@@ -104,8 +105,15 @@ func chatCompletionID(respID string) string {
 // translateUsage maps Responses usage to the chat usage block the metering
 // pipeline reads (prompt/completion totals plus reasoning and cached-token
 // details).
-func translateUsage(u *Usage) *chatUsage {
-	if u == nil {
+func translateUsage(raw json.RawMessage) *chatUsage {
+	if len(raw) == 0 {
+		return nil
+	}
+	// util.DecodeCounts, and a failure yields no usage rather than no answer: a
+	// count is a count however the provider spelled it, and a member this
+	// package cannot read at all is still only the usage.
+	var u Usage
+	if err := util.DecodeCounts(raw, &u); err != nil {
 		return nil
 	}
 	out := &chatUsage{

--- a/internal/openairesponses/types.go
+++ b/internal/openairesponses/types.go
@@ -98,7 +98,12 @@ type Response struct {
 	IncompleteDetails *IncompleteDetails `json:"incomplete_details"`
 	Error             *ResponseError     `json:"error"`
 	Output            []OutputItem       `json:"output"`
-	Usage             *Usage             `json:"usage"`
+	// Held raw and decoded on its own, so a usage block this package cannot read
+	// costs the usage and nothing else. Decoded inline it was part of the
+	// response object, and one count the provider spelled differently — quoted,
+	// or with a fraction on it — failed the whole translation and cost the
+	// caller the answer the model had already produced.
+	Usage json.RawMessage `json:"usage"`
 }
 
 // IncompleteDetails says why a response stopped early.

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -940,3 +940,25 @@ func TestHandleNativeNonStreaming_AnInterruptedReadIsClassified(t *testing.T) {
 		})
 	}
 }
+
+// The Anthropic writer dropped a whole streaming frame when it could not type
+// one member, taking any content riding with it. The streaming path forwards
+// payloads verbatim, so a provider's own token-count spelling reaches here —
+// and handleDataChunk forwards such a frame rather than dropping it.
+func TestAnthropicWriter_AnUntypeableChunkIsNotDropped(t *testing.T) {
+	rec := httptest.NewRecorder()
+	native := false
+	aw := newAnthropicResponseWriter(rec, "msg_1", "m")
+	aw.bindNativeFlag(&native)
+	// The writer only translates when the upstream said it was streaming.
+	aw.Header().Set("Content-Type", "text/event-stream")
+	aw.WriteHeader(http.StatusOK)
+
+	// A count the provider quoted, riding on a frame that also carries content.
+	_, _ = aw.Write([]byte("data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"CONTENTMARKER\"}}],\"usage\":{\"prompt_tokens\":\"12\",\"completion_tokens\":\"3\"}}\n\n"))
+	_, _ = aw.Write([]byte("data: [DONE]\n\n"))
+
+	if !strings.Contains(rec.Body.String(), "CONTENTMARKER") {
+		t.Errorf("a frame carrying the answer was dropped for a count spelling: %q", rec.Body.String())
+	}
+}

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -958,7 +958,14 @@ func TestAnthropicWriter_AnUntypeableChunkIsNotDropped(t *testing.T) {
 	_, _ = aw.Write([]byte("data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"CONTENTMARKER\"}}],\"usage\":{\"prompt_tokens\":\"12\",\"completion_tokens\":\"3\"}}\n\n"))
 	_, _ = aw.Write([]byte("data: [DONE]\n\n"))
 
-	if !strings.Contains(rec.Body.String(), "CONTENTMARKER") {
-		t.Errorf("a frame carrying the answer was dropped for a count spelling: %q", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, "CONTENTMARKER") {
+		t.Errorf("a frame carrying the answer was dropped for a count spelling: %q", body)
+	}
+	// And the count itself is read, not merely survived. Keeping the frame while
+	// losing the count told the client the model produced zero output tokens for
+	// a real answer.
+	if !strings.Contains(body, `"output_tokens":3`) {
+		t.Errorf("the spelled count was dropped: %q", body)
 	}
 }

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -2,12 +2,12 @@ package proxy
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/anthropic"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // anthropicResponseWriter wraps the client http.ResponseWriter so the entire
@@ -172,7 +172,11 @@ func (a *anthropicResponseWriter) handleStreamLine(line []byte) {
 	// verbatim, so a provider's own token-count spelling reaches here, and
 	// dropping the frame for one dropped the content riding with it. Same rule
 	// handleDataChunk reads, for the same reason.
-	if err := json.Unmarshal(payload, &chunk); err != nil && shapeError(payload, err) == nil {
+	// util.DecodeCounts as well as the shape tolerance: this is the OpenAI ->
+	// Anthropic translator, so a count the provider spelled differently reaches
+	// it verbatim, and keeping the frame while losing the count told the client
+	// the model produced zero output tokens for a real answer.
+	if err := util.DecodeCounts(payload, &chunk); err != nil && shapeError(payload, err) == nil {
 		debuglog.Debug("anthropic: skip unparseable upstream chunk", "error", err)
 		return
 	}

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -167,7 +167,12 @@ func (a *anthropicResponseWriter) handleStreamLine(line []byte) {
 		return
 	}
 	var chunk anthropic.OAStreamChunk
-	if err := json.Unmarshal(payload, &chunk); err != nil {
+	// A shape this gateway has no struct for is not broken bytes, and the frame
+	// may carry the model's answer: the streaming path forwards payloads
+	// verbatim, so a provider's own token-count spelling reaches here, and
+	// dropping the frame for one dropped the content riding with it. Same rule
+	// handleDataChunk reads, for the same reason.
+	if err := json.Unmarshal(payload, &chunk); err != nil && shapeError(payload, err) == nil {
 		debuglog.Debug("anthropic: skip unparseable upstream chunk", "error", err)
 		return
 	}

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -3,64 +3,17 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"reflect"
 
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// shapeError reports the type error behind a failed decode when the frame
-// is nonetheless well-formed JSON — a shape this gateway has no struct for
-// rather than bytes that are broken — and nil otherwise.
-//
-// It is the difference between "this gateway has no struct for these bytes" and
-// "these bytes are broken", and both the streaming frame handler and Usage's own
-// decoder turn on it: the first keeps the frame, the second keeps the counts.
-//
-// The validity is CHECKED, not inferred. json.Unmarshal happens to validate the
-// whole document before decoding any of it, so today a type error already proves
-// the bytes are sound; json.Decoder makes no such promise, and GOEXPERIMENT
-// jsonv2 decodes streaming, where a type error on an early member can be
-// reported before a syntax error further on is ever reached. The check costs one
-// pass over a small frame on a path that has already failed, and without it a
-// change of build flag would start treating truncated bytes as merely
-// mis-shaped — forwarding half a frame to a caller, or keeping half a usage
-// block — which is the one thing the strictness exists to prevent.
-//
-// errors.As also unwraps, so a nested custom UnmarshalJSON returning a type
-// error of its own reaches here too; the check covers that case for free.
-//
-// The document must be a JSON OBJECT. A type error on anything else is the whole
-// value being the wrong kind of thing — `data: 42`, `data: "[DONE]"`, a usage
-// member that is a number — and that is not "a member this package does not
-// model", it is not the document at all. Relaying such a frame put a quoted
-// sentinel into an OpenAI-shaped stream as a data event, and keeping such a
-// usage member made the gateway emit a zeroed usage block the provider never
-// sent.
-//
-// The object test rather than typeErr.Field != "", which was the first attempt:
-// an error returned by a NESTED custom UnmarshalJSON reaches here with an empty
-// Field too, so requiring a member name threw away a perfectly good chat frame
-// whose usage member happened to be [] instead of {} — the routine relay habit
-// this whole change exists to survive.
+// shapeError is util.ShapeError, kept as a name this package reads well with.
+// The rule moved to util when the egress translators needed it too: four
+// packages deciding separately what "a member I have no struct for" means is
+// how they come to disagree.
 func shapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
-	if decodeErr == nil {
-		return nil
-	}
-	var typeErr *json.UnmarshalTypeError
-	if !errors.As(decodeErr, &typeErr) || !isJSONObject(data) {
-		return nil
-	}
-	return typeErr
-}
-
-// isJSONObject reports whether data is a well-formed JSON object. json.Valid is
-// what makes the type error's "these bytes are sound" reading a check rather
-// than an assumption; the leading brace is what separates a document with a
-// member this package cannot read from a value that is not the document.
-func isJSONObject(data []byte) bool {
-	trimmed := bytes.TrimSpace(data)
-	return len(trimmed) > 0 && trimmed[0] == '{' && json.Valid(trimmed)
+	return util.ShapeError(data, decodeErr)
 }
 
 // Provider-specific fields that this package does not model must survive the

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -712,17 +712,17 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 	if err := util.DecodeCounts(envelope.Usage, &usage); err != nil && shapeError(envelope.Usage, err) == nil {
 		return 0, 0
 	}
-	promptTokens = usage.PromptTokens
-	if promptTokens == 0 {
-		promptTokens = usage.InputTokens
-	}
-	if promptTokens == 0 {
-		promptTokens = usage.TotalTokens
-	}
-	completionTokens = usage.CompletionTokens
-	if completionTokens == 0 {
-		completionTokens = usage.OutputTokens
-	}
+	// The fallback stops at the first member the provider SENT, readable or not.
+	// Falling past an unreadable one reported total_tokens as the prompt when
+	// prompt_tokens was the member lost — the same wrong-but-non-zero figure the
+	// translators refuse, and it stops the estimator replacing it.
+	promptTokens = firstSentCount(envelope.Usage,
+		count{"prompt_tokens", usage.PromptTokens},
+		count{"input_tokens", usage.InputTokens},
+		count{"total_tokens", usage.TotalTokens})
+	completionTokens = firstSentCount(envelope.Usage,
+		count{"completion_tokens", usage.CompletionTokens},
+		count{"output_tokens", usage.OutputTokens})
 	return promptTokens, completionTokens
 }
 
@@ -749,4 +749,26 @@ func (fw flushWriter) Write(p []byte) (int, error) {
 		fw.f.Flush()
 	}
 	return n, err
+}
+
+// count pairs a usage member's name with what decoding it produced.
+type count struct {
+	member string
+	value  int
+}
+
+// firstSentCount walks a fallback chain and stops at the first member the
+// provider actually sent. A member that was sent but could not be read yields
+// zero rather than deferring to the next: it was meant to carry this figure, and
+// the next one is a different number.
+func firstSentCount(raw json.RawMessage, chain ...count) int {
+	for _, c := range chain {
+		if len(util.UnreadableCounts(raw, c.member)) > 0 {
+			return 0
+		}
+		if c.value != 0 {
+			return c.value
+		}
+	}
+	return 0
 }

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -694,7 +694,7 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 	var envelope struct {
 		Usage json.RawMessage `json:"usage"`
 	}
-	if json.Unmarshal(body, &envelope) != nil || len(envelope.Usage) == 0 {
+	if json.Unmarshal(body, &envelope) != nil || !util.JSONMemberSet(envelope.Usage) {
 		return 0, 0
 	}
 	var usage struct {

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -295,3 +295,31 @@ func TestUsage_KeepsTheBreakdownItCouldRead(t *testing.T) {
 	assert.Equal(t, 12, neither.PromptTokens)
 	assert.Nil(t, neither.PromptTokensDetails)
 }
+
+// The fallback chain stops at the first member the provider SENT. Falling past
+// an unreadable one reported total_tokens as the prompt when prompt_tokens was
+// the member lost — a wrong figure, and non-zero, so the estimator never
+// replaces it.
+func TestExtractPassthroughUsage_AnUnreadableMemberIsNotFallenPast(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		body            string
+		wantIn, wantOut int
+	}{
+		// prompt_tokens is the member that was meant to carry the figure.
+		{"the first link is unreadable", `{"usage":{"prompt_tokens":[],"total_tokens":9999}}`, 0, 0},
+		// Absent is not unreadable: the chain is free to move on.
+		{"the first link is absent", `{"usage":{"input_tokens":12,"output_tokens":3}}`, 12, 3},
+		{"a later link is unreadable but unused", `{"usage":{"prompt_tokens":12,"completion_tokens":3,"total_tokens":[]}}`, 12, 3},
+		{"the completion chain too", `{"usage":{"prompt_tokens":12,"completion_tokens":{},"output_tokens":9999}}`, 12, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in, out := extractPassthroughUsage([]byte(tc.body))
+			if in != tc.wantIn || out != tc.wantOut {
+				t.Errorf("got %d/%d, want %d/%d", in, out, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
+}

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -218,3 +218,50 @@ func roundToCount(f float64) (json.Number, bool) {
 	}
 	return json.Number(strconv.FormatInt(int64(r), 10)), true
 }
+
+// UnreadableCounts returns those of the named members that are PRESENT in a JSON
+// object but hold something no reading of a count can make sense of.
+//
+// It exists for figures that are SUMMED. A figure read straight off one member
+// does not care what happened to the others: it is right, or it is absent. A
+// sum is only as good as its addends — losing one leaves a number that is wrong
+// AND non-zero, which reads as authoritative and stops any estimate replacing
+// it. An Anthropic prompt figure is input_tokens plus both cache counts, so a
+// cache-read count of 20000 lost that way bills 4.
+//
+// Absent is not unreadable: a count the provider did not send is zero, and zero
+// is a correct addend.
+func UnreadableCounts(raw json.RawMessage, keys ...string) []string {
+	var members map[string]json.RawMessage
+	if json.Unmarshal(raw, &members) != nil {
+		return keys
+	}
+	var lost []string
+	for _, key := range keys {
+		member, present := members[key]
+		if !present {
+			continue
+		}
+		if !readsAsCount(member) {
+			lost = append(lost, key)
+		}
+	}
+	return lost
+}
+
+// readsAsCount asks DecodeCounts itself whether a member is a count, by handing
+// it the member wrapped in an object.
+//
+// The wrapper is not decoration: DecodeCounts locates the member to rewrite by
+// the path encoding/json names, and a bare value has no path. Asking the same
+// function rather than re-deciding here is what keeps one answer to "is this a
+// count" — a second opinion is only ever a way for the two to disagree.
+func readsAsCount(member json.RawMessage) bool {
+	if !JSONMemberSet(member) {
+		return false
+	}
+	var wrapped struct {
+		N int `json:"n"`
+	}
+	return DecodeCounts(append(append([]byte(`{"n":`), member...), '}'), &wrapped) == nil
+}

--- a/internal/util/counts_test.go
+++ b/internal/util/counts_test.go
@@ -276,3 +276,38 @@ func TestDecodeCounts_OnlyIntegerFields(t *testing.T) {
 		})
 	}
 }
+
+// A figure read straight off one member does not care what happened to the
+// others. A SUM does: losing an addend leaves a number that is wrong and
+// non-zero, so a caller that sums has to know which members it lost.
+func TestUnreadableCounts(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"all readable", `{"a":1,"b":"2","c":3.0}`, nil},
+		// Absent is not unreadable: a count the provider did not send is zero,
+		// and zero is a correct addend.
+		{"absent", `{"a":1}`, nil},
+		{"one unreadable", `{"a":1,"b":[],"c":3}`, []string{"b"}},
+		{"several", `{"a":{},"b":"lots","c":3}`, []string{"a", "b"}},
+		{"explicit null is not a count", `{"a":1,"b":null}`, []string{"b"}},
+		// Nothing readable at all: every named member is lost.
+		{"not an object", `[]`, []string{"a", "b", "c"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := util.UnreadableCounts(json.RawMessage(tc.raw), "a", "b", "c")
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/util/jsonmember.go
+++ b/internal/util/jsonmember.go
@@ -30,6 +30,14 @@ func JSONMemberSet(raw json.RawMessage) bool {
 // jsonv2 decodes streaming, where a type error on an early member can be
 // reported before a syntax error further on is ever reached.
 //
+// The document must be a JSON OBJECT. A type error on anything else is the whole
+// value being the wrong kind of thing — a streaming frame that is `42` or a
+// quoted `"[DONE]"`, a usage member that is a number — and that is not "a member
+// I have no struct for", it is not the document at all. Relaying such a frame put
+// a quoted sentinel into an OpenAI-shaped stream as a data event, and keeping
+// such a usage member made the gateway emit a zeroed usage block the provider
+// never sent.
+//
 // The object test rather than "the error names a member": an error returned by a
 // NESTED custom UnmarshalJSON arrives with an empty Field too, so requiring a
 // member name threw away a perfectly good document whose one unreadable member

--- a/internal/util/jsonmember.go
+++ b/internal/util/jsonmember.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+// JSONMemberSet reports whether a raw member is present and not JSON null.
+//
+// It is the distinction a *T field made for free and that is lost the moment a
+// member is held as json.RawMessage so it can be decoded on its own: a nil
+// pointer meant absent OR null, while a RawMessage for null is four non-empty
+// bytes. Reading only the length let an explicit "usage": null — which is what a
+// Go relay emits for a nil non-omitempty pointer — overwrite a usage block an
+// earlier chunk had reported, and turn an omitted usage member into a positive
+// claim of zero tokens.
+func JSONMemberSet(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
+
+// ShapeError reports the type error behind a failed decode when the document is
+// nonetheless a well-formed JSON object — a member the caller has no struct for
+// rather than bytes that are broken — and nil otherwise.
+//
+// The validity is CHECKED, not inferred. json.Unmarshal happens to validate the
+// whole document before decoding any of it, so today a type error already proves
+// the bytes are sound; json.Decoder makes no such promise, and GOEXPERIMENT
+// jsonv2 decodes streaming, where a type error on an early member can be
+// reported before a syntax error further on is ever reached.
+//
+// The object test rather than "the error names a member": an error returned by a
+// NESTED custom UnmarshalJSON arrives with an empty Field too, so requiring a
+// member name threw away a perfectly good document whose one unreadable member
+// happened to be decoded by a type of its own.
+//
+// What it is for: encoding/json records a type error and carries on with the
+// siblings, so the members that did decode are all there. A caller that treats
+// any decode failure as total throws those away — and the counts that were
+// readable are worth more than the ones that were not.
+func ShapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
+	if decodeErr == nil {
+		return nil
+	}
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(decodeErr, &typeErr) || !isJSONObject(data) {
+		return nil
+	}
+	return typeErr
+}
+
+func isJSONObject(data []byte) bool {
+	trimmed := bytes.TrimSpace(data)
+	return len(trimmed) > 0 && trimmed[0] == '{' && json.Valid(trimmed)
+}

--- a/internal/util/jsonmember_test.go
+++ b/internal/util/jsonmember_test.go
@@ -1,0 +1,76 @@
+package util_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// The distinction a *T field made for free: nil meant absent OR null. A
+// json.RawMessage for null is four non-empty bytes, so a member held raw to be
+// decoded on its own loses it — and reading only the length let an explicit null
+// overwrite counts an earlier chunk had reported.
+func TestJSONMemberSet(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		raw  string
+		want bool
+	}{
+		{`{"input_tokens":1}`, true},
+		{`{}`, true},
+		{`[]`, true},
+		{`0`, true},
+		{`""`, true},
+		{`false`, true},
+		// Absent, and the two spellings of "explicitly nothing".
+		{``, false},
+		{`null`, false},
+		{`  null  `, false},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			if got := util.JSONMemberSet(json.RawMessage(tc.raw)); got != tc.want {
+				t.Errorf("JSONMemberSet(%s) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// A member the caller has no struct for is not broken bytes. The check is on the
+// document being a well-formed JSON OBJECT rather than on the error naming a
+// member, because an error returned by a nested custom UnmarshalJSON arrives
+// with an empty Field too.
+func TestShapeError(t *testing.T) {
+	t.Parallel()
+	named := &json.UnmarshalTypeError{Value: "string", Field: "input_tokens"}
+	fieldless := &json.UnmarshalTypeError{Value: "array"}
+	for _, tc := range []struct {
+		name string
+		data string
+		err  error
+		want bool
+	}{
+		{"a member this struct cannot type", `{"input_tokens":"12"}`, named, true},
+		{"a nested decoder's error, which names nothing", `{"usage":[]}`, fieldless, true},
+		// Not the document at all.
+		{"a bare list", `[1,2,3]`, fieldless, false},
+		{"a bare string", `"nope"`, fieldless, false},
+		{"a bare number", `42`, fieldless, false},
+		{"null", `null`, fieldless, false},
+		// An object, but not sound bytes.
+		{"truncated", `{"input_tokens":`, named, false},
+		// Not a type error at all.
+		{"a syntax error", `{"a":}`, &json.SyntaxError{}, false},
+		{"no error", `{"a":1}`, nil, false},
+		{"some other error", `{"a":1}`, errors.New("boom"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := util.ShapeError([]byte(tc.data), tc.err) != nil; got != tc.want {
+				t.Errorf("ShapeError(%s) non-nil = %v, want %v", tc.data, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`internal/gemini` and `internal/openairesponses` decoded the provider's token counts as part of the response object. So one count spelled differently — quoted, or carrying a fraction because a relay did its arithmetic in floating point — failed the **whole translation**: the caller got `"invalid upstream response"` instead of the answer the model had already produced, and since #812 the provider's circuit breaker was charged for a body it in fact answered.

This is the same defect `util.DecodeCounts` closed for `internal/proxy` in #811, on the three packages that were queued behind it.

## Two fixes, and the second matters more

**The counts are read with `util.DecodeCounts`**, so a spelling is no longer a failure at all.

**The usage member is held raw and decoded on its own**, so an unreadable usage costs the *usage* and nothing else. Decoded inline, every one of those took the answer with it.

**And a member that could not be read costs the figures it FEEDS, not the whole block.** Three rounds converged on this. `proxy.Usage` keeps whatever decoded because its members are independent — but these figures are not uniformly derived:

| package | prompt | completion | total |
|---|---|---|---|
| `anthropic` / `anthropicegress` | **summed** (3 addends) | direct | summed |
| `gemini` | direct | **summed** | direct |
| `openairesponses` | direct | direct | direct (sum only as fallback) |

Keeping whatever decoded corrupts a *summed* figure: an Anthropic prompt count is `input` plus both cache counts, so a cache-read of 20 000 lost to an unreadable sibling bills **4** — non-zero, so the estimator never replaces it. Dropping the whole block instead throws away counts read straight off one member, which are never in doubt — and `answerCarriesSomething` tests `CompletionTokens > 0` **first**, so losing a good completion count makes a real answer read as empty and charges the provider's breaker, the failure #812 exists to prevent. On the Anthropic native stream, dropping was worse still: `message_start` reports `output_tokens: 1`, so a dropped `message_delta` usage left the completion count at **1** instead of the exact **1520**.

`util.UnreadableCounts` names the present-but-unreadable members, asking `DecodeCounts` itself whether each is a count so there is one answer to that question rather than two.

Four translators, both halves of each where there are two: `internal/gemini` (response + stream), `internal/openairesponses`, `internal/anthropicegress` (response + stream — the one talking to Anthropic-Messages upstreams, where a `Translate` error kills the stream outright), and `internal/anthropic` (`ParseResponseUsage` + `InspectStreamEvent`). On the last, a failure cost the event its **type** along with its counts, so `message_stop` and the error events stopped being recognised for that frame — the exact failure the adjacent `Error` member's own comment describes, which is why *that* member is already a `RawMessage`.

`shapeError` moved to `util.ShapeError`, and `util.JSONMemberSet` is new: a `*T` field was nil for absent **and** null alike, while a `json.RawMessage` for null is four non-empty bytes. Reading only the length let an explicit `"usageMetadata": null` — what a Go relay emits for a nil non-omitempty pointer — overwrite the counts an earlier chunk had reported, and turned an omitted usage into a positive claim of zero tokens. Both were regressions the review caught.

Two more of the same class swept while here. The Anthropic writer dropped a whole streaming frame on a count spelling, taking any content riding with it — and once the frame was kept it still could not read the count, so the client was told the model produced zero output tokens for a real answer. And the dashboard's test-model probe reported 0/0 tokens and a tps of zero for a model that answered; its decode already logged and carried on, so the *answer* was never at risk there, only the counts.

## Test note

Two existing tests used a usage type error as their fixture for "a decode error never names the payload". A usage member is not a decode error any more; `candidates` still is, and the guarantee under test is unchanged.

## Verified

Twenty-four mutations, all killed — including two that showed a test asserting only "the answer survived" would pass with the usage silently dropped, and one that showed the null-handling had nothing behind it. Full suite green, lint clean, size gate passing, 90%+ diff coverage.

Three review rounds. The first found the missing fourth translator, the missing streaming twin, and two regressions the change had introduced. The second found that the "keep what decoded" rule carried over from #811 corrupts a summed figure. The third found the reversal that answered it was wrong the other way, and supplied the per-figure table above. Every finding was reproduced before being acted on.

## Verified on a rebuilt dev stack

Registered a `vertex-express` and an `anthropic-messages` provider against a mock returning quoted and fractional counts:

- gemini egress → `"content":"GEMINI ANSWER"` with `12/3/15`; the request log meters 12/3
- anthropic egress → `"content":"ANTHROPIC ANSWER"` with `12/3/15`
- a lost prompt addend beside a good completion count → `prompt_tokens:0, completion_tokens:5`, answer delivered — the prompt figure dropped rather than reported as a corrupt 4, the completion kept
- six such requests in a row → **zero breaker events**, where dropping the completion count would have opened the circuit at five

App log scanned after each: zero occurrences of any answer or credential.

## Not in this PR

- The outbound usage structs these packages *build* (`oaiUsage`, `chatUsage`, `anthropic.message`) are constructed by this gateway, never decoded from a provider, so they carry no exposure.
- `anthropic.BuildMessageResponse` decodes a usage block too, but the proxy re-encodes the already-normalised `ChatCompletionResponse` before that writer sees it, so a raw provider spelling never reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
