### PR TITLE
fix(frontdesk): brute force on Front Desk was invisible to the CrowdSec collection

### DIFF
--- a/contrib/crowdsec/README.md
+++ b/contrib/crowdsec/README.md
@@ -44,7 +44,7 @@ application-level one. The point is to drop the connection before it costs the g
 | Scenario | Counts | capacity / leakspeed / blackhole |
 |---|---|---|
 | `hugalafutro/model-hotel-vk-bf` | Rejected requests to `/v1`: a missing `Authorization` header, a virtual key the gateway does not know, a key whose owner is disabled. | 5 / 20s / 5m |
-| `hugalafutro/model-hotel-admin-bf` | Credentials that own the gateway: a wrong or missing admin token (admin API, metrics endpoint, backup restore), a failed dashboard login, a wrong TOTP code, a failed CSRF check, a restore archive not signed by this instance. | 5 / 60s / 5m |
+| `hugalafutro/model-hotel-admin-bf` | Credentials that own the gateway or the fleet: a wrong or missing admin token (admin API, metrics endpoint, backup restore, and Front Desk's whole control plane), a failed dashboard login, a wrong TOTP code, a rejected passkey assertion, a failed CSRF check, a restore archive not signed by this instance. | 5 / 60s / 5m |
 | `hugalafutro/model-hotel-throttled` | Throttling episodes from the gateway's own limiters: the IP rate limiter, and the login, TOTP and SSO callback throttles. | 3 / 60s / 10m |
 
 All three are leaky buckets grouped by source address. `capacity` is how many events fit at once,
@@ -386,13 +386,10 @@ docker restart <crowdsec-container>
   successful requests are invisible to CrowdSec. `DEBUG_LOG=true` would expose them at a cost of
   roughly six extra lines per request, which is not a trade worth making for this.
 
-- **Front Desk coverage is partial.** Front Desk has no access logger, and its session gate returns
-  401 without logging anything. What does reach CrowdSec from Front Desk is metrics-scrape failures
-  with a bad or missing token, TOTP and OIDC failures, and IP throttling. Ordinary rejected session
-  cookies do not.
-
-- **Passkey failures carry no client address.** They are logged, but with no IP in the record there
-  is nothing for a scenario to group on, so they cannot produce a decision.
+- **Front Desk's access log is opt-in like the gateway's.** Front Desk writes the same
+  `access: request` line the gateway does, but the parser that maps it onto `http_access-log` is
+  the opt-in `hugalafutro/model-hotel-access-logs`, not part of this collection. Without it, the
+  authentication lines below are what CrowdSec sees from Front Desk.
 
 - **Nothing here reads the database.** The App Logs page holds more than the container log does,
   and it is not an acquisition source. If a failure only appears in App Logs, no scenario will see
@@ -427,6 +424,12 @@ one an instance emits.
    ```
    time=2026-08-18T04:15:02.123Z level=WARN msg="frontdesk: metrics scrape with invalid token" remote_addr=203.0.113.7
    ```
+
+   Its attribute values escape their spaces the same way the gateway's do, so a value is always a
+   single whitespace-delimited token. slog quotes a value holding an `=` or a quote, which escapes
+   the backslash of that escape a second time, so a request path with a space reads
+   `path="/x\\x20y"` on Front Desk against `path="/x\x20y"` on the gateway. Both are one token
+   and both carry the same address rules; only the depth of quoting differs.
 
 ### Why a request path cannot ban a stranger
 

--- a/contrib/crowdsec/README.md
+++ b/contrib/crowdsec/README.md
@@ -380,16 +380,29 @@ docker restart <crowdsec-container>
 
 ## What is not covered
 
-- **Only warning and error records reach the container log.** With `DEBUG_LOG=false` (the default)
-  info and debug records never reach stderr; they still land in the App Logs page and in Postgres.
-  Every authentication failure is logged at warn or error, so the security signal is complete, but
-  successful requests are invisible to CrowdSec. `DEBUG_LOG=true` would expose them at a cost of
-  roughly six extra lines per request, which is not a trade worth making for this.
+- **On the gateway, only warning and error records reach the container log.** With
+  `DEBUG_LOG=false` (the default) info and debug records never reach stderr; they still land in the
+  App Logs page and in Postgres. Every authentication failure is logged at warn or error, so the
+  security signal is complete, but successful requests are invisible to CrowdSec. `DEBUG_LOG=true`
+  would expose them at a cost of roughly six extra lines per request, which is not a trade worth
+  making for this.
+
+  Front Desk is different: it writes straight to stdout with no such filter, so its info records
+  DO reach the container log. Successful requests to it are therefore visible, apart from the
+  reads the dashboard repeats on a timer (the member and device lists, per-member traffic, quota,
+  the event stream) and the machine probes (`/healthz`, `/traefik/config`, `/metrics`), which are
+  logged at debug on purpose so an idle browser tab does not fill the log.
 
 - **Front Desk's access log is opt-in like the gateway's.** Front Desk writes the same
   `access: request` line the gateway does, but the parser that maps it onto `http_access-log` is
   the opt-in `hugalafutro/model-hotel-access-logs`, not part of this collection. Without it, the
   authentication lines below are what CrowdSec sees from Front Desk.
+
+- **Front Desk's role refusals are not logged.** A paired Bellhop device reaching above its role
+  (a monitor device on a mutating route, any device on an admin-only route) gets a 403 from
+  `requireOperator` / `requireAdmin` with no line at all, so it produces no `forbidden` event the
+  way the gateway's `auth: insufficient permissions` does. A device holds a token an operator
+  issued, so this is an over-reaching companion app rather than an intruder, but it is a gap.
 
 - **Nothing here reads the database.** The App Logs page holds more than the container log does,
   and it is not an acquisition source. If a failure only appears in App Logs, no scenario will see
@@ -426,10 +439,18 @@ one an instance emits.
    ```
 
    Its attribute values escape their spaces the same way the gateway's do, so a value is always a
-   single whitespace-delimited token. slog quotes a value holding an `=` or a quote, which escapes
-   the backslash of that escape a second time, so a request path with a space reads
-   `path="/x\\x20y"` on Front Desk against `path="/x\x20y"` on the gateway. Both are one token
-   and both carry the same address rules; only the depth of quoting differs.
+   single whitespace-delimited token. The two differ only in how much quoting ends up around that
+   token, because Front Desk escapes first and slog then decides whether to quote the result:
+
+   | value | gateway writes | Front Desk writes |
+   |---|---|---|
+   | `/x y` | `path="/x\x20y"` | `path=/x\x20y` |
+   | `/x y?a=b` | `path="/x\x20y?a=b"` | `path="/x\\x20y?a=b"` |
+
+   The gateway always quotes a value it escaped. Front Desk leaves the escaped value bare unless it
+   also holds an `=`, a quote or a control character, and when slog does quote it, it escapes the
+   backslash of the escape a second time. Neither form can hold a literal space, so both are one
+   token and both carry the same address rules.
 
 ### Why a request path cannot ban a stranger
 

--- a/contrib/crowdsec/parsers/s01-parse/model-hotel-access-logs.yaml
+++ b/contrib/crowdsec/parsers/s01-parse/model-hotel-access-logs.yaml
@@ -1,8 +1,9 @@
 name: hugalafutro/model-hotel-access-logs
-description: "Map Model Hotel access log lines onto the generic HTTP access-log format"
+description: "Map Model Hotel and Front Desk access log lines onto the generic HTTP access-log format"
 # OPT-IN, and deliberately not part of the collection. Installing this makes the
-# gateway's own request log feed crowdsecurity/http-logs and every generic
-# http-* scenario. That is what you want when Model Hotel is exposed directly.
+# gateway's and Front Desk's own request logs feed crowdsecurity/http-logs and
+# every generic http-* scenario. That is what you want when either is exposed
+# directly.
 # Behind a reverse proxy whose logs CrowdSec already reads, it is not: the same
 # request then fills two buckets and one visitor earns two alerts.
 #
@@ -14,9 +15,10 @@ description: "Map Model Hotel access log lines onto the generic HTTP access-log 
 # rules as hugalafutro/model-hotel-logs: the line is recognised by a
 # position-anchored capture rather than by searching it, and every field is read
 # from the first "key=value" token of its name, the address being validated only
-# after it is taken. Model Hotel logs the path last, after every field read
-# here, and from v0.9.99 escapes the spaces inside quoted values so a path
-# cannot present a "key=value" token at all.
+# after it is taken. Both binaries log the path last, after every field read
+# here, and escape the spaces inside a value (Model Hotel from v0.9.99, Front
+# Desk from the release that gave it an access log), so a path cannot present a
+# "key=value" token at all.
 filter: "evt.Parsed.program startsWith 'model-hotel' || evt.Parsed.program startsWith 'front-desk'"
 pattern_syntax:
   MH_TIME: '%{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME}'
@@ -49,6 +51,16 @@ nodes:
     statics:
       - target: evt.StrTime
         expression: evt.Parsed.mha_time
+  # Front Desk text (stdlib slog) quotes the whole "scope: message" into msg=,
+  # so the message arrives already delimited. Front Desk writes the same access
+  # record as the gateway, field for field; only this framing differs.
+  - grok:
+      pattern: '^time=%{NOTSPACE:mha_fdtime} level=%{WORD:mha_level} msg="%{DATA:mha_body}"'
+      apply_on: message
+    statics:
+      - target: evt.StrTime
+        expression: evt.Parsed.mha_fdtime
+
   - grok:
       pattern: '(^| )remote=%{NOTSPACE:mha_addr}( |$)'
       apply_on: message

--- a/contrib/crowdsec/parsers/s01-parse/model-hotel-logs.yaml
+++ b/contrib/crowdsec/parsers/s01-parse/model-hotel-logs.yaml
@@ -18,10 +18,10 @@ description: "Parse Model Hotel and Front Desk security logs"
 #      rather than scanning for the first thing that looks like an IP, means a
 #      line whose real address is unparseable yields nothing instead of falling
 #      through to whatever a caller wrote further along.
-# From v0.9.99 Model Hotel also escapes the spaces inside any quoted attribute
-# value, so a caller-controlled value is a single token and cannot present a
-# "key=value" pair at all. Both rules hold without that, so this parser is safe
-# to point at an older instance.
+# From v0.9.99 Model Hotel also escapes the spaces inside any attribute value,
+# and Front Desk's stdout handler does the same, so a caller-controlled value is
+# a single token and cannot present a "key=value" pair at all. Both rules hold
+# without that, so this parser is safe to point at an older instance.
 filter: "evt.Parsed.program startsWith 'model-hotel' || evt.Parsed.program startsWith 'front-desk'"
 pattern_syntax:
   MH_TIME: '%{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME}'
@@ -88,7 +88,9 @@ nodes:
         value: vk_invalid
 
   # A request to the admin API, the metrics endpoint or the restore endpoint
-  # with a missing or wrong admin token.
+  # with a missing or wrong admin token. The two "auth: admin request …"
+  # messages come from both binaries: the gateway's admin middleware and the
+  # shared admin-or-session gate that fronts Front Desk's whole control plane.
   - filter: 'evt.Parsed.mh_body startsWith "auth: admin request with invalid token" || evt.Parsed.mh_body startsWith "auth: admin request missing bearer token" || evt.Parsed.mh_body startsWith "auth: metrics scrape with invalid token" || evt.Parsed.mh_body startsWith "auth: metrics scrape missing bearer token" || evt.Parsed.mh_body startsWith "auth: backup restore with invalid admin token" || evt.Parsed.mh_body startsWith "auth: backup restore with missing admin token" || evt.Parsed.mh_body startsWith "frontdesk: metrics scrape with invalid token" || evt.Parsed.mh_body startsWith "frontdesk: metrics scrape missing bearer token"'
     statics:
       - meta: log_type
@@ -96,9 +98,11 @@ nodes:
       - meta: sub_type
         value: admin_token
 
-  # Dashboard login: wrong password, wrong TOTP code, or a failed admin-token
-  # exchange behind the TOTP gate.
-  - filter: 'evt.Parsed.mh_body startsWith "userlogin: login failed" || evt.Parsed.mh_body startsWith "userlogin: invalid TOTP code" || evt.Parsed.mh_body startsWith "totp: login failed"'
+  # Dashboard login: wrong password, wrong TOTP code, a failed admin-token
+  # exchange behind the TOTP gate, or a passkey assertion that did not verify.
+  # The passkey endpoint is unauthenticated on both binaries, so a rejected
+  # assertion is an anonymous caller failing a login like any other.
+  - filter: 'evt.Parsed.mh_body startsWith "userlogin: login failed" || evt.Parsed.mh_body startsWith "userlogin: invalid TOTP code" || evt.Parsed.mh_body startsWith "totp: login failed" || evt.Parsed.mh_body startsWith "webauthn: passkey login failed"'
     statics:
       - meta: log_type
         value: model-hotel_auth_fail

--- a/contrib/crowdsec/scenarios/model-hotel-admin-bf.yaml
+++ b/contrib/crowdsec/scenarios/model-hotel-admin-bf.yaml
@@ -2,9 +2,10 @@ type: leaky
 name: hugalafutro/model-hotel-admin-bf
 description: "Detect brute force on the Model Hotel admin API and dashboard login"
 # Wrong admin tokens, failed dashboard passwords, wrong TOTP codes, rejected
-# CSRF tokens and unsigned backup restores all end up here. These are the
-# credentials that own the gateway, so the bucket is smaller and drains slower
-# than the virtual-key one.
+# passkey assertions, rejected CSRF tokens and unsigned backup restores all end
+# up here, from either binary: Front Desk's whole control plane sits behind the
+# same admin-or-session gate. These are the credentials that own the gateway and
+# the fleet, so the bucket is smaller and drains slower than the virtual-key one.
 filter: "evt.Meta.log_type == 'model-hotel_auth_fail' && evt.Meta.sub_type in ['admin_token', 'login', 'csrf', 'backup_signature'] && evt.Meta.source_ip != ''"
 groupby: evt.Meta.source_ip
 capacity: 5

--- a/contrib/crowdsec/tests/README.md
+++ b/contrib/crowdsec/tests/README.md
@@ -20,7 +20,7 @@ overflows, and a scenario test sets `ignore_parsers: true` and asserts nothing a
 
 ## What each test covers
 
-`model-hotel-logs` is the parser test. Its 25 lines carry one example of every `sub_type` the
+`model-hotel-logs` is the parser test. Its 31 lines carry one example of every `sub_type` the
 parser can emit (`vk_invalid`, `admin_token`, `login`, `sso`, `csrf`, `forbidden`,
 `backup_signature`), three throttling lines, all three log shapes Model Hotel and Front Desk emit
 (Model Hotel text, `LOG_FORMAT=json`, Front Desk slog text), one address that still carries a TCP
@@ -44,10 +44,19 @@ classify. Scan for the first thing that looks like an address instead of taking 
 token and the bare auth line picks the attacker's. Drop the duplicate-address check and the bare
 lines start naming strangers.
 
+The last six lines are Front Desk's own, in its slog framing: an access record, the two admin-gate
+rejections and the CSRF rejection its control plane emits, a rejected passkey assertion, and one
+admin rejection whose path carries an injected address. They pin that Front Desk reaches the same
+`admin_token`, `csrf` and `login` buckets as the gateway with the same messages, that its access
+record is refused by the main parser (it belongs to the opt-in access parser instead), and that its
+escaped path still resolves to the real client.
+
 `model-hotel-access-logs` covers the opt-in parser that is deliberately left out of the collection.
-It pins the mapping onto the generic `http_access-log` contract for both text and JSON, a pre-#674
-address that still carries its TCP port, and the same injection case: an auth line whose path holds
-a fake access record must not become an access log.
+It pins the mapping onto the generic `http_access-log` contract for all three shapes (Model Hotel
+text, JSON, Front Desk slog text), a pre-#674 address that still carries its TCP port, and the same
+injection case in both framings: an auth line whose path holds a fake access record must not become
+an access log, and an access line whose path holds an injected address must still name the real
+client.
 
 `model-hotel-vk-bf`, `model-hotel-admin-bf` and `model-hotel-throttled` are the scenario tests.
 Each pours enough lines from a single source address to overflow its bucket exactly once and

--- a/contrib/crowdsec/tests/README.md
+++ b/contrib/crowdsec/tests/README.md
@@ -26,11 +26,11 @@ parser can emit (`vk_invalid`, `admin_token`, `login`, `sso`, `csrf`, `forbidden
 (Model Hotel text, `LOG_FORMAT=json`, Front Desk slog text), one address that still carries a TCP
 port the way pre-#674 builds logged it, and one info level line the parser has to refuse. The
 asserts pin `log_type`, `sub_type`, `source_ip`, `log_format`, `service`, and where the line
-carries them `http_path` and `target_user`, per line. The last line, `auth: authenticated`,
-asserts `Success == false` in `s01-parse`: it reaches the parser and is dropped there, which is
-what keeps successful requests out of the buckets.
+carries them `http_path` and `target_user`, per line. Line 19, `auth: authenticated`, asserts
+`Success == false` in `s01-parse`: it reaches the parser and is dropped there, which is what keeps
+successful requests out of the buckets.
 
-The last six lines are the log-injection regression, and they come in pairs: the escaped form a
+Lines 20 to 25 are the log-injection regression, and they come in pairs: the escaped form a
 v0.9.99 instance emits, and the bare form an older build does. Two are access lines whose request
 path holds a complete copy of an authentication failure plus an attacker-chosen `remote_addr`, and
 neither may classify. Two are real auth failures whose path holds an injected address; the escaped
@@ -44,8 +44,9 @@ classify. Scan for the first thing that looks like an address instead of taking 
 token and the bare auth line picks the attacker's. Drop the duplicate-address check and the bare
 lines start naming strangers.
 
-The last six lines are Front Desk's own, in its slog framing: an access record, the two admin-gate
-rejections and the CSRF rejection its control plane emits, a rejected passkey assertion, and one
+Lines 26 to 31, the last six, are Front Desk's own, in its slog framing: an access record, the two
+admin-gate rejections and the CSRF rejection its control plane emits, a rejected passkey assertion,
+and one
 admin rejection whose path carries an injected address. They pin that Front Desk reaches the same
 `admin_token`, `csrf` and `login` buckets as the gateway with the same messages, that its access
 record is refused by the main parser (it belongs to the opt-in access parser instead), and that its

--- a/contrib/crowdsec/tests/model-hotel-access-logs/model-hotel-access-logs.log
+++ b/contrib/crowdsec/tests/model-hotel-access-logs/model-hotel-access-logs.log
@@ -4,3 +4,6 @@
 {"bytes":19,"host":"mh.example.com","level":"warning","method":"GET","msg":"request","path":"/api/zz","remote":"198.51.100.96","source":"access","status":404,"time":"2026-08-18T04:15:33.123456789Z"}
 2026/08/18 04:15:34 level=WARNING access: request method=GET host=mh.example.com remote=192.0.2.55:53110 path=/api/providers status=403 bytes=19
 2026/08/18 04:15:35 level=WARNING access: request method=GET host=mh.example.com remote=198.51.100.95 status=404 bytes=19 path=/api/zz remote=203.0.113.77 z
+time=2026-08-18T04:15:36.123Z level=WARN msg="access: request" method=GET host=fd.example.com remote=198.51.100.94 status=401 bytes=42 duration=1.234ms path=/api/members
+time=2026-08-18T04:15:37.123Z level=WARN msg="access: request" method=GET host=fd.example.com remote=198.51.100.93 status=404 bytes=19 duration=812µs path="/api/zz\\x20auth:\\x20key\\x20not\\x20found\\x20remote=203.0.113.77"
+time=2026-08-18T04:15:38.123Z level=WARN msg="auth: admin request with invalid token" remote_addr=198.51.100.92 path="/x\\x20access:\\x20request\\x20remote=203.0.113.77\\x20status=404"

--- a/contrib/crowdsec/tests/model-hotel-access-logs/parser.assert
+++ b/contrib/crowdsec/tests/model-hotel-access-logs/parser.assert
@@ -1,4 +1,4 @@
-len(results["s01-parse"]["hugalafutro/model-hotel-access-logs"]) == 6
+len(results["s01-parse"]["hugalafutro/model-hotel-access-logs"]) == 9
 
 results["s01-parse"]["hugalafutro/model-hotel-access-logs"][0].Success == true
 results["s01-parse"]["hugalafutro/model-hotel-access-logs"][0].Evt.Meta["log_type"] == "http_access-log"
@@ -31,3 +31,20 @@ results["s01-parse"]["hugalafutro/model-hotel-access-logs"][4].Evt.Meta["http_st
 results["s01-parse"]["hugalafutro/model-hotel-access-logs"][5].Success == false
 results["s01-parse"]["hugalafutro/model-hotel-access-logs"][5].Evt.Meta["source_ip"] == ""
 results["s01-parse"]["hugalafutro/model-hotel-access-logs"][5].Evt.Meta["log_type"] == ""
+
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["log_type"] == "http_access-log"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["service"] == "http"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["source_ip"] == "198.51.100.94"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["http_verb"] == "GET"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["http_status"] == "401"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["target_fqdn"] == "fd.example.com"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][6].Evt.Meta["http_path"] == "/api/members"
+
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][7].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][7].Evt.Meta["source_ip"] == "198.51.100.93"
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][7].Evt.Meta["http_status"] == "404"
+
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][8].Success == false
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][8].Evt.Meta["log_type"] == ""
+results["s01-parse"]["hugalafutro/model-hotel-access-logs"][8].Evt.Meta["source_ip"] == ""

