### PR TITLE
fix(proxy): a gateway error must not travel under the provider's success status

### DIFF
--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -303,8 +303,15 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 //
 // 502 rather than any other code because the multimodal pass-through already
 // answers exactly that for the same shape (serveBufferedJSONPassthrough on a
-// broken read, serveStreamedPassthrough on an empty body), and the upstream
-// status is not lost: upstreamClientMessage carries it in the message.
+// broken read, serveStreamedPassthrough on an empty body). The upstream status
+// still reaches the request-log row either way, and reaches the CLIENT only when
+// the provider is named: upstreamClientMessage appends it to the message with
+// the provider, and returns the bare reason without one.
+//
+// The non-2xx return is defensive rather than live. Every caller reaches this
+// handler through attemptCandidate, which sends anything that is not a 2xx to
+// forwardUpstreamError first (proxy_failover.go), so in production only the 2xx
+// branch runs; the other keeps the function total for a handler driven directly.
 //
 // This is not reached for 204/205, which are served by their own branch, nor for
 // a 2xx that decodes as a completion.

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -284,8 +284,35 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// Fire-and-forget: skip WaitForInsert to avoid blocking before error response.
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 		debuglog.Debug("proxy: non-streaming error details", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "error", detail, "duration_ms", totalDuration)
-		writeOpenAIError(w, upstreamClientMessage(logData.providerName, resp.StatusCode, reason), resp.StatusCode)
+		// The ROW keeps resp.StatusCode above: what the upstream said is the
+		// diagnostic. Only what the CLIENT is told changes.
+		writeOpenAIError(w, upstreamClientMessage(logData.providerName, resp.StatusCode, reason), nonCompletionClientStatus(resp.StatusCode))
 	}
