### PR TITLE
fix(anthropic): a quoted token count turned a real answer into a 502

### DIFF
--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -178,8 +178,6 @@ func TestBuildMessageResponse_CountSpellings(t *testing.T) {
 		{"quoted", `{"prompt_tokens":"12","completion_tokens":"3"}`, 12, 3},
 		{"fractional", `{"prompt_tokens":12.0,"completion_tokens":3.0}`, 12, 3},
 		{"mixed", `{"prompt_tokens":"12","completion_tokens":3}`, 12, 3},
-		// A member this translator has no field for keeps the counts beside it.
-		{"unmodelled sibling", `{"prompt_tokens":12,"completion_tokens":3,"prompt_tokens_details":[]}`, 12, 3},
 		// Not a count in any spelling: nothing is invented for the figure that
 		// could not be read, and the one that could is still reported.
 		{"one figure unreadable", `{"prompt_tokens":"lots","completion_tokens":3}`, 0, 3},
@@ -223,13 +221,16 @@ func TestBuildMessageResponse_CountSpellings(t *testing.T) {
 // differently, not for leniency across the response.
 func TestBuildMessageResponse_BrokenBytesStillFail(t *testing.T) {
 	t.Parallel()
-	for _, body := range []string{
-		`{"choices":[],"usage":{"prompt_tokens":1}`, // truncated object
-		`[]`, // a list is not a chat completion
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"truncated object", `{"choices":[],"usage":{"prompt_tokens":1}`},
+		{"a list", `[]`},
 	} {
-		t.Run(body, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if _, err := BuildMessageResponse([]byte(body), "msg_1", "m"); err == nil {
+			if _, err := BuildMessageResponse([]byte(tc.body), "msg_1", "m"); err == nil {
 				t.Error("want an error: these bytes are broken, not a count in another spelling")
 			}
 		})

--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -1,6 +1,9 @@
 package anthropic
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 // A count is a count however the provider spelled it. A plain int field met
 // neither the quoted nor the fractional form, so ParseResponseUsage returned
@@ -155,5 +158,80 @@ func TestInspectStreamEvent_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T)
 	}
 	if !start.HasOutput || start.OutputTokens != 1 {
 		t.Errorf("OutputTokens = %d (has=%v), want 1: it is read straight off its own member", start.OutputTokens, start.HasOutput)
+	}
+}
+
+// The OpenAI -> Anthropic translation of a NON-streaming answer read its counts
+// inline, off a struct of plain ints. The streaming twin
+// (proxy.anthropicResponseWriter.handleStreamLine) already tolerates a count the
+// provider spelled differently; this one did not, so a quoted prompt_tokens
+// failed the decode of the whole response object and the caller got a 502 in
+// place of the answer the model had already produced.
+func TestBuildMessageResponse_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		usage           string
+		wantIn, wantOut int
+	}{
+		{"plain integers", `{"prompt_tokens":12,"completion_tokens":3}`, 12, 3},
+		{"quoted", `{"prompt_tokens":"12","completion_tokens":"3"}`, 12, 3},
+		{"fractional", `{"prompt_tokens":12.0,"completion_tokens":3.0}`, 12, 3},
+		{"mixed", `{"prompt_tokens":"12","completion_tokens":3}`, 12, 3},
+		// A member this translator has no field for keeps the counts beside it.
+		{"unmodelled sibling", `{"prompt_tokens":12,"completion_tokens":3,"prompt_tokens_details":[]}`, 12, 3},
+		// Not a count in any spelling: nothing is invented for the figure that
+		// could not be read, and the one that could is still reported.
+		{"one figure unreadable", `{"prompt_tokens":"lots","completion_tokens":3}`, 0, 3},
+		// The usage member is not a usage block at all: no counts, but the
+		// answer still reaches the caller.
+		{"usage is not an object", `"none"`, 0, 0},
+		{"usage is null", `null`, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := `{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"Hi there"},` +
+				`"finish_reason":"stop"}],"usage":` + tc.usage + `}`
+			out, err := BuildMessageResponse([]byte(body), "msg_1", "m")
+			if err != nil {
+				t.Fatalf("BuildMessageResponse: %v: a usage block must never cost the caller the answer", err)
+			}
+			var m struct {
+				Content []struct {
+					Text string `json:"text"`
+				} `json:"content"`
+				Usage struct {
+					InputTokens  int `json:"input_tokens"`
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			}
+			if err := json.Unmarshal(out, &m); err != nil {
+				t.Fatalf("invalid output: %v", err)
+			}
+			if len(m.Content) != 1 || m.Content[0].Text != "Hi there" {
+				t.Errorf("content = %+v, want the answer the model produced", m.Content)
+			}
+			if m.Usage.InputTokens != tc.wantIn || m.Usage.OutputTokens != tc.wantOut {
+				t.Errorf("usage = %d/%d, want %d/%d", m.Usage.InputTokens, m.Usage.OutputTokens, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
+}
+
+// A count no reading can make sense of must not be invented, and bytes that are
+// not a document at all must still fail: the tolerance is for a number written
+// differently, not for leniency across the response.
+func TestBuildMessageResponse_BrokenBytesStillFail(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{
+		`{"choices":[],"usage":{"prompt_tokens":1}`, // truncated object
+		`[]`, // a list is not a chat completion
+	} {
+		t.Run(body, func(t *testing.T) {
+			t.Parallel()
+			if _, err := BuildMessageResponse([]byte(body), "msg_1", "m"); err == nil {
+				t.Error("want an error: these bytes are broken, not a count in another spelling")
+			}
+		})
 	}
 }

--- a/internal/anthropic/response.go
+++ b/internal/anthropic/response.go
@@ -15,7 +15,14 @@ type oaiResponse struct {
 	ID      string      `json:"id"`
 	Model   string      `json:"model"`
 	Choices []oaiChoice `json:"choices"`
-	Usage   *OAUsage    `json:"usage"`
+	// Held raw and decoded on its own, so a usage block this package cannot read
+	// costs the usage and nothing else. Decoded inline it was part of the
+	// response object, and one count the provider spelled differently — quoted,
+	// or with a fraction on it — failed the whole decode, which the caller met
+	// as a 502 in place of the answer the model had already produced. The
+	// streaming twin of this path already reads counts that way; see
+	// proxy.anthropicResponseWriter.handleStreamLine.
+	Usage json.RawMessage `json:"usage"`
 }
 
 type oaiChoice struct {
@@ -70,6 +77,27 @@ type oaiRespToolCall struct {
 	} `json:"function"`
 }
 
+// readOAUsage maps an OpenAI usage block to the Anthropic token accounting.
+//
+// util.DecodeCounts, so a count written as "12" or 12.0 is still a count; the
+// shape tolerance (util.ShapeError) so a member this translator has no field
+// for, or one figure that is not a count in any spelling, keeps the figure
+// beside it. Both counts are read straight off their own member — neither is a
+// sum — so an unreadable one costs only itself.
+//
+// Absent, null and unreadable all land on the same zeros, and there is no
+// util.JSONMemberSet guard here because there is nothing for it to protect: the
+// Anthropic Message schema makes usage mandatory, this translation reports one
+// response rather than accumulating across chunks, and metering reads the
+// upstream body, not this output.
+func readOAUsage(raw json.RawMessage) usage {
+	var u OAUsage
+	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
+		return usage{}
+	}
+	return usage{InputTokens: u.PromptTokens, OutputTokens: u.CompletionTokens}
+}
+
 // BuildMessageResponse converts a non-streaming OpenAI chat-completion response
 // body into an Anthropic Messages response body. model is echoed back to the
 // client (the model string it requested); messageID is the Anthropic id to
@@ -87,7 +115,6 @@ func BuildMessageResponse(body []byte, messageID, model string) ([]byte, error) 
 		Role:    "assistant",
 		Model:   model,
 		Content: []contentBlock{},
-		Usage:   usage{InputTokens: 0, OutputTokens: 0},
 	}
 
 	finish := "stop"
@@ -118,10 +145,7 @@ func BuildMessageResponse(body []byte, messageID, model string) ([]byte, error) 
 	stop := mapStopReason(finish)
 	msg.StopReason = &stop
 
-	if resp.Usage != nil {
-		msg.Usage.InputTokens = resp.Usage.PromptTokens
-		msg.Usage.OutputTokens = resp.Usage.CompletionTokens
-	}
+	msg.Usage = readOAUsage(resp.Usage)
 
 	out, err := json.Marshal(msg)
 	if err != nil {

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -130,3 +130,76 @@ func TestBuildChatCompletion_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T
 		}
 	}
 }