--- a/contrib/crowdsec/tests/model-hotel-logs/model-hotel-logs.log
+++ b/contrib/crowdsec/tests/model-hotel-logs/model-hotel-logs.log
@@ -23,3 +23,9 @@ time=2026-08-18T04:15:19.123Z level=WARN msg="ratelimit-ip: throttling started" 
 2026/08/18 04:15:24 level=WARNING auth: admin request with invalid token remote_addr=198.51.100.33 path=/api/x remote_addr=203.0.113.77
 2026/08/18 04:15:25 level=WARNING auth: key owner disabled remote_addr=198.51.100.34 key="pwn\x20remote_addr=203.0.113.99\x20x"
 2026/08/18 04:15:26 level=WARNING auth: key owner disabled key=pwn remote_addr=203.0.113.99 x remote_addr=198.51.100.35
+time=2026-08-18T04:15:27.123Z level=WARN msg="access: request" method=GET host=fd.example.com remote=203.0.113.21 status=401 bytes=42 duration=1.234ms path=/api/members
+time=2026-08-18T04:15:28.123Z level=WARN msg="auth: admin request with invalid token" remote_addr=203.0.113.23 path=/api/members
+time=2026-08-18T04:15:29.123Z level=WARN msg="auth: admin request missing bearer token" remote_addr=203.0.113.24 path=/api/fleet/status
+time=2026-08-18T04:15:30.123Z level=WARN msg="auth: CSRF check failed" remote_addr=203.0.113.25 path=/api/members/abc
+time=2026-08-18T04:15:31.123Z level=WARN msg="webauthn: passkey login failed" remote_addr=203.0.113.26 reason=assertion_rejected error=webauthn:\x20signature\x20is\x20not\x20valid
+time=2026-08-18T04:15:32.123Z level=WARN msg="auth: admin request with invalid token" remote_addr=203.0.113.27 path="/x\\x20remote_addr=203.0.113.77\\x20y"