+}
+
+// nonCompletionClientStatus is the status the CLIENT is answered with when an
+// upstream response is not a completion: the provider's own status, except for a
+// 2xx.
+//
+// A 2xx becomes 502, because the gateway's own error envelope must never travel
+// under a success status. An OpenAI SDK does not raise on a 2xx: it unmarshals
+// the envelope, finds no choices, and hands the caller an empty answer instead
+// of an error. A relay answering 200 with something that is not a completion
+// therefore leaves the request log reading "failed" beside a client that
+// believes it succeeded, and nothing retries and nothing alerts.
+//
+// 502 rather than any other code because the multimodal pass-through already
+// answers exactly that for the same shape (serveBufferedJSONPassthrough on a
+// broken read, serveStreamedPassthrough on an empty body), and the upstream
+// status is not lost: upstreamClientMessage carries it in the message.
+//
+// This is not reached for 204/205, which are served by their own branch, nor for
+// a 2xx that decodes as a completion.
+func nonCompletionClientStatus(upstreamStatus int) int {
+	if servedSuccessStatus(upstreamStatus) {
+		return http.StatusBadGateway
+	}
+	return upstreamStatus
 }
 
 // bodilessSuccessStatus reports whether a 2xx status is one HTTP forbids a body

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -667,11 +667,11 @@ func TestHandleNonStreamingResponse_UpstreamNonJSONResponse(t *testing.T) {
 	if !strings.Contains(logData.errorMessage, "response decode error") {
 		t.Errorf("expected errorMessage containing 'response decode error', got %q", logData.errorMessage)
 	}
-	// Non-JSON upstream body on a 200 response causes handleNonStreamingResponse
-	// to wrap it in an OpenAI error envelope at proxy.go line 825.
-	// The upstream status (200) is forwarded, so client gets 200 with error JSON.
-	if inner.Code != http.StatusOK {
-		t.Errorf("expected 200 (upstream status forwarded), got %d", inner.Code)
+	// A non-JSON body under a 200 is not a completion, so the client gets the
+	// gateway's OpenAI error envelope under 502 rather than under the provider's
+	// success — see nonCompletionClientStatus.
+	if inner.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 for a 200 that carried no completion, got %d", inner.Code)
 	}
 }
 

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -282,7 +282,9 @@ func TestHandleNonStreamingResponse_InvalidJSON(t *testing.T) {
 	result := w.Result()
 	defer result.Body.Close()
 
-	assert.Equal(t, http.StatusOK, result.StatusCode)
+	// 502, not the provider's 200: an error envelope under a success status is
+	// one an OpenAI SDK unmarshals into an empty completion instead of raising.
+	assert.Equal(t, http.StatusBadGateway, result.StatusCode)
 	assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
 
 	var responseBody map[string]any
@@ -337,7 +339,11 @@ func TestHandleNonStreamingResponse_EmptyBody(t *testing.T) {
 	result := w.Result()
 	defer result.Body.Close()
 
-	assert.Equal(t, http.StatusOK, result.StatusCode)
+	// A 200 with an empty body is a provider that answered nothing, so it fails,
+	// and the failure reaches the client as a 502 rather than hiding under the
+	// provider's success status. Only 204/205 promise no body, and they take
+	// their own branch.
+	assert.Equal(t, http.StatusBadGateway, result.StatusCode)
 	assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
 
 	var responseBody map[string]any

--- a/internal/proxy/success_status_test.go
+++ b/internal/proxy/success_status_test.go
@@ -2,9 +2,11 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -136,9 +138,8 @@ func TestAttemptCandidate_ASuccessIsNeverFailedOver(t *testing.T) {
 	}
 }
 
-// The deliberate narrowing that came with the fix. A 2xx carrying something
-// that is not a completion used to be forwarded to the client verbatim,
-// unmetered, with the row written as failed. It now gets an error BODY.
+// A 2xx carrying something that is not a completion is an error BODY under an
+// error STATUS.
 //
 // The caller asked for a chat completion; `accepted` is not one, and an OpenAI
 // client cannot parse it either. Forwarding an unreadable success is also
@@ -146,23 +147,50 @@ func TestAttemptCandidate_ASuccessIsNeverFailedOver(t *testing.T) {
 // exception, because their status promises no body — see
 // TestAttemptCandidate_A204IsForwardedWithoutAnInventedBody.
 //
-// The STATUS stays the upstream's 2xx, which an OpenAI SDK will not raise on:
-// it unmarshals and finds no choices. That is long-standing behaviour for a 200
-// with an undecodable body (TestHandleNonStreamingResponse_EmptyBody pins it),
-// and this change widens the set of statuses it applies to rather than
-// introducing it. Answering 502 instead, as the multimodal twin already does,
-// is a separate change to a contract clients depend on.
+// The status is 502 rather than the provider's 2xx, because an OpenAI SDK does
+// not raise on a 2xx: it unmarshals the gateway's error envelope, finds no
+// choices, and hands the caller an empty answer. Under the provider's status the
+// row reads failed while the client is told it succeeded, so nothing retries and
+// nothing alerts. The multimodal twin answers 502 for the same shape — a broken
+// read in serveBufferedJSONPassthrough, an empty body in
+// serveStreamedPassthrough — so the two paths agree rather than the chat path
+// inventing a rule.
+//
+// The ROW keeps the provider's own status: what the upstream said is the
+// diagnostic, and only what the client is told changes. A non-2xx keeps its
+// status on the way out too, which
+// TestHandleNonStreamingResponse_ChatShapedNon2xxGetsErrorEnvelope pins.
 func TestAttemptCandidate_A2xxThatIsNotACompletionIsAnError(t *testing.T) {
-	w, st, vkRepo := serveStatus(t, http.StatusAccepted, `accepted`)
+	for _, status := range []int{http.StatusOK, http.StatusCreated, http.StatusAccepted} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			w, st, vkRepo := serveStatus(t, status, `accepted`)
 
-	if st.logData.state != "failed" {
-		t.Errorf("row state = %q, want failed: a 202 that carried no completion was recorded as served", st.logData.state)
-	}
-	if n := len(vkRepo.addTokensCalls); n != 0 {
-		t.Errorf("charged %d times for a body that is not a completion, want 0", n)
-	}
-	if got := w.Body.String(); !strings.Contains(got, `"error"`) {
-		t.Errorf("client got %q, want an error envelope it can parse", got)
+			if st.logData.state != "failed" {
+				t.Errorf("row state = %q, want failed: a %d that carried no completion was recorded as served", st.logData.state, status)
+			}
+			if st.logData.statusCode != status {
+				t.Errorf("row status = %d, want %d: the row records what the upstream actually said", st.logData.statusCode, status)
+			}
+			if n := len(vkRepo.addTokensCalls); n != 0 {
+				t.Errorf("charged %d times for a body that is not a completion, want 0", n)
+			}
+			if w.Code != http.StatusBadGateway {
+				t.Errorf("client status = %d, want 502: the gateway's error envelope went out under the provider's %d", w.Code, status)
+			}
+			var body struct {
+				Error struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("client body is not an error envelope it can parse: %v (%s)", err, w.Body.String())
+			}
+			// The upstream status is not lost: it moves into the message, which
+			// is where an operator reads what the provider claimed.
+			if want := "upstream HTTP " + strconv.Itoa(status); !strings.Contains(body.Error.Message, want) {
+				t.Errorf("client message = %q, want it to name %q", body.Error.Message, want)
+			}
+		})
 	}
 }
 

