### PR TITLE
fix(translators): accept a tool call in the shape this gateway itself emits

### DIFF
--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -139,10 +139,11 @@ type oaiToolCall struct {
 		Name string `json:"name"`
 		// util.ToolArguments, not a plain string: the spec says a JSON string and
 		// several providers send the object, so #808 taught the RESPONSE side to
-		// accept both — which means the caller receives the object form, echoes
-		// the assistant turn back in its next request, and this decoder rejected
-		// what the gateway itself had handed it. In a failover group whose next
-		// turn lands here, that 400s for the life of the conversation.
+		// accept both — and an ingress decoder has no business being stricter
+		// than the decoder that produced the value. This gateway rewrites the
+		// object form on its own way out, so the client holding one got it from
+		// another gateway or SDK; rejecting it 400s that conversation on every
+		// retry, because each one replays the same transcript.
 		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }
@@ -658,9 +659,6 @@ func translateToolChoice(raw json.RawMessage) (*antToolChoice, bool) {
 	return nil, true
 }
 
-// toolInput converts OpenAI's tool-call arguments — a JSON string — into the
-// JSON object Anthropic's tool_use input expects. Empty, unparseable and
-// non-object arguments all become an empty object; anything else would be a
 // flattenText reduces a content field (string or part array) to plain text, for
 // the fields Anthropic types as text: the system prompt and tool_result content.
 func flattenText(raw json.RawMessage) string {

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // DefaultMaxTokens is the max_tokens supplied when the caller sends none.
@@ -135,8 +136,14 @@ type oaiFile struct {
 type oaiToolCall struct {
 	ID       string `json:"id"`
 	Function struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"` // a JSON *string*
+		Name string `json:"name"`
+		// util.ToolArguments, not a plain string: the spec says a JSON string and
+		// several providers send the object, so #808 taught the RESPONSE side to
+		// accept both — which means the caller receives the object form, echoes
+		// the assistant turn back in its next request, and this decoder rejected
+		// what the gateway itself had handed it. In a failover group whose next
+		// turn lands here, that 400s for the life of the conversation.
+		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }
 
@@ -443,7 +450,7 @@ func translateTurn(role string, m oaiMessage) (*antMessage, error) {
 			Type:  "tool_use",
 			ID:    tc.ID,
 			Name:  tc.Function.Name,
-			Input: toolInput(tc.Function.Arguments),
+			Input: toolInput(string(tc.Function.Arguments)),
 		})
 	}
 	if len(blocks) == 0 {

--- a/internal/anthropicegress/request.go
+++ b/internal/anthropicegress/request.go
@@ -450,7 +450,7 @@ func translateTurn(role string, m oaiMessage) (*antMessage, error) {
 			Type:  "tool_use",
 			ID:    tc.ID,
 			Name:  tc.Function.Name,
-			Input: toolInput(string(tc.Function.Arguments)),
+			Input: util.ToolArgumentsObject(tc.Function.Arguments),
 		})
 	}
 	if len(blocks) == 0 {
@@ -661,15 +661,6 @@ func translateToolChoice(raw json.RawMessage) (*antToolChoice, bool) {
 // toolInput converts OpenAI's tool-call arguments — a JSON string — into the
 // JSON object Anthropic's tool_use input expects. Empty, unparseable and
 // non-object arguments all become an empty object; anything else would be a
-// malformed tool_use block the model cannot read.
-func toolInput(arguments string) json.RawMessage {
-	raw := json.RawMessage(strings.TrimSpace(arguments))
-	if len(raw) == 0 || raw[0] != '{' || !json.Valid(raw) {
-		return json.RawMessage(`{}`)
-	}
-	return raw
-}
-
 // flattenText reduces a content field (string or part array) to plain text, for
 // the fields Anthropic types as text: the system prompt and tool_result content.
 func flattenText(raw json.RawMessage) string {

--- a/internal/anthropicegress/tool_arguments_test.go
+++ b/internal/anthropicegress/tool_arguments_test.go
@@ -6,36 +6,70 @@ import (
 )
 
 // The spec says a tool call's arguments are a JSON string, and several providers
-// send the object instead. #808 taught the RESPONSE side to accept both — so the
-// caller receives the object form, echoes the assistant turn back in its next
-// request, and this translator rejects what the gateway itself handed it.
+// send the object. #808 taught the response side to accept both, so an ingress
+// decoder that did not was stricter than the decoder that produced the value —
+// and a client holding the object form, from this gateway or another, had its
+// assistant turn rejected on every retry of the conversation.
 //
-// In a failover group whose next turn lands on an Anthropic member that 400s,
-// and keeps 400ing for the life of the conversation.
+// The assertion is the ARGUMENT TEXT, not the tool name: the name comes from a
+// field this change never touched, so a test that looks for it passes just as
+// well when the arguments are silently erased.
 func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		args string
+		want string
 	}{
-		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
-		{"the object several providers send", `{"city":"Oslo"}`},
-		{"an array", `["Oslo"]`},
-		{"a null, which carries no arguments", `null`},
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`, `"input":{"city":"Oslo"}`},
+		{"the object several providers send", `{"city":"Oslo"}`, `"input":{"city":"Oslo"}`},
+		// A call with no arguments is still a call, and null is how several
+		// models spell that.
+		{"null", `null`, `"input":{}`},
+		{"the empty string", `""`, `"input":{}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			body := `{"model":"m","max_tokens":16,"messages":[` +
-				`{"role":"user","content":"weather?"},` +
-				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
-				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
-			out, _, _, err := TranslateRequest([]byte(body))
+			out, _, _, err := TranslateRequest([]byte(toolCallBody(tc.args)))
 			if err != nil {
 				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
 			}
-			if !strings.Contains(string(out), "lookup") {
-				t.Errorf("the tool call was dropped: %s", out)
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("arguments did not survive translation, want %s in: %s", tc.want, out)
 			}
 		})
 	}