--- a/contrib/crowdsec/tests/model-hotel-logs/parser.assert
+++ b/contrib/crowdsec/tests/model-hotel-logs/parser.assert
@@ -286,3 +286,4 @@ results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Success == true
 results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["log_type"] == "model-hotel_auth_fail"
 results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["sub_type"] == "admin_token"
 results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["source_ip"] == "203.0.113.27"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["http_path"] == "/x\\\\x20remote_addr=203.0.113.77\\\\x20y"

--- a/contrib/crowdsec/tests/model-hotel-logs/parser.assert
+++ b/contrib/crowdsec/tests/model-hotel-logs/parser.assert
@@ -1,8 +1,8 @@
 len(results) == 4
-len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 25
-len(results["s00-raw"]["crowdsecurity/non-syslog"]) == 25
-len(results["s01-parse"]["hugalafutro/model-hotel-logs"]) == 25
-len(results["s02-enrich"]["crowdsecurity/dateparse-enrich"]) == 22
+len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 31
+len(results["s00-raw"]["crowdsecurity/non-syslog"]) == 31
+len(results["s01-parse"]["hugalafutro/model-hotel-logs"]) == 31
+len(results["s02-enrich"]["crowdsecurity/dateparse-enrich"]) == 27
 len(results["success"][""]) == 0
 
 results["s01-parse"]["hugalafutro/model-hotel-logs"][0].Success == true
@@ -251,3 +251,38 @@ results["s01-parse"]["hugalafutro/model-hotel-logs"][23].Evt.Meta["sub_type"] ==
 results["s01-parse"]["hugalafutro/model-hotel-logs"][23].Evt.Meta["source_ip"] == "198.51.100.34"
 results["s01-parse"]["hugalafutro/model-hotel-logs"][24].Evt.Meta["sub_type"] == "vk_invalid"
 results["s01-parse"]["hugalafutro/model-hotel-logs"][24].Evt.Meta["source_ip"] == ""
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][25].Success == false
+results["s01-parse"]["hugalafutro/model-hotel-logs"][25].Evt.Meta["log_type"] == ""
+results["s01-parse"]["hugalafutro/model-hotel-logs"][25].Evt.Meta["source_ip"] == ""
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["log_format"] == "text"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["log_type"] == "model-hotel_auth_fail"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["sub_type"] == "admin_token"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["service"] == "model-hotel"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["source_ip"] == "203.0.113.23"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Meta["http_path"] == "/api/members"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][26].Evt.Whitelisted == false
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][27].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-logs"][27].Evt.Meta["log_type"] == "model-hotel_auth_fail"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][27].Evt.Meta["sub_type"] == "admin_token"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][27].Evt.Meta["source_ip"] == "203.0.113.24"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][27].Evt.Meta["http_path"] == "/api/fleet/status"
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][28].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-logs"][28].Evt.Meta["log_type"] == "model-hotel_auth_fail"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][28].Evt.Meta["sub_type"] == "csrf"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][28].Evt.Meta["source_ip"] == "203.0.113.25"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][28].Evt.Meta["http_path"] == "/api/members/abc"
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][29].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-logs"][29].Evt.Meta["log_type"] == "model-hotel_auth_fail"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][29].Evt.Meta["sub_type"] == "login"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][29].Evt.Meta["source_ip"] == "203.0.113.26"
+
+results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Success == true
+results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["log_type"] == "model-hotel_auth_fail"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["sub_type"] == "admin_token"
+results["s01-parse"]["hugalafutro/model-hotel-logs"][30].Evt.Meta["source_ip"] == "203.0.113.27"

--- a/internal/adminauth/middleware.go
+++ b/internal/adminauth/middleware.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/clientip"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -44,6 +45,7 @@ func RequireAdminOrSession(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if tok, res, ok := adminCookieSession(r, sessionMgr, jar, true); ok {
 			if !authcookie.IsSafeMethod(r.Method) && !jar.ValidCSRF(r) {
+				debuglog.Warn("auth: CSRF check failed", "remote_addr", clientip.From(r), "path", r.URL.Path)
 				http.Error(w, "CSRF token missing or invalid", http.StatusForbidden)
 				return
 			}