+
+// The streaming surface, which #813 left untested: the terminal usage chunk is
+// assembled by Finish() from the raw usageMetadata Translate() stashed, so the
+// count spellings have to survive the stream's own path to the client, not only
+// the non-streaming one. A count read here is what the metering pipeline bills.
+func TestStreamTranslator_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		usage           string
+		wantIn, wantOut int
+	}{
+		{"plain integers", `{"promptTokenCount":12,"candidatesTokenCount":3,"totalTokenCount":15}`, 12, 3},
+		{"quoted", `{"promptTokenCount":"12","candidatesTokenCount":"3","totalTokenCount":"15"}`, 12, 3},
+		{"fractional", `{"promptTokenCount":12.0,"candidatesTokenCount":3.0,"totalTokenCount":15.0}`, 12, 3},
+		// A member this translator has no field for keeps the counts beside it.
+		{"unmodelled sibling", `{"promptTokenCount":12,"candidatesTokenCount":3,"promptTokensDetails":[]}`, 12, 3},
+		// Not a count in any spelling: the prompt figure is read straight off
+		// its own member and stands, the one that could not be read is not
+		// invented.
+		{"one figure unreadable", `{"promptTokenCount":12,"candidatesTokenCount":"lots"}`, 12, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := NewStreamTranslator("id", "m", 0)
+			if _, err := tr.Translate([]byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"}}],"usageMetadata":` + tc.usage + `}`)); err != nil {
+				t.Fatalf("a usage member cost the stream its chunk: %v", err)
+			}
+			out, err := tr.Finish()
+			if err != nil {
+				t.Fatalf("finish: %v", err)
+			}
+			got := streamUsage(t, out)
+			if got.PromptTokens != tc.wantIn || got.CompletionTokens != tc.wantOut {
+				t.Errorf("metered %d/%d, want %d/%d", got.PromptTokens, got.CompletionTokens, tc.wantIn, tc.wantOut)
+			}
+		})
+	}
+}
+
+type streamUsageCounts struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+// streamUsage reads the usage block off the last chat chunk that carries one.
+// Parsing the frames rather than substring-matching the SSE bytes: "12" is a
+// substring of "121", and a count is exactly the thing that must not be matched
+// loosely.
+func streamUsage(t *testing.T, sse []byte) streamUsageCounts {
+	t.Helper()
+	var last streamUsageCounts
+	var seen bool
+	for _, line := range strings.Split(string(sse), "\n") {
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok || strings.TrimSpace(payload) == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Usage *streamUsageCounts `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			t.Fatalf("stream frame did not decode: %v", err)
+		}
+		if chunk.Usage != nil {
+			last, seen = *chunk.Usage, true
+		}
+	}
+	if !seen {
+		t.Fatalf("no chunk carried a usage block: %s", sse)
+	}
+	return last
+}

--- a/internal/gemini/count_spelling_test.go
+++ b/internal/gemini/count_spelling_test.go
@@ -145,8 +145,6 @@ func TestStreamTranslator_CountSpellings(t *testing.T) {
 		{"plain integers", `{"promptTokenCount":12,"candidatesTokenCount":3,"totalTokenCount":15}`, 12, 3},
 		{"quoted", `{"promptTokenCount":"12","candidatesTokenCount":"3","totalTokenCount":"15"}`, 12, 3},
 		{"fractional", `{"promptTokenCount":12.0,"candidatesTokenCount":3.0,"totalTokenCount":15.0}`, 12, 3},
-		// A member this translator has no field for keeps the counts beside it.
-		{"unmodelled sibling", `{"promptTokenCount":12,"candidatesTokenCount":3,"promptTokensDetails":[]}`, 12, 3},
 		// Not a count in any spelling: the prompt figure is read straight off
 		// its own member and stands, the one that could not be read is not
 		// invented.
@@ -175,24 +173,26 @@ type streamUsageCounts struct {
 	CompletionTokens int `json:"completion_tokens"`
 }
 
-// streamUsage reads the usage block off the last chat chunk that carries one.
-// Parsing the frames rather than substring-matching the SSE bytes: "12" is a
-// substring of "121", and a count is exactly the thing that must not be matched
-// loosely.
+// streamUsage reads the usage block off the last translated chunk that carries
+// one, on top of the frame splitter the rest of the stream tests use.
+//
+// A typed re-decode rather than reading decodeChunk's map[string]any: a count
+// through that map is a float64 to be re-asserted, and asserting on the SSE
+// bytes as a string would match "12" inside "121" — a count is exactly the
+// thing that must not be matched loosely.
 func streamUsage(t *testing.T, sse []byte) streamUsageCounts {
 	t.Helper()
 	var last streamUsageCounts
 	var seen bool
-	for _, line := range strings.Split(string(sse), "\n") {
-		payload, ok := strings.CutPrefix(line, "data: ")
-		if !ok || strings.TrimSpace(payload) == "[DONE]" {
+	for _, payload := range parseFrames(t, sse) {
+		if payload == "[DONE]" {
 			continue
 		}
 		var chunk struct {
 			Usage *streamUsageCounts `json:"usage"`
 		}
 		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
-			t.Fatalf("stream frame did not decode: %v", err)
+			t.Fatalf("stream frame did not decode: %v\n%s", err, payload)
 		}
 		if chunk.Usage != nil {
 			last, seen = *chunk.Usage, true

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -185,28 +185,31 @@ type streamUsageCounts struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-// streamUsage reads the usage block off the last chat chunk that carries one.
-// Parsing the frames rather than substring-matching the SSE bytes: "12" is a
-// substring of "121", and a count is exactly the thing that must not be matched
-// loosely.
+// streamUsage reads the usage block off the last translated chunk that carries
+// one, on top of the frame splitter the rest of the stream tests use.
+//
+// The re-encode is what makes the read typed: collectChunks hands back
+// map[string]any, where every count is a float64 to be re-asserted, and
+// asserting on the SSE bytes as a string would match "12" inside "121" — a count
+// is exactly the thing that must not be matched loosely.
 func streamUsage(t *testing.T, sse []byte) streamUsageCounts {
 	t.Helper()
+	chunks, _ := collectChunks(t, sse)
 	var last streamUsageCounts
 	var seen bool
-	for _, line := range strings.Split(string(sse), "\n") {
-		payload, ok := strings.CutPrefix(line, "data: ")
-		if !ok || strings.TrimSpace(payload) == "[DONE]" {
+	for _, chunk := range chunks {
+		block, ok := chunk["usage"]
+		if !ok || block == nil {
 			continue
 		}
-		var chunk struct {
-			Usage *streamUsageCounts `json:"usage"`
+		encoded, err := json.Marshal(block)
+		if err != nil {
+			t.Fatalf("usage block did not re-encode: %v", err)
 		}
-		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
-			t.Fatalf("stream frame did not decode: %v", err)
+		if err := json.Unmarshal(encoded, &last); err != nil {
+			t.Fatalf("usage block did not decode: %v\n%s", err, encoded)
 		}
-		if chunk.Usage != nil {
-			last, seen = *chunk.Usage, true
-		}
+		seen = true
 	}
 	if !seen {
 		t.Fatalf("no chunk carried a usage block: %s", sse)

--- a/internal/openairesponses/count_spelling_test.go
+++ b/internal/openairesponses/count_spelling_test.go
@@ -138,3 +138,78 @@ func TestTranslateResponsesToChat_AnUnreadableMemberCostsOnlyWhatItFeeds(t *test
 		})
 	}
 }
+
+// The streaming surface, which #813 left untested: the terminal usage chunk is
+// built by finishChunks from the raw usage member held on the response event, so
+// the count spellings have to survive the stream's own path to the client, not
+// only the non-streaming one. A count read here is what the metering pipeline
+// bills.
+func TestStreamTranslator_CountSpellings(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                    string
+		usage                   string
+		wantIn, wantOut, wantTo int
+	}{
+		{"plain integers", `{"input_tokens":12,"output_tokens":3,"total_tokens":15}`, 12, 3, 15},
+		{"quoted", `{"input_tokens":"12","output_tokens":"3","total_tokens":"15"}`, 12, 3, 15},
+		{"fractional", `{"input_tokens":12.0,"output_tokens":3.0,"total_tokens":15.0}`, 12, 3, 15},
+		// A member this translator has no field for keeps the counts beside it.
+		{"unmodelled sibling", `{"input_tokens":12,"output_tokens":3,"total_tokens":15,"input_tokens_details":[]}`, 12, 3, 15},
+		// Not a count in any spelling: the figures read straight off their own
+		// member stand, the one that could not be read is not invented.
+		{"one figure unreadable", `{"input_tokens":12,"output_tokens":"lots","total_tokens":15}`, 12, 0, 15},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := NewStreamTranslator("m")
+			if _, err := tr.TranslateEvent([]byte(`{"type":"response.output_text.delta","delta":"hi"}`)); err != nil {
+				t.Fatalf("delta event: %v", err)
+			}
+			out, err := tr.TranslateEvent([]byte(`{"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":` + tc.usage + `}}`))
+			if err != nil {
+				t.Fatalf("a usage member cost the stream its terminal event: %v", err)
+			}
+			got := streamUsage(t, out)
+			if got.PromptTokens != tc.wantIn || got.CompletionTokens != tc.wantOut || got.TotalTokens != tc.wantTo {
+				t.Errorf("metered %d/%d/%d, want %d/%d/%d",
+					got.PromptTokens, got.CompletionTokens, got.TotalTokens, tc.wantIn, tc.wantOut, tc.wantTo)
+			}
+		})
+	}
+}
+
+type streamUsageCounts struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// streamUsage reads the usage block off the last chat chunk that carries one.
+// Parsing the frames rather than substring-matching the SSE bytes: "12" is a
+// substring of "121", and a count is exactly the thing that must not be matched
+// loosely.
+func streamUsage(t *testing.T, sse []byte) streamUsageCounts {
+	t.Helper()
+	var last streamUsageCounts
+	var seen bool
+	for _, line := range strings.Split(string(sse), "\n") {
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok || strings.TrimSpace(payload) == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Usage *streamUsageCounts `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			t.Fatalf("stream frame did not decode: %v", err)
+		}
+		if chunk.Usage != nil {
+			last, seen = *chunk.Usage, true
+		}
+	}
+	if !seen {
+		t.Fatalf("no chunk carried a usage block: %s", sse)
+	}
+	return last
+}