+}
+
+// Arguments that are not an object become an empty one — this repo's existing
+// decision (see TestTranslateRequest_ToolCallArgumentsBecomeAnObject): a model
+// that emits junk mid-conversation must not kill the whole request.
+//
+// What was wrong was that the three egress translators each made that decision
+// differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
+// array the Responses model reads as garbage. Which one a caller met depended on
+// which member of a failover group the turn landed on, and that divergence is
+// what a tolerant decode exists to remove. Asserted in all three, on the same
+// inputs, so they cannot drift apart again.
+func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
+	t.Parallel()
+	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {
+		t.Run(args, func(t *testing.T) {
+			t.Parallel()
+			out, _, _, err := TranslateRequest([]byte(toolCallBody(args)))
+			if err != nil {
+				t.Fatalf("junk arguments killed the whole request: %v", err)
+			}
+			if !strings.Contains(string(out), `"input":{}`) {
+				t.Errorf("want the empty object every egress path agrees on, got: %s", out)
+			}
+		})
+	}
+}
+
+func toolCallBody(args string) string {
+	return `{"model":"m","max_tokens":16,"messages":[` +
+		`{"role":"user","content":"weather?"},` +
+		`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + args + `}}]},` +
+		`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
 }

--- a/internal/anthropicegress/tool_arguments_test.go
+++ b/internal/anthropicegress/tool_arguments_test.go
@@ -49,8 +49,11 @@ func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 // differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
 // array the Responses model reads as garbage. Which one a caller met depended on
 // which member of a failover group the turn landed on, and that divergence is