@@ -58,8 +60,16 @@ func RequireAdminOrSession(
 		// carrying one that does not resolve is told it was rejected. The two
 		// messages stay distinct, so the bearer branch is asked separately
 		// rather than folded into one boolean.
+		//
+		// Both rejections are logged at warning with the client address, never
+		// the token, so repeated attempts against the admin surface are visible
+		// to abuse detection without polluting the operator-actionable Error
+		// stream. The messages match the ones the gateway's own admin gate
+		// emits (internal/api/admin.go), so one log parser covers both binaries;
+		// the caller-controlled path goes last.
 		token, ok := util.ParseBearerToken(r)
 		if !ok {
+			debuglog.Warn("auth: admin request missing bearer token", "remote_addr", clientip.From(r), "path", r.URL.Path)
 			http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)
 			return
 		}
@@ -69,6 +79,7 @@ func RequireAdminOrSession(
 			return
 		}
 
+		debuglog.Warn("auth: admin request with invalid token", "remote_addr", clientip.From(r), "path", r.URL.Path)
 		http.Error(w, "Invalid admin token or session token", http.StatusUnauthorized)
 	})
 }

--- a/internal/adminauth/middleware_logging_test.go
+++ b/internal/adminauth/middleware_logging_test.go
@@ -1,0 +1,163 @@
+package adminauth
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// captureLogLines installs a text handler over a buffer as the process logger
+// and returns the lines it collected. The rendered line, not the record, is
+// what a log reader sees, so the assertions below are about its exact shape.
+func captureLogLines(t *testing.T) func() []string {
+	t.Helper()
+	var buf bytes.Buffer
+	debuglog.SetHandler(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { debuglog.Init(false) })
+	return func() []string {
+		var lines []string
+		for _, l := range strings.Split(buf.String(), "\n") {
+			if strings.TrimSpace(l) != "" {
+				lines = append(lines, l)
+			}
+		}
+		return lines
+	}
+}
+
+// findLine returns the first captured line whose message is msg, matched on the
+// rendered msg="..." field so a message quoted inside an attribute value cannot
+// stand in for the real one.
+func findLine(lines []string, msg string) (string, bool) {
+	want := `msg="` + msg + `"`
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+// assertAddressBeforePath pins the two rules the CrowdSec collection relies on:
+// the line names the real client under remote_addr, and the caller-controlled
+// request path comes after it, so a reader meets every field the binary
+// vouches for before anything a visitor wrote.
+func assertAddressBeforePath(t *testing.T, line, wantAddr string) {
+	t.Helper()
+	addr := strings.Index(line, " remote_addr="+wantAddr)
+	if addr < 0 {
+		t.Fatalf("line does not name the client under remote_addr=%s: %s", wantAddr, line)
+	}
+	path := strings.Index(line, " path=")
+	if path < 0 {
+		t.Fatalf("line carries no path attribute: %s", line)
+	}
+	if addr > path {
+		t.Errorf("remote_addr comes after the caller-controlled path: %s", line)
+	}
+}
+
+// A rejected admin request has to leave a trace naming the caller, or admin
+// token brute force against Front Desk (whose whole control plane sits behind
+// this middleware) is invisible to anything reading the logs. The two
+// rejections carry the two distinct messages the collection's admin_token
+// classification anchors on.
+func TestRequireAdminOrSession_LogsRejectedCredentials(t *testing.T) {
+	mgr, adminTok, _ := newValidAdminSession(t)
+	adminOnly := &mockAdminAuth{validateFn: func(token string) bool { return token == "raw-admin" }}
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	tests := []struct {
+		name    string
+		method  string
+		build   func(r *http.Request)
+		wantMsg string
+		status  int
+	}{
+		{
+			name:    "no bearer at all",
+			build:   func(*http.Request) {},
+			wantMsg: "auth: admin request missing bearer token",
+			status:  http.StatusUnauthorized,
+		},
+		{
+			name:    "a bearer that resolves to nothing",
+			build:   func(r *http.Request) { r.Header.Set("Authorization", "Bearer nope") },
+			wantMsg: "auth: admin request with invalid token",
+			status:  http.StatusUnauthorized,
+		},
+		{
+			name:   "an admin cookie on an unsafe method with no CSRF header",
+			method: http.MethodPost,
+			build: func(r *http.Request) {
+				r.AddCookie(&http.Cookie{Name: authcookie.FrontDesk.SessionCookie, Value: adminTok})
+			},
+			wantMsg: "auth: CSRF check failed",
+			status:  http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := captureLogLines(t)
+			method := tc.method
+			if method == "" {
+				method = http.MethodGet
+			}
+			r := httptest.NewRequest(method, "/api/members", http.NoBody)
+			r.RemoteAddr = "203.0.113.42:51000"
+			tc.build(r)
+			w := httptest.NewRecorder()
+
+			RequireAdminOrSession(adminOnly, mgr, nil, authcookie.FrontDesk, "auto", next).ServeHTTP(w, r)
+
+			if w.Code != tc.status {
+				t.Fatalf("status = %d, want %d", w.Code, tc.status)
+			}
+			line, ok := findLine(lines(), tc.wantMsg)
+			if !ok {
+				t.Fatalf("no line with msg=%q; got %v", tc.wantMsg, lines())
+			}
+			if !strings.Contains(line, "level=WARN") {
+				t.Errorf("rejection logged at the wrong level (abuse detection reads warnings): %s", line)
+			}
+			assertAddressBeforePath(t, line, "203.0.113.42")
+		})
+	}
+}
+
+// An admitted request must stay silent: a line per successful admin call would
+// bury the rejections and fill the brute-force bucket with legitimate traffic.
+func TestRequireAdminOrSession_AdmittedRequestLogsNothing(t *testing.T) {
+	mgr, adminTok, _ := newValidAdminSession(t)
+	adminOnly := &mockAdminAuth{validateFn: func(token string) bool { return token == "raw-admin" }}
+	lines := captureLogLines(t)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/members", http.NoBody)
+	r.RemoteAddr = "203.0.113.42:51000"
+	r.Header.Set("Authorization", "Bearer "+adminTok)
+	w := httptest.NewRecorder()
+	RequireAdminOrSession(adminOnly, mgr, nil, authcookie.FrontDesk, "auto", w2h(t)).ServeHTTP(w, r)
+
+	for _, msg := range []string{
+		"auth: admin request missing bearer token",
+		"auth: admin request with invalid token",
+		"auth: CSRF check failed",
+	} {
+		if line, ok := findLine(lines(), msg); ok {
+			t.Errorf("an admitted request logged a rejection: %s", line)
+		}
+	}
+}
+
+// w2h is a next handler that records nothing and answers 200.
+func w2h(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+}

--- a/internal/adminauth/middleware_logging_test.go
+++ b/internal/adminauth/middleware_logging_test.go
@@ -143,7 +143,7 @@ func TestRequireAdminOrSession_AdmittedRequestLogsNothing(t *testing.T) {
 	r.RemoteAddr = "203.0.113.42:51000"
 	r.Header.Set("Authorization", "Bearer "+adminTok)
 	w := httptest.NewRecorder()
-	RequireAdminOrSession(adminOnly, mgr, nil, authcookie.FrontDesk, "auto", w2h(t)).ServeHTTP(w, r)
+	RequireAdminOrSession(adminOnly, mgr, nil, authcookie.FrontDesk, "auto", admittedHandler()).ServeHTTP(w, r)
 
 	for _, msg := range []string{
 		"auth: admin request missing bearer token",
@@ -156,8 +156,8 @@ func TestRequireAdminOrSession_AdmittedRequestLogsNothing(t *testing.T) {
 	}
 }
 
-// w2h is a next handler that records nothing and answers 200.
-func w2h(t *testing.T) http.Handler {
-	t.Helper()
+// admittedHandler stands in for whatever the middleware protects: it answers
+// 200, so reaching it means the request was admitted.
+func admittedHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 }

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
+	"github.com/hugalafutro/model-hotel/internal/clientip"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -352,6 +353,21 @@ type loginFinishRequest struct {
 	Credential json.RawMessage `json:"credential"`
 }
 
+// logPasskeyLoginFailure records a passkey assertion that did not check out.
+//
+// The endpoint is unauthenticated, so a rejected assertion is a failed login by
+// an anonymous caller and the line has to name that caller: without an address
+// it tells an operator, and any log-driven ban, nothing. Warning, not error:
+// this is the caller's failure, not the server's, and it shares the level with
+// every other login rejection (userlogin, totp, oidc).
+//
+// reason is one of a fixed set chosen here, so it is safe to read before the
+// error; the error text quotes a caller-supplied credential blob, so it goes
+// last. Nothing about the credential itself is logged.
+func logPasskeyLoginFailure(r *http.Request, reason string, err error) {
+	debuglog.Warn("webauthn: passkey login failed", "remote_addr", clientip.From(r), "reason", reason, "error", err)
+}
+
 // LoginFinish completes a WebAuthn discoverable login ceremony.
 // POST /webauthn/login/finish (no auth required)
 func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
@@ -411,7 +427,7 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 		io.NopCloser(bytes.NewReader(req.Credential)),
 	)
 	if err != nil {
-		debuglog.Error("webauthn: failed to parse credential request response", "error", err)
+		logPasskeyLoginFailure(r, "assertion_unparseable", err)
 		respondBadRequest(w, "invalid credential response", err)
 		return
 	}
