### PR TITLE
fix(dev): a plain rebuild must not silently kill the observability exports

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -29,5 +29,16 @@ services:
             # can turn the trust OFF; :- would resurrect the fallback.
             - KNOWN_PROXIES=${KNOWN_PROXIES-}
             - TRUSTED_PROXIES=${TRUSTED_PROXIES-172.16.0.0/12}
+            # Observability passthroughs, same .env pattern as the proxy CIDRs
+            # above: all three are inert when .env does not define them (empty
+            # LOG_FORMAT falls back to text, an empty OTLP endpoint disables
+            # the export, an empty METRICS_TOKEN behaves like an unset one).
+            # With them in .env a plain `make docker-build` keeps the local
+            # observability overlay's log/metric/trace exports wired instead
+            # of silently dropping them on every rebuild.
+            - LOG_FORMAT=${LOG_FORMAT-}
+            - METRICS_TOKEN=${METRICS_TOKEN-}
+            - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-}
+            - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME-model-hotel-dev}
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## A plain rebuild must not silently kill the observability exports

The local observability overlay (gitignored `tools/observability/`) injected `LOG_FORMAT=json`, `METRICS_TOKEN` and the OTLP endpoint through its own compose file. Any ordinary `make docker-build` / `make docker-up` therefore recreated the app **without** them: Prometheus scrapes 401'd, the OTLP log export vanished, and Vector's tailed lines landed in Loki unparsed (`json_ok=false, level=none`) - while every sink container stayed green, so nothing looked broken. This has bitten repeatedly since 2026-08-20.

The fix reuses the `.env` passthrough pattern `compose.dev.yml` already established for the proxy CIDRs: four `${VAR-}` passthroughs, values living only in the gitignored `.env`. All four are inert for anyone whose `.env` does not define them - empty `LOG_FORMAT` falls back to text (`config.go` compares against "json"), an empty OTLP endpoint disables the export (`config.go` checks `!= ""`), and an empty `METRICS_TOKEN` behaves exactly like an unset one (`metrics.go` guards on `!= ""`). `OTEL_SERVICE_NAME` defaults to `model-hotel-dev`, meaningful only when an endpoint is set.

## Verified live

After this change, a plain `make docker-build` (no overlay script) produced: all four vars in the container env, the Prometheus `model-hotel` target **up**, Vector→Loki parsing with `json_ok=true` and real `level`/`source` labels, and OTLP streams for `service_name="model-hotel-dev"` carrying records from real traffic (two 200s through a failover group).

Compose-only change; no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhhaxiRLY3Sh2Q3H2Hdv23
