### PR TITLE
fix(proxy): a terminal request-log update must not lose the race with its own insert

### DIFF
--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -13,17 +13,24 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/metrics"
 )
 
+// isTerminalLogState reports whether a request-log state is one a row can end
+// on. A terminal update is the last thing that will ever touch its row, so it is
+// the one that must not lose the race with the INSERT it is updating.
+func isTerminalLogState(state string) bool {
+	return state == "completed" || state == "failed"
+}
+
 // updateLogOption configures updateRequestLog behavior.
 type updateLogOption struct {
 	// skipWaitForInsert skips the WaitForInsert call before the UPDATE.
 	// Used for all log updates that run before the response is written to the
 	// client, to avoid adding up to 5s INSERT-wait latency under DB stress.
 	//
-	// Tradeoff: if the UPDATE wins the race against the async INSERT goroutine,
-	// the UPDATE hits 0 rows and the row stays at state='pending' with no final
-	// metrics. This is a low-probability event (the INSERT has the entire
-	// provider round-trip to complete). Only the streaming final update (after
-	// the stream completes, off the hot path) still waits.
+	// Honoured for interim states only. A terminal state overrides it in
+	// updateRequestLog, because an UPDATE that wins the race against the async
+	// INSERT hits 0 rows and strands the request at 'pending' — see the comment
+	// there for why the "the INSERT has the entire provider round-trip to
+	// complete" reasoning does not hold on the paths that strand.
 	skipWaitForInsert bool
 }
 
@@ -198,6 +205,27 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		if o.skipWaitForInsert {
 			skipWait = true
 		}