@@ -428,7 +444,7 @@ func (h *WebAuthnHandler) LoginFinish(w http.ResponseWriter, r *http.Request) {
 
 	user, parsedCred, err := h.relyingParty.ValidatePasskeyLogin(userLookup, session, parsedResponse)
 	if err != nil {
-		debuglog.Error("webauthn: ValidatePasskeyLogin failed", "error", err)
+		logPasskeyLoginFailure(r, "assertion_rejected", err)
 		respondBadRequest(w, "passkey login verification failed", err)
 		return
 	}

--- a/internal/adminauth/webauthn_login_logging_test.go
+++ b/internal/adminauth/webauthn_login_logging_test.go
@@ -162,8 +162,9 @@ func TestWebAuthnHandler_LoginFinish_LogsRejectedAssertions(t *testing.T) {
 	}
 }
 
-// A successful ceremony logs no failure line, so the brute-force bucket never
-// fills from legitimate logins.
+// A ceremony id that resolves to nothing never reached a credential, so it is
+// not a rejected passkey and must not fill the brute-force bucket. A stale
+// browser tab retrying its old session produces exactly this.
 func TestWebAuthnHandler_LoginFinish_SessionMissLogsNoPasskeyFailure(t *testing.T) {
 	if apiTestDBURL == "" {
 		t.Fatal("test database not available")

--- a/internal/adminauth/webauthn_login_logging_test.go
+++ b/internal/adminauth/webauthn_login_logging_test.go
@@ -1,0 +1,193 @@
+package adminauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/webauthn"
+)
+
+// newLoginSession stores a live login ceremony and returns its id, so a test
+// can drive LoginFinish past the session lookup and into the assertion check.
+func newLoginSession(t *testing.T, repo *webauthn.Repository) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	id := uuid.New()
+	rec := &webauthn.SessionRecord{
+		ID:          id,
+		Challenge:   "test-challenge",
+		SessionData: []byte(`{"challenge":"test"}`),
+		Type:        "login",
+		UserID:      []byte("admin"),
+		ExpiresAt:   time.Now().Add(5 * time.Minute),
+	}
+	if err := repo.CreateSession(ctx, rec); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.DeleteSession(ctx, id) })
+	return id
+}
+
+// A rejected passkey assertion is an unauthenticated caller failing a login, so
+// the line has to name the caller. Without an address it tells an operator (and
+// a log-driven ban) nothing at all, and the credential blob it reports on is
+// caller-supplied, so the error it produces goes last.
+func TestWebAuthnHandler_LoginFinish_LogsTheClientAddress(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	repo := webauthn.NewRepository(pool)
+	h := newTestWebAuthnHandler(repo, nil, nil, &mockAdminAuth{validateFn: func(string) bool { return true }})
+	sessionID := newLoginSession(t, repo)
+
+	lines := captureLogLines(t)
+
+	body := `{"session_id": "` + sessionID.String() + `", "credential": {"nonsense": true}}`
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.77:44100"
+	w := httptest.NewRecorder()
+
+	h.LoginFinish(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	line, ok := findLine(lines(), "webauthn: passkey login failed")
+	if !ok {
+		t.Fatalf(`no line with msg="webauthn: passkey login failed"; got %v`, lines())
+	}
+	if !strings.Contains(line, "level=WARN") {
+		t.Errorf("a rejected assertion is a caller failure and belongs at warning: %s", line)
+	}
+	addr := strings.Index(line, " remote_addr=203.0.113.77")
+	if addr < 0 {
+		t.Fatalf("line does not name the client: %s", line)
+	}
+	errIdx := strings.Index(line, " error=")
+	if errIdx < 0 {
+		t.Fatalf("line carries no error attribute: %s", line)
+	}
+	if addr > errIdx {
+		t.Errorf("remote_addr comes after the caller-influenced error text: %s", line)
+	}
+	if !strings.Contains(line[:errIdx], `reason=assertion_unparseable`) {
+		t.Errorf("line does not say why the login failed ahead of the error text: %s", line)
+	}
+}
+
+// A well-formed assertion that does not verify is the shape a real credential
+// stuffing attempt takes, and it has to name its caller the same way.
+func TestWebAuthnHandler_LoginFinish_LogsRejectedAssertions(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	ctx := context.Background()
+	repo := webauthn.NewRepository(pool)
+	rp, err := webauthn.NewRelyingParty("localhost", "Model Hotel Test", []string{"http://localhost"})
+	if err != nil {
+		t.Fatalf("NewRelyingParty: %v", err)
+	}
+	h := newTestWebAuthnHandler(repo, rp, nil, &mockAdminAuth{validateFn: func(string) bool { return true }})
+
+	req, w := newChiRequest(http.MethodPost, "/webauthn/login/start", http.NoBody)
+	h.LoginStart(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("LoginStart = %d: %s", w.Code, w.Body.String())
+	}
+	var startResp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&startResp); err != nil {
+		t.Fatalf("decode LoginStart: %v", err)
+	}
+	sessionID, _ := startResp["session_id"].(string)
+	if sessionID == "" {
+		t.Fatal("LoginStart returned no session_id")
+	}
+	t.Cleanup(func() { _ = repo.DeleteSession(ctx, uuid.MustParse(sessionID)) })
+
+	lines := captureLogLines(t)
+
+	finishBytes, err := json.Marshal(map[string]any{
+		"session_id": sessionID,
+		"credential": buildFakeLoginCredential(t, "dGVzdA"),
+	})
+	if err != nil {
+		t.Fatalf("marshal finish body: %v", err)
+	}
+	req2 := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", strings.NewReader(string(finishBytes)))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.RemoteAddr = "203.0.113.79:44100"
+	w2 := httptest.NewRecorder()
+
+	h.LoginFinish(w2, req2)
+
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w2.Code, http.StatusBadRequest, w2.Body.String())
+	}
+	line, ok := findLine(lines(), "webauthn: passkey login failed")
+	if !ok {
+		t.Fatalf(`no line with msg="webauthn: passkey login failed"; got %v`, lines())
+	}
+	addr := strings.Index(line, " remote_addr=203.0.113.79")
+	errIdx := strings.Index(line, " error=")
+	if addr < 0 || errIdx < 0 {
+		t.Fatalf("line is missing the address or the error: %s", line)
+	}
+	if addr > errIdx {
+		t.Errorf("remote_addr comes after the caller-influenced error text: %s", line)
+	}
+	if !strings.Contains(line[:errIdx], "reason=assertion_rejected") {
+		t.Errorf("a verification failure is not distinguished from an unparseable one: %s", line)
+	}
+}
+
+// A successful ceremony logs no failure line, so the brute-force bucket never
+// fills from legitimate logins.
+func TestWebAuthnHandler_LoginFinish_SessionMissLogsNoPasskeyFailure(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	repo := webauthn.NewRepository(pool)
+	h := newTestWebAuthnHandler(repo, nil, nil, &mockAdminAuth{validateFn: func(string) bool { return true }})
+
+	lines := captureLogLines(t)
+
+	body := `{"session_id": "` + uuid.New().String() + `", "credential": {}}`
+	req := httptest.NewRequest(http.MethodPost, "/webauthn/login/finish", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.78:44100"
+	w := httptest.NewRecorder()
+
+	h.LoginFinish(w, req)
+
+	if line, ok := findLine(lines(), "webauthn: passkey login failed"); ok {
+		t.Errorf("an unknown ceremony id is not a rejected passkey: %s", line)
+	}
+}

--- a/internal/debuglog/debuglog.go
+++ b/internal/debuglog/debuglog.go
@@ -120,7 +120,11 @@ func StdoutHandler() slog.Handler {
 //
 // The built-in time/level/msg/source attributes are the handler's own and are
 // left alone: the message carries the "scope: message" text every log reader
-// classifies on, and its spaces are load-bearing.
+// classifies on, and its spaces are load-bearing. That exemption is by key
+// name, so it rests on no caller passing a caller-controlled value under one of
+// those four keys. No call site does today, and a new one must not: an
+// attribute keyed "msg" carrying upstream text would be exempt from the
+// escaping and could present a "key=value" token of its own.
 func escapeAttrSpaces(groups []string, a slog.Attr) slog.Attr {
 	if len(groups) == 0 {
 		switch a.Key {

--- a/internal/debuglog/debuglog.go
+++ b/internal/debuglog/debuglog.go
@@ -86,7 +86,58 @@ func StdoutHandler() slog.Handler {
 	if JSONFormat() {
 		return newJSONHandler(os.Stdout, currentLevel)
 	}
-	return slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: currentLevel})
+	return slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level:       currentLevel,
+		ReplaceAttr: escapeAttrSpaces,
+	})
+}
+
+// escapeAttrSpaces renders every attribute value as a single whitespace
+// delimited token by escaping the spaces inside it, the same guarantee the
+// gateway's own handler gives (quoteLogValue in internal/api/applogs_slog.go).
+//
+// slog's text handler quotes a value holding a space, but the space survives
+// inside the quotes. Request paths, key names and error strings are
+// caller-controlled and are logged as attributes, so a value like
+//
+//	pwn remote_addr=203.0.113.99 x
+//
+// would otherwise still present a "key=value" token to any reader that splits
+// on whitespace before it considers quotes (a CrowdSec grok, a fail2ban regex,
+// an awk one-liner), and that token would read as the binary's own.
+//
+// Backslashes are escaped first, so a value that already spells "\x20" cannot
+// masquerade as an escaped space. Values with no space are returned untouched,
+// so ordinary lines read exactly as before.
+//
+// slog resolves a LogValuer and skips a group attribute before it calls this,
+// so a value here is already final and never a container.
+//
+// Only text-shaped values are considered. A number, a bool, a duration or a
+// time renders without a space and has its own rendering in the text handler
+// (a time is RFC3339 there, not the sprawling form its String method gives),
+// so rewriting one to a string would change how it reads for no gain.
+//
+// The built-in time/level/msg/source attributes are the handler's own and are
+// left alone: the message carries the "scope: message" text every log reader
+// classifies on, and its spaces are load-bearing.
+func escapeAttrSpaces(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 {
+		switch a.Key {
+		case slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey:
+			return a
+		}
+	}
+	switch a.Value.Kind() {
+	case slog.KindString, slog.KindAny:
+	default:
+		return a
+	}
+	if s := a.Value.String(); strings.Contains(s, " ") {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		return slog.String(a.Key, strings.ReplaceAll(s, " ", `\x20`))
+	}
+	return a
 }
 
 // maybeScopeFilter wraps h with per-scope Debug filtering, but only when

--- a/internal/debuglog/textescape_test.go
+++ b/internal/debuglog/textescape_test.go
@@ -1,0 +1,178 @@
+package debuglog
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStdout runs fn with os.Stdout replaced by a pipe and returns whatever
+// fn wrote to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	prev := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = prev }()
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close pipe reader: %v", err)
+	}
+	return out
+}
+
+// addressTokens returns the whitespace-delimited tokens of line that name a
+// client address, which is exactly what the CrowdSec grok reads: it takes the
+// FIRST such token on the line and validates it as an IP afterwards, and it
+// drops the address entirely when a second one is present.
+func addressTokens(line string) []string {
+	var found []string
+	for _, tok := range strings.Fields(line) {
+		for _, key := range []string{"remote_addr=", "remote=", "client_ip=", "ip="} {
+			if strings.HasPrefix(tok, key) {
+				found = append(found, tok)
+			}
+		}
+	}
+	return found
+}
+
+// A caller-controlled attribute value must never be able to present a second
+// "key=value" token to a log reader that splits on whitespace. The gateway's
+// own handler escapes the spaces inside such a value (quoteLogValue in
+// internal/api/applogs_slog.go); the stdout text handler that Front Desk runs
+// on has to carry the same guarantee, or a request path is all it takes to
+// name a stranger as the client of an authentication failure.
+func TestStdoutHandler_TextEscapesSpacesInAttributeValues(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	out := captureStdout(t, func() {
+		logger := slog.New(StdoutHandler())
+		logger.Warn("access: request",
+			"method", "GET",
+			"remote", "203.0.113.5",
+			"status", 404,
+			"path", "/x remote=198.51.100.9 y")
+	})
+
+	line := strings.TrimRight(out, "\n")
+	if strings.Count(line, "\n") != 0 {
+		t.Fatalf("one record must be one line, got %q", out)
+	}
+
+	got := addressTokens(line)
+	if len(got) != 1 {
+		t.Fatalf("address tokens = %v (want exactly one, the real client), line: %s", got, line)
+	}
+	if got[0] != "remote=203.0.113.5" {
+		t.Errorf("address token = %q, want %q; line: %s", got[0], "remote=203.0.113.5", line)
+	}
+}
+
+// The message carries the scope the parser classifies on and is not
+// caller-controlled, so escaping must leave its spaces alone: mangling them
+// would break every "scope: message" match in the collection.
+func TestStdoutHandler_TextLeavesTheMessageIntact(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	out := captureStdout(t, func() {
+		slog.New(StdoutHandler()).Warn("auth: admin request with invalid token", "remote_addr", "203.0.113.5")
+	})
+
+	if !strings.Contains(out, `msg="auth: admin request with invalid token"`) {
+		t.Errorf("message not emitted verbatim; line: %s", out)
+	}
+}
+
+// An ordinary value has nothing to escape and must read exactly as before, so
+// the common line stays human-readable and the existing fixtures keep matching.
+func TestStdoutHandler_TextLeavesOrdinaryValuesBare(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	out := captureStdout(t, func() {
+		slog.New(StdoutHandler()).Warn("auth: CSRF check failed", "remote_addr", "203.0.113.5", "path", "/api/members")
+	})
+
+	if !strings.Contains(out, " remote_addr=203.0.113.5 path=/api/members") {
+		t.Errorf("bare values were rewritten; line: %s", out)
+	}
+}
+
+// A group is a container, not a value: it keeps expanding into dotted keys and
+// the escaping applies to the values inside it, rather than the whole group
+// collapsing into one stringified attribute.
+func TestStdoutHandler_TextKeepsGroupsExpanded(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	out := captureStdout(t, func() {
+		slog.New(StdoutHandler()).Warn("access: request", slog.Group("req", "path", "/a b"))
+	})
+
+	if !strings.Contains(out, `req.path=/a\x20b`) {
+		t.Errorf("group not expanded with its values escaped; line: %s", out)
+	}
+}
+
+// A timestamp renders as RFC3339 in slog's text handler, which holds no space
+// at all. Rewriting it to a string would swap that for Go's sprawling default
+// time format, so a typed value keeps its own rendering.
+func TestStdoutHandler_TextLeavesTypedValuesAlone(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	when := time.Date(2026, 8, 18, 4, 15, 2, 123000000, time.UTC)
+	out := captureStdout(t, func() {
+		slog.New(StdoutHandler()).Warn("frontdesk: stamp device last_seen", "when", when, "took", 1500*time.Millisecond)
+	})
+
+	if !strings.Contains(out, "when=2026-08-18T04:15:02.123Z") {
+		t.Errorf("a time attribute lost its RFC3339 rendering; line: %s", out)
+	}
+	if !strings.Contains(out, "took=1.5s") {
+		t.Errorf("a duration attribute lost its rendering; line: %s", out)
+	}
+}
+
+// A backslash already in the value must not be able to masquerade as the
+// escape this introduces, or a caller could write a literal "\x20" and have a
+// reader that unescapes the value put the space back.
+func TestStdoutHandler_TextEscapesBackslashesInEscapedValues(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	Init(false)
+
+	out := captureStdout(t, func() {
+		slog.New(StdoutHandler()).Warn("access: request", "remote", "203.0.113.5", "path", `/a\x20b c`)
+	})
+
+	if !strings.Contains(out, `path=/a\\x20b\x20c`) {
+		t.Errorf("backslash not escaped ahead of the space escape; line: %s", out)
+	}
+}

