### PR TITLE
fix(api,frontdesk): two cross-tenant usage aggregates were readable by any caller

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -69,7 +69,13 @@ func (h *Handler) metricsAuth(next http.Handler) http.Handler {
 			http.Error(w, "invalid metrics token", http.StatusUnauthorized)
 			return
 		}
-		// No dedicated token configured — fall back to admin auth.
-		h.AuthMiddleware(next).ServeHTTP(w, r)
+		// No dedicated token configured — fall back to ADMIN auth, which is
+		// AuthMiddleware plus requireAdmin. AuthMiddleware alone only proves the
+		// caller is authenticated: it admits any resolved identity, including a
+		// non-admin multi-user session. The exported counters carry provider and
+		// model labels but no owner label, so they are fleet-wide totals across
+		// every virtual-key owner and belong to nobody in particular — the same
+		// cross-tenant aggregate /api/stats scopes with an owner filter.
+		h.AuthMiddleware(requireAdmin(next)).ServeHTTP(w, r)
 	})
 }

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -177,6 +177,23 @@ var (
 	reqTodayMu      sync.Mutex
 )
 
+// requestsTodayGroup coalesces concurrent cold counts for the same owner and
+// window. Unlike the cache it is keyed on the caller-controlled `since` too, but
+// singleflight drops each entry as its flight ends, so nothing accumulates.
+var requestsTodayGroup singleflight.Group
+
+// cachedRequestsToday returns this owner's count for sinceKey while it is inside
+// the TTL.
+func cachedRequestsToday(ownerScope, sinceKey string) (int64, bool) {
+	reqTodayMu.Lock()
+	defer reqTodayMu.Unlock()
+	e, ok := reqTodayByOwner[ownerScope]
+	if ok && e.since == sinceKey && time.Since(e.at) < requestsTodayTTL {
+		return e.val, true
+	}
+	return 0, false
+}
+
 // resetRequestsTodayCache drops every owner's cached count.
 func resetRequestsTodayCache() {
 	reqTodayMu.Lock()
@@ -249,12 +266,39 @@ func (h *SystemHandler) GetSystem(w http.ResponseWriter, r *http.Request) {
 // `since` parameter alone, so a scoped count living inside it would be computed
 // for whichever caller missed the cache first and then served to everyone else —
 // which is the leak this scoping exists to close, arriving by another route.
+//
+// Being outside that cache means it is also outside systemCollectGroup and the
+// detached context collect runs under, and it must not lose either. Both are
+// restored here rather than given up:
+//
+//   - Coalesced on owner+since, because a cold entry no longer serialises behind
+//     the payload collect. Without this a burst of pollers sharing an identity
+//     each issued their own COUNT, and the scoped predicate is DEARER than the
+//     unscoped one it replaced: a correlated subquery over virtual_keys, whose
+//     request_logs.virtual_key_id is deliberately unindexed (migration 067).
+//   - Detached and bounded, for the reason collect states above: a caller that
+//     gives up early must not abort the query, or the entry is never cached and
+//     the next caller pays for the same seq-scan again. A cancelled query also
+//     returns zero, and a fabricated zero under a 200 is worse than a stale one.
 func (h *SystemHandler) attachRequestsToday(r *http.Request, stats *SystemStats, sinceParam string) {
 	since, err := sinceTime(sinceParam)
 	if err != nil {
 		return // collect already rejected it; a cache hit cannot reach here with a bad value
 	}
-	stats.App.RequestsToday = h.requestsSince(r.Context(), since, sinceParam, ownerScopeFromIdentity(r))
+	ownerScope := ownerScopeFromIdentity(r)
+	if v, ok := cachedRequestsToday(ownerScope, sinceParam); ok {
+		stats.App.RequestsToday = v
+		return
+	}
+	// The key carries the owner so two identities never share a flight — the
+	// same reason the cache is keyed on it.
+	v, _, _ := requestsTodayGroup.Do(ownerScope+"\x00"+sinceParam, func() (any, error) {
+		cctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), systemCollectTimeout)
+		defer cancel()
+		return h.requestsSince(cctx, since, sinceParam, ownerScope), nil
+	})
+	n, _ := v.(int64)
+	stats.App.RequestsToday = n
 }
 
 // cachedSystemFor returns a copy of the cached payload for `since` when it is
