### PR TITLE
fix(api): a log entry the database refused leaves evidence

### DIFF
--- a/internal/api/applog_drops_test.go
+++ b/internal/api/applog_drops_test.go
@@ -3,18 +3,39 @@ package api
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// A batch the database refused used to vanish with `_ = err`: up to 50 entries
-// gone from the App Logs history with no evidence anywhere, which reads exactly
-// like the gateway never having logged at all. That is what made a filtered
-// docker-logs surface look like a stack "dropping INFO logs".
-func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
+// syncBuffer is a capture destination safe to read while the writer goroutine
+// is still writing to it. A plain bytes.Buffer here is a data race, and the
+// race is the point of one of the tests below.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// closedTestPool returns a pool whose every Exec fails, for driving the
+// batch-insert failure path.
+func closedTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
 	if apiTestDBURL == "" {
 		t.Fatal("apiTestDBURL not set: test database required")
 	}
@@ -22,12 +43,20 @@ func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create pool: %v", err)
 	}
-	pool.Close() // every Exec from here on fails
+	pool.Close()
+	return pool
+}
 
-	var out bytes.Buffer
-	w := newDBLogWriter(pool, dbLogFlushInterval)
-	defer w.stop()
-	w.drops.dst = &out
+// A batch the database refused used to vanish with `_ = err`: up to 50 entries
+// gone from the App Logs history with no evidence anywhere, which reads exactly
+// like the gateway never having logged at all.
+func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
+	t.Parallel()
+	var out syncBuffer
+	// Built as a literal rather than through newDBLogWriter: flush needs only
+	// the pool and the reporter, and this way the capture destination is set
+	// before anything could read it, with no run goroutine in the picture.
+	w := &dbLogWriter{pool: closedTestPool(t), drops: &logDropReporter{dst: &out, interval: time.Hour}}
 
 	w.flush([]AppLogEntry{
 		{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: "first"},
@@ -39,14 +68,15 @@ func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
 	if got == "" {
 		t.Fatal("a batch was discarded with no notice anywhere")
 	}
-	if !strings.Contains(got, "3") {
+	// Anchored to the start of the notice: "3 entries dropped" is itself a
+	// substring of "33 entries dropped", so only the prefix pins the count.
+	if !strings.Contains(got, "applog: 3 entries dropped") {
 		t.Errorf("notice does not say how many were lost: %q", got)
 	}
 	// The reason has to be actionable, not just "something failed".
 	if !strings.Contains(got, "closed") {
 		t.Errorf("notice does not carry the database's own reason: %q", got)
 	}
-	// The entries themselves are not repeated into the notice.
 	for _, msg := range []string{"first", "second", "third"} {
 		if strings.Contains(got, msg) {
 			t.Errorf("notice echoes log content %q: %q", msg, got)
@@ -59,12 +89,12 @@ func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
 // in between are still counted, and still reported.
 func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
 	t.Parallel()
-	var out bytes.Buffer
+	var out syncBuffer
 	r := &logDropReporter{dst: &out, interval: time.Hour}
 
 	r.drop(3, "first failure")
 	first := out.String()
-	if !strings.Contains(first, "3") {
+	if !strings.Contains(first, "applog: 3 entries dropped") {
 		t.Fatalf("the first drop must be reported at once, got %q", first)
 	}
 
@@ -74,11 +104,51 @@ func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
 		t.Errorf("drops inside the interval were not throttled: %q", out.String())
 	}
 
-	// Shutdown must not swallow what the throttle was holding.
 	r.reportPending()
 	tail := strings.TrimPrefix(out.String(), first)
-	if !strings.Contains(tail, "7") {
+	if !strings.Contains(tail, "applog: 7 entries dropped") {
 		t.Errorf("the 7 suppressed entries were never accounted for: %q", tail)
+	}
+}
+
+// And the tail reaches stderr through the shutdown path that actually runs:
+// main calls StopAppLogWriter before closing the database, which is what makes
+// reportPending more than a method nothing invokes.
+func TestDBLogWriter_StopReportsTheSuppressedTail(t *testing.T) {
+	t.Parallel()
+	var out syncBuffer
+	w := &dbLogWriter{
+		pool:          closedTestPool(t),
+		ch:            make(chan AppLogEntry, 16),
+		done:          make(chan struct{}),
+		flushInterval: 10 * time.Millisecond,
+		sendTimeout:   time.Second,
+		drops:         &logDropReporter{dst: &out, interval: time.Hour},
+	}
+	go w.run()
+
+	entry := func(m string) AppLogEntry {
+		return AppLogEntry{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: m}
+	}
+	// First failing flush: reported immediately, and it starts the interval.
+	w.ch <- entry("one")
+	deadline := time.Now().Add(5 * time.Second)
+	for out.String() == "" && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	firstNotice := out.String()
+	if firstNotice == "" {
+		t.Fatal("the first failing flush was never reported")
+	}
+
+	// Second one is inside the interval, so it is suppressed and must survive
+	// only on the pending count.
+	w.ch <- entry("two")
+	w.stop()
+
+	tail := strings.TrimPrefix(out.String(), firstNotice)
+	if !strings.Contains(tail, "(final)") {
+		t.Errorf("shutdown swallowed the throttled tail: %q", tail)
 	}
 }
 
@@ -86,7 +156,7 @@ func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
 // rather than blocking the caller.
 func TestDBLogWriter_ReportsAnEntryTheQueueCouldNotTake(t *testing.T) {
 	t.Parallel()
-	var out bytes.Buffer
+	var out syncBuffer
 	w := &dbLogWriter{
 		ch:          make(chan AppLogEntry, 1),
 		sendTimeout: 50 * time.Millisecond,
@@ -100,7 +170,7 @@ func TestDBLogWriter_ReportsAnEntryTheQueueCouldNotTake(t *testing.T) {
 	if got == "" {
 		t.Fatal("an entry was dropped from a full queue with no notice")
 	}
-	if !strings.Contains(got, "1") {
+	if !strings.Contains(got, "applog: 1 entries dropped") {
 		t.Errorf("notice does not say how many were lost: %q", got)
 	}
 	if strings.Contains(got, "dropped-entry-text") {
@@ -108,8 +178,11 @@ func TestDBLogWriter_ReportsAnEntryTheQueueCouldNotTake(t *testing.T) {
 	}
 }
 
-// A writer built the normal way reports to stderr and uses the real timeout;
-// nothing here is wired only for the tests above.
+// A writer built the normal way reports to STDERR and uses the real timeout.
+//
+// The destination is the assertion that matters: point it at io.Discard and
+// every other test here still passes while production is silently dropping
+// entries again, which is the whole bug.
 func TestNewDBLogWriter_ProductionDefaults(t *testing.T) {
 	t.Parallel()
 	w := newDBLogWriter(nil, dbLogFlushInterval)
@@ -120,21 +193,33 @@ func TestNewDBLogWriter_ProductionDefaults(t *testing.T) {
 	if w.drops == nil {
 		t.Fatal("a writer with no drop reporter discards entries silently again")
 	}
+	if w.drops.dst != os.Stderr {
+		t.Errorf("drop notices go to %T, not os.Stderr: nothing would ever see them", w.drops.dst)
+	}
 	if w.drops.interval != dbLogDropReportInterval {
 		t.Errorf("report interval = %s, want %s", w.drops.interval, dbLogDropReportInterval)
 	}
 }
 
-// A writer assembled without a reporter still works. The nil check is not
-// decoration: dbLogWriter is built as a struct literal in several tests, and a
-// dropped entry must not take the whole process down over a missing diagnostic.
+// A reporter that is missing, or has nowhere to write, must not take the
+// process down. flush runs on the run goroutine, which has no recover of its
+// own, so a panic there would kill the server over a missing diagnostic.
 func TestLogDropReporter_NilIsInert(t *testing.T) {
 	t.Parallel()
-	var r *logDropReporter
-	r.drop(5, "no reporter attached")
-	r.reportPending()
+	var nilReporter *logDropReporter
+	nilReporter.drop(5, "no reporter attached")
+	nilReporter.reportPending()
 
-	w := &dbLogWriter{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond}
-	w.ch <- AppLogEntry{Message: "occupies the queue"}
-	w.write(AppLogEntry{Level: "info", Source: "test", Message: "discarded"})
+	noDst := &logDropReporter{interval: time.Hour}
+	noDst.drop(5, "reporter with nowhere to write")
+	noDst.reportPending()
+
+	for _, w := range []*dbLogWriter{
+		{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond},
+		{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond, drops: noDst},
+	} {
+		w.ch <- AppLogEntry{Message: "occupies the queue"}
+		w.write(AppLogEntry{Level: "info", Source: "test", Message: "discarded"})
+		w.flush([]AppLogEntry{{Level: "info", Source: "test", Message: "discarded"}})
+	}
 }

--- a/internal/api/applog_drops_test.go
+++ b/internal/api/applog_drops_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// A batch the database refused used to vanish with `_ = err`: up to 50 entries
+// gone from the App Logs history with no evidence anywhere, which reads exactly
+// like the gateway never having logged at all. That is what made a filtered
+// docker-logs surface look like a stack "dropping INFO logs".
+func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("apiTestDBURL not set: test database required")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	pool.Close() // every Exec from here on fails
+
+	var out bytes.Buffer
+	w := newDBLogWriter(pool, dbLogFlushInterval)
+	defer w.stop()
+	w.drops.dst = &out
+
+	w.flush([]AppLogEntry{
+		{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: "first"},
+		{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: "second"},
+		{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: "third"},
+	})
+
+	got := out.String()
+	if got == "" {
+		t.Fatal("a batch was discarded with no notice anywhere")
+	}
+	if !strings.Contains(got, "3") {
+		t.Errorf("notice does not say how many were lost: %q", got)
+	}
+	// The reason has to be actionable, not just "something failed".
+	if !strings.Contains(got, "closed") {
+		t.Errorf("notice does not carry the database's own reason: %q", got)
+	}
+	// The entries themselves are not repeated into the notice.
+	for _, msg := range []string{"first", "second", "third"} {
+		if strings.Contains(got, msg) {
+			t.Errorf("notice echoes log content %q: %q", msg, got)
+		}
+	}
+}
+
+// The condition that causes drops repeats on every flush, so the notice has to
+// be throttled — but throttled is not the same as lost: the entries suppressed
+// in between are still counted, and still reported.
+func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	r := &logDropReporter{dst: &out, interval: time.Hour}
+
+	r.drop(3, "first failure")
+	first := out.String()
+	if !strings.Contains(first, "3") {
+		t.Fatalf("the first drop must be reported at once, got %q", first)
+	}
+
+	r.drop(5, "second failure")
+	r.drop(2, "third failure")
+	if out.String() != first {
+		t.Errorf("drops inside the interval were not throttled: %q", out.String())
+	}
+
+	// Shutdown must not swallow what the throttle was holding.
+	r.reportPending()
+	tail := strings.TrimPrefix(out.String(), first)
+	if !strings.Contains(tail, "7") {
+		t.Errorf("the 7 suppressed entries were never accounted for: %q", tail)
+	}
+}
+
+// The other silent door: the writer's queue is full and the entry is discarded
+// rather than blocking the caller.
+func TestDBLogWriter_ReportsAnEntryTheQueueCouldNotTake(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	w := &dbLogWriter{
+		ch:          make(chan AppLogEntry, 1),
+		sendTimeout: 50 * time.Millisecond,
+		drops:       &logDropReporter{dst: &out, interval: time.Hour},
+	}
+	w.ch <- AppLogEntry{Message: "occupies the queue"} // nothing drains it
+
+	w.write(AppLogEntry{Level: "info", Source: "test", Message: "dropped-entry-text"})
+
+	got := out.String()
+	if got == "" {
+		t.Fatal("an entry was dropped from a full queue with no notice")
+	}
+	if !strings.Contains(got, "1") {
+		t.Errorf("notice does not say how many were lost: %q", got)
+	}
+	if strings.Contains(got, "dropped-entry-text") {
+		t.Errorf("notice echoes log content: %q", got)
+	}
+}
+
+// A writer built the normal way reports to stderr and uses the real timeout;
+// nothing here is wired only for the tests above.
+func TestNewDBLogWriter_ProductionDefaults(t *testing.T) {
+	t.Parallel()
+	w := newDBLogWriter(nil, dbLogFlushInterval)
+	defer w.stop()
+	if w.sendTimeout != dbLogSendTimeout {
+		t.Errorf("sendTimeout = %s, want %s", w.sendTimeout, dbLogSendTimeout)
+	}
+	if w.drops == nil {
+		t.Fatal("a writer with no drop reporter discards entries silently again")
+	}
+	if w.drops.interval != dbLogDropReportInterval {
+		t.Errorf("report interval = %s, want %s", w.drops.interval, dbLogDropReportInterval)
+	}
+}
+
+// A writer assembled without a reporter still works. The nil check is not
+// decoration: dbLogWriter is built as a struct literal in several tests, and a
+// dropped entry must not take the whole process down over a missing diagnostic.
+func TestLogDropReporter_NilIsInert(t *testing.T) {
+	t.Parallel()
+	var r *logDropReporter
+	r.drop(5, "no reporter attached")
+	r.reportPending()
+
+	w := &dbLogWriter{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond}
+	w.ch <- AppLogEntry{Message: "occupies the queue"}
+	w.write(AppLogEntry{Level: "info", Source: "test", Message: "discarded"})
+}

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -115,6 +115,74 @@ type dbLogWriter struct {
 	ch            chan AppLogEntry
 	done          chan struct{}
 	flushInterval time.Duration
+	// sendTimeout is how long write blocks before discarding an entry. A field
+	// for the same reason flushInterval is one: the writer goroutine reads it
+	// while another test would be assigning to a package var, which is a real
+	// race and not a test artifact.
+	sendTimeout time.Duration
+	drops       *logDropReporter
+}
+
+// dbLogDropReportInterval throttles the drop notice. The condition that causes
+// drops — a database that is unreachable or refusing the batch — recurs on every
+// flush, so an unthrottled notice would become the flood it is reporting.
+const dbLogDropReportInterval = 10 * time.Second
+
+// logDropReporter accounts for app-log entries that never reached the database
+// and says so on stderr.
+//
+// Straight to stderr, never through debuglog: a notice about the log writer
+// would route back into the log writer and recurse. That is why the flush error
+// was swallowed outright — but swallowing it loses up to a whole batch from the
+// App Logs history with no evidence anywhere, which is indistinguishable from
+// the gateway never having logged at all. The ring buffer is not a substitute:
+// it holds appLogBufferSize entries for the live view, not the history.
+//
+// Only the count and the database's own reason are printed. A pgx PgError
+// renders as severity, message and SQLSTATE — never its DETAIL — so a rejected
+// row's contents are not echoed into the notice.
+type logDropReporter struct {
+	dst        io.Writer
+	interval   time.Duration
+	mu         sync.Mutex
+	pending    int
+	lastReport time.Time
+}
+
+// drop records n dropped entries, reporting them unless the last report was
+// inside the interval. Suppressed entries stay on the count and are carried into
+// the next report, or into reportPending at shutdown.
+func (r *logDropReporter) drop(n int, reason string) {
+	if r == nil || n <= 0 {
+		return
+	}
+	r.mu.Lock()
+	r.pending += n
+	now := time.Now()
+	if !r.lastReport.IsZero() && now.Sub(r.lastReport) < r.interval {
+		r.mu.Unlock()
+		return
+	}
+	r.lastReport = now
+	dropped, dst := r.pending, r.dst
+	r.pending = 0
+	r.mu.Unlock()
+	_, _ = fmt.Fprintf(dst, "applog: %d entries dropped, not persisted: %s\n", dropped, reason)
+}
+
+// reportPending states whatever the throttle is still holding, so a shutdown
+// during an outage does not swallow the tail of it.
+func (r *logDropReporter) reportPending() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	dropped, dst := r.pending, r.dst
+	r.pending = 0
+	r.mu.Unlock()
+	if dropped > 0 {
+		_, _ = fmt.Fprintf(dst, "applog: %d entries dropped, not persisted (final)\n", dropped)
+	}
 }
 
 // newDBLogWriter starts a writer that drains a partial batch every
@@ -128,6 +196,8 @@ func newDBLogWriter(pool *pgxpool.Pool, flushInterval time.Duration) *dbLogWrite
 		ch:            make(chan AppLogEntry, dbLogChannelSize),
 		done:          make(chan struct{}),
 		flushInterval: flushInterval,
+		sendTimeout:   dbLogSendTimeout,
+		drops:         &logDropReporter{dst: os.Stderr, interval: dbLogDropReportInterval},
 	}
 	go w.run()
 	return w
@@ -187,9 +257,9 @@ func (w *dbLogWriter) flush(entries []AppLogEntry) {
 	}
 	_, err := w.pool.Exec(ctx, builder.String(), args...)
 	if err != nil {
-		// Don't log with log.Printf here — that would cause infinite recursion!
-		// Just silently drop — the ring buffer still has the data for live view.
-		_ = err
+		// Never debuglog here — it routes back into this writer and recurses.
+		// The reporter writes to stderr directly for that reason.
+		w.drops.drop(len(entries), "batch insert failed: "+err.Error())
 	}
 }
 
@@ -203,7 +273,7 @@ func (w *dbLogWriter) write(entry AppLogEntry) {
 			fmt.Fprintf(os.Stderr, "applog: entry dropped, write panicked: %v\n", r)
 		}
 	}()
-	timer := time.NewTimer(dbLogSendTimeout)
+	timer := time.NewTimer(w.sendTimeout)
 	defer timer.Stop()
 	select {
 	case w.ch <- entry:
@@ -211,13 +281,16 @@ func (w *dbLogWriter) write(entry AppLogEntry) {
 	case <-timer.C:
 		// DB writer is backed up — drop the entry rather than blocking the
 		// caller. The ring buffer still has it for live UI, and this only
-		// happens if the DB is unreachable for >25 seconds.
+		// happens if the DB is unreachable for >25 seconds. Reported, because a
+		// history with holes in it and no notice is worse than a slow caller.
+		w.drops.drop(1, "writer queue full for "+w.sendTimeout.String())
 	}
 }
 
 func (w *dbLogWriter) stop() {
 	close(w.ch)
 	<-w.done
+	w.drops.reportPending()
 }
 
 // InitAppLogBuffer initializes the application log ring buffer and optional DB writer.

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -115,10 +115,11 @@ type dbLogWriter struct {
 	ch            chan AppLogEntry
 	done          chan struct{}
 	flushInterval time.Duration
-	// sendTimeout is how long write blocks before discarding an entry. A field
-	// for the same reason flushInterval is one: the writer goroutine reads it
-	// while another test would be assigning to a package var, which is a real
-	// race and not a test artifact.
+	// sendTimeout is how long write blocks before discarding an entry, always
+	// dbLogSendTimeout in production. A field purely so the queue-full test can
+	// prove the drop in milliseconds instead of sitting out the real five
+	// seconds; nothing else varies it, and no race requires it — write runs on
+	// the CALLER's goroutine, and the run goroutine reads only flushInterval.
 	sendTimeout time.Duration
 	drops       *logDropReporter
 }
@@ -152,37 +153,51 @@ type logDropReporter struct {
 // drop records n dropped entries, reporting them unless the last report was
 // inside the interval. Suppressed entries stay on the count and are carried into
 // the next report, or into reportPending at shutdown.
+//
+// The count covers every drop since the last notice; the reason is the most
+// recent one, which is why it is labelled as such rather than presented as the
+// cause of all of them. "not persisted" is also the confident reading of an
+// ambiguous case — a deadline that expires after the server committed but before
+// the reply arrives reports rows that did in fact land — but over-reporting a
+// hole is the right default when the alternative is silence.
 func (r *logDropReporter) drop(n int, reason string) {
-	if r == nil || n <= 0 {
+	if r == nil || r.dst == nil || n <= 0 {
 		return
 	}
+	// Held across the write. drop is called from the run goroutine (flush) and
+	// from arbitrary callers (write), and a notice is at most one per interval,
+	// so there is nothing to gain by releasing early and a interleaved line to
+	// lose. os.Stderr survives concurrent writes; an io.Writer in general does
+	// not, and this type carries a mutex precisely so it need not care which.
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.pending += n
 	now := time.Now()
-	if !r.lastReport.IsZero() && now.Sub(r.lastReport) < r.interval {
-		r.mu.Unlock()
+	// No IsZero special case: the zero Time is far enough in the past that Sub
+	// saturates well past any interval, so the first drop always reports.
+	if now.Sub(r.lastReport) < r.interval {
 		return
 	}
 	r.lastReport = now
-	dropped, dst := r.pending, r.dst
+	dropped := r.pending
 	r.pending = 0
-	r.mu.Unlock()
-	_, _ = fmt.Fprintf(dst, "applog: %d entries dropped, not persisted: %s\n", dropped, reason)
+	_, _ = fmt.Fprintf(r.dst, "applog: %d entries dropped, not persisted (most recent: %s)\n", dropped, reason)
 }
 
 // reportPending states whatever the throttle is still holding, so a shutdown
 // during an outage does not swallow the tail of it.
 func (r *logDropReporter) reportPending() {
-	if r == nil {
+	if r == nil || r.dst == nil {
 		return
 	}
 	r.mu.Lock()
-	dropped, dst := r.pending, r.dst
-	r.pending = 0
-	r.mu.Unlock()
-	if dropped > 0 {
-		_, _ = fmt.Fprintf(dst, "applog: %d entries dropped, not persisted (final)\n", dropped)
+	defer r.mu.Unlock()
+	if r.pending == 0 {
+		return
 	}
+	dropped := r.pending
+	r.pending = 0
+	_, _ = fmt.Fprintf(r.dst, "applog: %d entries dropped, not persisted (final)\n", dropped)
 }
 
 // newDBLogWriter starts a writer that drains a partial batch every
@@ -281,8 +296,10 @@ func (w *dbLogWriter) write(entry AppLogEntry) {
 	case <-timer.C:
 		// DB writer is backed up — drop the entry rather than blocking the
 		// caller. The ring buffer still has it for live UI, and this only
-		// happens if the DB is unreachable for >25 seconds. Reported, because a
-		// history with holes in it and no notice is worse than a slow caller.
+		// happens once the DB has been unreachable long enough to fill the
+		// channel (~25s, see dbLogChannelSize) and then hold this caller for
+		// sendTimeout on top. Reported, because a history with holes in it and
+		// no notice is worse than a slow caller.
 		w.drops.drop(1, "writer queue full for "+w.sendTimeout.String())
 	}
 }


### PR DESCRIPTION
Found while working out why the dev stack looked like it was "dropping INFO logs" (it wasn't — that was `stderrLogFilter` doing its job on a container I had recreated without the dev overlay). But the code next to it really can lose log entries, and does it silently.

`dbLogWriter.flush` discarded a whole failed batch — up to 50 entries — with `_ = err`, and a comment saying the ring buffer still has them. It does not: the ring buffer holds `appLogBufferSize` (500) entries for the live view, not the history the App Logs page reads. So a database that is unreachable or refusing the batch could punch holes in that history with no evidence anywhere, which is indistinguishable from the gateway never having logged at all. `write`'s queue-full path dropped just as quietly.

## Why stderr, directly

The obvious channel is the one that cannot be used: a notice about the log writer routed through `debuglog` comes straight back into the log writer and recurses. That is exactly why the error was swallowed in the first place — the original comment says so. Writing to `os.Stderr` directly is what the `recover` handler in the same function already does.

## Throttled, but nothing is lost

One notice per 10s. The condition that causes drops recurs on every flush, so an unthrottled notice would become the flood it is reporting. Suppressed entries stay on the count and ride into the next notice, or into a final one at shutdown — so a shutdown during an outage does not swallow the tail.

## No content in the notice

Only the count and the database's own reason. A pgx `PgError` renders as severity, message and SQLSTATE and never its `DETAIL`, so a rejected row's contents cannot be echoed. Both tests assert the dropped entries' text does not appear in the output.

## Incidental

`dbLogSendTimeout` becomes a field for the same reason `flushInterval` already is — the writer goroutine reads it while a test would be assigning to the package var, which is a real race rather than a test artifact.

## Mutations

Five, all killed: swallowing either drop; a throttle that forgets its suppressed count; a shutdown that discards the tail; a writer built with no reporter at all.
