### PR TITLE
fix(proxy): bound the client model field before it reaches any sink

### DIFF
--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -240,6 +240,22 @@ func (h *Handler) execRequestLogUpdate(logEntry *requestLogData) (int64, error) 
 	return tag.RowsAffected(), nil
 }
 
+// maxLogMessageRunes bounds request_logs.error_message and the
+// request.completed event built from it. Every current writer already passes
+// a bounded message (a constant, errString's cap, or a SanitizeLogBody body);
+// the bound lives at the sink so a future writer cannot miss it. It matches
+// the 10,000-character budget SanitizeLogBody gives upstream bodies.
+const maxLogMessageRunes = 10000
+
+// truncateLogMessage caps s at maxLogMessageRunes runes, cutting on a rune
+// boundary so the stored text stays valid UTF-8, and marks the cut.
+func truncateLogMessage(s string) string {
+	if utf8.RuneCountInString(s) <= maxLogMessageRunes {
+		return s
+	}
+	return string([]rune(s)[:maxLogMessageRunes]) + "…"
+}
+
 func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOption) {
 	// Guard: if the log entry was never assigned an ID (insertRequestLogAsync
 	// not called), there is no row to update. An empty string is not a valid
@@ -251,6 +267,14 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		debuglog.Warn("proxy: skipping updateRequestLog — log entry has no ID")
 		return
 	}