--- a/internal/proxy/success_status_test.go
+++ b/internal/proxy/success_status_test.go
@@ -185,8 +185,11 @@ func TestAttemptCandidate_A2xxThatIsNotACompletionIsAnError(t *testing.T) {
 			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 				t.Fatalf("client body is not an error envelope it can parse: %v (%s)", err, w.Body.String())
 			}
-			// The upstream status is not lost: it moves into the message, which
-			// is where an operator reads what the provider claimed.
+			// The upstream status is not lost: the row keeps it, and it reaches
+			// the client in the message too whenever the provider is named,
+			// which is the case here. upstreamClientMessage returns the bare
+			// reason for an unnamed provider, so the row is the guarantee and
+			// the message is the convenience.
 			if want := "upstream HTTP " + strconv.Itoa(status); !strings.Contains(body.Error.Message, want) {
 				t.Errorf("client message = %q, want it to name %q", body.Error.Message, want)
 			}


### PR DESCRIPTION
## A gateway error must not travel under the provider's success status

When a provider answers 2xx but the body is not a chat completion (an error object, or bytes that do not decode), the non-streaming chat path built the gateway's error envelope and then wrote it to the caller under the upstream's own 2xx status. A client saw `200 OK` wrapping `{"error": ...}`, which tooling reads as success. The multimodal twin already answered 502 for the same shape, and PR #817's own test comments deferred this as a separate change. This is that change.

`nonCompletionClientStatus` is the rule: a 2xx that did not carry a completion becomes `502 Bad Gateway` to the client; a non-2xx keeps the provider's status (that arm is defensive, production routes every non-2xx to `forwardUpstreamError` first). Everything else is deliberately unchanged: the request-log row keeps the upstream's real status, `error_kind` and `state` are as before, 204/205 stay bodiless completions, and the Anthropic writer now lifts the diagnostic into a proper error event where it previously failed to translate the mislabeled 200 and discarded it. No breaker-visible change: outcome recording reads row state, not the client status.

The brief's second claim, that multimodal credits the breaker on an empty 2xx, was verified stale: #817's round-3 commit `4c9ed1ab` already fixed it on both serve paths, pinned by four tests. Two residuals are disclosed in review rather than fixed here: `passthroughAnswered` content-checks embeddings only (a 200 `{"data":[]}` on images/rerank still credits the breaker), and a `(0, nil)` first read in the streamed path is unreachable through net/http.

## Tests

Integration-level through `attemptCandidate` against a real httptest upstream: 200/201/202 with an error body now yield client 502 while the row keeps the upstream status (four independent assertions per case: client status, row status, row state, no metering). Two mutations killed: reverting the rule fails 5 tests, dropping the `servedSuccessStatus` guard fails 3.

## Review

One opus review round (approved; verified the 204/205 and Anthropic-writer pass-throughs intact and the claim-B skip legitimate on current code) + one scoped re-review of two comment-accuracy fixes (comment-only diff, verified accurate against source).

Also surfaced by review, deliberately NOT in this PR: a non-completion 2xx still returns `outcomeServed`, so no sibling candidate is tried; making it failover-eligible is a design change (retry amplification on relays that habitually 200-error) and is queued for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhhaxiRLY3Sh2Q3H2Hdv23