--- a/internal/frontdesk/accesslog.go
+++ b/internal/frontdesk/accesslog.go
@@ -76,8 +76,21 @@ func isStaticAsset(path string) bool {
 
 // isPollingEndpoint reports whether the request is machine-to-machine liveness
 // traffic rather than a person using Front Desk: the container HEALTHCHECK,
-// Traefik's provider poll, a Prometheus scrape, and the dashboard's own event
-// stream. At their frequency one info line apiece buries everything else.
+// Traefik's provider poll, a Prometheus scrape, the dashboard's own event
+// stream, and the reads the open dashboard repeats on a timer.
+//
+// The timed reads matter more here than they do on the gateway. Front Desk's
+// stdout handler has no stderr filter in front of it, so an info line really is
+// written, and the SPA re-reads the member list and the device list every five
+// seconds (frontdesk/web/src/hooks/useMembers.ts and
+// frontdesk/web/src/components/PairedDevicesPanel.tsx),
+// the Traffic page re-pulls every member's traffic on the same cadence, and the
+// quota panel reads every minute. One idle tab would otherwise write a dozen
+// lines a minute forever, which buries the rejections this log exists for. They
+// are the SPA's and Bellhop's liveness reads, not a person doing anything.
+//
+// Only GET qualifies among the API reads: the same paths are mutating routes
+// under another method, and a mutation is never noise.
 //
 // The comparison is against a slash-normalized path, so a trailing slash from a
 // client or a reverse proxy cannot defeat an exact match and lift the endpoint
@@ -87,11 +100,16 @@ func isPollingEndpoint(method, path string) bool {
 	if len(np) > 1 {
 		np = strings.TrimRight(np, "/")
 	}
-	switch np {
-	case "/healthz", "/traefik/config", "/metrics":
+	if np == "/healthz" || np == "/traefik/config" || np == "/metrics" {
 		return true
-	case "/api/sse":
-		return method == http.MethodGet
 	}
-	return false
+	if method != http.MethodGet {
+		return false
+	}
+	switch np {
+	case "/api/sse", "/api/members", "/api/devices", "/api/quota":
+		return true
+	}
+	// Per-member traffic, which the Traffic page pulls once per member per tick.
+	return strings.HasPrefix(np, "/api/members/") && strings.HasSuffix(np, "/traffic")
 }

--- a/internal/frontdesk/accesslog.go
+++ b/internal/frontdesk/accesslog.go
@@ -1,0 +1,97 @@
+package frontdesk
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/hugalafutro/model-hotel/internal/clientip"
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// accessLogger writes one line per request, in the same shape and with the same
+// field names the gateway's own access log uses (silentLogger in
+// cmd/server/middleware.go), so one log parser reads both binaries.
+//
+// Front Desk is the fleet's control plane and its whole API is admin-gated, so
+// until this existed nothing reading its container output could tell that a
+// stranger was knocking: a rejected request left no trace whatsoever.
+//
+// Mount it inside clientip.Middleware, which resolves the trusted-proxy-aware
+// client address the line reports; in production Front Desk sits behind Traefik,
+// so the TCP peer is the proxy and never the visitor.
+func accessLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		start := time.Now()
+		next.ServeHTTP(ww, r)
+		duration := time.Since(start)
+
+		status := ww.Status()
+		if status == 0 {
+			// A handler that wrote a body without calling WriteHeader answered
+			// 200; the wrapper reports 0 until something is written, and a
+			// handler that wrote nothing at all still answered 200.
+			status = http.StatusOK
+		}
+		if isStaticAsset(r.URL.Path) && status < 400 {
+			return
+		}
+
+		// The path goes last in every branch. It is caller-controlled, so a
+		// reader scanning left to right meets every field Front Desk vouches
+		// for before it reaches anything a visitor wrote, and the stdout text
+		// handler escapes the spaces inside it (debuglog.StdoutHandler) so it
+		// cannot present a "key=value" token of its own.
+		args := []any{
+			"method", r.Method,
+			"host", r.Host,
+			"remote", clientip.From(r),
+			"status", status,
+			"bytes", ww.BytesWritten(),
+			"duration", duration,
+			"path", r.URL.Path,
+		}
+		switch {
+		case status >= 500:
+			debuglog.Error("access: request", args...)
+		case status >= 400:
+			debuglog.Warn("access: request", args...)
+		case isPollingEndpoint(r.Method, r.URL.Path):
+			debuglog.Debug("access: request", args...)
+		default:
+			debuglog.Info("access: request", args...)
+		}
+	})
+}
+
+// isStaticAsset reports whether path serves the embedded SPA bundle. A
+// successful asset fetch is not traffic anyone reads, and the SPA pulls a
+// dozen of them per page load.
+func isStaticAsset(path string) bool {
+	return strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/favicon")
+}
+
+// isPollingEndpoint reports whether the request is machine-to-machine liveness
+// traffic rather than a person using Front Desk: the container HEALTHCHECK,
+// Traefik's provider poll, a Prometheus scrape, and the dashboard's own event
+// stream. At their frequency one info line apiece buries everything else.
+//
+// The comparison is against a slash-normalized path, so a trailing slash from a
+// client or a reverse proxy cannot defeat an exact match and lift the endpoint
+// back to info. Root "/" is preserved.
+func isPollingEndpoint(method, path string) bool {
+	np := path
+	if len(np) > 1 {
+		np = strings.TrimRight(np, "/")
+	}
+	switch np {
+	case "/healthz", "/traefik/config", "/metrics":
+		return true
+	case "/api/sse":
+		return method == http.MethodGet
+	}
+	return false
+}