+
+	// Bound the message here, at the one place every terminal write and the
+	// request.completed event pass through. failRequest is not that place:
+	// four paths assign errorMessage directly and call this function
+	// themselves (the native Anthropic and non-streaming readers, the stream
+	// finaliser, the multimodal passthrough), so a clamp in failRequest would
+	// be a guarantee only some callers get.
+	logEntry.errorMessage = truncateLogMessage(logEntry.errorMessage)
 
 	// Skip DB operations when no pool is available (unit tests without DB).
 	if h.dbPool == nil {

--- a/internal/proxy/model_limit_test.go
+++ b/internal/proxy/model_limit_test.go
@@ -1,0 +1,243 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+)
+
+// oversizedModelWithPrefix builds a model one rune past the bound. The random
+// prefix is how the test finds its own request_logs row afterwards; it must
+// fit inside the excerpt the row keeps.
+func oversizedModelWithPrefix() (model, prefix string) {
+	prefix = "toolong-" + uuid.NewString()[:8] + "-"
+	return prefix + strings.Repeat("a", maxModelNameRunes+1-utf8.RuneCountInString(prefix)), prefix
+}
+
+// modelRow is what the request-log row looks like after ingest refused it.
+type modelRow struct {
+	modelID, state, errorKind, errorMessage string
+}
+
+// findModelRow polls for the row whose model_id starts with prefix. The
+// pending INSERT and the terminal UPDATE are both asynchronous, so the row can
+// exist before it is closed; the poll waits for the closed state.
+func findModelRow(t *testing.T, h *Handler, prefix string) modelRow {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var row modelRow
+		err := h.dbPool.QueryRow(context.Background(),
+			`SELECT model_id, state, COALESCE(error_kind, ''), COALESCE(error_message, '')
+			 FROM request_logs WHERE model_id LIKE $1 || '%' ORDER BY created_at DESC LIMIT 1`, prefix,
+		).Scan(&row.modelID, &row.state, &row.errorKind, &row.errorMessage)
+		if err == nil && row.state == "failed" {
+			return row
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no closed request_logs row with model_id prefix %q (last err: %v, last state: %q)", prefix, err, row.state)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// assertRefusal checks the response is the constant refusal and nothing more:
+// a 400, the bounded message, and a body far smaller than the model it refused.
+func assertRefusal(t *testing.T, rr *httptest.ResponseRecorder) {
+	t.Helper()
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %.200s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not the OpenAI error shape: %v; body: %.200s", err, rr.Body.String())
+	}
+	if resp.Error.Message != modelTooLongMessage {
+		t.Errorf("message = %q, want %q", resp.Error.Message, modelTooLongMessage)
+	}
+	if n := rr.Body.Len(); n > 256 {
+		t.Errorf("response body is %d bytes: the refusal must not echo the model", n)
+	}
+}
+
+// assertBoundedRow checks the refusal left an attributed row carrying only the
+// excerpt, the validation kind, and the constant message.
+func assertBoundedRow(t *testing.T, row modelRow, model string) {
+	t.Helper()
+	if want := modelExcerpt(model); row.modelID != want {
+		t.Errorf("model_id = %q (%d runes), want the excerpt %q", row.modelID, utf8.RuneCountInString(row.modelID), want)
+	}
+	if row.errorKind != string(KindValidation) {
+		t.Errorf("error_kind = %q, want %q", row.errorKind, KindValidation)
+	}
+	if row.errorMessage != modelTooLongMessage {
+		t.Errorf("error_message = %q, want %q", row.errorMessage, modelTooLongMessage)
+	}
+}
+
+// TestIngest_ModelTooLong_BodyParsed covers the fallback path: no middleware
+// pre-parse, the model comes out of the body after the pending row was
+// inserted with an empty model. The refusal must close that row with the
+// excerpt, never the field.
+func TestIngest_ModelTooLong_BodyParsed(t *testing.T) {
+	h := newIntegrationHandler()
+	model, prefix := oversizedModelWithPrefix()
+	req := httptest.NewRequest(http.MethodPost, "/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[]}`))
+	req = withAuthContext(req)
+
+	rr := httptest.NewRecorder()
+	h.ChatCompletions(rr, req)
+
+	assertRefusal(t, rr)
+	assertBoundedRow(t, findModelRow(t, h, prefix), model)
+}
+
+// TestIngest_ModelTooLong_MiddlewarePreparsed covers the path every /v1 JSON
+// route and /api/chat take in production: streamingAwareTimeout has already
+// put the model in the context, so the pending INSERT would carry it. The row
+// must still exist (the refusal stays attributed to the key) and carry the
+// excerpt.
+func TestIngest_ModelTooLong_MiddlewarePreparsed(t *testing.T) {
+	h := newIntegrationHandler()
+	model, prefix := oversizedModelWithPrefix()
+	req := httptest.NewRequest(http.MethodPost, "/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[]}`))
+	req = withAuthContext(req)
+	ctx := context.WithValue(req.Context(), ctxkeys.RequestModelKey, model)
+	ctx = context.WithValue(ctx, ctxkeys.IsStreamingKey, true)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	h.ChatCompletions(rr, req)
+
+	assertRefusal(t, rr)
+	assertBoundedRow(t, findModelRow(t, h, prefix), model)
+}
+
+// TestIngest_ModelTooLong_Multipart covers the form-field path of the audio
+// endpoints, where the model is parsed out of the multipart body.
+func TestIngest_ModelTooLong_Multipart(t *testing.T) {
+	h := newIntegrationHandler()
+	model, prefix := oversizedModelWithPrefix()
+	body := "--xyz\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n" + model + "\r\n--xyz--\r\n"
+	req := httptest.NewRequest(http.MethodPost, "/audio/transcriptions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xyz")
+	req = withAuthContext(req)
+
+	rr := httptest.NewRecorder()
+	h.AudioTranscriptions(rr, req)
+
+	assertRefusal(t, rr)
+	assertBoundedRow(t, findModelRow(t, h, prefix), model)
+}
+
+// TestIngest_ModelAtLimit_ReachesFormatValidation pins that the bound does not
+// over-reject: a model of exactly maxModelNameRunes runes, in multi-byte
+// characters so a byte count would refuse it, passes the length guard and is
+// refused by the ordinary format validation instead.
+func TestIngest_ModelAtLimit_ReachesFormatValidation(t *testing.T) {
+	h := newIntegrationHandler()
+	model := strings.Repeat("é", maxModelNameRunes)
+	req := httptest.NewRequest(http.MethodPost, "/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[]}`))
+	req = withAuthContext(req)
+
+	rr := httptest.NewRecorder()
+	h.ChatCompletions(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 from format validation", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), modelTooLongMessage) {
+		t.Errorf("an at-limit model must not hit the length refusal; body: %.200s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "invalid model format") {
+		t.Errorf("want the format refusal, got: %.200s", rr.Body.String())
+	}
+}
+
+func TestModelTooLong_CountsRunesNotBytes(t *testing.T) {
+	if modelTooLong("") {
+		t.Error("empty model is not too long")
+	}
+	if modelTooLong(strings.Repeat("é", maxModelNameRunes)) {
+		t.Errorf("%d multi-byte runes are at the bound, not over it", maxModelNameRunes)
+	}
+	if !modelTooLong(strings.Repeat("é", maxModelNameRunes+1)) {
+		t.Errorf("%d runes are over the bound", maxModelNameRunes+1)
+	}
+}
+
+func TestModelExcerpt(t *testing.T) {
+	short := "openai/gpt-4o"
+	if got := modelExcerpt(short); got != short {
+		t.Errorf("short model changed: %q", got)
+	}
+	exact := strings.Repeat("é", modelExcerptRunes)
+	if got := modelExcerpt(exact); got != exact {
+		t.Errorf("model at the excerpt length changed: %q", got)
+	}
+	long := strings.Repeat("é", modelExcerptRunes+1)
+	got := modelExcerpt(long)
+	if !utf8.ValidString(got) {
+		t.Fatalf("excerpt is not valid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") || utf8.RuneCountInString(got) != modelExcerptRunes+1 {
+		t.Errorf("excerpt = %d runes %q, want %d runes plus an ellipsis", utf8.RuneCountInString(got), got, modelExcerptRunes)
+	}
+	if !strings.HasPrefix(got, strings.Repeat("é", modelExcerptRunes)) {
+		t.Errorf("excerpt must be the model's own prefix, got %q", got)
+	}
+}
+
+func TestTruncateLogMessage(t *testing.T) {
+	short := "provider request failed"
+	if got := truncateLogMessage(short); got != short {
+		t.Errorf("short message changed: %q", got)
+	}
+	exact := strings.Repeat("é", maxLogMessageRunes)
+	if got := truncateLogMessage(exact); got != exact {
+		t.Errorf("message at the bound changed")
+	}
+	long := strings.Repeat("é", maxLogMessageRunes+50)
+	got := truncateLogMessage(long)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated message is not valid UTF-8")
+	}
+	if n := utf8.RuneCountInString(got); n != maxLogMessageRunes+1 {
+		t.Errorf("truncated length = %d runes, want %d plus the ellipsis", n, maxLogMessageRunes)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated message must end with an ellipsis")
+	}
+}
+
+// TestFailRequest_BoundsErrorMessage pins the clamp at the sink: a caller
+// handing failRequest an oversized message gets a bounded row, whatever the
+// caller was.
+func TestFailRequest_BoundsErrorMessage(t *testing.T) {
+	h := newIntegrationHandler()
+	prefix := "clamp-" + uuid.NewString()[:8]
+	req := withAuthContext(httptest.NewRequest(http.MethodPost, "/chat/completions", http.NoBody))
+	logData, _ := h.newPendingRequestLog(req, endpointTypeChat, prefix, false)
+	h.failRequest(logData, http.StatusBadGateway, KindProviderError, strings.Repeat("x", maxLogMessageRunes*2), 0, time.Now(), 0, resolveTimings{}, resolveCacheHits{}, 0)
+
+	row := findModelRow(t, h, prefix)
+	if n := utf8.RuneCountInString(row.errorMessage); n != maxLogMessageRunes+1 {
+		t.Errorf("stored error_message is %d runes, want %d plus the ellipsis", n, maxLogMessageRunes)
+	}
+	if row.errorKind != string(KindProviderError) {
+		t.Errorf("error_kind = %q, want %q", row.errorKind, KindProviderError)
+	}
+}

--- a/internal/proxy/model_limit_test.go
+++ b/internal/proxy/model_limit_test.go
@@ -3,9 +3,9 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -30,14 +30,15 @@ func oversizedModelWithPrefix() (model, prefix string) {
 // compressed bytes; a run of one repeated byte compresses under that and is
 // accepted, random hex is not. That is what makes the fixture discriminate:
 // a guard that lets this model reach the pending INSERT loses the row.
-func incompressibleModelWithPrefix(runes int) (model, prefix string) {
+// length is in bytes, which equals runes here because the content is ASCII.
+func incompressibleModelWithPrefix(length int) (model, prefix string) {
 	prefix = "toolong-" + uuid.NewString()[:8] + "-"
 	var b strings.Builder
 	b.WriteString(prefix)
-	for b.Len() < runes {
+	for b.Len() < length {
 		b.WriteString(strings.ReplaceAll(uuid.NewString(), "-", ""))
 	}
-	return b.String()[:runes], prefix
+	return b.String()[:length], prefix
 }
 
 // modelRow is what the request-log row looks like after ingest refused it.
@@ -267,8 +268,8 @@ func TestModelTooLong_CountsRunesNotBytes(t *testing.T) {
 // TestModelTooLongMessage_SpellsTheBound keeps the constant message honest
 // about the number it quotes.
 func TestModelTooLongMessage_SpellsTheBound(t *testing.T) {
-	if !strings.Contains(modelTooLongMessage, strconv.Itoa(maxModelNameRunes)) {
-		t.Errorf("message %q does not spell the bound %d", modelTooLongMessage, maxModelNameRunes)
+	if want := fmt.Sprintf("model exceeds maximum length of %d characters", maxModelNameRunes); modelTooLongMessage != want {
+		t.Errorf("message = %q, want %q", modelTooLongMessage, want)
 	}
 }
 

--- a/internal/proxy/model_limit_test.go
+++ b/internal/proxy/model_limit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,22 @@ import (
 func oversizedModelWithPrefix() (model, prefix string) {
 	prefix = "toolong-" + uuid.NewString()[:8] + "-"
 	return prefix + strings.Repeat("a", maxModelNameRunes+1-utf8.RuneCountInString(prefix)), prefix
+}
+
+// incompressibleModelWithPrefix builds a model of the given length out of
+// random hex, so it stays large after TOAST compression. request_logs.model_id
+// is btree-indexed and Postgres refuses an index entry over roughly 2.7 KB of
+// compressed bytes; a run of one repeated byte compresses under that and is
+// accepted, random hex is not. That is what makes the fixture discriminate:
+// a guard that lets this model reach the pending INSERT loses the row.
+func incompressibleModelWithPrefix(runes int) (model, prefix string) {
+	prefix = "toolong-" + uuid.NewString()[:8] + "-"
+	var b strings.Builder
+	b.WriteString(prefix)
+	for b.Len() < runes {
+		b.WriteString(strings.ReplaceAll(uuid.NewString(), "-", ""))
+	}
+	return b.String()[:runes], prefix
 }
 
 // modelRow is what the request-log row looks like after ingest refused it.
@@ -110,9 +127,15 @@ func TestIngest_ModelTooLong_BodyParsed(t *testing.T) {
 // put the model in the context, so the pending INSERT would carry it. The row
 // must still exist (the refusal stays attributed to the key) and carry the
 // excerpt.
+//
+// The fixture is 8 KB of random hex on purpose. If the guard before the INSERT
+// regresses, the INSERT carries the field, the btree index refuses it, the
+// terminal UPDATE finds no row, and this test times out waiting for one; a
+// compressible fixture would be accepted by the index and let the terminal
+// UPDATE rewrite model_id to the excerpt, hiding the regression.
 func TestIngest_ModelTooLong_MiddlewarePreparsed(t *testing.T) {
 	h := newIntegrationHandler()
-	model, prefix := oversizedModelWithPrefix()
+	model, prefix := incompressibleModelWithPrefix(8192)
 	req := httptest.NewRequest(http.MethodPost, "/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[]}`))
 	req = withAuthContext(req)
 	ctx := context.WithValue(req.Context(), ctxkeys.RequestModelKey, model)
@@ -126,21 +149,83 @@ func TestIngest_ModelTooLong_MiddlewarePreparsed(t *testing.T) {
 	assertBoundedRow(t, findModelRow(t, h, prefix), model)
 }
 
+// TestIngest_ModelTooLong_Messages covers the native Anthropic ingress, which
+// sets the context model itself and answers in the Anthropic error envelope.
+func TestIngest_ModelTooLong_Messages(t *testing.T) {
+	h := newIntegrationHandler()
+	model, prefix := oversizedModelWithPrefix()
+	body := `{"model":"` + model + `","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req = withAuthContext(req)
+
+	rr := httptest.NewRecorder()
+	h.Messages(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %.200s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Type  string `json:"type"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil || resp.Type != "error" {
+		t.Fatalf("response is not the Anthropic error envelope (err %v); body: %.200s", err, rr.Body.String())
+	}
+	if resp.Error.Message != modelTooLongMessage {
+		t.Errorf("message = %q, want %q", resp.Error.Message, modelTooLongMessage)
+	}
+	if n := rr.Body.Len(); n > 256 {
+		t.Errorf("response body is %d bytes: the refusal must not echo the model", n)
+	}
+	assertBoundedRow(t, findModelRow(t, h, prefix), model)
+}
+
 // TestIngest_ModelTooLong_Multipart covers the form-field path of the audio
 // endpoints, where the model is parsed out of the multipart body.
 func TestIngest_ModelTooLong_Multipart(t *testing.T) {
 	h := newIntegrationHandler()
 	model, prefix := oversizedModelWithPrefix()
-	body := "--xyz\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n" + model + "\r\n--xyz--\r\n"
-	req := httptest.NewRequest(http.MethodPost, "/audio/transcriptions", strings.NewReader(body))
-	req.Header.Set("Content-Type", "multipart/form-data; boundary=xyz")
-	req = withAuthContext(req)
+	req := multipartModelRequest(model)
 
 	rr := httptest.NewRecorder()
 	h.AudioTranscriptions(rr, req)
 
 	assertRefusal(t, rr)
 	assertBoundedRow(t, findModelRow(t, h, prefix), model)
+}
+
+// TestIngest_MultipartModel_InvalidUTF8Normalized pins the form field's UTF-8
+// normalisation: the JSON paths get valid UTF-8 from encoding/json, the form
+// field is raw bytes, and Postgres refuses an invalid byte in model_id, which
+// would lose the row. The byte must be replaced, and the row must land.
+func TestIngest_MultipartModel_InvalidUTF8Normalized(t *testing.T) {
+	h := newIntegrationHandler()
+	prefix := "badutf8-" + uuid.NewString()[:8] + "-"
+	req := multipartModelRequest(prefix + "\x80\x80")
+
+	rr := httptest.NewRecorder()
+	h.AudioTranscriptions(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 from format validation; body: %.200s", rr.Code, rr.Body.String())
+	}
+	row := findModelRow(t, h, prefix)
+	// One replacement for the run of two invalid bytes: that is
+	// strings.ToValidUTF8's contract, a run, not a byte.
+	if want := prefix + "�"; row.modelID != want {
+		t.Errorf("model_id = %q, want the replacement character %q", row.modelID, want)
+	}
+}
+
+// multipartModelRequest builds an audio transcription request whose only form
+// field is the model.
+func multipartModelRequest(model string) *http.Request {
+	body := "--xyz\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n" + model + "\r\n--xyz--\r\n"
+	req := httptest.NewRequest(http.MethodPost, "/audio/transcriptions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xyz")
+	return withAuthContext(req)
 }
 
 // TestIngest_ModelAtLimit_ReachesFormatValidation pins that the bound does not
@@ -176,6 +261,14 @@ func TestModelTooLong_CountsRunesNotBytes(t *testing.T) {
 	}
 	if !modelTooLong(strings.Repeat("é", maxModelNameRunes+1)) {
 		t.Errorf("%d runes are over the bound", maxModelNameRunes+1)
+	}
+}
+
+// TestModelTooLongMessage_SpellsTheBound keeps the constant message honest
+// about the number it quotes.
+func TestModelTooLongMessage_SpellsTheBound(t *testing.T) {
+	if !strings.Contains(modelTooLongMessage, strconv.Itoa(maxModelNameRunes)) {
+		t.Errorf("message %q does not spell the bound %d", modelTooLongMessage, maxModelNameRunes)
 	}
 }
 
@@ -223,15 +316,19 @@ func TestTruncateLogMessage(t *testing.T) {
 	}
 }
 
-// TestFailRequest_BoundsErrorMessage pins the clamp at the sink: a caller
-// handing failRequest an oversized message gets a bounded row, whatever the
-// caller was.
-func TestFailRequest_BoundsErrorMessage(t *testing.T) {
+// TestUpdateRequestLog_BoundsErrorMessage pins the clamp at the sink. The
+// message is assigned directly, the way the stream finaliser and the native
+// readers do it, bypassing failRequest: the bound must still hold.
+func TestUpdateRequestLog_BoundsErrorMessage(t *testing.T) {
 	h := newIntegrationHandler()
 	prefix := "clamp-" + uuid.NewString()[:8]
 	req := withAuthContext(httptest.NewRequest(http.MethodPost, "/chat/completions", http.NoBody))
 	logData, _ := h.newPendingRequestLog(req, endpointTypeChat, prefix, false)
-	h.failRequest(logData, http.StatusBadGateway, KindProviderError, strings.Repeat("x", maxLogMessageRunes*2), 0, time.Now(), 0, resolveTimings{}, resolveCacheHits{}, 0)
+	logData.statusCode = http.StatusBadGateway
+	logData.errorKind = KindProviderError
+	logData.errorMessage = strings.Repeat("x", maxLogMessageRunes*2)
+	logData.state = "failed"
+	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 	row := findModelRow(t, h, prefix)
 	if n := utf8.RuneCountInString(row.errorMessage); n != maxLogMessageRunes+1 {

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -51,7 +51,11 @@ func parseMultipartParts(body []byte, boundary string) ([]multipartPart, string,
 			data:        data,
 		}
 		if part.fieldName == "model" && part.fileName == "" {
-			model = strings.TrimSpace(string(data))
+			// The form field is raw bytes. The JSON paths get valid UTF-8 for
+			// free from encoding/json; here an invalid byte would reach the
+			// request-log INSERT verbatim and Postgres refuses it, losing the
+			// row. Replace it the way the JSON decoder would.
+			model = strings.ToValidUTF8(strings.TrimSpace(string(data)), "�")
 		}
 		parts = append(parts, part)
 	}
@@ -204,8 +208,7 @@ func (h *Handler) ingestMultipartRequest(w http.ResponseWriter, r *http.Request,
 	// The `model` form field gets the same bound as the JSON ingest paths,
 	// checked before it is assigned to the log entry, published, or logged.
 	if modelTooLong(reqModel) {
-		logData.modelID = modelExcerpt(reqModel)
-		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		h.rejectOversizedModel(w, logData, reqModel, startTime, parseMs)
 		return nil, nil, false
 	}
 

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -201,6 +201,14 @@ func (h *Handler) ingestMultipartRequest(w http.ResponseWriter, r *http.Request,
 	}
 	parseMs := float64(time.Since(parseStart).Microseconds()) / 1000.0
 
+	// The `model` form field gets the same bound as the JSON ingest paths,
+	// checked before it is assigned to the log entry, published, or logged.
+	if modelTooLong(reqModel) {
+		logData.modelID = modelExcerpt(reqModel)
+		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		return nil, nil, false
+	}
+
 	logData.modelID = reqModel
 	publishRequestStartedEvent(logData)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -29,7 +30,7 @@ var newRequestWithContext = http.NewRequestWithContext
 func (h *Handler) failRequest(logData *requestLogData, statusCode int, kind ErrorKind, errMsg string, attempt int, startTime time.Time, parseMs float64, timings resolveTimings, cacheHits resolveCacheHits, proxyOverhead float64) {
 	logData.statusCode = statusCode
 	logData.errorKind = kind
-	logData.errorMessage = errMsg
+	logData.errorMessage = truncateLogMessage(errMsg)
 	logData.durationMs = float64(time.Since(startTime).Microseconds()) / 1000.0
 	logData.proxyOverheadMs = proxyOverhead
 	logData.parseMs = parseMs
@@ -44,6 +45,24 @@ func (h *Handler) failRequest(logData *requestLogData, statusCode int, kind Erro
 	logData.state = "failed"
 	// Fire-and-forget: skip WaitForInsert to avoid blocking before error response.
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
+}
+
+// maxLogMessageRunes bounds request_logs.error_message and the
+// request.completed event built from it. Every current caller of failRequest
+// already passes a bounded message (a constant, errString's cap, or a
+// SanitizeLogBody body), but failRequest is the one sink every failure path
+// funnels through, so the bound lives here where a future caller cannot miss
+// it. It matches the 10,000-character budget SanitizeLogBody gives upstream
+// bodies.
+const maxLogMessageRunes = 10000
+
+// truncateLogMessage caps s at maxLogMessageRunes runes, cutting on a rune
+// boundary so the stored text stays valid UTF-8, and marks the cut.
+func truncateLogMessage(s string) string {
+	if utf8.RuneCountInString(s) <= maxLogMessageRunes {
+		return s
+	}
+	return string([]rune(s)[:maxLogMessageRunes]) + "…"
 }
 
 // ChatCompletions handles OpenAI-compatible chat completion requests with failover support.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode/utf8"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -30,7 +29,7 @@ var newRequestWithContext = http.NewRequestWithContext
 func (h *Handler) failRequest(logData *requestLogData, statusCode int, kind ErrorKind, errMsg string, attempt int, startTime time.Time, parseMs float64, timings resolveTimings, cacheHits resolveCacheHits, proxyOverhead float64) {
 	logData.statusCode = statusCode
 	logData.errorKind = kind
-	logData.errorMessage = truncateLogMessage(errMsg)
+	logData.errorMessage = errMsg
 	logData.durationMs = float64(time.Since(startTime).Microseconds()) / 1000.0
 	logData.proxyOverheadMs = proxyOverhead
 	logData.parseMs = parseMs
@@ -45,24 +44,6 @@ func (h *Handler) failRequest(logData *requestLogData, statusCode int, kind Erro
 	logData.state = "failed"
 	// Fire-and-forget: skip WaitForInsert to avoid blocking before error response.
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
-}
-
-// maxLogMessageRunes bounds request_logs.error_message and the
-// request.completed event built from it. Every current caller of failRequest
-// already passes a bounded message (a constant, errString's cap, or a
-// SanitizeLogBody body), but failRequest is the one sink every failure path
-// funnels through, so the bound lives here where a future caller cannot miss
-// it. It matches the 10,000-character budget SanitizeLogBody gives upstream
-// bodies.
-const maxLogMessageRunes = 10000
-
-// truncateLogMessage caps s at maxLogMessageRunes runes, cutting on a rune
-// boundary so the stored text stays valid UTF-8, and marks the cut.
-func truncateLogMessage(s string) string {
-	if utf8.RuneCountInString(s) <= maxLogMessageRunes {
-		return s
-	}
-	return string([]rune(s)[:maxLogMessageRunes]) + "…"
 }
 
 // ChatCompletions handles OpenAI-compatible chat completion requests with failover support.

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -27,9 +26,9 @@ import (
 // above anything that can resolve.
 const maxModelNameRunes = 512
 
-// modelTooLongMessage is the constant refusal for an oversized model. It is
-// derived from the bound rather than spelled beside it so the two cannot drift.
-var modelTooLongMessage = fmt.Sprintf("model exceeds maximum length of %d characters", maxModelNameRunes)
+// modelTooLongMessage is the constant refusal for an oversized model. A test
+// pins the number it spells to maxModelNameRunes so the two cannot drift.
+const modelTooLongMessage = "model exceeds maximum length of 512 characters"
 
 // modelExcerptRunes is how much of an oversized model the request-log row
 // keeps. The row exists so the refusal stays attributed to its virtual key;
@@ -54,12 +53,14 @@ func modelExcerpt(model string) string {
 }
 
 // rejectOversizedModel is the one outcome every ingest path has for a model
-// past maxModelNameRunes: the pending row (already inserted by the caller,
-// carrying the excerpt rather than the field) is closed as a validation
-// failure with the constant message, subscribers see the started/completed
-// pair every other early guard emits, and the caller gets the same constant
-// message back. The response never quotes the field.
-func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLogData, startTime time.Time, parseMs float64) {
+// past maxModelNameRunes: the pending row (already inserted by the caller) is
+// closed as a validation failure carrying the excerpt rather than the field,
+// subscribers see the started/completed pair every other early guard emits,
+// and the caller gets the constant message back. The response never quotes
+// the field. It takes the raw model and derives the excerpt itself so no
+// ingest path can put the field on the row by forgetting to.
+func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLogData, model string, startTime time.Time, parseMs float64) {
+	logData.modelID = modelExcerpt(model)
 	publishRequestStartedEvent(logData)
 	h.failRequest(logData, http.StatusBadRequest, KindValidation, modelTooLongMessage, 0, startTime, parseMs, resolveTimings{}, resolveCacheHits{}, 0)
 	writeOpenAIError(w, modelTooLongMessage, http.StatusBadRequest)
@@ -111,7 +112,7 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 	// (the event, the app-log lines, the response) is behind the return.
 	if modelTooLong(reqModel) {
 		logData, _ := h.newPendingRequestLog(r, endpointType, modelExcerpt(reqModel), isStreaming)
-		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		h.rejectOversizedModel(w, logData, reqModel, startTime, parseMs)
 		return nil, false
 	}
 
@@ -157,9 +158,8 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 	// inserted with an empty model, and modelID, the event and the app-log
 	// lines all come after this point. Same refusal, same excerpt on the row.
 	if modelTooLong(reqModel) {
-		logData.modelID = modelExcerpt(reqModel)
 		logData.streaming = isStreaming
-		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		h.rejectOversizedModel(w, logData, reqModel, startTime, parseMs)
 		return nil, false
 	}
 

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -58,7 +58,9 @@ func modelExcerpt(model string) string {
 // subscribers see the started/completed pair every other early guard emits,
 // and the caller gets the constant message back. The response never quotes
 // the field. It takes the raw model and derives the excerpt itself so no
-// ingest path can put the field on the row by forgetting to.
+// ingest path can put the field on the row at the refusal by forgetting to;
+// the middleware-preparsed path must still hand the excerpt to its own
+// pending INSERT, which runs before this can.
 func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLogData, model string, startTime time.Time, parseMs float64) {
 	logData.modelID = modelExcerpt(model)
 	publishRequestStartedEvent(logData)

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -2,15 +2,68 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hugalafutro/model-hotel/internal/clientip"
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
+
+// maxModelNameRunes bounds the client-supplied `model` routing field.
+//
+// The field is routing metadata, and the pipeline persists it before it
+// validates it: the pending request-log row carries it, the request.started
+// event carries it, the "request start" app-log line carries it, and the
+// resolve failures quote it back in the error response. None of those sinks
+// had a bound of its own, so a multi-megabyte model inside the (legal, capped)
+// request body was a multi-megabyte write to every one of them, from one
+// virtual key. Real routing targets are "provider/model" or "hotel/group";
+// the admin write paths cap display models at 128 characters, so 512 is far
+// above anything that can resolve.
+const maxModelNameRunes = 512
+
+// modelTooLongMessage is the constant refusal for an oversized model. It is
+// derived from the bound rather than spelled beside it so the two cannot drift.
+var modelTooLongMessage = fmt.Sprintf("model exceeds maximum length of %d characters", maxModelNameRunes)
+
+// modelExcerptRunes is how much of an oversized model the request-log row
+// keeps. The row exists so the refusal stays attributed to its virtual key;
+// a prefix is enough to recognise the request in the log and small enough that
+// the attacker's string cannot use the row as its sink.
+const modelExcerptRunes = 64
+
+// modelTooLong reports whether the model field is over the bound. An empty
+// model is not too long; "model is required" is a separate guard downstream.
+func modelTooLong(model string) bool {
+	return utf8.RuneCountInString(model) > maxModelNameRunes
+}
+
+// modelExcerpt returns the bounded form of an oversized model for the
+// request-log row: the first modelExcerptRunes runes and an ellipsis, cut on a
+// rune boundary so the stored text stays valid UTF-8.
+func modelExcerpt(model string) string {
+	if utf8.RuneCountInString(model) <= modelExcerptRunes {
+		return model
+	}
+	return string([]rune(model)[:modelExcerptRunes]) + "…"
+}
+
+// rejectOversizedModel is the one outcome every ingest path has for a model
+// past maxModelNameRunes: the pending row (already inserted by the caller,
+// carrying the excerpt rather than the field) is closed as a validation
+// failure with the constant message, subscribers see the started/completed
+// pair every other early guard emits, and the caller gets the same constant
+// message back. The response never quotes the field.
+func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLogData, startTime time.Time, parseMs float64) {
+	publishRequestStartedEvent(logData)
+	h.failRequest(logData, http.StatusBadRequest, KindValidation, modelTooLongMessage, 0, startTime, parseMs, resolveTimings{}, resolveCacheHits{}, 0)
+	writeOpenAIError(w, modelTooLongMessage, http.StatusBadRequest)
+}
 
 // ingestRequest performs phase A of ChatCompletions and the JSON multimodal
 // endpoints: read the pre-parsed model/stream/parse-time and virtual-key
@@ -52,6 +105,16 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 	// not covered by streamingAwareTimeout), parse from body directly.
 	var bodyBytes []byte
 
+	// The middleware-provided model is what the pending INSERT below would
+	// carry, so the bound is checked before the row exists: the row is
+	// inserted with the excerpt and closed as the refusal. Every later sink
+	// (the event, the app-log lines, the response) is behind the return.
+	if modelTooLong(reqModel) {
+		logData, _ := h.newPendingRequestLog(r, endpointType, modelExcerpt(reqModel), isStreaming)
+		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		return nil, false
+	}
+
 	logData, vkHash := h.newPendingRequestLog(r, endpointType, reqModel, isStreaming)
 
 	if reqModel == "" {
@@ -88,6 +151,16 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 		if cached, ok := r.Context().Value(ctxkeys.RequestBodyKey).([]byte); ok {
 			bodyBytes = cached
 		}
+	}
+
+	// The body-parsed model has not touched any sink yet: the pending row was
+	// inserted with an empty model, and modelID, the event and the app-log
+	// lines all come after this point. Same refusal, same excerpt on the row.
+	if modelTooLong(reqModel) {
+		logData.modelID = modelExcerpt(reqModel)
+		logData.streaming = isStreaming
+		h.rejectOversizedModel(w, logData, startTime, parseMs)
+		return nil, false
 	}
 
 	// Update log entry with model resolved from body parsing (if not set by middleware).


### PR DESCRIPTION
## What

Bounds the client-supplied `model` routing field at 512 runes, at every ingest path, before the field reaches any sink. Clamps `request_logs.error_message` at 10,000 runes at the one sink every terminal write passes through.

## Why

Strix 2026-08-31 vuln-0004 (CWE-400, medium), verified against the code. The `model` field was persisted and echoed before it was validated: the pending request-log row carried it, the `request.started` event carried it, the "request start" app-log line carried it, and the resolve error responses quoted it back. None of those sinks had a bound of its own, so a multi-megabyte model inside the (legal, capped) request body was a multi-megabyte write to every one of them, from a single virtual key, at the per-key rate: a 5 MB 404 body plus two 5 MB `app_logs` rows per request, and RSS growth from the log ring.

## How

- `maxModelNameRunes = 512`, far above any routing target (`provider/model`, `hotel/group`; display models cap at 128) and safely under the `model_id` btree index limit.
- Three guards, one outcome (`rejectOversizedModel`): the middleware-preparsed JSON path (covers `/v1`, `/v1/messages`, `/api/chat`) checks before the pending INSERT; the body-parsed fallback checks before `modelID` is assigned; the multipart form path checks before the log entry is filled. Every refusal still leaves an attributed row so the operator can see who sent it, carrying a 64-rune excerpt of the field rather than the field. The response is a constant message and never quotes the field.
- `error_message` is clamped in `updateRequestLog`, not `failRequest`: four paths assign it directly and call `updateRequestLog` themselves.
- The multipart `model` form field is normalised to valid UTF-8 the way `encoding/json` already does for the JSON paths (an invalid byte reached the INSERT verbatim and Postgres refused it, losing the row).

## Tests

11 new tests against the real test DB: each of the three guards plus the native `/v1/messages` envelope, asserting a bounded response body and the stored row; an at-limit multi-byte model still reaching format validation; rune-vs-byte counting; the excerpt; the clamp on a directly assigned message; the multipart UTF-8 normalisation. The middleware-path fixture is 8 KB of random hex on purpose: a regressed guard trips the `model_id` btree limit and loses the row instead of being rewritten to the excerpt by the terminal UPDATE (a compressible fixture let that regression pass). `internal/proxy`: 2,076 pass, lint clean, size gate OK, diff coverage 32/32.

## Review

Adversarial subagent review (Opus) with a verification round: seven findings, all addressed (clamp moved to the sink, discriminating fixture, excerpt owned by the refusal, Messages test, multipart UTF-8, exact message pin); re-review verdict ready to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S2nsLenYbQm6235Sv8o55