-// what a tolerant decode exists to remove. Asserted in all three, on the same
-// inputs, so they cannot drift apart again.
+// what a tolerant decode exists to remove.
+//
+// The same inputs in all three packages, as three hand-kept tables rather than
+// one shared list — so this documents the agreement rather than enforcing it,
+// and editing one still breaks nothing.
 func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
 	t.Parallel()
 	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {

--- a/internal/anthropicegress/tool_arguments_test.go
+++ b/internal/anthropicegress/tool_arguments_test.go
@@ -1,0 +1,41 @@
+package anthropicegress
+
+import (
+	"strings"
+	"testing"
+)
+
+// The spec says a tool call's arguments are a JSON string, and several providers
+// send the object instead. #808 taught the RESPONSE side to accept both — so the
+// caller receives the object form, echoes the assistant turn back in its next
+// request, and this translator rejects what the gateway itself handed it.
+//
+// In a failover group whose next turn lands on an Anthropic member that 400s,
+// and keeps 400ing for the life of the conversation.
+func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
+		{"the object several providers send", `{"city":"Oslo"}`},
+		{"an array", `["Oslo"]`},
+		{"a null, which carries no arguments", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"model":"m","max_tokens":16,"messages":[` +
+				`{"role":"user","content":"weather?"},` +
+				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
+				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
+			out, _, _, err := TranslateRequest([]byte(body))
+			if err != nil {
+				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
+			}
+			if !strings.Contains(string(out), "lookup") {
+				t.Errorf("the tool call was dropped: %s", out)
+			}
+		})
+	}
+}

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -61,10 +61,11 @@ type oaiToolCall struct {
 		Name string `json:"name"`
 		// util.ToolArguments, not a plain string: the spec says a JSON string and
 		// several providers send the object, so #808 taught the RESPONSE side to
-		// accept both — which means the caller receives the object form, echoes
-		// the assistant turn back in its next request, and this decoder rejected
-		// what the gateway itself had handed it. In a failover group whose next
-		// turn lands here, that 400s for the life of the conversation.
+		// accept both — and an ingress decoder has no business being stricter
+		// than the decoder that produced the value. This gateway rewrites the
+		// object form on its own way out, so the client holding one got it from
+		// another gateway or SDK; rejecting it 400s that conversation on every
+		// retry, because each one replays the same transcript.
 		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming OpenAI chat-completions request shape ---
@@ -57,8 +58,14 @@ type oaiContentPart struct {
 type oaiToolCall struct {
 	ID       string `json:"id"`
 	Function struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
+		Name string `json:"name"`
+		// util.ToolArguments, not a plain string: the spec says a JSON string and
+		// several providers send the object, so #808 taught the RESPONSE side to
+		// accept both — which means the caller receives the object form, echoes
+		// the assistant turn back in its next request, and this decoder rejected
+		// what the gateway itself had handed it. In a failover group whose next
+		// turn lands here, that 400s for the life of the conversation.
+		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }
 

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -232,10 +232,10 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 			}
 			for _, tc := range m.ToolCalls {
 				callNames[tc.ID] = tc.Function.Name
-				args := json.RawMessage(tc.Function.Arguments)
-				if len(args) == 0 || !json.Valid(args) {
-					args = json.RawMessage("{}")
-				}
+				// Gemini types functionCall.args as a Struct, so forwarding a
+				// non-object was a 400 from the provider where the other two
+				// egress paths quietly substituted something. One decision now.
+				args := util.ToolArgumentsObject(tc.Function.Arguments)
 				parts = append(parts, genPart{FunctionCall: &genFunctionCall{Name: tc.Function.Name, Args: args}})
 			}
 			if len(parts) > 0 {

--- a/internal/gemini/tool_arguments_test.go
+++ b/internal/gemini/tool_arguments_test.go
@@ -44,8 +44,11 @@ func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 // differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
 // array the Responses model reads as garbage. Which one a caller met depended on
 // which member of a failover group the turn landed on, and that divergence is
-// what a tolerant decode exists to remove. Asserted in all three, on the same
-// inputs, so they cannot drift apart again.
+// what a tolerant decode exists to remove.
+//
+// The same inputs in all three packages, as three hand-kept tables rather than
+// one shared list — so this documents the agreement rather than enforcing it,
+// and editing one still breaks nothing.
 func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
 	t.Parallel()
 	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {

--- a/internal/gemini/tool_arguments_test.go
+++ b/internal/gemini/tool_arguments_test.go
@@ -1,0 +1,37 @@
+package gemini
+
+import (
+	"strings"
+	"testing"
+)
+
+// See the anthropicegress twin: #808 taught the response side to accept the
+// object form, so the caller echoes it back and this translator rejected what
+// the gateway had handed it.
+func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
+		{"the object several providers send", `{"city":"Oslo"}`},
+		{"an array", `["Oslo"]`},
+		{"a null, which carries no arguments", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"model":"m","messages":[` +
+				`{"role":"user","content":"weather?"},` +
+				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
+				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
+			out, _, _, err := TranslateRequest([]byte(body))
+			if err != nil {
+				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
+			}
+			if !strings.Contains(string(out), "lookup") {
+				t.Errorf("the tool call was dropped: %s", out)
+			}
+		})
+	}
+}

--- a/internal/gemini/tool_arguments_test.go
+++ b/internal/gemini/tool_arguments_test.go
@@ -6,32 +6,65 @@ import (
 )
 
 // See the anthropicegress twin: #808 taught the response side to accept the
-// object form, so the caller echoes it back and this translator rejected what
-// the gateway had handed it.
+// object form, so an ingress decoder that did not was stricter than the decoder
+// that produced the value.
+//
+// The assertion is the ARGUMENT TEXT, not the tool name — the name comes from a
+// field this change never touched.
 func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		args string
+		want string
 	}{
-		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
-		{"the object several providers send", `{"city":"Oslo"}`},
-		{"an array", `["Oslo"]`},
-		{"a null, which carries no arguments", `null`},
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`, `"args":{"city":"Oslo"}`},
+		{"the object several providers send", `{"city":"Oslo"}`, `"args":{"city":"Oslo"}`},
+		{"null", `null`, `"args":{}`},
+		{"the empty string", `""`, `"args":{}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			body := `{"model":"m","messages":[` +
-				`{"role":"user","content":"weather?"},` +
-				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
-				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
-			out, _, _, err := TranslateRequest([]byte(body))
+			out, _, _, err := TranslateRequest([]byte(toolCallBody(tc.args)))
 			if err != nil {
 				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
 			}
-			if !strings.Contains(string(out), "lookup") {
-				t.Errorf("the tool call was dropped: %s", out)
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("arguments did not survive translation, want %s in: %s", tc.want, out)
 			}
 		})
 	}