--- a/internal/frontdesk/accesslog_test.go
+++ b/internal/frontdesk/accesslog_test.go
@@ -1,0 +1,187 @@
+package frontdesk
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// captureAccessLines installs a text handler over a buffer as the process
+// logger and returns the non-empty lines it collected. The rendered line, not
+// the record, is what the log parser reads, so the assertions are about its
+// exact shape.
+func captureAccessLines(t *testing.T) func() []string {
+	t.Helper()
+	var buf bytes.Buffer
+	debuglog.SetHandler(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { debuglog.Init(false) })
+	return func() []string {
+		var lines []string
+		for _, l := range strings.Split(buf.String(), "\n") {
+			if strings.TrimSpace(l) != "" {
+				lines = append(lines, l)
+			}
+		}
+		return lines
+	}
+}
+
+// serveThrough runs one request through the access logger and returns the
+// captured lines.
+func serveThrough(t *testing.T, method, target string, status int) []string {
+	t.Helper()
+	lines := captureAccessLines(t)
+	h := accessLogger(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte("body"))
+	}))
+	r := httptest.NewRequest(method, target, http.NoBody)
+	r.RemoteAddr = "203.0.113.11:40000"
+	r.Host = "fd.example.com"
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	return lines()
+}
+
+// onlyLine fails unless exactly one line was captured, and returns it.
+func onlyLine(t *testing.T, lines []string) string {
+	t.Helper()
+	if len(lines) != 1 {
+		t.Fatalf("want exactly one access line, got %d: %v", len(lines), lines)
+	}
+	return lines[0]
+}
+
+// Front Desk has no access log at all today, so nothing reading its container
+// output can see who is knocking. The line it gains has to be the one the
+// gateway already emits, field for field, or the shared parser sees Front Desk
+// traffic as a different service.
+func TestAccessLogger_RejectedRequestCarriesTheGatewayLineShape(t *testing.T) {
+	line := onlyLine(t, serveThrough(t, http.MethodGet, "/api/members", http.StatusUnauthorized))
+
+	if !strings.Contains(line, `msg="access: request"`) {
+		t.Fatalf("wrong message: %s", line)
+	}
+	if !strings.Contains(line, "level=WARN") {
+		t.Errorf("a 4xx is a client failure and belongs at warning: %s", line)
+	}
+	for _, want := range []string{
+		"method=GET",
+		"host=fd.example.com",
+		"remote=203.0.113.11",
+		"status=401",
+		"bytes=4",
+	} {
+		if !strings.Contains(line, " "+want) {
+			t.Errorf("line is missing %q: %s", want, line)
+		}
+	}
+	remote := strings.Index(line, " remote=203.0.113.11")
+	path := strings.Index(line, " path=/api/members")
+	if remote < 0 || path < 0 {
+		t.Fatalf("line is missing the address or the path: %s", line)
+	}
+	if remote > path {
+		t.Errorf("the address must precede the caller-controlled path: %s", line)
+	}
+	if !strings.HasSuffix(line, " path=/api/members") {
+		t.Errorf("the caller-controlled path must be the last field: %s", line)
+	}
+}
+
+// The level says how a reader should treat the line, and the collection's
+// scenarios only ever care about the rejections.
+func TestAccessLogger_LevelFollowsTheStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		status int
+		want   string
+	}{
+		{"server error", "/api/members", http.StatusInternalServerError, "level=ERROR"},
+		{"client error", "/api/members", http.StatusUnauthorized, "level=WARN"},
+		{"ordinary request", "/api/members", http.StatusOK, "level=INFO"},
+		{"liveness probe", "/healthz", http.StatusOK, "level=DEBUG"},
+		{"traefik provider poll", "/traefik/config", http.StatusOK, "level=DEBUG"},
+		{"metrics scrape", "/metrics", http.StatusOK, "level=DEBUG"},
+		{"event stream", "/api/sse", http.StatusOK, "level=DEBUG"},
+		{"probe that was refused", "/healthz", http.StatusServiceUnavailable, "level=ERROR"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			line := onlyLine(t, serveThrough(t, http.MethodGet, tc.target, tc.status))
+			if !strings.Contains(line, tc.want) {
+				t.Errorf("level = not %s: %s", tc.want, line)
+			}
+		})
+	}
+}
+
+// A trailing slash must not lift a polling endpoint back to info: the SPA and
+// a reverse proxy both add one, and one line per poll drowns the log.
+func TestAccessLogger_NoiseAllowlistIgnoresATrailingSlash(t *testing.T) {
+	line := onlyLine(t, serveThrough(t, http.MethodGet, "/healthz/", http.StatusOK))
+	if !strings.Contains(line, "level=DEBUG") {
+		t.Errorf("a trailing slash defeated the noise allowlist: %s", line)
+	}
+}
+
+// Serving the SPA's own bundle is not traffic anyone reads, so a successful
+// asset fetch logs nothing at all; a missing one still does.
+func TestAccessLogger_StaticAssets(t *testing.T) {
+	if lines := serveThrough(t, http.MethodGet, "/assets/index-abc123.js", http.StatusOK); len(lines) != 0 {
+		t.Errorf("a served asset logged a line: %v", lines)
+	}
+	line := onlyLine(t, serveThrough(t, http.MethodGet, "/assets/gone.js", http.StatusNotFound))
+	if !strings.Contains(line, "level=WARN") {
+		t.Errorf("a missing asset must still be logged: %s", line)
+	}
+}
+
+// The middleware only helps if the router actually runs it, and it has to run
+// inside the client-IP resolution so the address it reports is the visitor's
+// and not the reverse proxy's.
+func TestServer_LogsRejectedControlPlaneRequests(t *testing.T) {
+	srv, _ := newTestServer(t)
+	lines := captureAccessLines(t)
+
+	rec := do(t, srv, http.MethodGet, "/api/members", "", false)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	var access string
+	for _, l := range lines() {
+		if strings.Contains(l, `msg="access: request"`) {
+			access = l
+		}
+	}
+	if access == "" {
+		t.Fatalf("the router logged no access line; got %v", lines())
+	}
+	if !strings.Contains(access, " status=401") || !strings.Contains(access, " remote=192.0.2.1") {
+		t.Errorf("access line does not report the rejection and its client: %s", access)
+	}
+	if !strings.HasSuffix(access, " path=/api/members") {
+		t.Errorf("the caller-controlled path must be the last field: %s", access)
+	}
+}
+
+// A handler that writes nothing at all still answered 200, and the line has to
+// say so rather than reporting a status of zero, which no reader can classify.
+func TestAccessLogger_ImplicitStatus(t *testing.T) {
+	lines := captureAccessLines(t)
+	h := accessLogger(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := httptest.NewRequest(http.MethodGet, "/api/members", http.NoBody)
+	r.RemoteAddr = "203.0.113.11:40000"
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	line := onlyLine(t, lines())
+	if !strings.Contains(line, " status=200") {
+		t.Errorf("implicit 200 not reported: %s", line)
+	}
+}

--- a/internal/frontdesk/accesslog_test.go
+++ b/internal/frontdesk/accesslog_test.go
@@ -2,9 +2,11 @@ package frontdesk
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -104,7 +106,7 @@ func TestAccessLogger_LevelFollowsTheStatus(t *testing.T) {
 	}{
 		{"server error", "/api/members", http.StatusInternalServerError, "level=ERROR"},
 		{"client error", "/api/members", http.StatusUnauthorized, "level=WARN"},
-		{"ordinary request", "/api/members", http.StatusOK, "level=INFO"},
+		{"ordinary request", "/api/settings", http.StatusOK, "level=INFO"},
 		{"liveness probe", "/healthz", http.StatusOK, "level=DEBUG"},
 		{"traefik provider poll", "/traefik/config", http.StatusOK, "level=DEBUG"},
 		{"metrics scrape", "/metrics", http.StatusOK, "level=DEBUG"},
@@ -118,6 +120,58 @@ func TestAccessLogger_LevelFollowsTheStatus(t *testing.T) {
 				t.Errorf("level = not %s: %s", tc.want, line)
 			}
 		})