@@ -273,19 +317,18 @@ func writeSystemJSON(w http.ResponseWriter, stats *SystemStats) {
 	writeJSON(w, stats)
 }
 
-// requestsSince returns the number of request_logs rows at or after `since`,
-// cached for requestsTodayTTL under sinceKey. A query error yields 0 and is not
-// cached, so a transient failure is retried on the next collect rather than
-// pinned. Keeping this COUNT off every collect is what stops a stale-planner-stats
-// seq-scan on a freshly restarted primary from tipping the whole status endpoint
-// past a caller's timeout.
+// requestsSince returns the number of request_logs rows at or after `since` that
+// ownerScope may see, cached for requestsTodayTTL under owner + sinceKey. A query
+// error yields 0 and is not cached, so a transient failure is retried on the next
+// request rather than pinned. Running this COUNT at most once per window per
+// owner is what stops a stale-planner-stats seq-scan on a freshly restarted
+// primary from tipping the whole status endpoint past a caller's timeout;
+// attachRequestsToday adds the coalescing and the detached context that keep
+// that true under a burst.
 func (h *SystemHandler) requestsSince(ctx context.Context, since time.Time, sinceKey, ownerScope string) int64 {
-	reqTodayMu.Lock()
-	if e, ok := reqTodayByOwner[ownerScope]; ok && e.since == sinceKey && time.Since(e.at) < requestsTodayTTL {
-		reqTodayMu.Unlock()
-		return e.val
+	if v, ok := cachedRequestsToday(ownerScope, sinceKey); ok {
+		return v
 	}
-	reqTodayMu.Unlock()
 
 	// rl is the alias ownerFilterFragment writes its predicate against. An empty
 	// ownerScope (an admin) yields no fragment and the fleet-wide count; a

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -54,11 +54,7 @@ func resetSystemCache() {
 	cachedSystemSince = ""
 	cachedSystemMu.Unlock()
 
-	reqTodayMu.Lock()
-	reqTodayVal = 0
-	reqTodayTime = time.Time{}
-	reqTodaySince = ""
-	reqTodayMu.Unlock()
+	resetRequestsTodayCache()
 
 	prevBlksMu.Lock()
 	prevBlksHit = 0
@@ -166,18 +162,46 @@ var systemCollectGroup singleflight.Group
 // per this window instead of on every collect.
 const requestsTodayTTL = 30 * time.Second
 
+// reqTodayEntry is one owner's cached count. Keyed by OWNER, not by `since`:
+// `since` comes straight off the query string, so a map keyed on it would grow
+// with whatever a caller sends, while the number of identities is bounded by the
+// user table. A request for a different `since` simply misses.
+type reqTodayEntry struct {
+	val   int64
+	at    time.Time
+	since string
+}
+
 var (
-	reqTodayVal   int64
-	reqTodayTime  time.Time
-	reqTodaySince string
-	reqTodayMu    sync.Mutex
+	reqTodayByOwner = map[string]reqTodayEntry{}
+	reqTodayMu      sync.Mutex
 )
+
+// resetRequestsTodayCache drops every owner's cached count.
+func resetRequestsTodayCache() {
+	reqTodayMu.Lock()
+	reqTodayByOwner = map[string]reqTodayEntry{}
+	reqTodayMu.Unlock()
+}
+
+// sinceTime resolves the `since` query parameter, defaulting to UTC midnight.
+func sinceTime(sinceParam string) (time.Time, error) {
+	if sinceParam == "" {
+		return time.Now().Truncate(24 * time.Hour), nil
+	}
+	parsed, err := time.Parse(time.RFC3339, sinceParam)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid since parameter: %w", err)
+	}
+	return parsed, nil
+}
 
 // GetSystem returns system health metrics (app, database, Docker).
 func (h *SystemHandler) GetSystem(w http.ResponseWriter, r *http.Request) {
 	since := r.URL.Query().Get("since")
 
 	if stats, ok := cachedSystemFor(since); ok {
+		h.attachRequestsToday(r, stats, since)
 		writeSystemJSON(w, stats)
 		return
 	}
@@ -211,7 +235,26 @@ func (h *SystemHandler) GetSystem(w http.ResponseWriter, r *http.Request) {
 		respondError(w, "failed to collect system stats", err, http.StatusInternalServerError)
 		return
 	}
-	writeSystemJSON(w, v.(*SystemStats))
+	// A copy: the singleflight result is the same pointer stored in the shared
+	// cache, and requests_today is the one field that differs per caller.
+	stats := *v.(*SystemStats)
+	h.attachRequestsToday(r, &stats, since)
+	writeSystemJSON(w, &stats)
+}
+
+// attachRequestsToday fills in the one owner-scoped field on an otherwise shared
+// payload.
+//
+// It is deliberately outside the 3s payload cache. That cache is keyed on the
+// `since` parameter alone, so a scoped count living inside it would be computed
+// for whichever caller missed the cache first and then served to everyone else —
+// which is the leak this scoping exists to close, arriving by another route.
+func (h *SystemHandler) attachRequestsToday(r *http.Request, stats *SystemStats, sinceParam string) {
+	since, err := sinceTime(sinceParam)
+	if err != nil {
+		return // collect already rejected it; a cache hit cannot reach here with a bad value
+	}
+	stats.App.RequestsToday = h.requestsSince(r.Context(), since, sinceParam, ownerScopeFromIdentity(r))
 }
 
 // cachedSystemFor returns a copy of the cached payload for `since` when it is
@@ -236,26 +279,31 @@ func writeSystemJSON(w http.ResponseWriter, stats *SystemStats) {
 // pinned. Keeping this COUNT off every collect is what stops a stale-planner-stats
 // seq-scan on a freshly restarted primary from tipping the whole status endpoint
 // past a caller's timeout.
-func (h *SystemHandler) requestsSince(ctx context.Context, since time.Time, sinceKey string) int64 {
+func (h *SystemHandler) requestsSince(ctx context.Context, since time.Time, sinceKey, ownerScope string) int64 {
 	reqTodayMu.Lock()
-	if reqTodaySince == sinceKey && time.Since(reqTodayTime) < requestsTodayTTL {
-		v := reqTodayVal
+	if e, ok := reqTodayByOwner[ownerScope]; ok && e.since == sinceKey && time.Since(e.at) < requestsTodayTTL {
 		reqTodayMu.Unlock()
-		return v
+		return e.val
 	}
 	reqTodayMu.Unlock()
 
+	// rl is the alias ownerFilterFragment writes its predicate against. An empty
+	// ownerScope (an admin) yields no fragment and the fleet-wide count; a
+	// non-admin is restricted to traffic they own, keyed rows through the key's
+	// current owner and keyless rows through the stamped owner_user_id. A
+	// malformed id fails CLOSED to " AND 1=0" rather than to no filter.
+	ownerFrag, ownerArgs := ownerFilterFragment(ownerScope, 2)
+	args := append([]any{since}, ownerArgs...)
+
 	var n int64
 	if err := h.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM request_logs WHERE created_at >= $1`, since).Scan(&n); err != nil {
+		`SELECT COUNT(*) FROM request_logs rl WHERE rl.created_at >= $1`+ownerFrag, args...).Scan(&n); err != nil {
 		debuglog.Error("system: query failed", "query", "requestsToday", "error", err)
 		return 0
 	}
 
 	reqTodayMu.Lock()
-	reqTodayVal = n
-	reqTodayTime = time.Now()
-	reqTodaySince = sinceKey
+	reqTodayByOwner[ownerScope] = reqTodayEntry{val: n, at: time.Now(), since: sinceKey}
 	reqTodayMu.Unlock()
 	return n
 }
@@ -280,15 +328,13 @@ func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*System
 	diskReadPerSec, diskWritePerSec := util.ReadCgroupDiskIO()
 	procs := util.ReadCgroupProcs()
 
-	since := time.Now().Truncate(24 * time.Hour) // fallback: UTC midnight
-	if sinceParam != "" {
-		parsed, err := time.Parse(time.RFC3339, sinceParam)
-		if err != nil {
-			return nil, fmt.Errorf("invalid since parameter: %w", err)
-		}
-		since = parsed
+	// The `since` parse stays here so a malformed value is still rejected before
+	// anything else runs; the COUNT it used to feed is per-caller and is attached
+	// in GetSystem instead. This payload is shared by every caller through the 3s
+	// cache, so an owner-scoped number must not live in it.
+	if _, err := sinceTime(sinceParam); err != nil {
+		return nil, err
 	}
-	requestsToday := h.requestsSince(ctx, since, sinceParam)
 
 	stats.App = AppStats{
 		HeapAllocMB:       float64(heapAlloc) / 1024 / 1024,
@@ -300,7 +346,6 @@ func (h *SystemHandler) collect(ctx context.Context, sinceParam string) (*System
 		InContainer:       inContainer,
 		UptimeSeconds:     int64(time.Since(startedAt).Seconds()),
 		CPUPercent:        cpuPercent,
-		RequestsToday:     requestsToday,
 		NetRxBytesSec:     netRxPerSec,
 		NetTxBytesSec:     netTxPerSec,
 		DiskReadBytesSec:  diskReadPerSec,

--- a/internal/api/system_test.go
+++ b/internal/api/system_test.go
@@ -470,7 +470,8 @@ func TestRequestsSince_CachesWithinTTL(t *testing.T) {
 	const key = "cache-test-window"
 	since := time.Now().Add(-time.Hour)
 
-	baseline := sh.requestsSince(ctx, since, key)
+	// Empty scope: the admin/unscoped case, which is what this test is about.
+	baseline := sh.requestsSince(ctx, since, key, "")
 
 	// Insert a row inside the window AFTER the value was cached. Within the TTL the
 	// cached baseline must come back: the COUNT is not re-run on every collect,
@@ -479,13 +480,13 @@ func TestRequestsSince_CachesWithinTTL(t *testing.T) {
 		`INSERT INTO request_logs (created_at) VALUES ($1)`, time.Now()); err != nil {
 		t.Fatalf("insert request_log: %v", err)
 	}
-	if got := sh.requestsSince(ctx, since, key); got != baseline {
+	if got := sh.requestsSince(ctx, since, key, ""); got != baseline {
 		t.Errorf("within TTL expected cached %d, got %d (COUNT re-ran)", baseline, got)
 	}
 
 	// After a cache reset the fresh COUNT sees the inserted row.
 	resetSystemCache()
-	if got := sh.requestsSince(ctx, since, key); got != baseline+1 {
+	if got := sh.requestsSince(ctx, since, key, ""); got != baseline+1 {
 		t.Errorf("after reset expected fresh %d, got %d", baseline+1, got)
 	}
 }

--- a/internal/api/unscoped_usage_test.go
+++ b/internal/api/unscoped_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -118,16 +119,31 @@ func TestGetSystem_RequestsTodayIsScopedToTheCaller(t *testing.T) {
 	}
 
 	mineID, theirsID := mkUser("owner-one"), mkUser("owner-two")
-	// Keyless rows carry owner_user_id directly (migration 067): one for the
-	// first owner, two for the second.
-	for _, owner := range []string{mineID, theirsID, theirsID} {
+
+	// ownerFilterFragment resolves TWO disjoint row shapes and both need
+	// covering, or half the predicate is unpinned here: keyless rows (dashboard
+	// chat/arena) carry owner_user_id directly, while keyed rows resolve through
+	// the virtual key's CURRENT owner so reassigning a key moves its history.
+	keyID := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO virtual_keys (id, name, key_hash, key_preview, owner_user_id)
+		VALUES ($1, 'scoped-key', $2, 'sk-...aa', $3)`,
+		keyID, uuid.NewString(), mineID); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	seed := func(owner any, vk any) {
+		t.Helper()
 		if _, err := pool.Exec(ctx, `
-			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type, owner_user_id, created_at)
-			VALUES ($1, 'm', $2, false, 'k', 0, 'completed', 'chat', $3, NOW())`,
-			uuid.New(), uuid.NewString()[:16], owner); err != nil {
+			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type, owner_user_id, virtual_key_id, created_at)
+			VALUES ($1, 'm', $2, false, 'k', 0, 'completed', 'chat', $3, $4, NOW())`,
+			uuid.New(), uuid.NewString()[:16], owner, vk); err != nil {
 			t.Fatalf("seed: %v", err)
 		}
 	}
+	seed(mineID, nil)   // keyless, first owner
+	seed(nil, keyID)    // KEYED, first owner via the key
+	seed(theirsID, nil) // keyless, second owner
+	seed(theirsID, nil)
 
 	r := chi.NewRouter()
 	r.Use(h.AuthMiddleware)
@@ -153,13 +169,97 @@ func TestGetSystem_RequestsTodayIsScopedToTheCaller(t *testing.T) {
 	theirs := get(login(theirsID))
 	all := get(envAdminToken)
 
-	if mine != 1 {
-		t.Errorf("first owner saw requests_today = %d, want 1: the count is not scoped", mine)
+	// One keyless plus one keyed: a predicate that lost either disjunct reports 1.
+	if mine != 2 {
+		t.Errorf("first owner saw requests_today = %d, want 2 (one keyless + one keyed): the count is not scoped", mine)
 	}
 	if theirs != 2 {
 		t.Errorf("second owner saw requests_today = %d, want 2: a cached count leaked across callers", theirs)
 	}
-	if all != 3 {
-		t.Errorf("admin saw requests_today = %d, want 3 (the fleet total)", all)
+	if all != 4 {
+		t.Errorf("admin saw requests_today = %d, want 4 (the fleet total)", all)
+	}
+}
+
+// Moving requests_today out of the shared payload moved it out from behind
+// systemCollectGroup, so a burst of pollers sharing an identity each issued
+// their own COUNT where the payload collect had coalesced them to one. That
+// matters more than it did before the scoping, because the scoped predicate is
+// dearer than the unscoped one it replaced: a correlated subquery over
+// virtual_keys, whose request_logs.virtual_key_id is deliberately unindexed.
+//
+// Connection acquisitions are the observable proxy: every query takes one, so a
+// coalesced burst costs about one and an uncoalesced burst costs about N.
+func TestAttachRequestsToday_CoalescesConcurrentColdCounts(t *testing.T) {
+	// Not parallel: reads a pool-wide counter and the package-level count cache.
+	h, _, mkUser := usageScopeHarness(t)
+	sh := NewSystemHandler(h.Pool().Pool(), h.settingsRepo)
+	resetRequestsTodayCache()
+
+	ownerID := mkUser("burst-owner")
+	uid := uuid.MustParse(ownerID)
+	id := &user.Identity{Role: user.RoleUser, UserID: &uid}
+	since := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+	const callers = 30
+	before := sh.pool.Stat().AcquireCount()
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/system/?since="+since, http.NoBody)
+			req = req.WithContext(user.WithIdentity(req.Context(), id))
+			var stats SystemStats
+			sh.attachRequestsToday(req, &stats, since)
+		}()
+	}
+	wg.Wait()
+	acquired := sh.pool.Stat().AcquireCount() - before
+
+	// Generous: the point is one-ish versus thirty-ish, not an exact number.
+	if acquired > callers/3 {
+		t.Errorf("%d concurrent cold counts took %d connection acquisitions, want ~1: the burst was not coalesced", callers, acquired)
+	}
+}
+
+// The count must not run on the caller's cancellable context.
+//
+// collect is deliberately detached (context.WithoutCancel) so a caller that
+// gives up early cannot abort the work and leave the cache unwritten — the
+// comment above it says so. Attaching this field per caller put it back on the
+// request context, where an aborted fetch killed the query, cached nothing, and
+// still answered 200 with a fabricated requests_today of 0.
+func TestAttachRequestsToday_SurvivesACancelledCaller(t *testing.T) {
+	h, _, mkUser := usageScopeHarness(t)
+	pool := h.Pool().Pool()
+	sh := NewSystemHandler(pool, h.settingsRepo)
+	resetRequestsTodayCache()
+	if _, err := pool.Exec(context.Background(), `DELETE FROM request_logs`); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	ownerID := mkUser("cancelled-caller")
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type, owner_user_id, created_at)
+		VALUES ($1, 'm', $2, false, 'k', 0, 'completed', 'chat', $3, NOW())`,
+		uuid.New(), uuid.NewString()[:16], ownerID); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	uid := uuid.MustParse(ownerID)
+	id := &user.Identity{Role: user.RoleUser, UserID: &uid}
+	since := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the caller has already gone
+	req := httptest.NewRequest(http.MethodGet, "/system/?since="+since, http.NoBody)
+	req = req.WithContext(user.WithIdentity(ctx, id))
+
+	var stats SystemStats
+	sh.attachRequestsToday(req, &stats, since)
+
+	if stats.App.RequestsToday != 1 {
+		t.Errorf("requests_today = %d, want 1: the count ran on the caller's cancelled context", stats.App.RequestsToday)
 	}
 }

--- a/internal/api/unscoped_usage_test.go
+++ b/internal/api/unscoped_usage_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/user"
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// usageScopeHarness builds a handler with real multi-user auth, so these tests
+// drive the actual middleware chain with a real session token rather than a
+// hand-placed identity. Placing the identity directly would exercise the guard
+// in isolation and prove nothing about whether the endpoint applies it.
+func usageScopeHarness(t *testing.T) (h *Handler, login func(userID string) string, mkUser func(name string) string) {
+	t.Helper()
+	h = newTestHandler(t)
+	pool := h.Pool().Pool()
+	if _, err := pool.Exec(context.Background(), `TRUNCATE users, webauthn_sessions, virtual_keys CASCADE`); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	userRepo := user.NewRepository(pool)
+	webauthnRepo := webauthn.NewRepository(pool)
+	sessionMgr := webauthn.NewSessionManager(webauthnRepo)
+	h.SetWebAuthnSessionManager(sessionMgr)
+	h.SetUserAuth(userRepo, webauthnRepo)
+
+	adminRouter := chi.NewRouter()
+	adminRouter.Use(h.AuthMiddleware)
+	h.Register(adminRouter)
+
+	login = func(userID string) string {
+		token, err := sessionMgr.CreateAuthToken(context.Background(), []byte(userID), nil, webauthn.SessionMeta{})
+		if err != nil {
+			t.Fatalf("CreateAuthToken: %v", err)
+		}
+		return token
+	}
+	mkUser = func(name string) string {
+		w := doJSON(t, adminRouter, http.MethodPost, "/users", envAdminToken,
+			fmt.Sprintf(`{"username":%q,"password":"password123","role":"user","grants":["usage"]}`, name))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create user %s: %d %s", name, w.Code, w.Body.String())
+		}
+		var resp struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode user: %v", err)
+		}
+		return resp.ID
+	}
+	return h, login, mkUser
+}
+
+// /metrics carries modelhotel_tokens_total{provider,model,kind} and
+// modelhotel_requests_total, neither of which has an owner label: they are
+// fleet-wide totals across every virtual-key owner.
+//
+// With METRICS_TOKEN unset the endpoint fell back to AuthMiddleware, which
+// admits ANY resolved identity — requireAdmin is a separate middleware that this
+// path never applied. So a non-admin multi-user session could scrape every other
+// tenant's token consumption. The code called that fallback "admin auth"; it was
+// merely authenticated auth.
+func TestMetricsHandler_FallbackAdmitsAdminsOnly(t *testing.T) {
+	h, login, mkUser := usageScopeHarness(t)
+	if h.cfg.MetricsToken != "" {
+		t.Fatalf("test config sets METRICS_TOKEN (%q); the fallback is what is under test", h.cfg.MetricsToken)
+	}
+
+	userID := mkUser("metrics-scoper")
+	r := chi.NewRouter()
+	r.Handle("/metrics", h.MetricsHandler())
+
+	for _, tc := range []struct {
+		name  string
+		token string
+		want  int
+	}{
+		{"admin token", envAdminToken, http.StatusOK},
+		{"non-admin session", login(userID), http.StatusForbidden},
+		{"no credential", "", http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody)
+			if tc.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.token)
+			}
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Errorf("status = %d, want %d: %s", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// GET /api/system/ is deliberately open to every authenticated role — its own
+// comment says "routing metadata and process gauges only". requests_today was
+// neither: a COUNT(*) over request_logs with no owner filter, so a non-admin
+// read the fleet's total traffic volume. Its 30s cache was keyed on the `since`
+// param alone, never on the caller, so scoping the query without scoping the
+// cache would still have served one owner's number to the next.
+func TestGetSystem_RequestsTodayIsScopedToTheCaller(t *testing.T) {
+	h, login, mkUser := usageScopeHarness(t)
+	pool := h.Pool().Pool()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `DELETE FROM request_logs`); err != nil {
+		t.Fatalf("clear request_logs: %v", err)
+	}
+
+	mineID, theirsID := mkUser("owner-one"), mkUser("owner-two")
+	// Keyless rows carry owner_user_id directly (migration 067): one for the
+	// first owner, two for the second.
+	for _, owner := range []string{mineID, theirsID, theirsID} {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO request_logs (id, model_id, request_hash, streaming, virtual_key_name, failover_attempt, state, endpoint_type, owner_user_id, created_at)
+			VALUES ($1, 'm', $2, false, 'k', 0, 'completed', 'chat', $3, NOW())`,
+			uuid.New(), uuid.NewString()[:16], owner); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	r := chi.NewRouter()
+	r.Use(h.AuthMiddleware)
+	h.Register(r)
+
+	since := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	get := func(token string) int64 {
+		t.Helper()
+		w := doJSON(t, r, http.MethodGet, "/system/?since="+since, token, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+		}
+		var out SystemStats
+		if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return out.App.RequestsToday
+	}
+
+	mine := get(login(mineID))
+	// Immediately after, inside both cache windows: a cache keyed only on
+	// `since` hands this caller the number above.
+	theirs := get(login(theirsID))
+	all := get(envAdminToken)
+
+	if mine != 1 {
+		t.Errorf("first owner saw requests_today = %d, want 1: the count is not scoped", mine)
+	}
+	if theirs != 2 {
+		t.Errorf("second owner saw requests_today = %d, want 2: a cached count leaked across callers", theirs)
+	}
+	if all != 3 {
+		t.Errorf("admin saw requests_today = %d, want 3 (the fleet total)", all)
+	}
+}

--- a/internal/frontdesk/metrics_test.go
+++ b/internal/frontdesk/metrics_test.go
@@ -222,3 +222,28 @@ func TestMetricsEventSeams(t *testing.T) {
 		}
 	}
 }
+
+// The admin fallback must mean ADMIN, not merely authenticated.
+//
+// It ran requireAuth alone, which admits every authenticated caller including a
+// PAIRED DEVICE — the very thing requireAdmin exists to refuse. So a phone
+// paired as operator or monitor could scrape the fleet's Prometheus counters,
+// which carry no per-device scoping at all. The comment above the function
+// called that "admin auth"; it was authenticated auth.
+func TestMetricsAdminFallback_RefusesPairedDevices(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	for _, role := range []DeviceRole{RoleOperator, RoleMonitor} {
+		t.Run(string(role), func(t *testing.T) {
+			token, _ := pairDevice(t, srv, role, "Pixel "+string(role))
+			if rec := scrape(t, srv, token); rec.Code != http.StatusForbidden {
+				t.Errorf("paired %s device GET /metrics = %d, want 403: %s", role, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// The admin path is unaffected.
+	if rec := scrape(t, srv, testFrontdeskToken); rec.Code != http.StatusOK {
+		t.Errorf("admin GET /metrics = %d, want 200", rec.Code)
+	}
+}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -581,8 +581,8 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 
 // metricsAuth gates the Prometheus scrape endpoint, mirroring the main
 // server's metricsAuth. A dedicated FRONTDESK_METRICS_TOKEN (so the scrape
-// config need not hold the admin token) takes precedence; without one, the
-// standard admin-or-session auth applies. The token must be presented as an
+// config need not hold the admin token) takes precedence; without one, admin
+// auth applies — authenticated AND not a paired device. The token must be presented as an
 // Authorization: Bearer header — not a query parameter — so it does not leak
 // into reverse-proxy access logs, browser history, or referrers. The endpoint
 // is never served unauthenticated.
@@ -602,8 +602,12 @@ func (s *Server) metricsAuth(next http.Handler) http.Handler {
 			http.Error(w, "invalid metrics token", http.StatusUnauthorized)
 			return
 		}
-		// No dedicated token configured — fall back to admin auth.
-		s.requireAuth(next).ServeHTTP(w, r)
+		// No dedicated token configured — fall back to ADMIN auth. requireAuth
+		// alone admits every authenticated caller including a PAIRED DEVICE,
+		// which is exactly what requireAdmin exists to refuse: a phone paired as
+		// operator or viewer would otherwise scrape the fleet's Prometheus
+		// counters. Same reasoning as the main server's metricsAuth.
+		s.requireAuth(s.requireAdmin(next)).ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
Strix findings 1 and 2 from the glm52 run against `29edaec0`. Both are the same class — a cross-tenant usage aggregate readable by a caller who should not see it — so they travel together.

## `/metrics` was readable by any authenticated caller

`modelhotel_tokens_total{provider,model,kind}` and `modelhotel_requests_total` carry no owner label: they are fleet-wide totals across every virtual-key owner. With `METRICS_TOKEN` unset the endpoint fell back to `AuthMiddleware`, which admits **any** resolved identity — `requireAdmin` is a separate middleware this path never applied — so a non-admin multi-user session could scrape every other tenant's token consumption.

The code called that fallback *"admin auth"*. It was authenticated auth.

**Front Desk had the same shape and slightly worse.** Its fallback ran `requireAuth` alone, which admits a **paired device** — precisely what its own `requireAdmin` exists to refuse. A phone paired as operator or monitor could scrape the fleet's counters.

## `GET /api/system/` leaked the fleet-wide request count

The endpoint is deliberately open to every authenticated role, and its comment says why: *"routing metadata and process gauges only, so any authenticated caller may read it."* `requests_today` was neither — `COUNT(*) FROM request_logs` with no owner filter.

It now goes through `ownerFilterFragment`, the same predicate `/api/stats` uses: keyed rows resolve through the key's current owner, keyless rows through the stamped `owner_user_id` (migration 067), and a malformed id fails **closed** to `AND 1=0` rather than to no filter.

### Scoping the query alone would not have been enough

Both of that endpoint's caches are keyed on the `since` parameter and **never on the caller**, so a scoped count computed for whichever caller missed the cache first would then be served to everyone else — the same leak by another route. So `requests_today` leaves the shared 3s payload entirely and is attached per caller, over a 30s cache keyed by **owner** rather than by `since`. That direction matters: `since` comes straight off the query string, so a map keyed on it would grow with whatever a caller sends, while the number of identities is bounded by the user table.

## Mutations

Four, all killed:

| mutation | caught by |
|---|---|
| `/metrics` back to authenticated-only | non-admin session gets 200 with the full dump |
| owner filter dropped from the count | both owners see the fleet total |
| count cache ignores the owner | second owner served the first's number |
| Front Desk back to `requireAuth` | paired device gets 200 |

## A note on the tests

They drive the real middleware chain with real session and device tokens. An earlier draft placed the identity directly in the request context and called `requireAdmin` on its own — which proved the guard works and nothing about whether the endpoint applies it. It passed against the unfixed code.
