### PR TITLE
fix(proxy): a model your plan excludes must not darken the whole provider

### DIFF
--- a/internal/proxy/breaker_action_test.go
+++ b/internal/proxy/breaker_action_test.go
@@ -19,7 +19,10 @@ func TestBreakerRecordAction(t *testing.T) {
 		{name: "502_bad_gateway", statusCode: 502, want: breakerActionFailure},
 		{name: "503_service_unavailable", statusCode: 503, want: breakerActionFailure},
 		{name: "504_gateway_timeout", statusCode: 504, want: breakerActionFailure},
-		{name: "429_rate_limited", statusCode: 429, want: breakerActionFailure},
+		// Deferred, not failure: a 429 is either overload (provider health) or a
+		// plan that does not cover this model (not provider health), and only the
+		// body separates them. recordClassifiedOutcome finishes the verdict.
+		{name: "429_rate_limited", statusCode: 429, want: breakerActionDeferred},
 		{name: "401_unauthorized", statusCode: 401, want: breakerActionFailure},
 		{name: "403_forbidden", statusCode: 403, want: breakerActionFailure},
 		{name: "402_payment_required", statusCode: 402, want: breakerActionFailure},

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
@@ -50,6 +51,12 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 			// failure history (resetting consecutiveFails in Closed state)
 			// and could prematurely close a half-open circuit based on a
 			// model-specific error that says nothing about provider health.
+		case breakerActionDeferred:
+			// The status does not decide; recordClassifiedOutcome does, once the
+			// body has been read. Every path that reaches here goes on to
+			// classify that body — the drain when there is another candidate,
+			// forwardUpstreamError when there is not, and the hedge race's own
+			// drain — so the verdict is never simply dropped.
 		case breakerActionSuccess:
 			// Not reached for failover-eligible codes: shouldFailover only
 			// returns true for {5xx,429,401,403,402,404,499}, all of which map
@@ -68,6 +75,55 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 	if !servedSuccessStatus(statusCode) {
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
 	}
+}
+
+// recordClassifiedOutcome finishes a verdict recordBreakerOutcome deferred,
+// once the upstream body has been classified.
+//
+// It charges unless the kind is a refusal ABOUT THE MODEL rather than about the
+// provider. Those say nothing about whether the provider can serve anything
+// else, and charging the provider-wide breaker for one takes its healthy models
+// down with the refused one. That is the same argument breakerRecordAction
+// already makes for a 404, whose comment reads "model-specific, not provider
+// health"; this extends it to the refusal that arrives as a 429.
+//
+// Deliberately not a RecordSuccess: a refusal is not evidence of health either,
+// and crediting one would reset consecutiveFails and erase real failures the
+// provider had accrued — the hole #805 closed.
+func (h *Handler) recordClassifiedOutcome(st *requestState, candidate modelCandidate, statusCode int, kind ErrorKind, body string) {
+	if !st.circuitBreakerEnabled || breakerRecordAction(statusCode) != breakerActionDeferred {
+		return
+	}
+	if refusalIsAboutTheModel(kind, body) {
+		return
+	}
+	h.chargeBreaker(st, candidate, "upstream status")
+}
+
+// refusalIsAboutTheModel reports whether a classified upstream refusal concerns
+// the requested model rather than the provider's health.
+//
+// An entitlement refusal is only half of one. "Your account has no credit" is
+// provider-wide and its circuit should open; "your plan does not include this
+// model" is not, and opening the circuit for it takes the models the plan DOES
+// include down with it. Both arrive as KindProviderNotEntitled, so the kind
+// alone cannot separate them.
+//
+// A resource package is the per-model unit a plan is sold in, so naming one is
+// positive evidence that the refusal is about which model was asked for. That is
+// what separates the two in practice: Z.ai answers "Insufficient balance or no
+// resource package. Please recharge." for a model outside the coding plan, while
+// MiniMax's genuinely account-wide 1008 says only "insufficient balance". The
+// test is deliberately for the presence of the per-model concept rather than the
+// absence of the account-wide one, because Z.ai's sentence contains both.
+//
+// Requiring positive evidence is also the safe direction: an unrecognised
+// entitlement refusal keeps charging the breaker, as it always did.
+func refusalIsAboutTheModel(kind ErrorKind, body string) bool {
+	if kind == KindProviderModelGone {
+		return true
+	}
+	return kind == KindProviderNotEntitled && strings.Contains(strings.ToLower(body), "resource package")
 }
 
 // recordAnswerOutcome records the circuit-breaker verdict for a finished

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -59,8 +59,9 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 			// drain — so the verdict is never simply dropped.
 		case breakerActionSuccess:
 			// Not reached for failover-eligible codes: shouldFailover only