+}
+
+// Arguments that are not an object become an empty one — this repo's existing
+// decision (see TestTranslateRequest_ToolCallArgumentsBecomeAnObject): a model
+// that emits junk mid-conversation must not kill the whole request.
+//
+// What was wrong was that the three egress translators each made that decision
+// differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
+// array the Responses model reads as garbage. Which one a caller met depended on
+// which member of a failover group the turn landed on, and that divergence is
+// what a tolerant decode exists to remove. Asserted in all three, on the same
+// inputs, so they cannot drift apart again.
+func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
+	t.Parallel()
+	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {
+		t.Run(args, func(t *testing.T) {
+			t.Parallel()
+			out, _, _, err := TranslateRequest([]byte(toolCallBody(args)))
+			if err != nil {
+				t.Fatalf("junk arguments killed the whole request: %v", err)
+			}
+			if !strings.Contains(string(out), `"args":{}`) {
+				t.Errorf("want the empty object every egress path agrees on, got: %s", out)
+			}
+		})
+	}
+}
+
+func toolCallBody(args string) string {
+	return `{"model":"m","messages":[` +
+		`{"role":"user","content":"weather?"},` +
+		`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + args + `}}]},` +
+		`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
 }

--- a/internal/openairesponses/request.go
+++ b/internal/openairesponses/request.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming OpenAI chat-completions request shape ---
@@ -165,10 +166,11 @@ func translateChatMessages(msgs []chatReqMessage) (string, []any, error) {
 				})
 			}
 			for _, tc := range m.ToolCalls {
-				args := tc.Function.Arguments
-				if args == "" {
-					args = "{}"
-				}
+				// The Responses API types arguments as a string, so anything
+				// would forward — but a quoted array is garbage to the model,
+				// and the same input must not take a different fate here than on
+				// the other two egress paths.
+				args := util.ToolArguments(util.ToolArgumentsObject(tc.Function.Arguments))
 				input = append(input, functionCallItem{
 					Type:      "function_call",
 					CallID:    tc.ID,

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/egress"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // StreamTranslator converts the Responses API typed SSE event stream into the
@@ -121,7 +122,7 @@ func (t *StreamTranslator) TranslateEvent(data []byte) ([]byte, error) {
 		idx := t.toolIndex(ev.OutputIndex)
 		return t.deltaChunk(chatDelta{ToolCalls: []chatToolCall{{
 			Index:    &idx,
-			Function: chatToolCallFunc{Arguments: ev.Delta},
+			Function: chatToolCallFunc{Arguments: util.ToolArguments(ev.Delta)},
 		}}}), nil
 
 	case "response.completed", "response.incomplete":

--- a/internal/openairesponses/tool_arguments_test.go
+++ b/internal/openairesponses/tool_arguments_test.go
@@ -44,8 +44,11 @@ func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 // differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
 // array the Responses model reads as garbage. Which one a caller met depended on
 // which member of a failover group the turn landed on, and that divergence is
-// what a tolerant decode exists to remove. Asserted in all three, on the same
-// inputs, so they cannot drift apart again.
+// what a tolerant decode exists to remove.
+//
+// The same inputs in all three packages, as three hand-kept tables rather than
+// one shared list — so this documents the agreement rather than enforcing it,
+// and editing one still breaks nothing.
 func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
 	t.Parallel()
 	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {

--- a/internal/openairesponses/tool_arguments_test.go
+++ b/internal/openairesponses/tool_arguments_test.go
@@ -6,50 +6,88 @@ import (
 )
 
 // See the anthropicegress twin: #808 taught the response side to accept the
-// object form, so the caller echoes it back and this translator rejected what
-// the gateway had handed it.
-func TestTranslateChatToResponses_ToolArgumentsInEitherSpelling(t *testing.T) {
+// object form, so an ingress decoder that did not was stricter than the decoder
+// that produced the value.
+//
+// The assertion is the ARGUMENT TEXT, not the tool name — the name comes from a
+// field this change never touched.
+func TestTranslateRequest_ToolArgumentsInEitherSpelling(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		args string
+		want string
 	}{
-		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
-		{"the object several providers send", `{"city":"Oslo"}`},
-		{"an array", `["Oslo"]`},
-		{"a null, which carries no arguments", `null`},
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`, `"arguments":"{\"city\":\"Oslo\"}"`},
+		{"the object several providers send", `{"city":"Oslo"}`, `"arguments":"{\"city\":\"Oslo\"}"`},
+		{"null", `null`, `"arguments":"{}"`},
+		{"the empty string", `""`, `"arguments":"{}"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			body := `{"model":"m","messages":[` +
-				`{"role":"user","content":"weather?"},` +
-				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
-				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
-			out, err := TranslateChatToResponses([]byte(body), "m")
+			out, err := TranslateChatToResponses([]byte(toolCallBody(tc.args)), "m")
 			if err != nil {
 				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
 			}
-			if !strings.Contains(string(out), "lookup") {
-				t.Errorf("the tool call was dropped: %s", out)
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("arguments did not survive translation, want %s in: %s", tc.want, out)
 			}
 		})
 	}
 }
 
-// And the response side of this same translator: a provider that answers with
-// the object form must not cost the caller its tool call.
-func TestTranslateResponsesToChat_ToolArgumentsInEitherSpelling(t *testing.T) {
+// Arguments that are not an object become an empty one — this repo's existing
+// decision (see TestTranslateRequest_ToolCallArgumentsBecomeAnObject): a model
+// that emits junk mid-conversation must not kill the whole request.
+//
+// What was wrong was that the three egress translators each made that decision
+// differently: {} here, a non-Struct `args` Gemini answers 400 to, and a quoted
+// array the Responses model reads as garbage. Which one a caller met depended on
+// which member of a failover group the turn landed on, and that divergence is
+// what a tolerant decode exists to remove. Asserted in all three, on the same
+// inputs, so they cannot drift apart again.
+func TestTranslateRequest_ArgumentsThatAreNotAnObjectBecomeAnEmptyOne(t *testing.T) {
 	t.Parallel()
-	for _, args := range []string{`"{\"city\":\"Oslo\"}"`, `{"city":"Oslo"}`, `["Oslo"]`} {
+	for _, args := range []string{`["Oslo"]`, `42`, `"not an object"`, `true`, `"{not json"`} {
 		t.Run(args, func(t *testing.T) {
 			t.Parallel()
-			body := `{"id":"resp_1","status":"completed","output":[{"type":"function_call","call_id":"c1","name":"lookup","arguments":` + args + `}]}`
+			out, err := TranslateChatToResponses([]byte(toolCallBody(args)), "m")
+			if err != nil {
+				t.Fatalf("junk arguments killed the whole request: %v", err)
+			}
+			if !strings.Contains(string(out), `"arguments":"{}"`) {
+				t.Errorf("want the empty object every egress path agrees on, got: %s", out)
+			}
+		})
+	}
+}
+
+func toolCallBody(args string) string {
+	return `{"model":"m","messages":[` +
+		`{"role":"user","content":"weather?"},` +
+		`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + args + `}}]},` +
+		`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
+}
+
+// And the response side of this same translator: a provider that answers with
+// the object form must not cost the caller its tool call, and the arguments must
+// come back as the spec's JSON string whatever spelling arrived.
+func TestTranslateResponsesToChat_ToolArgumentsInEitherSpelling(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ args, want string }{
+		{`"{\"city\":\"Oslo\"}"`, `"arguments":"{\"city\":\"Oslo\"}"`},
+		{`{"city":"Oslo"}`, `"arguments":"{\"city\":\"Oslo\"}"`},
+		{`["Oslo"]`, `"arguments":"[\"Oslo\"]"`},
+	} {
+		t.Run(tc.args, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"resp_1","status":"completed","output":[{"type":"function_call","call_id":"c1","name":"lookup","arguments":` + tc.args + `}]}`
 			out, err := TranslateResponsesToChat([]byte(body), "m")
 			if err != nil {
 				t.Fatalf("a tool call the provider sent cost the caller the response: %v", err)
 			}
-			if !strings.Contains(string(out), "lookup") {
-				t.Errorf("the tool call was dropped: %s", out)
+			if !strings.Contains(string(out), tc.want) {
+				t.Errorf("arguments did not survive translation, want %s in: %s", tc.want, out)
 			}
 		})
 	}

--- a/internal/openairesponses/tool_arguments_test.go
+++ b/internal/openairesponses/tool_arguments_test.go
@@ -1,0 +1,56 @@
+package openairesponses
+
+import (
+	"strings"
+	"testing"
+)
+
+// See the anthropicegress twin: #808 taught the response side to accept the
+// object form, so the caller echoes it back and this translator rejected what
+// the gateway had handed it.
+func TestTranslateChatToResponses_ToolArgumentsInEitherSpelling(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args string
+	}{
+		{"the spec's JSON string", `"{\"city\":\"Oslo\"}"`},
+		{"the object several providers send", `{"city":"Oslo"}`},
+		{"an array", `["Oslo"]`},
+		{"a null, which carries no arguments", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"model":"m","messages":[` +
+				`{"role":"user","content":"weather?"},` +
+				`{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"lookup","arguments":` + tc.args + `}}]},` +
+				`{"role":"tool","tool_call_id":"c1","content":"sunny"}]}`
+			out, err := TranslateChatToResponses([]byte(body), "m")
+			if err != nil {
+				t.Fatalf("the gateway rejected an assistant turn it can itself emit: %v", err)
+			}
+			if !strings.Contains(string(out), "lookup") {
+				t.Errorf("the tool call was dropped: %s", out)
+			}
+		})
+	}
+}
+
+// And the response side of this same translator: a provider that answers with
+// the object form must not cost the caller its tool call.
+func TestTranslateResponsesToChat_ToolArgumentsInEitherSpelling(t *testing.T) {
+	t.Parallel()
+	for _, args := range []string{`"{\"city\":\"Oslo\"}"`, `{"city":"Oslo"}`, `["Oslo"]`} {
+		t.Run(args, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"resp_1","status":"completed","output":[{"type":"function_call","call_id":"c1","name":"lookup","arguments":` + args + `}]}`
+			out, err := TranslateResponsesToChat([]byte(body), "m")
+			if err != nil {
+				t.Fatalf("a tool call the provider sent cost the caller the response: %v", err)
+			}
+			if !strings.Contains(string(out), "lookup") {
+				t.Errorf("the tool call was dropped: %s", out)
+			}
+		})
+	}
+}

--- a/internal/openairesponses/types.go
+++ b/internal/openairesponses/types.go
@@ -11,7 +11,11 @@
 // anthropic package this is a leaf: the proxy composes it, never the reverse.
 package openairesponses
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
 
 // --- Responses API request shape (outgoing) ---
 
@@ -74,10 +78,12 @@ type contentPart struct {
 
 // functionCallItem replays a prior assistant tool call from the transcript.
 type functionCallItem struct {
-	Type      string `json:"type"` // "function_call"
-	CallID    string `json:"call_id"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	Type   string `json:"type"` // "function_call"
+	CallID string `json:"call_id"`
+	Name   string `json:"name"`
+	// Built from the caller's chat request, and marshalled as the spec's JSON
+	// string whatever spelling arrived.
+	Arguments util.ToolArguments `json:"arguments"`
 }
 
 // functionCallOutputItem replays a prior tool result from the transcript.
@@ -129,9 +135,11 @@ type OutputItem struct {
 	// reasoning
 	Summary []SummaryPart `json:"summary"`
 	// function_call
-	CallID    string `json:"call_id"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	CallID string `json:"call_id"`
+	Name   string `json:"name"`
+	// The provider's side of the same asymmetry: an object here failed the whole
+	// Response decode, so a tool call cost the caller the answer around it.
+	Arguments util.ToolArguments `json:"arguments"`
 }
 
 // OutputContent is one content part of a message output item.
@@ -202,8 +210,14 @@ type chatToolCall struct {
 }
 
 type chatToolCallFunc struct {
-	Name      string `json:"name,omitempty"`
-	Arguments string `json:"arguments"`
+	Name string `json:"name,omitempty"`
+	// util.ToolArguments, not a plain string: the spec says a JSON string and
+	// several providers send the object, so #808 taught the response side to
+	// accept both — which means the caller receives the object form, echoes the
+	// assistant turn back in its next request, and this decoder rejected what
+	// the gateway itself had handed it. It marshals back as the spec's string,
+	// so the caller is still answered in the shape it asked for.
+	Arguments util.ToolArguments `json:"arguments"`
 }
 
 type chatUsage struct {

--- a/internal/openairesponses/types.go
+++ b/internal/openairesponses/types.go
@@ -213,10 +213,11 @@ type chatToolCallFunc struct {
 	Name string `json:"name,omitempty"`
 	// util.ToolArguments, not a plain string: the spec says a JSON string and
 	// several providers send the object, so #808 taught the response side to
-	// accept both — which means the caller receives the object form, echoes the
-	// assistant turn back in its next request, and this decoder rejected what
-	// the gateway itself had handed it. It marshals back as the spec's string,
-	// so the caller is still answered in the shape it asked for.
+	// accept both — and an ingress decoder has no business being stricter than
+	// the decoder that produced the value. This gateway rewrites the object form
+	// on its own way out, so a client holding one got it from another gateway or
+	// SDK. It marshals back as the spec's string either way, so the caller is
+	// still answered in the shape it asked for.
 	Arguments util.ToolArguments `json:"arguments"`
 }
 

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -402,14 +402,15 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			_ = json.Unmarshal(masked, &chunk)
 		}
 
-		// Rewrite an object-form tool call into the spec's JSON string before
-		// it leaves the gateway. Accepting the object on the way IN is what
-		// stops the frame being dropped; forwarding it on the way OUT would
-		// hand the caller a shape this gateway's own request translators
-		// (anthropicegress, gemini, openairesponses) cannot read back — and the
-		// caller echoes the assistant turn into the next request. In a failover
-		// group whose next turn lands on an Anthropic or Gemini member, that
-		// request 400s, and keeps 400ing for the life of the conversation.
+		// Rewrite an object-form tool call into the spec's JSON string before it
+		// leaves the gateway. Accepting the object on the way IN is what stops
+		// the frame being dropped; rewriting it on the way OUT is what makes the
+		// caller's next request spec-shaped, whoever reads it.
+		//
+		// This used to be load-bearing for the gateway's own egress translators,
+		// which could not read the object form back. They can now, so what is
+		// left is conformance: the caller asked this gateway for the OpenAI
+		// shape, and an SDK or another gateway downstream is entitled to it.
 		if normalized, changed := normalizeToolArguments(payload); changed {
 			payload = normalized
 			line = append([]byte("data: "), normalized...)

--- a/internal/util/toolargs.go
+++ b/internal/util/toolargs.go
@@ -1,6 +1,9 @@
 package util
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // ToolArguments is an OpenAI tool-call arguments value.
 //
@@ -17,7 +20,8 @@ import "encoding/json"
 // wherever the value is re-encoded rather than relayed.
 //
 // The streaming surface relays bytes rather than re-encoding, so it normalises
-// explicitly — see normalizeToolArguments.
+// explicitly — see normalizeToolArguments. That normalisation is conformance
+// rather than repair: every decoder in this repo reads either spelling now.
 type ToolArguments string
 
 // UnmarshalJSON accepts the spec's JSON string or the argument object itself.
@@ -32,4 +36,27 @@ func (a *ToolArguments) UnmarshalJSON(b []byte) error {
 	// The object (or array, or number) form: its own JSON is the argument text.
 	*a = ToolArguments(b)
 	return nil
+}
+
+// ToolArgumentsObject renders tool-call arguments as the JSON OBJECT the
+// dialects that type them as one require.
+//
+// Anything that is not one becomes an empty object. That is this repo's existing
+// decision, not a new one — see TestTranslateRequest_ToolCallArgumentsBecomeAnObject:
+// a model that emits junk arguments mid-conversation should not kill the whole
+// request, and a call with no arguments is still a call.
+//
+// One helper because the three egress translators each made that decision for
+// themselves and each made it differently: an array became {} for Anthropic, was
+// forwarded to Gemini as a non-Struct `args` it answers 400 to, and reached the
+// Responses API as a quoted array the model reads as garbage. Which of those a
+// caller met depended on which member of a failover group the turn landed on —
+// and removing exactly that divergence is what these arguments are decoded
+// tolerantly for. The coercion was never the defect; three of them were.
+func ToolArgumentsObject(a ToolArguments) json.RawMessage {
+	raw := json.RawMessage(strings.TrimSpace(string(a)))
+	if len(raw) == 0 || raw[0] != '{' || !json.Valid(raw) {
+		return json.RawMessage(`{}`)
+	}
+	return raw
 }

--- a/internal/util/toolargs_test.go
+++ b/internal/util/toolargs_test.go
@@ -75,3 +75,35 @@ func TestToolArguments_ReEncodeIsStable(t *testing.T) {
 		}
 	}
 }
+
+// The one decision the three egress translators used to make three different
+// ways. It is tested here as well as through each of them, because it is the
+// place they now agree — and agreement is the property, not any one output.
+func TestToolArgumentsObject(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args string
+		want string
+	}{
+		{"an object", `{"city":"Oslo"}`, `{"city":"Oslo"}`},
+		{"an object with whitespace round it", "  {\"city\":\"Oslo\"}\n", `{"city":"Oslo"}`},
+		// A call with no arguments is still a call.
+		{"absent", ``, `{}`},
+		// Not a tool input. This repo's existing decision is to substitute the
+		// empty object rather than kill the request; what was wrong was that
+		// each translator substituted something different.
+		{"an array", `["Oslo"]`, `{}`},
+		{"a number", `42`, `{}`},
+		{"a bare word", `not an object`, `{}`},
+		{"an object that does not parse", `{not json`, `{}`},
+		{"a JSON null", `null`, `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(util.ToolArgumentsObject(util.ToolArguments(tc.args))); got != tc.want {
+				t.Errorf("ToolArgumentsObject(%q) = %s, want %s", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/util/toolargs_test.go
+++ b/internal/util/toolargs_test.go
@@ -97,6 +97,11 @@ func TestToolArgumentsObject(t *testing.T) {
 		{"a number", `42`, `{}`},
 		{"a bare word", `not an object`, `{}`},
 		{"an object that does not parse", `{not json`, `{}`},
+		// A valid object with bytes after it. json.Valid rejects the whole
+		// thing, and it has to: forwarding the prefix hands Gemini an args value
+		// that fails to marshal, so a request that works today would 400.
+		{"an object with trailing bytes", `{"a":1} trailing`, `{}`},
+		{"two objects concatenated", `{"a":1}{"b":2}`, `{}`},
 		{"a JSON null", `null`, `{}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The spec says a tool call's `arguments` are a JSON string; several providers send the object. #808 taught the **response** side to accept both — which is what makes this an asymmetry rather than a gap: the caller receives whatever spelling arrived, echoes the assistant turn back in its next request, and the **ingress** decoders reject what the gateway had just handed it.

In a failover group whose next turn lands on an Anthropic, Gemini or Responses member, that request 400s — and keeps 400ing for the life of the conversation, because every retry replays the same transcript. The comment on `normalizeToolArguments` in #811 named this exact sequence as the reason the *streaming* path rewrites the object form on the way out; these decoders are the other half of it.

## What changed

`util.ToolArguments` accepts either spelling and marshals back as the spec's JSON string, so the caller is still answered in the shape it asked for. Four sites:

- `internal/anthropicegress/request.go` — the chat request being translated to Messages
- `internal/gemini/request.go` — the chat request being translated to `generateContent`
- `internal/openairesponses/types.go` `chatToolCallFunc` — decoded from the chat request *and* marshalled back to the caller
- `internal/openairesponses/types.go` `OutputItem` — the provider's side of the same asymmetry, where an object failed the whole Response decode and a tool call cost the caller the answer around it

## Sweep

Every remaining `Arguments string` under `internal/` is a shape this gateway **builds**, so none can meet a provider's spelling: gemini's and anthropicegress's outbound chunks and completions, and the OpenAI body `internal/anthropic` assembles from Messages blocks. Listed rather than assumed.

## One decision, not three

The review found the deeper half. Each egress translator also decided for itself what to do with arguments that are **not** an object, and each decided differently — an array became `{}` for Anthropic, was forwarded to Gemini as a non-Struct `args` it answers 400 to, and reached the Responses API as a quoted array the model reads as garbage. Which one a caller met depended on which member of a failover group the turn landed on: the same divergence a tolerant decode exists to remove, left standing one step further along.

`util.ToolArgumentsObject` is that decision, once. It returns `{}` for anything that is not an object — this repo's existing choice rather than a new one, asserted by `TestTranslateRequest_ToolCallArgumentsBecomeAnObject` since before this branch, because a model emitting junk arguments mid-conversation should not kill the whole request. I briefly made it an error instead and two existing tests correctly refused that. **The coercion was never the defect; three of them were.**

## Verified

The first round of tests here gave **no protection at all**: each asserted the tool *name* appeared in the output — a field this change never touches — so a mutation decoding the object spelling to no arguments left all fifteen subtests green while the arguments were silently erased. They assert the argument **text** now, in each translator's own output shape, and that mutation fails nine of them. The divergence is pinned by the same inputs in all three packages, so they cannot drift apart again.

A second round found one real defect — deleting `toolInput` left three orphaned lines of its doc comment running into `flattenText`'s, which `gofmt` and `vet` both pass — plus a gap where nothing pinned `json.Valid`'s rejection of trailing bytes. That guard is not cosmetic: accepting `{"a":1} trailing` hands Gemini an `args` value whose outer body then fails to marshal, so a request that works today would 400.

Full suite green, lint clean, size gate passing.

## Verified on a rebuilt dev stack

A `vertex-express` and an `anthropic-messages` provider against a mock that records what the translator actually sent, so the arguments are read rather than inferred from a 200:

| assistant turn's `arguments` | gemini `args` | anthropic `input` |
|---|---|---|
| `{"city":"Oslo"}` (object) | `{"city":"Oslo"}` | `{"city":"Oslo"}` |
| `"{\"city\":\"Oslo\"}"` (spec string) | `{"city":"Oslo"}` | `{"city":"Oslo"}` |
| `["Oslo"]` | `{}` | `{}` |
| `null` | `{}` | `{}` |
| `"{not json"` | `{}` | `{}` |

The first two 400'd at the gateway before this PR. The last three used to take different fates per dialect and now converge. App log scanned after: zero occurrences of any argument value or credential.

## Also in scope, and not needed

**`util.ShapeError`.** An earlier review round flagged that it had lost its cross-package consumers. That was true of an intermediate state only — the per-figure rule that landed in #813 restored it, and it now has six callers across four packages. Checked rather than taken on trust; no change made.

Also corrected: the comment on `normalizeToolArguments` said the egress translators "cannot read back" the object form. After this branch they can, so what is left there is conformance — the caller asked this gateway for the OpenAI shape and an SDK downstream is entitled to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