+	}
+}
+
+// The dashboard re-reads these on a timer while a tab is merely open, and Front
+// Desk has no stderr filter to drop info records the way the gateway does, so
+// an info line apiece would write a dozen lines a minute forever and bury the
+// rejections. They are the SPA's liveness reads, not a person doing anything.
+func TestAccessLogger_DashboardPollsStayOutOfTheInfoStream(t *testing.T) {
+	polled := []string{
+		"/api/members",
+		"/api/devices",
+		"/api/quota",
+		"/api/members/9d1f0e5a-0000-4000-8000-000000000001/traffic",
+	}
+	for _, target := range polled {
+		t.Run(target, func(t *testing.T) {
+			line := onlyLine(t, serveThrough(t, http.MethodGet, target, http.StatusOK))
+			if !strings.Contains(line, "level=DEBUG") {
+				t.Errorf("a five-second dashboard poll reached the info stream: %s", line)
+			}
+		})
+	}
+}
+
+// The noise allowlist is a statement about reads. The same paths mutate under
+// another method, and a mutation is somebody doing something.
+func TestAccessLogger_OnlyReadsAreNoise(t *testing.T) {
+	tests := []struct {
+		method string
+		target string
+	}{
+		{http.MethodPost, "/api/members"},
+		{http.MethodDelete, "/api/devices"},
+		{http.MethodPost, "/api/quota"},
+		{http.MethodPost, "/api/sse"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.target, func(t *testing.T) {
+			line := onlyLine(t, serveThrough(t, tc.method, tc.target, http.StatusOK))
+			if !strings.Contains(line, "level=INFO") {
+				t.Errorf("a mutation was treated as polling noise: %s", line)
+			}
+		})
+	}
+}
+
+// A path that merely starts like the traffic endpoint is not it: the suffix has
+// to be there, or a caller could pick their own level by prefix alone.
+func TestAccessLogger_TrafficMatchNeedsBothEnds(t *testing.T) {
+	line := onlyLine(t, serveThrough(t, http.MethodGet, "/api/members/abc/traffic-not", http.StatusOK))
+	if !strings.Contains(line, "level=INFO") {
+		t.Errorf("a lookalike path claimed the traffic endpoint's level: %s", line)
 	}
 }
 
@@ -183,5 +237,82 @@ func TestAccessLogger_ImplicitStatus(t *testing.T) {
 	line := onlyLine(t, lines())
 	if !strings.Contains(line, " status=200") {
 		t.Errorf("implicit 200 not reported: %s", line)
+	}
+}
+
+// captureStdoutLines runs fn with os.Stdout replaced by a pipe and returns what
+// fn wrote to it.
+func captureStdoutLines(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	prev := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = prev }()
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out := <-done
+	if err := r.Close(); err != nil {
+		t.Fatalf("close pipe reader: %v", err)
+	}
+	return out
+}
+
+// End to end, through the handler Front Desk actually installs rather than a
+// bare text handler: a request path holding a complete forged authentication
+// record plus an attacker-chosen address must leave the line naming the real
+// client and nobody else. This is the byte-for-byte form the CrowdSec fixture
+// in contrib/crowdsec/tests carries, so the two cannot drift apart.
+func TestAccessLogger_EscapedPathCannotNameAStranger(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "")
+	t.Setenv("DEBUG_LOG", "")
+	debuglog.Init(false)
+	t.Cleanup(func() { debuglog.Init(false) })
+
+	out := captureStdoutLines(t, func() {
+		debuglog.SetHandler(debuglog.StdoutHandler())
+		h := accessLogger(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("body"))
+		}))
+		r := httptest.NewRequest(http.MethodGet,
+			"/api/zz%20auth:%20key%20not%20found%20remote=203.0.113.77", http.NoBody)
+		r.RemoteAddr = "198.51.100.93:40000"
+		r.Host = "fd.example.com"
+		h.ServeHTTP(httptest.NewRecorder(), r)
+	})
+
+	line := strings.TrimRight(out, "\n")
+	if strings.Contains(line, "\n") {
+		t.Fatalf("one request must be one line, got %q", out)
+	}
+
+	var addrs []string
+	for _, tok := range strings.Fields(line) {
+		for _, key := range []string{"remote_addr=", "remote=", "client_ip=", "ip="} {
+			if strings.HasPrefix(tok, key) {
+				addrs = append(addrs, tok)
+			}
+		}
+	}
+	if len(addrs) != 1 || addrs[0] != "remote=198.51.100.93" {
+		t.Fatalf("address tokens = %v, want exactly [remote=198.51.100.93]; line: %s", addrs, line)
+	}
+
+	const wantPath = ` path="/api/zz\\x20auth:\\x20key\\x20not\\x20found\\x20remote=203.0.113.77"`
+	if !strings.HasSuffix(line, wantPath) {
+		t.Errorf("escaped path token is not the fixture's form\n got: %s\nwant suffix: %s", line, wantPath)
 	}
 }

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -430,6 +430,11 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 	// logs an address, so every warn/error line reports the real client.
 	r.Use(clientip.Middleware(s.trustedProxies))
 
+	// One line per request, in the gateway's own access-log shape, immediately
+	// inside the address resolution so it reports the real client. Front Desk
+	// otherwise leaves no trace of a rejected request at all.
+	r.Use(accessLogger)
+
 	// Security headers. The Front Desk admin UI manages the whole HA fleet
 	// (member admin tokens, device pairing, config sync, OIDC/alert settings),
 	// so framing it is only ever an attack: a same-origin frame inherits the


### PR DESCRIPTION
## Front Desk brute force was invisible to the CrowdSec collection

The collection (#702) classifies gateway auth failures into ban scenarios, but Front Desk gave it nothing to read: no access logger, `adminauth` returned its 401/403s silently, and passkey rejections carried no client address. An attacker hammering FD's admin token or passkey login never produced a line a scenario could count.

Four changes, every message shaped to a prefix the parser already anchors on (one new classification node total, for the genuinely new passkey message):

- **FD access logger** (`internal/frontdesk/accesslog.go`): the gateway's `access: request` line, field for field, mounted inside `clientip.Middleware` so the address is the trusted-proxy-resolved client. Path logged without query string; caller-controlled values last and escaped. The dashboard's own 5-second polls (members, devices, quota, traffic; GET-only) are noise-classed so an idle tab does not flood the container log; a 401/403 on those same paths still logs at Warn because status is judged before the polling branch.
- **`adminauth.RequireAdminOrSession`** logs its three refusals (missing/wrong token, CSRF) with `remote_addr` first and `path` last, in the gateway's existing `admin_token`/`csrf` message shapes. No token material, no timing change.
- **Passkey rejections** log `webauthn: passkey login failed` with the address before the caller-influenced error; added to the parser's `login` node. Stale-tab ceremony misses stay quiet by choice (documented).
- **`/api/webauthn/available`** was verified already served by FD (`adminauth/webauthn.go:105` via `frontdesk/server.go:492`, unauthenticated, SPA contract matched) and correctly skipped.

One cross-cutting hole closed on the way: FD's stdlib slog text output kept literal spaces inside quoted values, so a request path could present a second `remote_addr=` token to a whitespace-splitting reader. `debuglog.StdoutHandler`'s text branch now escapes spaces (`\x20`) in string values, backslash before space, built-in keys exempt (assumption documented). The gateway's own pipeline is untouched (it installs `api.NewAppSlogHandler`); `LOG_FORMAT=json` and OTLP keep raw values.

## Tests

928 tests across debuglog/adminauth/frontdesk; every changed prod line killed by a named mutation. Injection defense pinned end to end: a `%20` path through the real `StdoutHandler` + access logger renders byte-identical to the CrowdSec fixture line, and the parser assert for that line pins the escaped form. Hubtest cannot run here (no cscli), so both parsers were replayed assertion-by-assertion (178 + 41, zero mismatches) and the reviewer independently re-derived the new lines against the parser YAML and reproduced the escaping byte-for-byte.

## Review

One opus review round with four named risks (double-escaping, hostile-request line content, parser-replay fidelity, 401-oracle) - verdict needs-fixes for a real flood: the access logger logged FD's own dashboard polls. One fix round (nine findings, all verified ADDRESSED by scoped re-review, including the poll allowlist and three contract-doc corrections).

Known gaps, recorded in the collection README rather than silently: FD's role 403s (`requireOperator`/`requireAdmin`) still log nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhhaxiRLY3Sh2Q3H2Hdv23