-			// returns true for {5xx,429,401,403,402,404,499}, all of which map
-			// to failure or no-op above. Retained so the switch stays exhaustive
+			// returns true for {5xx,429,401,403,402,404,499}, which map to
+			// failure, no-op, or — for 429 — deferred above. Retained so the
+			// switch stays exhaustive
 			// over breakerAction — if the shouldFailover/breakerRecordAction
 			// mappings ever diverge, a success is recorded rather than dropped.
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name)
@@ -90,8 +91,19 @@ func (h *Handler) recordBreakerOutcome(st *requestState, candidate modelCandidat
 // Deliberately not a RecordSuccess: a refusal is not evidence of health either,
 // and crediting one would reset consecutiveFails and erase real failures the
 // provider had accrued — the hole #805 closed.
-func (h *Handler) recordClassifiedOutcome(st *requestState, candidate modelCandidate, statusCode int, kind ErrorKind, body string) {
+func (h *Handler) recordClassifiedOutcome(st *requestState, candidate modelCandidate, statusCode int, isFailoverEligible bool, kind ErrorKind, body string) {
 	if !st.circuitBreakerEnabled || breakerRecordAction(statusCode) != breakerActionDeferred {
+		return
+	}
+	// Only a verdict that was actually DEFERRED can be finished here.
+	// recordBreakerOutcome defers only on the failover-eligible branch; a status
+	// that is not eligible took its else branch and has already been credited a
+	// success. For a 429 that credit is the configured policy — with
+	// failover_on_rate_limit off the operator has asked to ride out rate limits
+	// on this provider rather than trip its breaker — so charging on top of it
+	// would both contradict the setting and, at a threshold of one, open the
+	// circuit on the first rate limit.
+	if !isFailoverEligible {
 		return
 	}
 	if refusalIsAboutTheModel(kind, body) {

--- a/internal/proxy/entitlement_breaker_test.go
+++ b/internal/proxy/entitlement_breaker_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/model"
+)
+
+// zaiEntitlementBody is the real refusal Z.ai's coding-plan endpoint returns for
+// a model outside the subscription. Note it names BOTH the account-wide
+// condition and the per-model one in a single sentence, which is why the phrases
+// alone cannot separate them.
+const zaiEntitlementBody = `{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}`
+
+// runEntitlementAttempt drives one attempt against an upstream answering status
+// with body, and reports whether the provider's circuit ended up open.
+func runEntitlementAttempt(t *testing.T, h *Handler, cand modelCandidate, srvURL string, totalCandidates int) {
+	t.Helper()
+	st := &requestState{
+		startTime: time.Now(), reqModel: "plan-model",
+		bodyBytes:             []byte(`{"model":"plan-model","messages":[{"role":"user","content":"hi"}]}`),
+		failoverTimeout:       30 * time.Second,
+		circuitBreakerEnabled: true,
+		vkHash:                "test-hash",
+		logData: &requestLogData{
+			id: uuid.New().String(), modelID: "plan-model",
+			providerID: cand.provider.ID, providerName: "Z.ai Coding Plan",
+			endpointType: endpointTypeChat, state: "pending",
+			virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+		},
+	}
+	h.insertRequestLogAsync(st.logData)
+	h.attemptCandidate(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody),
+		st, cand, 0, totalCandidates)
+}
+
+func entitlementHandler(t *testing.T, status int, body string) (*Handler, modelCandidate) {
+	t.Helper()
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThreshold(t, h, "2")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	m := &model.Model{ID: uuid.New(), ModelID: "plan-model"}
+	return h, goneCandidateAt(m, "Z.ai Coding Plan", "http://api.z.ai")
+}
+
+// A plan that does not cover ONE model says nothing about the provider's health,
+// and must not take the whole provider out of rotation.
+//
+// breakerRecordAction keyed purely on the status, so every 429 charged the
+// provider-wide breaker. Z.ai answers 429 for a model outside the coding plan
+// while other models on the same provider and the same key answer 200 — verified
+// against production: glm-5.1 returned 200 while glm-4.7-flashx and glm-4.5-x
+// returned 429. Two probes to an uncovered model therefore blacked out every
+// Z.ai model for the cooldown, the working ones included.
+//
+// Both routes through attemptCandidate are covered: the last candidate (which
+// classifies inside forwardUpstreamError) and a failover-eligible one with a
+// candidate to fall back to (which classifies on the drain path).
+func TestAttemptCandidate_AModelOutsideThePlanDoesNotDarkenTheProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		totalCandidates int
+	}{
+		{"last candidate", 1},
+		{"with a candidate to fall back to", 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, cand := entitlementHandler(t, http.StatusTooManyRequests, zaiEntitlementBody)
+			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+
+			if h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen {
+				t.Error("a model outside the plan opened the provider's circuit: every other model on it is now skipped")
+			}
+		})
+	}
+}
+
+// The other half of the rule. An ordinary 429 is the provider saying it is
+// overloaded, which IS about its health, so it must keep charging — otherwise
+// this fix would simply stop the breaker reacting to rate limiting.
+func TestAttemptCandidate_AnOrdinaryRateLimitStillChargesTheBreaker(t *testing.T) {
+	const rateLimited = `{"error":{"message":"Rate limit reached for this model, please retry shortly"}}`
+	for _, tc := range []struct {
+		name            string
+		totalCandidates int
+	}{
+		{"last candidate", 1},
+		{"with a candidate to fall back to", 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h, cand := entitlementHandler(t, http.StatusTooManyRequests, rateLimited)
+			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+
+			if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+				t.Error("two rate-limit 429s did not open the circuit: the breaker stopped reacting to overload")
+			}
+		})
+	}
+}
+
+// A 5xx is unambiguous provider unhealth and is unaffected by any of this.
+func TestAttemptCandidate_AServerFaultStillChargesTheBreaker(t *testing.T) {
+	h, cand := entitlementHandler(t, http.StatusInternalServerError, `{"error":{"message":"boom"}}`)
+	runEntitlementAttempt(t, h, cand, "", 1)
+	runEntitlementAttempt(t, h, cand, "", 1)
+
+	if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+		t.Error("two 500s did not open the circuit")
+	}
+}

