### PR TITLE
Put the Front Desk TOTP and OIDC login ceremonies behind the per-IP limiter

### DIFF
--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -167,9 +167,19 @@ type oidcLoginState struct {
 // it. Mount on the same unauthenticated group as the WebAuthn/TOTP login routes.
 func (h *OIDCHandler) Register(r chi.Router) {
 	r.Route("/auth/oidc", func(r chi.Router) {
+		// Status is the login screen's poll: it builds no provider and touches
+		// no network or database, so it stays outside the limiter and a cold
+		// dashboard load cannot spend the ceremonies' budget on it.
 		r.Get("/status", h.Status)
-		r.Get("/start", h.Start)
-		r.Get("/callback", h.Callback)
+		// Start and Callback carry the per-IP request limiter the way the other
+		// login ceremonies do. Start writes a login-state row on every request
+		// that reaches a configured IdP, and only an hourly sweep reclaims
+		// them, so an unbounded request rate is an unbounded row count.
+		r.Group(func(r chi.Router) {
+			r.Use(h.ipLimiter.Middleware)
+			r.Get("/start", h.Start)
+			r.Get("/callback", h.Callback)
+		})
 	})
 }
 

--- a/internal/adminauth/oidc.go
+++ b/internal/adminauth/oidc.go
@@ -167,9 +167,11 @@ type oidcLoginState struct {
 // it. Mount on the same unauthenticated group as the WebAuthn/TOTP login routes.
 func (h *OIDCHandler) Register(r chi.Router) {
 	r.Route("/auth/oidc", func(r chi.Router) {
-		// Status is the login screen's poll: it builds no provider and touches
-		// no network or database, so it stays outside the limiter and a cold
-		// dashboard load cannot spend the ceremonies' budget on it.
+		// Status is the login screen's poll. It reads four settings keys and
+		// nothing else: no provider build, no outbound IdP call, no state
+		// write, and the settings behind it are TTL-cached, so it stays outside
+		// the limiter and a cold dashboard load cannot spend the ceremonies'
+		// budget on it.
 		r.Get("/status", h.Status)
 		// Start and Callback carry the per-IP request limiter the way the other
 		// login ceremonies do. Start writes a login-state row on every request

--- a/internal/adminauth/totp.go
+++ b/internal/adminauth/totp.go
@@ -88,7 +88,15 @@ func NewTotpHandler(
 func (h *TotpHandler) Register(r chi.Router) {
 	r.Route("/totp", func(r chi.Router) {
 		r.Get("/status", h.Status)
-		r.Post("/login", h.Login)
+		// The second factor is a public login ceremony, so it carries the
+		// per-IP request limiter the way the passkey login routes do. The
+		// loginThrottle below is a different bound: it counts FAILURES, so it
+		// engages only after maxFailures and never caps the rate of the
+		// attempts that reach the verification before it does.
+		r.Group(func(r chi.Router) {
+			r.Use(h.ipLimiter.Middleware)
+			r.Post("/login", h.Login)
+		})
 		r.Group(func(r chi.Router) {
 			if h.demoReadOnly {
 				r.Use(readOnlyGuard)

--- a/internal/adminauth/webauthn.go
+++ b/internal/adminauth/webauthn.go
@@ -103,7 +103,13 @@ func (h *WebAuthnHandler) Available(w http.ResponseWriter, r *http.Request) {
 // Login endpoints are public (called from the login screen).
 func (h *WebAuthnHandler) Register(r chi.Router) {
 	r.Route("/webauthn", func(r chi.Router) {
-		r.Get("/available", h.Available)
+		// Available is public like the other login-screen polls, but unlike them
+		// it runs an uncached credential listing on every request, so it rides
+		// the per-IP limiter rather than the polls' exemption.
+		r.Group(func(r chi.Router) {
+			r.Use(h.ipLimiter.Middleware)
+			r.Get("/available", h.Available)
+		})
 		r.Group(func(r chi.Router) {
 			// In read-only (demo) mode, passkey management is an admin mutation
 			// and must be refused like the rest of the admin CRUD surface —

--- a/internal/frontdesk/loginratelimit_test.go
+++ b/internal/frontdesk/loginratelimit_test.go
@@ -2,7 +2,6 @@ package frontdesk
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
@@ -98,34 +97,5 @@ func TestLoginScreenPolls_AreNotRateLimited(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// TestOneRequestCostsOneToken pins that mounting the same limiter twice on a
-// route bills a request once. The login ceremonies sit under a route-level
-// limiter and, on the gateway binary, under a tree-wide one as well; billing
-// twice would refuse every login below about 5 rps, because the second charge
-// lands on a bucket the first just emptied.
-func TestOneRequestCostsOneToken(t *testing.T) {
-	lim := limiterFor(t)
-	served := 0
-	h := lim.Middleware(lim.Middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		served++
-	})))
-
-	for i := range loginBurst {
-		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
-		if rec.Code == http.StatusTooManyRequests {
-			t.Fatalf("request %d of the burst was refused: the doubled mount is charging twice", i+1)
-		}
-	}
-	if served != loginBurst {
-		t.Errorf("handler ran %d times, want %d", served, loginBurst)
-	}
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
-	if rec.Code != http.StatusTooManyRequests {
-		t.Errorf("past the burst got %d, want %d: the limiter stopped counting", rec.Code, http.StatusTooManyRequests)
 	}
 }

--- a/internal/frontdesk/loginratelimit_test.go
+++ b/internal/frontdesk/loginratelimit_test.go
@@ -1,0 +1,80 @@
+package frontdesk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/ratelimit"
+)
+
+// loginBurst is the burst the tests below run against. Two is the smallest
+// value that still tells "the limiter covers this route" apart from "the route
+// is broken": the first requests must be ADMITTED and only the one past the
+// burst refused.
+const loginBurst = 2
+
+// TestPublicLoginRoutes_RideThePerIPLimiter pins the property the Front Desk
+// route table claims: every unauthenticated login front-end is behind the
+// per-IP request limiter.
+//
+// TOTP login and the OIDC redirect endpoints were reachable at unlimited rate
+// while /api/pair next to them was limited, which left the TOTP second factor
+// without a rate bound (its own throttle counts FAILURES, so it does not bound
+// the rate of the attempts before it engages) and let an unauthenticated caller
+// drive one webauthn_sessions INSERT per OIDC start with only an hourly sweep
+// to reclaim them.
+//
+// Each route gets its own server so it starts on a full bucket, which is what
+// makes an admitted-then-refused sequence evidence about THAT route rather than
+// about a bucket some earlier route drained.
+func TestPublicLoginRoutes_RideThePerIPLimiter(t *testing.T) {
+	routes := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"totp login", http.MethodPost, "/api/totp/login", `{"code":"000000"}`},
+		{"oidc start", http.MethodGet, "/api/auth/oidc/start", ""},
+		{"oidc callback", http.MethodGet, "/api/auth/oidc/callback", ""},
+		// The control: this one was already limited, so a failure here means
+		// the limiter itself stopped working rather than the scope regressing.
+		{"pair", http.MethodPost, "/api/pair", `{"code":"nope"}`},
+	}
+
+	for _, rt := range routes {
+		t.Run(rt.name, func(t *testing.T) {
+			srv, _ := newTestServerLimited(t, nil, ratelimit.NewIPLimiter(1, loginBurst, nil, nil))
+
+			for i := range loginBurst {
+				if rec := do(t, srv, rt.method, rt.path, rt.body, false); rec.Code == http.StatusTooManyRequests {
+					t.Fatalf("request %d of the burst was refused: the limiter is tighter than the burst it was given", i+1)
+				}
+			}
+			if rec := do(t, srv, rt.method, rt.path, rt.body, false); rec.Code != http.StatusTooManyRequests {
+				t.Errorf("%s %s past the burst returned %d, want %d: the route is not behind the per-IP limiter",
+					rt.method, rt.path, rec.Code, http.StatusTooManyRequests)
+			}
+		})
+	}
+}
+
+// TestLoginScreenPolls_AreNotRateLimited is the other half of the scope: the
+// login screen polls these two to decide which buttons to render, and they do
+// no work an attacker can amplify. Putting the whole /api tree behind a 5 rps
+// limiter would throttle a dashboard cold-load, so the fix is deliberately
+// scoped to the ceremonies rather than the tree.
+func TestLoginScreenPolls_AreNotRateLimited(t *testing.T) {
+	for _, path := range []string{"/api/totp/status", "/api/auth/oidc/status"} {
+		t.Run(path, func(t *testing.T) {
+			srv, _ := newTestServerLimited(t, nil, ratelimit.NewIPLimiter(1, loginBurst, nil, nil))
+
+			for i := range loginBurst + 3 {
+				if rec := do(t, srv, http.MethodGet, path, "", false); rec.Code == http.StatusTooManyRequests {
+					t.Fatalf("GET %s was rate limited on request %d: the login screen's poll must not share the ceremonies' budget",
+						path, i+1)
+				}
+			}
+		})
+	}
+}

--- a/internal/frontdesk/loginratelimit_test.go
+++ b/internal/frontdesk/loginratelimit_test.go
@@ -2,6 +2,7 @@ package frontdesk
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
@@ -12,6 +13,21 @@ import (
 // is broken": the first requests must be ADMITTED and only the one past the
 // burst refused.
 const loginBurst = 2
+
+// loginRPS refills the bucket once every 100 seconds, so a burst spent inside a
+// test cannot refill mid-test. At 1 rps the middleware's graceful backpressure
+// sleeps and serves whenever ~800ms passes between the burst and the probe,
+// which would make these tests depend on how long the routes' own DB work took.
+const loginRPS = 0.01
+
+// limiterFor builds a per-IP limiter tight enough to observe and stops its
+// cleanup goroutine with the test.
+func limiterFor(t *testing.T) *ratelimit.IPLimiter {
+	t.Helper()
+	lim := ratelimit.NewIPLimiter(loginRPS, loginBurst, nil, nil)
+	t.Cleanup(lim.Stop)
+	return lim
+}
 
 // TestPublicLoginRoutes_RideThePerIPLimiter pins the property the Front Desk
 // route table claims: every unauthenticated login front-end is behind the
@@ -37,6 +53,9 @@ func TestPublicLoginRoutes_RideThePerIPLimiter(t *testing.T) {
 		{"totp login", http.MethodPost, "/api/totp/login", `{"code":"000000"}`},
 		{"oidc start", http.MethodGet, "/api/auth/oidc/start", ""},
 		{"oidc callback", http.MethodGet, "/api/auth/oidc/callback", ""},
+		// Public like the two status polls, but it runs an uncached credential
+		// listing per request, so it is limited rather than exempt.
+		{"webauthn available", http.MethodGet, "/api/webauthn/available", ""},
 		// The control: this one was already limited, so a failure here means
 		// the limiter itself stopped working rather than the scope regressing.
 		{"pair", http.MethodPost, "/api/pair", `{"code":"nope"}`},
@@ -44,7 +63,7 @@ func TestPublicLoginRoutes_RideThePerIPLimiter(t *testing.T) {
 
 	for _, rt := range routes {
 		t.Run(rt.name, func(t *testing.T) {
-			srv, _ := newTestServerLimited(t, nil, ratelimit.NewIPLimiter(1, loginBurst, nil, nil))
+			srv, _ := newTestServerLimited(t, nil, limiterFor(t))
 
 			for i := range loginBurst {
 				if rec := do(t, srv, rt.method, rt.path, rt.body, false); rec.Code == http.StatusTooManyRequests {
@@ -59,22 +78,54 @@ func TestPublicLoginRoutes_RideThePerIPLimiter(t *testing.T) {
 	}
 }
 
-// TestLoginScreenPolls_AreNotRateLimited is the other half of the scope: the
-// login screen polls these two to decide which buttons to render, and they do
-// no work an attacker can amplify. Putting the whole /api tree behind a 5 rps
-// limiter would throttle a dashboard cold-load, so the fix is deliberately
-// scoped to the ceremonies rather than the tree.
+// TestLoginScreenPolls_AreNotRateLimited is the other half of the scope: these
+// two polls are served from a TTL cache and write nothing, so they stay outside
+// the limiter. Putting the whole /api tree behind Front Desk's 5 rps limiter
+// would throttle a dashboard cold load, so the fix is scoped to the ceremonies
+// rather than the tree.
+//
+// The 200 assertion is load-bearing: without it, deleting the route entirely
+// would 404 and satisfy a "never 429" check.
 func TestLoginScreenPolls_AreNotRateLimited(t *testing.T) {
 	for _, path := range []string{"/api/totp/status", "/api/auth/oidc/status"} {
 		t.Run(path, func(t *testing.T) {
-			srv, _ := newTestServerLimited(t, nil, ratelimit.NewIPLimiter(1, loginBurst, nil, nil))
+			srv, _ := newTestServerLimited(t, nil, limiterFor(t))
 
 			for i := range loginBurst + 3 {
-				if rec := do(t, srv, http.MethodGet, path, "", false); rec.Code == http.StatusTooManyRequests {
-					t.Fatalf("GET %s was rate limited on request %d: the login screen's poll must not share the ceremonies' budget",
-						path, i+1)
+				if rec := do(t, srv, http.MethodGet, path, "", false); rec.Code != http.StatusOK {
+					t.Fatalf("GET %s returned %d on request %d, want %d: the login screen's poll must stay served and outside the ceremonies' budget",
+						path, rec.Code, i+1, http.StatusOK)
 				}
 			}
 		})
+	}
+}
+
+// TestOneRequestCostsOneToken pins that mounting the same limiter twice on a
+// route bills a request once. The login ceremonies sit under a route-level
+// limiter and, on the gateway binary, under a tree-wide one as well; billing
+// twice would refuse every login below about 5 rps, because the second charge
+// lands on a bucket the first just emptied.
+func TestOneRequestCostsOneToken(t *testing.T) {
+	lim := limiterFor(t)
+	served := 0
+	h := lim.Middleware(lim.Middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		served++
+	})))
+
+	for i := range loginBurst {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d of the burst was refused: the doubled mount is charging twice", i+1)
+		}
+	}
+	if served != loginBurst {
+		t.Errorf("handler ran %d times, want %d", served, loginBurst)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("past the burst got %d, want %d: the limiter stopped counting", rec.Code, http.StatusTooManyRequests)
 	}
 }

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -18,6 +18,7 @@ import (
 	otptotp "github.com/pquerna/otp/totp"
 
 	"github.com/hugalafutro/model-hotel/internal/admin"
+	"github.com/hugalafutro/model-hotel/internal/adminauth"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
 	"github.com/hugalafutro/model-hotel/internal/webauthn"
@@ -65,6 +66,14 @@ func newTestServer(t *testing.T) (*Server, *Store) {
 // exercise the "/" UI surface (e.g. security headers on the framed page).
 func newTestServerUI(t *testing.T, ui fs.FS) (*Server, *Store) {
 	t.Helper()
+	// A limit no test can reach, so unrelated suites never see a 429.
+	return newTestServerLimited(t, ui, ratelimit.NewIPLimiter(1000, 1000, nil, nil))
+}
+
+// newTestServerLimited is newTestServerUI with a caller-chosen per-IP limiter,
+// for tests that assert which routes the limiter actually covers.
+func newTestServerLimited(t *testing.T, ui fs.FS, limiter adminauth.IPLimiterMiddleware) (*Server, *Store) {
+	t.Helper()
 	store := newTestStore(t)
 	bus := events.NewBus()
 	poller := NewPoller(store, bus, "")
@@ -84,7 +93,7 @@ func newTestServerUI(t *testing.T, ui fs.FS) (*Server, *Store) {
 		AdminMgr:     adminMgr,
 		MasterKey:    testMasterKey,
 		RelyingParty: rp,
-		IPLimiter:    ratelimit.NewIPLimiter(1000, 1000, nil, nil),
+		IPLimiter:    limiter,
 		UI:           ui,
 	})
 	// Drain any detached background goroutine (e.g. an auto-sync kick) before

--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -103,9 +103,21 @@ func (l *IPLimiter) ClientIP(r *http.Request) string {
 	return clientip.Resolve(r, l.trustedProxies)
 }
 
+// chargedMarker marks a request as already charged against one limiter.
+//
+// The same limiter is mounted both across a whole route tree and again on
+// individual login ceremonies, so without this a single login request draws two
+// tokens from its bucket. That is not merely wasteful: the second charge is
+// billed when the bucket is already one token poorer, so below ~5 rps its delay
+// exceeds max_wait and every login attempt is refused, locking an operator out
+// of every way in. The marker is keyed by the limiter so two DIFFERENT limiters
+// on one request still charge independently.
+type chargedMarker struct{ limiter *IPLimiter }
+
 // Middleware returns an HTTP middleware that rate-limits requests per
 // client IP. On limit violation the middleware responds with HTTP 429
-// and sets Retry-After and X-RateLimit-* headers.
+// and sets Retry-After and X-RateLimit-* headers. One request costs one token
+// however many times this limiter is mounted on the route.
 func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Runtime toggle from DB settings; default true for safety.
@@ -115,6 +127,12 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 				return
 			}
 		}
+
+		if r.Context().Value(chargedMarker{l}) != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		r = r.WithContext(context.WithValue(r.Context(), chargedMarker{l}, struct{}{}))
 
 		ip := clientip.Resolve(r, l.trustedProxies)
 		entry := l.getLimiter(r.Context(), ip)

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -78,6 +78,80 @@ func TestIPLimiter_AllowsWithinBurst(t *testing.T) {
 	}
 }
 
+// TestIPLimiter_MountedTwiceChargesOnce pins that one request costs one token
+// no matter how many times the same limiter wraps the route.
+//
+// The login ceremonies carry a route-level limiter and, on the gateway, sit
+// under the tree-wide one as well. Charging twice bills the second token
+// against a bucket the first just emptied, so below roughly 5 rps the second
+// charge's delay exceeds max_wait and every login is refused, locking an
+// operator out of passkey, 2FA and SSO alike.
+func TestIPLimiter_MountedTwiceChargesOnce(t *testing.T) {
+	lim := NewIPLimiter(10, 3, nil, ipSettingsNoBackpressure())
+	defer lim.Stop()
+
+	served := 0
+	handler := lim.Middleware(lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	// The burst is 3, so a double charge runs out of tokens on request 2.
+	for i := range 3 {
+		req := httptest.NewRequest("POST", "/api/totp/login", http.NoBody)
+		req.RemoteAddr = "1.2.3.4:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("request %d: got %d, want 200: the doubled mount is charging twice", i+1, rr.Code)
+		}
+	}
+	if served != 3 {
+		t.Errorf("handler ran %d times, want 3", served)
+	}
+
+	// Still counting: the marker must skip the second charge, not the first.
+	req := httptest.NewRequest("POST", "/api/totp/login", http.NoBody)
+	req.RemoteAddr = "1.2.3.4:1234"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Errorf("past the burst: got %d, want 429: the limiter stopped counting", rr.Code)
+	}
+}
+
+// TestIPLimiter_TwoLimitersChargeIndependently guards the other side of the
+// marker: it is keyed by limiter, so a second, different limiter on the same
+// request still takes its own token.
+func TestIPLimiter_TwoLimitersChargeIndependently(t *testing.T) {
+	outer := NewIPLimiter(10, 5, nil, ipSettingsNoBackpressure())
+	defer outer.Stop()
+	inner := NewIPLimiter(10, 1, nil, ipSettingsNoBackpressure())
+	defer inner.Stop()
+
+	handler := outer.Middleware(inner.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest("POST", "/api/totp/login", http.NoBody)
+	req.RemoteAddr = "1.2.3.4:1234"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", rr.Code)
+	}
+
+	// The inner limiter's burst of 1 is spent, so it must refuse even though
+	// the outer one still has tokens.
+	req = httptest.NewRequest("POST", "/api/totp/login", http.NoBody)
+	req.RemoteAddr = "1.2.3.4:1234"
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Errorf("second request: got %d, want 429: the marker is suppressing a different limiter's charge", rr.Code)
+	}
+}
+
 func TestIPLimiter_BlocksBeyondBurst(t *testing.T) {
 	lim := NewIPLimiter(10, 3, nil, ipSettingsNoBackpressure())
 	defer lim.Stop()


### PR DESCRIPTION
Front Desk mounted its per-IP request limiter on `/api/pair`, `/api/auth/admin-exchange` and `/api/logout` only, leaving `POST /api/totp/login` and `GET /api/auth/oidc/{start,callback}` reachable at unlimited request rate. The gateway binary applies the limiter across its whole `/api` tree, so the two binaries disagreed about the same handlers.

Found by a Strix (GLM 5.2) run on 2026-08-30, then verified against the code before anything was written.

## Why it is a bug and not a scoping choice

- The comment above the limited group (`internal/frontdesk/server.go:500`) already says these routes "ride the same per-IP limiter as the login ceremonies". The routing did not do that.
- Both handlers were **already given** the limiter (`server.go:301,306`) and simply never applied it.
- The `WebAuthnHandler` does exactly this for its own login routes (`webauthn.go:125-129`), so the pattern was established and two of the three ceremonies missed it.

Neither handler's own defense closes the gap. TOTP's `loginThrottle` counts **failures**, so it engages only after `maxFailures` and never bounds the rate of the attempts that reach verification before it does. OIDC `Start` writes a `webauthn_sessions` row on every request that reaches a configured IdP (`oidc.go:235`), reclaimed only by the hourly sweep, so an unbounded request rate is an unbounded row count.

## What changed

The limiter now sits **inside** `TotpHandler.Register` and `OIDCHandler.Register`, wrapping the public ceremonies only. Attaching it at the mount point would fix today's route table and leave the next reshuffle free to drop it again, which is how this arose; attached to the route, the protection travels with it and holds in both binaries.

`/api/totp/status` and `/api/auth/oidc/status` stay outside the limiter. They are the login screen's polls, they build no provider and touch no network or database, and the second test pins that they are not throttled.

## The scanner's proposed fix was rejected

Strix recommended applying the limiter at the `/api` route level "matching the gateway". That would regress the dashboard: Front Desk runs **5 rps / burst 10** (`cmd/frontdesk/main.go:231-232`) against the gateway's **30 / 60**, so a tree-wide limiter puts every authenticated dashboard and Bellhop device poll on a 5 rps budget, and a cold dashboard load bursts past 10 on its own. A passing test suite cannot see that.

Known trade: on the gateway these routes now sit under two limiters (the `/api` one and the handler's), so a login request spends two tokens. That is already true of WebAuthn login today, it only affects login ceremonies, and at 30 rps it is not a practical bound.

## Tests

`TestPublicLoginRoutes_RideThePerIPLimiter` drives each ceremony past its burst on a real Front Desk router, with `/api/pair` as a control so a failure tells "the limiter died" apart from "the scope regressed". Before the fix it failed exactly as the finding predicts (`totp/login` 400, `oidc/start` 400, `oidc/callback` 302 past the burst) while the control correctly returned 429.

`TestLoginScreenPolls_AreNotRateLimited` pins the other half of the scope. Mutation-tested by pulling `/status` into the limited group: the test fails, so it is not vacuous.

Green: 896 tests in `adminauth` + `frontdesk`, 2482 in `api` + `cmd` (no gateway regression), `golangci-lint` 0 issues, size gate clean, diff coverage **100%** (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdXExqKDnnixu6PYxfPQPy