### PR DESCRIPTION
## A quoted token count turned a real answer into a 502

PR #813 gave the egress translators (`gemini`, `openairesponses`, `anthropic/native`, `anthropicegress`) the shared tolerance rule: `util.DecodeCounts` accepts a count spelled `"12"` or `12.0` (coercing only the member `encoding/json` named), and `util.ShapeError` keeps a usage object whose unmodelled sibling fails to type. One site was missed: `internal/anthropic` `BuildMessageResponse`, the OpenAI-to-Anthropic **non-streaming** writer, still decoded usage inline off plain ints. A relay that quoted one token count there failed the whole decode and `anthropic_writer.go` returned the caller a 502 in place of the answer the model had already produced, while the streaming twin of the same path tolerated it.

The fix is the same one-line idiom the five peer sites use: hold `usage` raw in the enclosing strict decode, render it through `DecodeCounts` + `ShapeError`.

One deliberate asymmetry, documented at the site: this output cannot report an unreadable usage as *absent* because the Anthropic Message schema makes `usage` mandatory; zeros render as before. That is display only, metering reads the upstream body, not this writer.

## Tests

Table-driven count-spelling tests for quoted, fractional, non-numeric (still fails, no invented figure), one-figure-unreadable, and broken bytes, across anthropic, and streaming spellings for gemini + openairesponses (rebuilt on each package's existing SSE splitter). Every case also asserts the answer survived, which is the user-visible harm. Six mutations killed by named tests, including removing the `ShapeError` tolerance and reverting to inline decode. Vacuous "unmodelled sibling" rows for the two all-plain-int structs were dropped in review: there is no member for a sibling to type-error against, so the case proved only what `encoding/json` does.

## Review

One opus review round (approved; independently verified on both surfaces of all four translators that this diff is the whole remaining gap after #813) + one scoped re-review of the test-hygiene fixes (all addressed, no new breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhhaxiRLY3Sh2Q3H2Hdv23