+	}
+
+	// That last sentence is an invariant, so it is decided HERE rather than by
+	// each caller remembering: every terminal caller passed the flag, and a
+	// terminal UPDATE that beat its own INSERT hit 0 rows and left the request
+	// at 'pending' for ever — no status, no duration, no error, and a row the
+	// dashboard shows as still in flight.
+	//
+	// The flag's reasoning is sound for an interim update and false for a
+	// terminal one on the paths that need it most. "The INSERT has the entire
+	// provider round-trip to complete" is true of a request that reached a
+	// provider; a request that failed before one — an unknown model, an invalid
+	// model format, a rejected key — updates microseconds after the insert is
+	// queued, so for those it was not a low-probability race but the normal
+	// case. And those are exactly the rows whose error is the only thing worth
+	// reading.
+	//
+	// The cost where the premise did hold is nil: the insert is long finished by
+	// then, so the wait returns at once. WaitForInsert is bounded either way.
+	if isTerminalLogState(logEntry.state) {
+		skipWait = false
 	}
 
 	if !skipWait {

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -14,7 +14,7 @@ import (
 )
 
 // isTerminalLogState reports whether a request-log state is one a row can end
-// on. A terminal update is the last thing that will ever touch its row, so it is
+// on. Nothing touches the row after a terminal update lands, so that update is
 // the one that must not lose the race with the INSERT it is updating.
 func isTerminalLogState(state string) bool {
 	return state == "completed" || state == "failed"
@@ -26,11 +26,10 @@ type updateLogOption struct {
 	// Used for all log updates that run before the response is written to the
 	// client, to avoid adding up to 5s INSERT-wait latency under DB stress.
 	//
-	// Honoured for interim states only. A terminal state overrides it in
-	// updateRequestLog, because an UPDATE that wins the race against the async
-	// INSERT hits 0 rows and strands the request at 'pending' — see the comment
-	// there for why the "the INSERT has the entire provider round-trip to
-	// complete" reasoning does not hold on the paths that strand.
+	// It is honoured as given: nothing waits before the first UPDATE. A terminal
+	// update that then finds no row waits and retries once — see
+	// updateRequestLog — so the wait is paid only where skipping it would have
+	// stranded the request at 'pending'.
 	skipWaitForInsert bool
 }
 
@@ -178,61 +177,11 @@ func (h *Handler) WaitForInsert(logEntry *requestLogData) {
 	}
 }
 
-func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOption) {
-	// Guard: if the log entry was never assigned an ID (insertRequestLogAsync
-	// not called), there is no row to update. An empty string is not a valid
-	// UUID and would cause "invalid input syntax for type uuid" errors.
-	// Note: if insertRequestLogAsync was called but the async INSERT failed,
-	// the ID will still be set (assigned synchronously), and the UPDATE will
-	// simply affect 0 rows (logged as a warning below).
-	if logEntry.id == "" {
-		debuglog.Warn("proxy: skipping updateRequestLog — log entry has no ID")
-		return
-	}
-
-	// Skip DB operations when no pool is available (unit tests without DB).
-	if h.dbPool == nil {
-		return
-	}
-
-	// Determine if we should skip WaitForInsert (fire-and-forget).
-	// The interim "streaming" state update runs on the hot path before the
-	// first streamed byte — blocking on the DB INSERT can delay the client
-	// by up to waitInsertTimeout (5s). Terminal states (completed/failed)
-	// always wait to guarantee the row exists for the final UPDATE.
-	skipWait := false
-	for _, o := range opts {
-		if o.skipWaitForInsert {
-			skipWait = true
-		}
-	}
-
-	// That last sentence is an invariant, so it is decided HERE rather than by
-	// each caller remembering: every terminal caller passed the flag, and a
-	// terminal UPDATE that beat its own INSERT hit 0 rows and left the request
-	// at 'pending' for ever — no status, no duration, no error, and a row the
-	// dashboard shows as still in flight.
-	//
-	// The flag's reasoning is sound for an interim update and false for a
-	// terminal one on the paths that need it most. "The INSERT has the entire
-	// provider round-trip to complete" is true of a request that reached a
-	// provider; a request that failed before one — an unknown model, an invalid
-	// model format, a rejected key — updates microseconds after the insert is
-	// queued, so for those it was not a low-probability race but the normal
-	// case. And those are exactly the rows whose error is the only thing worth
-	// reading.
-	//
-	// The cost where the premise did hold is nil: the insert is long finished by
-	// then, so the wait returns at once. WaitForInsert is bounded either way.
-	if isTerminalLogState(logEntry.state) {
-		skipWait = false
-	}
-
-	if !skipWait {
-		// Ensure the async INSERT has completed before we try to UPDATE the row.
-		h.WaitForInsert(logEntry)
-	}
-
+// execRequestLogUpdate runs the terminal/interim UPDATE and reports how many
+// rows it touched. Separated from updateRequestLog because that function runs it
+// twice: a row count of zero means the UPDATE arrived before its own INSERT, and
+// the retry has to send exactly the same statement.
+func (h *Handler) execRequestLogUpdate(logEntry *requestLogData) (int64, error) {
 	var providerID any
 	if logEntry.providerID != uuid.Nil {
 		providerID = logEntry.providerID
@@ -243,7 +192,6 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 	if logEntry.errorKind != "" {
 		errKind = string(logEntry.errorKind)
 	}
-	logEntry.latencyMs = logEntry.durationMs - logEntry.proxyOverheadMs
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -287,13 +235,78 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		logEntry.resolvedModelID, logEntry.cacheHits, errKind,
 	)
 	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOption) {
+	// Guard: if the log entry was never assigned an ID (insertRequestLogAsync
+	// not called), there is no row to update. An empty string is not a valid
+	// UUID and would cause "invalid input syntax for type uuid" errors.
+	// Note: if insertRequestLogAsync was called but the async INSERT failed,
+	// the ID will still be set (assigned synchronously), and the UPDATE will
+	// simply affect 0 rows (logged as a warning below).
+	if logEntry.id == "" {
+		debuglog.Warn("proxy: skipping updateRequestLog — log entry has no ID")
+		return
+	}
+
+	// Skip DB operations when no pool is available (unit tests without DB).
+	if h.dbPool == nil {
+		return
+	}
+
+	// The interim "streaming" state update runs on the hot path before the first
+	// streamed byte, and blocking it on the DB INSERT delays the client by up to
+	// waitInsertTimeout (5s). That is what the flag is for, and it is honoured as
+	// given: nothing waits before the first UPDATE.
+	skipWait := false
+	for _, o := range opts {
+		if o.skipWaitForInsert {
+			skipWait = true
+		}
+	}
+
+	if !skipWait {
+		// Ensure the async INSERT has completed before we try to UPDATE the row.
+		h.WaitForInsert(logEntry)
+	}
+
+	logEntry.latencyMs = logEntry.durationMs - logEntry.proxyOverheadMs
+	rows, err := h.execRequestLogUpdate(logEntry)
+
+	// Nothing touches the row after a terminal update, so a terminal update that
+	// loses the race with its own INSERT hits 0 rows and leaves the request at
+	// 'pending': no status, no duration, no error, and a row the dashboard shows
+	// as still in flight until a cleanup pass relabels it "request interrupted
+	// (stale)" up to half an hour later.
+	//
+	// The flag's reasoning — "the INSERT has the entire provider round-trip to
+	// complete" — holds for a request that reached a provider and fails for one
+	// that did not. An unknown model, an invalid model format or a rejected key
+	// updates microseconds after the insert is queued, so for those it was never
+	// a low-probability race; it was the normal case, and those are exactly the
+	// rows whose error message is the only thing worth reading.
+	//
+	// Waiting up front would fix that and charge every request for it, because
+	// the terminal update runs BEFORE the response body is written. So the wait
+	// is paid where it buys something instead: 0 rows IS the race, and from there
+	// the row either appears while we wait or the INSERT itself failed, which no
+	// amount of waiting up front would have repaired either.
+	if err == nil && rows == 0 && skipWait && isTerminalLogState(logEntry.state) {
+		h.WaitForInsert(logEntry)
+		rows, err = h.execRequestLogUpdate(logEntry)
+	}
+
+	if err != nil {
 		debuglog.Error("proxy: failed to update request log", "request_id", logEntry.id, "error", err)
-	} else if tag.RowsAffected() == 0 {
+	} else if rows == 0 {
 		debuglog.Warn("proxy: updateRequestLog no rows affected", "request_id", logEntry.id)
 	}
 
 	// Publish request lifecycle event for terminal states
-	if logEntry.state == "completed" || logEntry.state == "failed" {
+	if isTerminalLogState(logEntry.state) {
 		// Single Prometheus recording seam: every terminal request passes
 		// through here exactly once with its provider/model/status/tokens.
 		// Validation failures carry the raw, client-supplied model string, which

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -295,6 +295,10 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 	// the row either appears while we wait or the INSERT itself failed, which no
 	// amount of waiting up front would have repaired either.
 	if err == nil && rows == 0 && skipWait && isTerminalLogState(logEntry.state) {
+		// Debug, not Warn: this is the repair working, and on the paths that
+		// strand it is the normal case rather than an incident. What is worth a
+		// Warn is the retry ALSO finding no row, which falls through below.
+		debuglog.Debug("proxy: terminal log update arrived before its own insert", "request_id", logEntry.id, "state", logEntry.state)
 		h.WaitForInsert(logEntry)
 		rows, err = h.execRequestLogUpdate(logEntry)
 	}

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -294,6 +294,11 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 	// is paid where it buys something instead: 0 rows IS the race, and from there
 	// the row either appears while we wait or the INSERT itself failed, which no
 	// amount of waiting up front would have repaired either.
+	//
+	// 0 rows is not the only way a row is left behind, and this repairs only that
+	// one. An UPDATE that ERRORS — an exhausted pool, a reset connection — has no
+	// row count to believe and no insert to wait for, so it strands the same row
+	// by a different door and only staleLogCleanupPass will reach it.
 	if err == nil && rows == 0 && skipWait && isTerminalLogState(logEntry.state) {
 		// Debug, not Warn: this is the repair working, and on the paths that
 		// strand it is the normal case rather than an incident. What is worth a

--- a/internal/proxy/pending_row_test.go
+++ b/internal/proxy/pending_row_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -160,6 +161,251 @@ func TestIsTerminalLogState(t *testing.T) {
 	} {
 		if got := isTerminalLogState(state); got != want {
 			t.Errorf("isTerminalLogState(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+// The production shape end to end: the real insertRequestLogAsync, and a
+// terminal update fired the instant it returns — which is what a request that
+// fails before reaching a provider does.
+//
+// The hand-rolled tests above reproduce the RACE; this one reproduces the
+// INSERT as well, so a change to insertRequestLogAsync (moving the id
+// assignment inside the goroutine, say) cannot leave them green while
+// production re-breaks. Run against master it strands the majority of the
+// batch; the fix must strand none of it.
+func TestUpdateRequestLog_ConcurrentTerminalUpdatesNeverStrand(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	const requests = 60
+	entries := make([]*requestLogData, requests)
+	var wg sync.WaitGroup
+	for i := range entries {
+		logData := &requestLogData{
+			modelID: "concurrent-model", virtualKeyName: "k", state: "pending",
+			endpointType: endpointTypeChat,
+		}
+		entries[i] = logData
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.insertRequestLogAsync(logData)
+			// No pause: an unknown model or an invalid model format fails here,
+			// microseconds after the insert was queued.
+			logData.state = "failed"
+			logData.statusCode = 400
+			logData.errorKind = KindValidation
+			logData.errorMessage = "invalid model format"
+			h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+		}()
+	}
+	wg.Wait()
+
+	ids := make([]string, 0, requests)
+	for _, e := range entries {
+		e.insertWg.Wait() // every row is certainly written by now
+		ids = append(ids, e.id)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	rows, err := h.dbPool.Query(ctx, `SELECT state FROM request_logs WHERE id = ANY($1)`, ids)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	defer rows.Close()
+	stranded, seen := 0, 0
+	for rows.Next() {
+		var state string
+		if err := rows.Scan(&state); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		seen++
+		if state != "failed" {
+			stranded++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if seen != requests {
+		t.Fatalf("read back %d rows, want %d", seen, requests)
+	}
+	if stranded != 0 {
+		t.Errorf("%d of %d requests stranded before the terminal update landed", stranded, requests)
+	}
+}
+
+// A terminal caller that did NOT skip the wait does not wait a second time.
+//
+// stream_finalize is the one such caller. Its up-front WaitForInsert can only
+// return with the insert still outstanding by timing out, and the insert
+// goroutine is bounded by a context of its own — so 0 rows there means the
+// INSERT failed outright, which no further waiting repairs.
+func TestUpdateRequestLog_ATerminalUpdateThatAlreadyWaitedDoesNotWaitAgain(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	h.waitInsertTimeout = 300 * time.Millisecond
+
+	logData := &requestLogData{modelID: "m", virtualKeyName: "k", endpointType: endpointTypeChat}
+	logData.id = uuid.New().String()
+	logData.requestHash = generateRequestHash()
+	logData.insertWg.Add(1)
+	defer logData.insertWg.Done()
+
+	// No row and an insert that never completes: the up-front wait times out,
+	// the UPDATE finds nothing. One timeout is the whole budget.
+	logData.state = "completed"
+	start := time.Now()
+	h.updateRequestLog(logData)
+	if waited := time.Since(start); waited > 450*time.Millisecond {
+		t.Errorf("waited %s, about twice the %s timeout: the update waited for the insert twice", waited, h.waitInsertTimeout)
+	}
+}
+
+// An UPDATE that ERRORS is not the race and must not be treated as one. There
+// is no row count to believe either way, and waiting for an insert cannot fix a
+// statement the database refused.
+func TestUpdateRequestLog_AFailedUpdateDoesNotWait(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	logData := &requestLogData{modelID: "m", virtualKeyName: "k", endpointType: endpointTypeChat}
+	// Non-empty, so it clears the "no ID" guard, and not a UUID, so Postgres
+	// rejects the statement rather than matching no rows.
+	logData.id = "not-a-uuid"
+	logData.insertWg.Add(1)
+	defer logData.insertWg.Done()
+
+	logData.state = "failed"
+	start := time.Now()
+	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("a rejected UPDATE blocked for %s waiting for an insert that could not have helped", waited)
+	}
+}
+
+// Twenty-eight positional parameters, and this PR is what moved them into a
+// function of their own. A transposition between two columns of the same type
+// is silent — every figure below is distinct, and exactly representable in
+// float4, so it can only read back from the column it was written to.
+func TestUpdateRequestLog_WritesEachFigureToItsOwnColumn(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	logData := &requestLogData{
+		modelID: "column-model", virtualKeyName: "k", state: "pending",
+		endpointType: endpointTypeChat,
+	}
+	logData.id = uuid.New().String()
+	logData.requestHash = generateRequestHash()
+	seedRequestLogRow(t, h, logData)
+
+	logData.state = "completed"
+	logData.statusCode = 201
+	logData.durationMs = 111.5
+	logData.proxyOverheadMs = 22.25 // latencyMs is derived: 111.5 - 22.25
+	logData.parseMs = 1.5
+	logData.failoverLookupMs = 2.5
+	logData.modelLookupMs = 3.5
+	logData.providerLookupMs = 4.5
+	logData.keyDecryptMs = 5.5
+	logData.dialMs = 6.5
+	logData.settingsReadMs = 7.5
+	logData.responseHeaderMs = 8.5
+	logData.ttftMs = 9.5
+	logData.tokensPerSecond = 12.5
+	logData.tokensPrompt = 101
+	logData.tokensCompletion = 102
+	logData.tokensCompletionReasoning = 103
+	logData.tokensPromptCacheHit = 104
+	logData.tokensPromptCacheMiss = 105
+	logData.failoverAttempt = 3
+	logData.errorMessage = "column-error"
+	logData.resolvedModelID = "column-resolved"
+	logData.errorKind = KindValidation
+	h.updateRequestLog(logData)
+
+	var got struct {
+		model                                     string
+		status, attempt                           int
+		prompt, completion, reasoning, hit, miss  int
+		duration, latency, overhead, parse, fLook float64
+		mLook, pLook, keyDec, dial, settings      float64
+		header, ttft, tps                         float64
+		errMsg, resolved, kind, state             string
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := h.dbPool.QueryRow(ctx, `
+		SELECT model_id, status_code, failover_attempt,
+		       tokens_prompt, tokens_completion, tokens_completion_reasoning,
+		       tokens_prompt_cache_hit, tokens_prompt_cache_miss,
+		       duration_ms, latency_ms, proxy_overhead_ms, parse_ms, failover_lookup_ms,
+		       model_lookup_ms, provider_lookup_ms, key_decrypt_ms, dial_ms, settings_read_ms,
+		       response_header_ms, ttft_ms, tokens_per_second,
+		       error_message, resolved_model_id, error_kind, state
+		  FROM request_logs WHERE id = $1`, logData.id).Scan(
+		&got.model, &got.status, &got.attempt,
+		&got.prompt, &got.completion, &got.reasoning, &got.hit, &got.miss,
+		&got.duration, &got.latency, &got.overhead, &got.parse, &got.fLook,
+		&got.mLook, &got.pLook, &got.keyDec, &got.dial, &got.settings,
+		&got.header, &got.ttft, &got.tps,
+		&got.errMsg, &got.resolved, &got.kind, &got.state)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	for _, c := range []struct {
+		column    string
+		got, want float64
+	}{
+		{"duration_ms", got.duration, 111.5},
+		{"latency_ms", got.latency, 89.25},
+		{"proxy_overhead_ms", got.overhead, 22.25},
+		{"parse_ms", got.parse, 1.5},
+		{"failover_lookup_ms", got.fLook, 2.5},
+		{"model_lookup_ms", got.mLook, 3.5},
+		{"provider_lookup_ms", got.pLook, 4.5},
+		{"key_decrypt_ms", got.keyDec, 5.5},
+		{"dial_ms", got.dial, 6.5},
+		{"settings_read_ms", got.settings, 7.5},
+		{"response_header_ms", got.header, 8.5},
+		{"ttft_ms", got.ttft, 9.5},
+		{"tokens_per_second", got.tps, 12.5},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.column, c.got, c.want)
+		}
+	}
+	for _, c := range []struct {
+		column    string
+		got, want int
+	}{
+		{"status_code", got.status, 201},
+		{"failover_attempt", got.attempt, 3},
+		{"tokens_prompt", got.prompt, 101},
+		{"tokens_completion", got.completion, 102},
+		{"tokens_completion_reasoning", got.reasoning, 103},
+		{"tokens_prompt_cache_hit", got.hit, 104},
+		{"tokens_prompt_cache_miss", got.miss, 105},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.column, c.got, c.want)
+		}
+	}
+	for _, c := range []struct {
+		column, got, want string
+	}{
+		{"model_id", got.model, "column-model"},
+		{"error_message", got.errMsg, "column-error"},
+		{"resolved_model_id", got.resolved, "column-resolved"},
+		{"error_kind", got.kind, string(KindValidation)},
+		{"state", got.state, "completed"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.column, c.got, c.want)
 		}
 	}
 }

--- a/internal/proxy/pending_row_test.go
+++ b/internal/proxy/pending_row_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// A terminal update must not lose the race with the INSERT it is updating.
+//
+// updateRequestLog's own comment states the invariant — "Terminal states
+// (completed/failed) always wait to guarantee the row exists for the final
+// UPDATE" — but every terminal caller passed skipWaitForInsert, so the UPDATE
+// could run first, hit 0 rows, and leave the request at 'pending' for ever with
+// no status, no duration and no error.
+//
+// The flag's reasoning was that the INSERT "has the entire provider round-trip
+// to complete". That is true of a request that reached a provider and false of
+// every request that failed before one: an unknown model, an invalid model
+// format, a rejected key. Those update microseconds after the insert is queued,
+// so for them it was not a low-probability race, it was the normal case.
+func TestUpdateRequestLog_ATerminalUpdateWaitsForItsRow(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	for _, state := range []string{"failed", "completed"} {
+		t.Run(state, func(t *testing.T) {
+			logData := &requestLogData{
+				modelID: "m", virtualKeyName: "k", state: "pending",
+				endpointType: endpointTypeChat,
+			}
+			// The production shape: the id is assigned synchronously and the row
+			// is written by a goroutine the wait group guards. Held open here so
+			// the update genuinely has to wait rather than happening to win.
+			logData.id = uuid.New().String()
+			logData.requestHash = generateRequestHash()
+			logData.insertWg.Add(1)
+			go func() {
+				defer logData.insertWg.Done()
+				time.Sleep(150 * time.Millisecond)
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_, err := h.dbPool.Exec(ctx, `
+					INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type)
+					VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+					logData.id, logData.modelID, logData.requestHash, false, logData.virtualKeyName, 0, "pending", endpointTypeChat)
+				if err != nil {
+					t.Errorf("seed insert: %v", err)
+				}
+			}()
+
+			logData.state = state
+			logData.statusCode = 404
+			logData.errorMessage = "model not found"
+			// The flag every terminal caller passes, and which a terminal update
+			// must decline to honour.
+			h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+
+			// The row certainly exists by now, so what is read back says only
+			// whether the UPDATE landed on it or ran before it and hit nothing.
+			logData.insertWg.Wait()
+			var got string
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := h.dbPool.QueryRow(ctx, `SELECT state FROM request_logs WHERE id = $1`, logData.id).Scan(&got); err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if got != state {
+				t.Errorf("row state = %q, want %q: the update beat its own insert and stranded the request", got, state)
+			}
+		})
+	}
+}
+
+// The flag still means what it meant for an interim update: those run on the hot
+// path before the client's first byte, and blocking them on the DB is the
+// latency the flag exists to avoid.
+func TestUpdateRequestLog_AnInterimUpdateStillDoesNotWait(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	logData := &requestLogData{modelID: "m", virtualKeyName: "k", endpointType: endpointTypeChat}
+	logData.id = uuid.New().String()
+	logData.requestHash = generateRequestHash()
+	logData.insertWg.Add(1)
+	defer logData.insertWg.Done()
+
+	// The insert is never released, so anything that waits would block until
+	// WaitForInsert's timeout. An interim update must return long before that.
+	logData.state = "streaming"
+	start := time.Now()
+	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("an interim update blocked for %s on the hot path", waited)
+	}
+}
+
+func TestIsTerminalLogState(t *testing.T) {
+	t.Parallel()
+	for state, want := range map[string]bool{
+		"completed": true,
+		"failed":    true,
+		"pending":   false,
+		"streaming": false,
+		"":          false,
+	} {
+		if got := isTerminalLogState(state); got != want {
+			t.Errorf("isTerminalLogState(%q) = %v, want %v", state, got, want)
+		}
+	}
+}

--- a/internal/proxy/pending_row_test.go
+++ b/internal/proxy/pending_row_test.go
@@ -8,13 +8,28 @@ import (
 	"github.com/google/uuid"
 )
 
+// seedRequestLogRow writes the row insertRequestLogAsync would have written.
+func seedRequestLogRow(t *testing.T, h *Handler, logData *requestLogData) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := h.dbPool.Exec(ctx, `
+		INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		logData.id, logData.modelID, logData.requestHash, false, logData.virtualKeyName, 0, "pending", endpointTypeChat)
+	if err != nil {
+		t.Errorf("seed insert: %v", err)
+	}
+}
+
 // A terminal update must not lose the race with the INSERT it is updating.
 //
-// updateRequestLog's own comment states the invariant — "Terminal states
+// updateRequestLog's own comment stated the invariant — "Terminal states
 // (completed/failed) always wait to guarantee the row exists for the final
-// UPDATE" — but every terminal caller passed skipWaitForInsert, so the UPDATE
-// could run first, hit 0 rows, and leave the request at 'pending' for ever with
-// no status, no duration and no error.
+// UPDATE" — but six of the seven terminal call sites passed skipWaitForInsert
+// (only the streaming finalize waited), so the UPDATE could run first, hit 0
+// rows, and leave the request at 'pending' with no status, no duration and no
+// error.
 //
 // The flag's reasoning was that the INSERT "has the entire provider round-trip
 // to complete". That is true of a request that reached a provider and false of
@@ -40,22 +55,14 @@ func TestUpdateRequestLog_ATerminalUpdateWaitsForItsRow(t *testing.T) {
 			go func() {
 				defer logData.insertWg.Done()
 				time.Sleep(150 * time.Millisecond)
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				_, err := h.dbPool.Exec(ctx, `
-					INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type)
-					VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-					logData.id, logData.modelID, logData.requestHash, false, logData.virtualKeyName, 0, "pending", endpointTypeChat)
-				if err != nil {
-					t.Errorf("seed insert: %v", err)
-				}
+				seedRequestLogRow(t, h, logData)
 			}()
 
 			logData.state = state
 			logData.statusCode = 404
 			logData.errorMessage = "model not found"
-			// The flag every terminal caller passes, and which a terminal update
-			// must decline to honour.
+			// The flag six of the seven terminal callers pass, and which must not
+			// cost a terminal update its row.
 			h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 			// The row certainly exists by now, so what is read back says only
@@ -74,9 +81,53 @@ func TestUpdateRequestLog_ATerminalUpdateWaitsForItsRow(t *testing.T) {
 	}
 }
 
+// And it must not pay for that row when it already has one.
+//
+// The terminal update on the non-streaming path runs BEFORE the response body is
+// encoded, so a wait there is pure added latency on every successful completion —
+// up to waitInsertTimeout (5s) whenever the pool is contended. Waiting only after
+// an UPDATE reports 0 rows keeps the fix and charges nothing for it: the row is
+// normally long since inserted, and then the retry never fires.
+func TestUpdateRequestLog_ATerminalUpdateWithARowDoesNotWait(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	logData := &requestLogData{
+		modelID: "m", virtualKeyName: "k", state: "pending",
+		endpointType: endpointTypeChat,
+	}
+	logData.id = uuid.New().String()
+	logData.requestHash = generateRequestHash()
+	seedRequestLogRow(t, h, logData)
+
+	// Never released. Anything that waits on the insert blocks until
+	// WaitForInsert's timeout, whether it waits before the UPDATE or after it.
+	logData.insertWg.Add(1)
+	defer logData.insertWg.Done()
+
+	logData.state = "completed"
+	logData.statusCode = 200
+	start := time.Now()
+	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("a terminal update whose row exists blocked for %s before the response was written", waited)
+	}
+
+	var got string
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.dbPool.QueryRow(ctx, `SELECT state FROM request_logs WHERE id = $1`, logData.id).Scan(&got); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got != "completed" {
+		t.Errorf("row state = %q, want completed", got)
+	}
+}
+
 // The flag still means what it meant for an interim update: those run on the hot
 // path before the client's first byte, and blocking them on the DB is the
-// latency the flag exists to avoid.
+// latency the flag exists to avoid. An interim update that finds no row does not
+// retry — the terminal update that follows it writes the same row anyway.
 func TestUpdateRequestLog_AnInterimUpdateStillDoesNotWait(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
@@ -87,8 +138,9 @@ func TestUpdateRequestLog_AnInterimUpdateStillDoesNotWait(t *testing.T) {
 	logData.insertWg.Add(1)
 	defer logData.insertWg.Done()
 
-	// The insert is never released, so anything that waits would block until
-	// WaitForInsert's timeout. An interim update must return long before that.
+	// The insert is never released and no row is seeded, so the UPDATE hits 0
+	// rows — the one condition that makes a TERMINAL update wait. An interim one
+	// must return long before WaitForInsert's timeout.
 	logData.state = "streaming"
 	start := time.Now()
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})


### PR DESCRIPTION
`updateRequestLog`'s own comment stated the invariant — *"Terminal states (completed/failed) always wait to guarantee the row exists for the final UPDATE"* — and six of the seven terminal call sites passed `skipWaitForInsert: true` anyway. So a terminal UPDATE could run before its own async INSERT, hit 0 rows, and leave the request at `state='pending'`: no status, no duration, no error, and a row the dashboard shows as still in flight until `staleLogCleanupPass` relabels it `request interrupted (stale)` up to half an hour later.

The flag's reasoning — *"the INSERT has the entire provider round-trip to complete"* — holds for a request that reached a provider and fails for one that did not. An unknown model, an invalid model format or a rejected key updates microseconds after the insert is queued, so for those it was never a low-probability race; it was the normal case, and those are exactly the rows whose error message is the only thing worth reading.

## Why the wait moved behind the failure

Making a terminal state override the flag is correct and charges every request for it: the terminal update runs *before* the response body is encoded, so an up-front wait is pure added latency on every successful non-streaming completion — up to `waitInsertTimeout` (5s, hardcoded in production) whenever the pool is contended. The first review round measured it.

A row count of zero *is* the race, so the wait hangs off it. The UPDATE runs immediately; only when it reports 0 rows on a terminal state does it wait for the insert and send the same statement once more. Nothing is given up: from 0 rows the row either lands while we wait or the INSERT itself failed, which no up-front wait would have repaired either.

The statement moved into `execRequestLogUpdate` so both attempts send exactly the same one.

## Measured

| | before | after |
|---|---|---|
| 60 concurrent early-failures, stranded rows | **40 / 60** | **0 / 60** |
| early-fail, serial, avg | 268µs | 599µs |
| early-fail, 100 concurrent, avg | 46.8ms | 49.6ms |
| non-streaming success, avg | 1.099ms | 1.137ms |

On the dev stack, 7 of 10 pre-provider failures hit the race and the retry repaired every one — zero stranded rows, zero "no rows affected" warnings. Six successful completions returned in 12–53ms and never fired the retry.

## Side effect worth naming

`metrics.Record` and the `request.completed` SSE event now fire after the row is confirmed present, so a dashboard refetching by id no longer races into a `'pending'` row.

## Not fixed here

An UPDATE that *errors* — exhausted pool, reset connection — has no row count to believe and no insert to wait for, so it strands the row by a different door and only the stale-log reaper reaches it. Unchanged from before; the comment now says so rather than implying 0 rows is the only cause.