--- a/internal/proxy/entitlement_breaker_test.go
+++ b/internal/proxy/entitlement_breaker_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,7 @@ const zaiEntitlementBody = `{"error":{"code":"1113","message":"Insufficient bala
 
 // runEntitlementAttempt drives one attempt against an upstream answering status
 // with body, and reports whether the provider's circuit ended up open.
-func runEntitlementAttempt(t *testing.T, h *Handler, cand modelCandidate, srvURL string, totalCandidates int) {
+func runEntitlementAttempt(t *testing.T, h *Handler, cand modelCandidate, totalCandidates int) {
 	t.Helper()
 	st := &requestState{
 		startTime: time.Now(), reqModel: "plan-model",
@@ -82,8 +83,8 @@ func TestAttemptCandidate_AModelOutsideThePlanDoesNotDarkenTheProvider(t *testin
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h, cand := entitlementHandler(t, http.StatusTooManyRequests, zaiEntitlementBody)
-			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
-			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, tc.totalCandidates)
 
 			if h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen {
 				t.Error("a model outside the plan opened the provider's circuit: every other model on it is now skipped")
@@ -106,8 +107,8 @@ func TestAttemptCandidate_AnOrdinaryRateLimitStillChargesTheBreaker(t *testing.T
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h, cand := entitlementHandler(t, http.StatusTooManyRequests, rateLimited)
-			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
-			runEntitlementAttempt(t, h, cand, "", tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, tc.totalCandidates)
+			runEntitlementAttempt(t, h, cand, tc.totalCandidates)
 
 			if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
 				t.Error("two rate-limit 429s did not open the circuit: the breaker stopped reacting to overload")
@@ -119,10 +120,165 @@ func TestAttemptCandidate_AnOrdinaryRateLimitStillChargesTheBreaker(t *testing.T
 // A 5xx is unambiguous provider unhealth and is unaffected by any of this.
 func TestAttemptCandidate_AServerFaultStillChargesTheBreaker(t *testing.T) {
 	h, cand := entitlementHandler(t, http.StatusInternalServerError, `{"error":{"message":"boom"}}`)
-	runEntitlementAttempt(t, h, cand, "", 1)
-	runEntitlementAttempt(t, h, cand, "", 1)
+	runEntitlementAttempt(t, h, cand, 1)
+	runEntitlementAttempt(t, h, cand, 1)
 
 	if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
 		t.Error("two 500s did not open the circuit")
+	}
+}
+
+// withRateLimitFailover sets failover_on_rate_limit for one test.
+func withRateLimitFailover(t *testing.T, h *Handler, enabled string) {
+	t.Helper()
+	if err := h.settingsRepo.Set(context.Background(), "failover_on_rate_limit", enabled); err != nil {
+		t.Fatalf("set failover_on_rate_limit: %v", err)
+	}
+	h.settingsRepo.InvalidateCache("failover_on_rate_limit")
+	t.Cleanup(func() {
+		_ = h.settingsRepo.Set(context.Background(), "failover_on_rate_limit", "true")
+		h.settingsRepo.InvalidateCache("failover_on_rate_limit")
+	})
+}
+
+// With failover_on_rate_limit OFF, a 429 is deliberately recorded as a SUCCESS:
+// the operator has asked to ride out rate limits on this provider rather than
+// trip its breaker. Deferring the 429 verdict must not undo that.
+//
+// The first cut gated recordClassifiedOutcome only on the status, so a 429 that
+// was never failover-eligible got the documented credit and then a charge on top
+// — at a threshold of one, the very first rate limit blacked the provider out,
+// which is the opposite of what the setting asks for.
+func TestAttemptCandidate_ARateLimitIsNotChargedWhenFailoverIsOff(t *testing.T) {
+	const rateLimited = `{"error":{"message":"Rate limit reached for this model, please retry shortly"}}`
+	h, cand := entitlementHandler(t, http.StatusTooManyRequests, rateLimited)
+	withBreakerThreshold(t, h, "1")
+	withRateLimitFailover(t, h, "false")
+
+	runEntitlementAttempt(t, h, cand, 1)
+
+	if h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen {
+		t.Error("a 429 opened the circuit with failover_on_rate_limit off: the setting asks to stay on the provider")
+	}
+}
+
+// The hedged-streaming path is now the ONLY thing charging the breaker for a 429
+// there, since the header-time charge this PR removed used to cover it. Deleting
+// that one line left the whole suite green before this test existed.
+func TestProbeStreamingCandidate_ChargesARateLimit(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThreshold(t, h, "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"Rate limit reached, retry shortly"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	st, cand := probeStateForServer(srv.URL)
+	st.circuitBreakerEnabled = true
+	if res := h.probeStreamingCandidate(context.Background(), st, cand, 0, time.Second, time.Second); res.won {
+		t.Fatal("a 429 must not win the race")
+	}
+	if h.circuitBreaker.GetState(cand.provider.ID) != failover.StateOpen {
+		t.Error("the hedge race did not charge a rate limit: nothing else does on that path now")
+	}
+}
+
+// And its sibling: a plan refusal on the hedged path must not darken the
+// provider either.
+func TestProbeStreamingCandidate_DoesNotChargeAPlanRefusal(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThreshold(t, h, "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, zaiEntitlementBody)
+	}))
+	t.Cleanup(srv.Close)
+	h.upstreamTransport = dialToTestServer(t, srv)
+
+	st, cand := probeStateForServer(srv.URL)
+	st.circuitBreakerEnabled = true
+	_ = h.probeStreamingCandidate(context.Background(), st, cand, 0, time.Second, time.Second)
+
+	if h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen {
+		t.Error("a model outside the plan opened the provider's circuit on the hedged path")
+	}
+}
+
+// The multimodal drain path is the other site the header-time charge used to
+// cover. Two candidates, so the eligible-with-a-fallback branch runs.
+func TestAttemptPassthroughCandidate_ChargesARateLimitButNotAPlanRefusal(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		body     string
+		wantOpen bool
+	}{
+		{"ordinary rate limit", `{"error":{"message":"Rate limit reached, retry shortly"}}`, true},
+		{"model outside the plan", zaiEntitlementBody, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			withBreakerThreshold(t, h, "1")
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+			h.upstreamTransport = dialToTestServer(t, srv)
+
+			m := &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"}
+			cand := goneCandidateAt(m, "Z.ai Coding Plan", "http://api.z.ai")
+			st := &requestState{
+				startTime: time.Now(), reqModel: "text-embedding-3-small",
+				bodyBytes:             []byte(`{"model":"text-embedding-3-small","input":"hi"}`),
+				failoverTimeout:       30 * time.Second,
+				circuitBreakerEnabled: true,
+				vkHash:                "test-hash",
+				logData: &requestLogData{
+					id: uuid.New().String(), modelID: "text-embedding-3-small",
+					providerID: cand.provider.ID, providerName: "Z.ai Coding Plan",
+					endpointType: endpointTypeEmbeddings, state: "pending",
+					virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
+				},
+			}
+			h.insertRequestLogAsync(st.logData)
+			// totalCandidates 2: eligible AND a fallback, which is the drain path.
+			h.attemptPassthroughCandidate(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, 0, 2)
+
+			if open := h.circuitBreaker.GetState(cand.provider.ID) == failover.StateOpen; open != tc.wantOpen {
+				t.Errorf("circuit open = %v, want %v", open, tc.wantOpen)
+			}
+		})
+	}
+}
+
+// The model-gone clause of refusalIsAboutTheModel: a 429 whose body says the
+// model is gone is about the model, not the provider.
+func TestRefusalIsAboutTheModel_ModelGoneIsNotProviderHealth(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		kind ErrorKind
+		body string
+		want bool
+	}{
+		{"model gone", KindProviderModelGone, "the model has been retired", true},
+		{"plan excludes this model", KindProviderNotEntitled, zaiEntitlementBody, true},
+		{"account out of credit", KindProviderNotEntitled, "insufficient balance", false},
+		{"ordinary overload", KindProviderError, "rate limit reached", false},
+	} {
+		if got := refusalIsAboutTheModel(tc.kind, tc.body); got != tc.want {
+			t.Errorf("%s: refusalIsAboutTheModel = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -316,7 +316,10 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// happened to win — almost never, since a model answering 404 loses the
 		// TTFT contest to anything that works. Same classification the sequential
 		// and pass-through loops do, on a body being discarded either way.
-		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(errBody), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
+		errBodyMsg := util.SanitizeLogBody(string(errBody), 10000)
+		kind, _ := classifyUpstreamError(resp.StatusCode, errBodyMsg, candidate.model.ModelID)
+		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, errBodyMsg)
+		if kind == KindProviderModelGone {
 			h.noteModelGone(candidate, st.logData.endpointType)
 		}
 		res.reqErr = reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)}

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -318,7 +318,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// and pass-through loops do, on a body being discarded either way.
 		errBodyMsg := util.SanitizeLogBody(string(errBody), 10000)
 		kind, _ := classifyUpstreamError(resp.StatusCode, errBodyMsg, candidate.model.ModelID)
-		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, errBodyMsg)
+		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, isFailoverEligible, kind, errBodyMsg)
 		if kind == KindProviderModelGone {
 			h.noteModelGone(candidate, st.logData.endpointType)
 		}

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -346,6 +346,10 @@ const (
 	breakerActionNoOp
 	// breakerActionSuccess records a success (provider is healthy).
 	breakerActionSuccess
+	// breakerActionDeferred records nothing yet: the status alone does not say
+	// whether the provider is unhealthy, and the body does. Whoever classifies
+	// that body calls recordClassifiedOutcome to finish the verdict.
+	breakerActionDeferred
 )
 
 // breakerRecordAction determines the circuit-breaker recording action for a
@@ -382,11 +386,28 @@ func servedSuccessStatus(statusCode int) bool {
 
 func breakerRecordAction(statusCode int) breakerAction {
 	switch {
-	case statusCode >= 500 || statusCode == 429 || statusCode == 401 || statusCode == 403 || statusCode == 402:
+	case statusCode == 429:
+		// 429 is two different claims wearing one number. Ordinary rate limiting
+		// is the provider saying it is overloaded, which is about its health; but
+		// a plan that does not cover ONE model is answered 429 too, and that says
+		// nothing about the provider — verified in production, where Z.ai
+		// returned 429 for glm-4.7-flashx while glm-5.1 answered 200 on the same
+		// provider and the same key. Charging the provider-wide breaker for the
+		// second kind took the working models out of rotation with the uncovered
+		// one.
+		//
+		// The two cannot be told apart from the status, and not from the phrases
+		// either: Z.ai's refusal reads "Insufficient balance or no resource
+		// package. Please recharge.", naming the account-wide condition and the
+		// per-model one in a single sentence. Only the classified KIND separates
+		// them, and that needs the body — so the verdict waits for whoever reads
+		// it, exactly as a 2xx does.
+		return breakerActionDeferred
+	case statusCode >= 500 || statusCode == 401 || statusCode == 403 || statusCode == 402:
 		// 5xx = server error (provider unhealthy)
-		// 429 = rate limit (provider overloaded; see policy note above)
 		// 401/403 = auth failure (provider-wide bad/expired key)
-		// 402 = out of credit (provider-wide billing condition, same class)
+		// 402 = out of credit (provider-wide billing condition, and unambiguous:
+		// unlike a 429 it is never a per-model refusal)
 		return breakerActionFailure
 	case statusCode == 404 || statusCode == 499:
 		// 404 = stale/renamed model (model-specific, not provider health)

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -356,12 +356,14 @@ const (
 // given upstream HTTP status code. This is the single source of truth for the
 // status→breaker mapping and is intended to be table-tested.
 //
-// Note on 429: this function maps it to a failure, but it is only consulted in
-// the failover-eligible branch of ChatCompletions — i.e. when shouldFailover
-// already returned true, which for 429 means failover_on_rate_limit is ON. When
-// that setting is OFF, a 429 is not failover-eligible and never reaches this
-// function; the caller's else branch intentionally records it as a success
-// (stay on the rate-limited provider rather than tripping its breaker). The 429
+// Note on 429: this function DEFERS it rather than mapping it to a failure, and
+// it is only consulted in the failover-eligible branch of ChatCompletions — i.e.
+// when shouldFailover already returned true, which for 429 means
+// failover_on_rate_limit is ON. When that setting is OFF, a 429 is not
+// failover-eligible and never reaches this function; the caller's else branch
+// intentionally records it as a success (stay on the rate-limited provider
+// rather than tripping its breaker), and recordClassifiedOutcome declines to
+// finish a verdict that was never deferred, so that credit stands. The 429
 // treatment is therefore consistent with the configured policy, not contradictory.
 // servedSuccessStatus reports whether an upstream status is one the gateway
 // treats as an answer it served, rather than a failure to route or report.
@@ -406,8 +408,11 @@ func breakerRecordAction(statusCode int) breakerAction {
 	case statusCode >= 500 || statusCode == 401 || statusCode == 403 || statusCode == 402:
 		// 5xx = server error (provider unhealthy)
 		// 401/403 = auth failure (provider-wide bad/expired key)
-		// 402 = out of credit (provider-wide billing condition, and unambiguous:
-		// unlike a 429 it is never a per-model refusal)
+		// 402 = out of credit (provider-wide billing condition). Not deferred
+		// like the 429: no provider has been seen answering 402 for a single
+		// model, so there is nothing to disambiguate. That is an observation
+		// about the providers in the catalogue, not a guarantee — if one turns
+		// up, it belongs in the deferred branch beside the 429.
 		return breakerActionFailure
 	case statusCode == 404 || statusCode == 499:
 		// 404 = stale/renamed model (model-specific, not provider health)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -220,7 +220,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 			if kind == KindProviderModelGone {
 				h.noteModelGone(candidate, logData.endpointType)
 			}
-			h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, drainedMsg)
+			h.recordClassifiedOutcome(st, candidate, resp.StatusCode, isFailoverEligible, kind, drainedMsg)
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 			debuglog.Info("proxy: failover triggered", "endpoint", logData.endpointType, "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 			logData.failoverAttempt = attempt

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -215,9 +215,12 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 			drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
-			if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
+			drainedMsg := util.SanitizeLogBody(string(drained), 10000)
+			kind, _ := classifyUpstreamError(resp.StatusCode, drainedMsg, candidate.model.ModelID)
+			if kind == KindProviderModelGone {
 				h.noteModelGone(candidate, logData.endpointType)
 			}
+			h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, drainedMsg)
 			st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 			debuglog.Info("proxy: failover triggered", "endpoint", logData.endpointType, "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 			logData.failoverAttempt = attempt

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -165,9 +165,13 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		// and the decrypted key already in hand here. The endpoint family comes
 		// off the log entry and decides whether the refusal can be adjudicated at
 		// all.
-		if kind, _ := classifyUpstreamError(resp.StatusCode, util.SanitizeLogBody(string(drained), 10000), candidate.model.ModelID); kind == KindProviderModelGone {
+		drainedMsg := util.SanitizeLogBody(string(drained), 10000)
+		kind, _ := classifyUpstreamError(resp.StatusCode, drainedMsg, candidate.model.ModelID)
+		if kind == KindProviderModelGone {
 			h.noteModelGone(candidate, logData.endpointType)
 		}
+		// The body is in hand, so a verdict deferred on the status can be made.
+		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, drainedMsg)
 		st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 		debuglog.Info("proxy: failover triggered", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 		logData.failoverAttempt = attempt

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -171,7 +171,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 			h.noteModelGone(candidate, logData.endpointType)
 		}
 		// The body is in hand, so a verdict deferred on the status can be made.
-		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, drainedMsg)
+		h.recordClassifiedOutcome(st, candidate, resp.StatusCode, isFailoverEligible, kind, drainedMsg)
 		st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode)})
 		debuglog.Info("proxy: failover triggered", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 		logData.failoverAttempt = attempt

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -85,7 +85,10 @@ func TestRecordBreakerOutcome(t *testing.T) {
 		want        breakerOutcome
 	}{
 		{"eligible 5xx -> failure", true, false, 500, true, breakerFailureRecorded},
-		{"eligible 429 -> failure", true, false, 429, true, breakerFailureRecorded},
+		// A 429 records nothing at header time — see breakerRecordAction. The
+		// charge, when it is owed, is made by recordClassifiedOutcome once the
+		// body has said which kind of 429 this is.
+		{"eligible 429 -> deferred (untouched)", true, false, 429, true, breakerUntouched},
 		{"eligible 401 -> failure", true, false, 401, true, breakerFailureRecorded},
 		{"eligible 403 -> failure", true, false, 403, true, breakerFailureRecorded},
 		{"eligible 404 -> no-op", true, false, 404, true, breakerUntouched},

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -307,11 +307,18 @@ func modelGoneAbout(body, modelID string) bool {
 // request_logs.error_message. Classifying it here makes it a queryable
 // error_kind and a Prometheus label instead.
 //
-// IMPORTANT: this is observability only. Failover eligibility, circuit-breaker
-// trips and quota handling stay purely status-code driven (see
+// IMPORTANT: this was observability only, and for ROUTING it still is —
+// failover eligibility and quota handling stay purely status-code driven (see
 // isFailoverEligible and the MiniMax 1008 -> 429 remap, which deliberately
-// funnels balance errors into the rate-limit path so failover moves on).
-// Returning a new kind here must never change where a request is routed.
+// funnels balance errors into the rate-limit path so failover moves on), and
+// returning a new kind here must never change where a request is routed.
+//
+// The CIRCUIT BREAKER is no longer in that list. A 429 defers its verdict to
+// this classification (see breakerActionDeferred and refusalIsAboutTheModel),
+// so the phrase lists below are load-bearing for it: a phrase added here that
+// catches an ordinary overload body would turn it into KindProviderNotEntitled
+// and stop that provider's circuit ever opening. Adding to the entitlement
+// phrases in particular is a breaker change, not just a label change.
 //
 // The returned reason is always gateway-authored static text. The upstream body
 // is never echoed to the caller: it can quote the request back at us, and the

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -97,7 +97,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, candidate.model.ModelID)
 	// The last candidate's verdict: nothing after this reads the body, so a
 	// status whose meaning waited for it is decided here.
-	h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, errMsg)
+	h.recordClassifiedOutcome(st, candidate, resp.StatusCode, isFailoverEligible, kind, errMsg)
 	if kind == KindProviderModelGone {
 		// Same as the drain path above: the candidate carries what the
 		// pre-retirement probe needs, and logData.endpointType is the family

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -95,6 +95,9 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	// Classify for the request log and metrics only — routing is unaffected,
 	// the caller already decided it from the status code.
 	kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, candidate.model.ModelID)
+	// The last candidate's verdict: nothing after this reads the body, so a
+	// status whose meaning waited for it is decided here.
+	h.recordClassifiedOutcome(st, candidate, resp.StatusCode, kind, errMsg)
 	if kind == KindProviderModelGone {
 		// Same as the drain path above: the candidate carries what the
 		// pre-retirement probe needs, and logData.endpointType is the family


### PR DESCRIPTION
Found by watching prod logs after the fleet rebuild, not by a scanner.

`breakerRecordAction` keyed purely on the status code, so **every** 429 charged the provider-wide circuit breaker. But a 429 is two different claims wearing one number: ordinary rate limiting, which is about the provider's health, and *"your plan does not cover this model"*, which is not.

## What it did in production

During the fleet matrix run, Z.ai answered 429 for `glm-4.7-flashx` and `glm-4.5-x` while **`glm-5.1` answered 200 on the same provider with the same key**. Two probes to an uncovered model opened the provider's circuit for 30s, so `buildFailoverCandidates` skipped every Z.ai model — the working ones included.

## The verdict waits for the body

`breakerRecordAction` returns a new `breakerActionDeferred` for 429, and `recordClassifiedOutcome` finishes the verdict at the four sites that already classify the body: the drain when there is another candidate, `forwardUpstreamError` when there is not, the hedge race's own drain, and the multimodal twin. Every 429 reaches one of them, so no charge is dropped — only moved a few lines later.

This is the same shape the codebase already uses for a 2xx, whose comment reads *"a status is not an answer… the verdict is deferred to whoever reads it"*.

## Telling the two apart

The phrases don't do it. Z.ai's refusal reads:

> Insufficient balance or no resource package. Please recharge.

which names the account-wide condition **and** the per-model one in a single sentence.

A *resource package* is the per-model unit a plan is sold in, so naming one is positive evidence that the refusal is about which model was asked for. The rule therefore tests for the presence of that per-model concept rather than the absence of the account-wide one — and an entitlement refusal it does not recognise keeps charging exactly as before, which is the safe direction.

## The first attempt was too broad, and an existing test said so

Exempting every `KindProviderNotEntitled` also exempted MiniMax's `1008`, which is genuinely account-wide and says only *"insufficient balance"*. `TestChatCompletions_MiniMaxBusinessErrorFailsOver` caught it. That test now also guards against the rule widening again: making the phrase match everything fails it.

## The trade this makes, stated plainly

Z.ai returns the byte-identical body when the account is genuinely out of credit as when the plan simply excludes the model — code 1113 covers both. So this change makes a fully drained Z.ai provider un-breakable: every model 429s, none of it charges, and each request burns an upstream round-trip before failing over.

The old behaviour got the drained case right and the per-model case wrong; this gets the per-model case right and the drained case wrong. Neither polarity is correct from the body alone. The reason to prefer this one is that the failure modes are not symmetric: charging wrongly makes *working* models unavailable to the tenant, while not charging wrongly costs one wasted round-trip per request against a provider that is failing fast anyway.

The real fix needs evidence the body does not carry — whether a sibling model on the same provider answered recently, which is exactly how this bug was identified by hand. That is a breaker-design change and belongs in its own PR.

## Not done, deliberately

Charging a `(provider, model)` circuit instead of exempting the refusal. The breaker is provider-keyed by design, and per-model circuits are an architectural change rather than a bug fix.

## Mutations

Three, all killed: the header-time charge restored; the resource-package evidence ignored; the model-specific exemption removed. Plus the over-broad variant, caught by the MiniMax test.
