### PR TITLE
fix(proxy): bound provider-reported token counts before they become gateway state

### DIFF
--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -229,7 +229,13 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		}
 	case "message_delta":
 		if usage, ok := readEventUsage(ev.Usage); ok {
-			info.OutputTokens, info.HasOutput = usage.OutputTokens, true
+			// The guard message_start has always had: an output figure that is
+			// not positive is not a reading. Assigned verbatim, a negative
+			// output_tokens here reached the completion metering after the
+			// whole answer had been forwarded and drew the key's usage down.
+			if usage.OutputTokens > 0 {
+				info.OutputTokens, info.HasOutput = usage.OutputTokens, true
+			}
 		}
 	case "error":
 		if util.ErrorMemberCarries(ev.Error) {

--- a/internal/anthropic/usage_guard_test.go
+++ b/internal/anthropic/usage_guard_test.go
@@ -1,0 +1,28 @@
+package anthropic
+
+import "testing"
+
+// A message_delta usage block arrives after the whole answer has been
+// forwarded, so a hostile or broken upstream controls it with no window for
+// anyone to notice. message_start has always refused a non-positive output
+// figure; message_delta assigned it verbatim, and a negative output_tokens
+// reached the completion metering and drew the key's usage down.
+
+func TestInspectStreamEvent_MessageDeltaRefusesNonPositiveOutput(t *testing.T) {
+	for _, payload := range []string{
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":-700}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}`,
+	} {
+		ev := InspectStreamEvent([]byte(payload))
+		if ev.HasOutput || ev.OutputTokens != 0 {
+			t.Errorf("%s: not a reading, got %+v", payload, ev)
+		}
+	}
+}
+
+func TestInspectStreamEvent_MessageDeltaKeepsPositiveOutput(t *testing.T) {
+	ev := InspectStreamEvent([]byte(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":23}}`))
+	if !ev.HasOutput || ev.OutputTokens != 23 {
+		t.Fatalf("a real reading must survive the guard: got %+v", ev)
+	}
+}

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -702,11 +702,17 @@ func parseTestModelResponse(respBody []byte, duration int64) (content string, tp
 		content = chatResp.Choices[0].Message.Content
 	}
 
-	if chatResp.Usage.CompletionTokens > 0 && duration > 0 {
-		tps = float64(chatResp.Usage.CompletionTokens) / float64(duration) * 1000
+	// The same bound the proxy holds every provider figure to: these two land
+	// in the request log's int4 token columns, where a negative skews the
+	// stats and an overflow fails the INSERT and loses the row.
+	promptTokens = util.ClampTokenCount(chatResp.Usage.PromptTokens)
+	completionTokens = util.ClampTokenCount(chatResp.Usage.CompletionTokens)
+
+	if completionTokens > 0 && duration > 0 {
+		tps = float64(completionTokens) / float64(duration) * 1000
 	}
 
-	return content, tps, chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens
+	return content, tps, promptTokens, completionTokens
 }
 
 // logTestModelRequestError records a failed test request (the upstream call

--- a/internal/api/models_helpers_test.go
+++ b/internal/api/models_helpers_test.go
@@ -403,6 +403,24 @@ func TestParseTestModelResponse_ValidJSON(t *testing.T) {
 	}
 }
 
+// The probe's figures land in the same int4 request-log columns the proxy
+// writes, so they are held to the same bound: a negative would skew the stats
+// aggregates and an overflow would fail the INSERT and lose the row.
+func TestParseTestModelResponse_ClampsProviderFigures(t *testing.T) {
+	body := []byte(`{"choices":[{"message":{"content":"Hi"}}],"usage":{"prompt_tokens":-500,"completion_tokens":9223372036854775807}}`)
+	_, tps, promptTokens, completionTokens := parseTestModelResponse(body, 1000)
+
+	if promptTokens != 0 {
+		t.Errorf("promptTokens: got %d, want 0 for a negative figure", promptTokens)
+	}
+	if completionTokens != util.MaxSaneTokenCount {
+		t.Errorf("completionTokens: got %d, want the ceiling %d", completionTokens, util.MaxSaneTokenCount)
+	}
+	if want := float64(util.MaxSaneTokenCount); tps != want {
+		t.Errorf("tps: got %f, want %f (derived from the clamped figure)", tps, want)
+	}
+}
+
 func TestParseTestModelResponse_InvalidJSON(t *testing.T) {
 	body := []byte(`not json at all`)
 	content, tps, promptTokens, completionTokens := parseTestModelResponse(body, 1000)

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -74,10 +74,11 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body = logData.masker.maskExact(body)
 
 	usage := anthropic.ParseResponseUsage(body)
-	// The native prompt figure is a sum of three members, so the per-member
-	// decode bound leaves it unbounded; clamped on entry like every other
-	// provider figure so the log row, the estimate and the charge agree.
-	inputTokens, outputTokens, _ := sanitizeUsageCounts(usage.PromptTokens, usage.CompletionTokens, 0)
+	// The native prompt figure and its cache miss are sums of members the
+	// decoder bounded one at a time, so they arrive unbounded; every figure
+	// this function writes is clamped so the log row's five token columns,
+	// the estimate and the charge agree.
+	inputTokens, outputTokens := clampTokenCount(usage.PromptTokens), clampTokenCount(usage.CompletionTokens)
 	totalDuration := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 
 	// The status the provider actually sent, not a flattened 200: a relay may
@@ -99,8 +100,8 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// The cache split, not just the total: metering the cache-inclusive prompt
 	// without it prices every cached token at full input rate. The translated
 	// path reaches the same two fields through extractCacheTokens.
-	logData.tokensPromptCacheHit = usage.CacheHitTokens
-	logData.tokensPromptCacheMiss = usage.CacheMissTokens
+	logData.tokensPromptCacheHit = clampTokenCount(usage.CacheHitTokens)
+	logData.tokensPromptCacheMiss = clampTokenCount(usage.CacheMissTokens)
 	logData.failoverAttempt = attempt
 	logData.state = "completed"
 	// What clears the model's gone-strike streak (see attemptCandidate), so the

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -77,8 +77,8 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// The native prompt figure and its cache miss are sums of members the
 	// decoder bounded one at a time, so they arrive unbounded; every figure
 	// this function writes is clamped so the log row's five token columns,
-	// the estimate and the charge agree.
-	inputTokens, outputTokens := clampTokenCount(usage.PromptTokens), clampTokenCount(usage.CompletionTokens)
+	// the estimate and the charge agree, and a rewrite is announced.
+	inputTokens, outputTokens, _ := h.clampReportedUsage(usage.PromptTokens, usage.CompletionTokens, 0, logData)
 	totalDuration := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 
 	// The status the provider actually sent, not a flattened 200: a relay may
@@ -142,19 +142,25 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 // Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
-	// Clamped like the translated path's observer: the native figures are
-	// sums and differences of members the decoder bounded one at a time.
-	if info.HasInput {
-		st.promptTokens = clampTokenCount(info.InputTokens)
+	// Judged like the translated path's observer, which REFUSES an
+	// out-of-range member rather than clamping it: on a stream there is an
+	// earlier reading to keep and an estimator to fall back on, so a chunk
+	// saying something absurd says nothing. Clamping here instead let the same
+	// figure that is discarded on an OpenAI-shaped stream charge the ceiling
+	// on this one, which is the attack surviving on one dialect.
+	if info.HasInput && isTokenReading(info.InputTokens) {
+		st.promptTokens = info.InputTokens
 		// Guarded like the translated path's observer: a later usage event
 		// without cache fields must not zero a split an earlier one reported.
+		// The split is clamped rather than refused, matching extractCacheTokens:
+		// these two are log columns, not a charge.
 		if info.CacheHitTokens > 0 || info.CacheMissTokens > 0 {
 			st.promptCacheHitTokens = clampTokenCount(info.CacheHitTokens)
 			st.promptCacheMissTokens = clampTokenCount(info.CacheMissTokens)
 		}
 	}
-	if info.HasOutput {
-		st.completionTokens = clampTokenCount(info.OutputTokens)
+	if info.HasOutput && isTokenReading(info.OutputTokens) {
+		st.completionTokens = info.OutputTokens
 	}
 	st.deliveredBytes += info.TextBytes
 	switch info.Type {

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -74,7 +74,10 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body = logData.masker.maskExact(body)
 
 	usage := anthropic.ParseResponseUsage(body)
-	inputTokens, outputTokens := usage.PromptTokens, usage.CompletionTokens
+	// The native prompt figure is a sum of three members, so the per-member
+	// decode bound leaves it unbounded; clamped on entry like every other
+	// provider figure so the log row, the estimate and the charge agree.
+	inputTokens, outputTokens, _ := sanitizeUsageCounts(usage.PromptTokens, usage.CompletionTokens, 0)
 	totalDuration := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 
 	// The status the provider actually sent, not a flattened 200: a relay may
@@ -138,17 +141,19 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 // Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
+	// Clamped like the translated path's observer: the native figures are
+	// sums and differences of members the decoder bounded one at a time.
 	if info.HasInput {
-		st.promptTokens = info.InputTokens
+		st.promptTokens = clampTokenCount(info.InputTokens)
 		// Guarded like the translated path's observer: a later usage event
 		// without cache fields must not zero a split an earlier one reported.
 		if info.CacheHitTokens > 0 || info.CacheMissTokens > 0 {
-			st.promptCacheHitTokens = info.CacheHitTokens
-			st.promptCacheMissTokens = info.CacheMissTokens
+			st.promptCacheHitTokens = clampTokenCount(info.CacheHitTokens)
+			st.promptCacheMissTokens = clampTokenCount(info.CacheMissTokens)
 		}
 	}
 	if info.HasOutput {
-		st.completionTokens = info.OutputTokens
+		st.completionTokens = clampTokenCount(info.OutputTokens)
 	}
 	st.deliveredBytes += info.TextBytes
 	switch info.Type {

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -134,16 +134,19 @@ func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastRe
 // guard the assignment (hit > 0 || miss > 0) to avoid zeroing out cache counts
 // from an earlier usage chunk; non-streaming callers can assign unconditionally
 func extractCacheTokens(u Usage) (hitTokens, missTokens int) {
-	if u.PromptCacheHitTokens > 0 {
-		return u.PromptCacheHitTokens, max(0, u.PromptTokens-u.PromptCacheHitTokens)
+	// Clamped like every other member: these two land in int4 request-log
+	// columns, and an out-of-range figure aborted the whole terminal UPDATE.
+	switch {
+	case u.PromptCacheHitTokens > 0:
+		hitTokens, missTokens = u.PromptCacheHitTokens, u.PromptTokens-u.PromptCacheHitTokens
+	case u.CacheReadInputTokens > 0:
+		hitTokens, missTokens = u.CacheReadInputTokens, u.PromptTokens-u.CacheReadInputTokens
+	case u.PromptTokensDetails != nil && u.PromptTokensDetails.CachedTokens > 0:
+		hitTokens, missTokens = u.PromptTokensDetails.CachedTokens, u.PromptTokens-u.PromptTokensDetails.CachedTokens
+	default:
+		return 0, 0
 	}
-	if u.CacheReadInputTokens > 0 {
-		return u.CacheReadInputTokens, max(0, u.PromptTokens-u.CacheReadInputTokens)
-	}
-	if u.PromptTokensDetails != nil && u.PromptTokensDetails.CachedTokens > 0 {
-		return u.PromptTokensDetails.CachedTokens, max(0, u.PromptTokens-u.PromptTokensDetails.CachedTokens)
-	}
-	return 0, 0
+	return clampTokenCount(hitTokens), clampTokenCount(missTokens)
 }
 
 // parsedChunk holds the decomposed fields from an SSE data line payload.
@@ -282,7 +285,14 @@ func generateRequestHash() string {
 //
 // The two are exclusive on purpose: running both would charge an owner twice.
 func (h *Handler) recordTokenUsage(vkHash string, logData *requestLogData, promptTokens, completionTokens, reasoningTokens int) {
-	totalTokens := promptTokens + completionTokens + reasoningTokens
+	// The charge is where provider figures become gateway state, so it is
+	// where they are policed, whatever path decoded them. The readers clamp
+	// too, so the log row and the charge agree; this is the fence a future
+	// reader cannot skip. The total is capped as well: three clamped members
+	// cannot wrap, but the cap keeps one response's charge inside the bound
+	// the members were held to.
+	promptTokens, completionTokens, reasoningTokens = sanitizeUsageCounts(promptTokens, completionTokens, reasoningTokens)
+	totalTokens := min(promptTokens+completionTokens+reasoningTokens, maxSaneTokenCount)
 	if h.tpmLimiter != nil {
 		switch {
 		case vkHash != "":
@@ -425,6 +435,45 @@ func estimateTokens(textBytes int) int {
 
 // bytesPerToken is the conventional text-to-token ratio the estimates above use.
 const bytesPerToken = 4
+
+// maxSaneTokenCount is the largest token figure one provider response may
+// contribute to metering or the request log. A count is bounded by a context
+// window, and no window ever shipped is within 50x of this number, so no
+// figure a real provider reports is touched. Past it a value is not a count in
+// another spelling; it is a different kind of wrong, and the decode layer,
+// which tolerates spellings, never judged plausibility. The upstream is
+// configured by the operator but its response body is the one input on the
+// metering path the gateway does not author, and before this bound a negative
+// member drew a key's tokens_used DOWN, a member at 2^31 put the owner's TPM
+// bucket weeks in debt, and a plain JSON integer near 2^63 wrapped the charge
+// sum into a credit while failing the int4 request-log UPDATE outright. The
+// ceiling sits far enough below both column widths that no member, and no
+// per-request sum of members, can reach one.
+const maxSaneTokenCount = 100_000_000
+
+// clampTokenCount folds one provider figure into the range a real count can
+// occupy: at least zero, at most maxSaneTokenCount.
+//
+// A negative folds to zero rather than rejecting the block: zero is what a
+// provider that omitted the member reports, and the estimate fallback then
+// fills it from the sizes the gateway measured itself, which is the honest
+// charge for a figure that was never a reading.
+func clampTokenCount(n int) int {
+	return min(max(n, 0), maxSaneTokenCount)
+}
+
+// isTokenReading reports whether a streamed usage member carries a count worth
+// recording: positive and inside the bound. The streaming observers keep an
+// earlier reading rather than clamping, because a chunk saying zero, or saying
+// something absurd, says nothing about the count a previous chunk reported.
+func isTokenReading(n int) bool {
+	return n > 0 && n <= maxSaneTokenCount
+}
+
+// sanitizeUsageCounts clamps the three members of one usage block.
+func sanitizeUsageCounts(promptTokens, completionTokens, reasoningTokens int) (prompt, completion, reasoning int) {
+	return clampTokenCount(promptTokens), clampTokenCount(completionTokens), clampTokenCount(reasoningTokens)
+}
 
 // minPassthroughTokens is the floor chargePassthroughUsage applies to a
 // pass-through request that was delivered but whose prompt sizes to nothing. It exists because the multipart

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -134,19 +134,25 @@ func normalizeFinishReasonInChoices(choices []map[string]json.RawMessage, lastRe
 // guard the assignment (hit > 0 || miss > 0) to avoid zeroing out cache counts
 // from an earlier usage chunk; non-streaming callers can assign unconditionally
 func extractCacheTokens(u Usage) (hitTokens, missTokens int) {
-	// Clamped like every other member: these two land in int4 request-log
-	// columns, and an out-of-range figure aborted the whole terminal UPDATE.
+	// Both members are clamped BEFORE the subtraction, not after it. These land
+	// in int4 request-log columns, and an out-of-range figure aborted the whole
+	// terminal UPDATE; but subtracting first is its own bug, because the
+	// difference is computed in signed arithmetic that wraps. A prompt of
+	// MinInt64 beside a cache hit of 5 wrapped to a large POSITIVE miss, which
+	// a clamp on the result then rounded down to a plausible-looking ceiling
+	// figure. Clamping the inputs makes the subtraction unwrappable.
+	prompt := clampTokenCount(u.PromptTokens)
 	switch {
 	case u.PromptCacheHitTokens > 0:
-		hitTokens, missTokens = u.PromptCacheHitTokens, u.PromptTokens-u.PromptCacheHitTokens
+		hitTokens = clampTokenCount(u.PromptCacheHitTokens)
 	case u.CacheReadInputTokens > 0:
-		hitTokens, missTokens = u.CacheReadInputTokens, u.PromptTokens-u.CacheReadInputTokens
+		hitTokens = clampTokenCount(u.CacheReadInputTokens)
 	case u.PromptTokensDetails != nil && u.PromptTokensDetails.CachedTokens > 0:
-		hitTokens, missTokens = u.PromptTokensDetails.CachedTokens, u.PromptTokens-u.PromptTokensDetails.CachedTokens
+		hitTokens = clampTokenCount(u.PromptTokensDetails.CachedTokens)
 	default:
 		return 0, 0
 	}
-	return clampTokenCount(hitTokens), clampTokenCount(missTokens)
+	return hitTokens, max(0, prompt-hitTokens)
 }
 
 // parsedChunk holds the decomposed fields from an SSE data line payload.
@@ -460,6 +466,32 @@ func isTokenReading(n int) bool {
 // sanitizeUsageCounts clamps the three members of one usage block.
 func sanitizeUsageCounts(promptTokens, completionTokens, reasoningTokens int) (prompt, completion, reasoning int) {
 	return clampTokenCount(promptTokens), clampTokenCount(completionTokens), clampTokenCount(reasoningTokens)
+}
+
+// clampReportedUsage is sanitizeUsageCounts for the paths that read a
+// provider's usage block whole, and it says so when it rewrites one.
+//
+// The bound exists because an upstream can report a figure the gateway must
+// not act on, and an operator who cannot see that happening has a provider
+// quietly poisoning their metering with no signal anywhere: a row reading 0 is
+// indistinguishable from "the provider omitted the member", and one reading
+// the ceiling is indistinguishable from nothing at all, because no honest
+// provider produces it. The estimate fallback already announces itself when it
+// substitutes; a rewrite is the larger claim and was silent.
+//
+// One line per response rather than one per member: the members of a block
+// are wrong together, and the reported figures are numbers, so the line
+// carries no provider text.
+func (h *Handler) clampReportedUsage(promptTokens, completionTokens, reasoningTokens int, logData *requestLogData) (prompt, completion, reasoning int) {
+	prompt, completion, reasoning = sanitizeUsageCounts(promptTokens, completionTokens, reasoningTokens)
+	if prompt != promptTokens || completion != completionTokens || reasoning != reasoningTokens {
+		debuglog.Warn("proxy: implausible usage figures from provider, clamped before metering",
+			"model", logData.modelID, "provider", logData.providerName,
+			"reported_prompt", promptTokens, "reported_completion", completionTokens, "reported_reasoning", reasoningTokens,
+			"recorded_prompt", prompt, "recorded_completion", completion, "recorded_reasoning", reasoning,
+			"ceiling", maxSaneTokenCount)
+	}
+	return prompt, completion, reasoning
 }
 
 // minPassthroughTokens is the floor chargePassthroughUsage applies to a

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -436,30 +436,17 @@ func estimateTokens(textBytes int) int {
 // bytesPerToken is the conventional text-to-token ratio the estimates above use.
 const bytesPerToken = 4
 
-// maxSaneTokenCount is the largest token figure one provider response may
-// contribute to metering or the request log. A count is bounded by a context
-// window, and no window ever shipped is within 50x of this number, so no
-// figure a real provider reports is touched. Past it a value is not a count in
-// another spelling; it is a different kind of wrong, and the decode layer,
-// which tolerates spellings, never judged plausibility. The upstream is
-// configured by the operator but its response body is the one input on the
-// metering path the gateway does not author, and before this bound a negative
-// member drew a key's tokens_used DOWN, a member at 2^31 put the owner's TPM
-// bucket weeks in debt, and a plain JSON integer near 2^63 wrapped the charge
-// sum into a credit while failing the int4 request-log UPDATE outright. The
-// ceiling sits far enough below both column widths that no member, and no
-// per-request sum of members, can reach one.
-const maxSaneTokenCount = 100_000_000
+// maxSaneTokenCount is the bound every provider-reported token figure is held
+// to before it becomes gateway state. The definition and its reasoning live in
+// internal/util so the dashboard's model test, which writes the same int4
+// columns, shares it.
+const maxSaneTokenCount = util.MaxSaneTokenCount
 
-// clampTokenCount folds one provider figure into the range a real count can
-// occupy: at least zero, at most maxSaneTokenCount.
-//
-// A negative folds to zero rather than rejecting the block: zero is what a
-// provider that omitted the member reports, and the estimate fallback then
-// fills it from the sizes the gateway measured itself, which is the honest
-// charge for a figure that was never a reading.
+// clampTokenCount folds one provider figure into [0, maxSaneTokenCount]. See
+// util.ClampTokenCount for why a negative folds to zero rather than rejecting
+// the block.
 func clampTokenCount(n int) int {
-	return min(max(n, 0), maxSaneTokenCount)
+	return util.ClampTokenCount(n)
 }
 
 // isTokenReading reports whether a streamed usage member carries a count worth

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -739,7 +739,10 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 	completionTokens = firstSentCount(envelope.Usage,
 		count{"completion_tokens", usage.CompletionTokens},
 		count{"output_tokens", usage.OutputTokens})
-	return promptTokens, completionTokens
+	// A first-sent count is still a provider figure, read off a body this
+	// gateway does not otherwise inspect, bound for the meter and two int4
+	// log columns. Same clamp as every other reader.
+	return clampTokenCount(promptTokens), clampTokenCount(completionTokens)
 }
 
 // extractPassthroughSSEUsage scrapes token counts from the trailing bytes of

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -235,7 +235,10 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		if err := json.NewEncoder(w).Encode(chatResp); err != nil {
 			debuglog.Error("proxy: failed to encode response", "model", logData.modelID, "provider", logData.providerName, "error", err)
 		}
-		debuglog.Info("proxy: non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "duration_ms", totalDuration, "prompt_tokens", chatResp.Usage.PromptTokens, "completion_tokens", chatResp.Usage.CompletionTokens)
+		// reported_*, because these are the provider's own figures and the row
+		// carries what was recorded: the two differ whenever the bound bit, and
+		// an operator comparing them needs to know which is which.
+		debuglog.Info("proxy: non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "duration_ms", totalDuration, "reported_prompt_tokens", chatResp.Usage.PromptTokens, "reported_completion_tokens", chatResp.Usage.CompletionTokens)
 	case bodilessSuccessStatus(resp.StatusCode):
 		// A success whose status forbids a body. There is nothing to decode and
 		// nothing to meter, and an error envelope written here would be a body

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -134,6 +134,10 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		if chatResp.Usage.CompletionTokensDetails != nil && chatResp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			reasoningTokens = chatResp.Usage.CompletionTokensDetails.ReasoningTokens
 		}
+		// Clamped once, here, so every later reader of this response (the TPS
+		// math, the log row's token columns, the estimate fallback, the charge)
+		// sees the same in-range figures. See maxSaneTokenCount.
+		chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens = sanitizeUsageCounts(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens)
 		totalOutputTokens := chatResp.Usage.CompletionTokens + reasoningTokens
 		generationDuration := totalDuration - responseHeaderMs
 		// Avoid absurd TPS when generation time is negligible

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -136,8 +136,15 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		}
 		// Clamped once, here, so every later reader of this response (the TPS
 		// math, the log row's token columns, the estimate fallback, the charge)
-		// sees the same in-range figures. See maxSaneTokenCount.
+		// sees the same in-range figures. See maxSaneTokenCount. chatResp is
+		// re-encoded to the caller further down, so the whole block is held
+		// to the bound, not only the members the meter reads: a body whose
+		// prompt was clamped but whose total was not is one no provider sent.
 		chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens = sanitizeUsageCounts(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens)
+		chatResp.Usage.TotalTokens = clampTokenCount(chatResp.Usage.TotalTokens)
+		if chatResp.Usage.CompletionTokensDetails != nil {
+			chatResp.Usage.CompletionTokensDetails.ReasoningTokens = reasoningTokens
+		}
 		totalOutputTokens := chatResp.Usage.CompletionTokens + reasoningTokens
 		generationDuration := totalDuration - responseHeaderMs
 		// Avoid absurd TPS when generation time is negligible

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -134,18 +134,17 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		if chatResp.Usage.CompletionTokensDetails != nil && chatResp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			reasoningTokens = chatResp.Usage.CompletionTokensDetails.ReasoningTokens
 		}
-		// Clamped once, here, so every later reader of this response (the TPS
-		// math, the log row's token columns, the estimate fallback, the charge)
-		// sees the same in-range figures. See maxSaneTokenCount. chatResp is
-		// re-encoded to the caller further down, so the whole block is held
-		// to the bound, not only the members the meter reads: a body whose
-		// prompt was clamped but whose total was not is one no provider sent.
-		chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens = sanitizeUsageCounts(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens)
-		chatResp.Usage.TotalTokens = clampTokenCount(chatResp.Usage.TotalTokens)
-		if chatResp.Usage.CompletionTokensDetails != nil {
-			chatResp.Usage.CompletionTokensDetails.ReasoningTokens = reasoningTokens
-		}
-		totalOutputTokens := chatResp.Usage.CompletionTokens + reasoningTokens
+		// Clamped into locals, leaving chatResp alone: the body is re-encoded
+		// to the caller further down, and rewriting a provider's usage block on
+		// the way through is not this gateway's job. The native Anthropic path
+		// forwards the provider's bytes untouched and is the right precedent;
+		// a partial rewrite is worse than none, because the block carries nine
+		// token members and clamping the three the meter reads hands the caller
+		// an arithmetic no provider produced. What the gateway owns is its OWN
+		// state, so the bound applies to the log row, the TPS math and the
+		// charge below, all of which read these locals.
+		promptTokens, completionTokens, reasoningTokens := h.clampReportedUsage(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens, logData)
+		totalOutputTokens := completionTokens + reasoningTokens
 		generationDuration := totalDuration - responseHeaderMs
 		// Avoid absurd TPS when generation time is negligible
 		// (e.g. non-streaming where response_header_ms ≈ duration_ms).
@@ -168,8 +167,8 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.settingsReadMs = settingsReadMs
 		logData.responseHeaderMs = responseHeaderMs
 		logData.tokensPerSecond = tps
-		logData.tokensPrompt = chatResp.Usage.PromptTokens
-		logData.tokensCompletion = chatResp.Usage.CompletionTokens
+		logData.tokensPrompt = promptTokens
+		logData.tokensCompletion = completionTokens
 		logData.tokensCompletionReasoning = reasoningTokens
 		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
 		logData.failoverAttempt = attempt
@@ -188,7 +187,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// UPDATE simply affects 0 rows (harmless, logged as warning).
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
-		promptTokens, completionTokens, reasoningTokens := estimateMissingUsage(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens, logData, chatAnswerBytes(chatResp))
+		promptTokens, completionTokens, reasoningTokens = estimateMissingUsage(promptTokens, completionTokens, reasoningTokens, logData, chatAnswerBytes(chatResp))
 		h.recordTokenUsage(vkHash, logData, promptTokens, completionTokens, reasoningTokens)
 
 		// Normalize reasoning fields in the response message so that

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -179,17 +179,21 @@ type streamChunk struct {
 // Usage, and a bare assignment then wrote zeros over counts an earlier chunk had
 // already reported. A usage chunk saying zero says nothing; only a count carries
 // a reading.
+//
+// The guard is a range, not a sign: a count is a reading only inside
+// (0, maxSaneTokenCount]. A member outside it neither replaces an earlier good
+// count nor becomes one, and the estimate fallback treats it as unreported.
 func (st *streamState) observeUsage(usage *Usage) {
 	if usage == nil {
 		return
 	}
-	if usage.PromptTokens > 0 {
+	if isTokenReading(usage.PromptTokens) {
 		st.promptTokens = usage.PromptTokens
 	}
-	if usage.CompletionTokens > 0 {
+	if isTokenReading(usage.CompletionTokens) {
 		st.completionTokens = usage.CompletionTokens
 	}
-	if usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.ReasoningTokens > 0 {
+	if usage.CompletionTokensDetails != nil && isTokenReading(usage.CompletionTokensDetails.ReasoningTokens) {
 		st.reasoningTokens = usage.CompletionTokensDetails.ReasoningTokens
 	}
 	if hit, miss := extractCacheTokens(*usage); hit > 0 || miss > 0 {

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // Provider-reported usage is the one input on the metering path the gateway
@@ -19,21 +21,16 @@ import (
 // integer near 2^63 wrapped the charge sum and failed the int4 request-log
 // UPDATE. These tests pin the bound at every reader and at the charge.
 
-func TestClampTokenCount(t *testing.T) {
-	for _, tc := range []struct{ in, want int }{
-		{0, 0},
-		{1, 1},
-		{75_000_000, 75_000_000},
-		{maxSaneTokenCount, maxSaneTokenCount},
-		{maxSaneTokenCount + 1, maxSaneTokenCount},
-		{-1, 0},
-		{-500, 0},
-		{math.MaxInt32, maxSaneTokenCount},
-		{math.MaxInt64, maxSaneTokenCount},
-		{math.MinInt64, 0},
-	} {
-		if got := clampTokenCount(tc.in); got != tc.want {
-			t.Errorf("clampTokenCount(%d) = %d, want %d", tc.in, got, tc.want)
+// The clamp's own table lives in internal/util, where the shared definition
+// is. This pins only that the proxy's alias is that definition, so a
+// re-definition here could not drift from it unnoticed.
+func TestClampTokenCount_IsTheSharedDefinition(t *testing.T) {
+	if maxSaneTokenCount != util.MaxSaneTokenCount {
+		t.Errorf("ceiling = %d, want the shared %d", maxSaneTokenCount, util.MaxSaneTokenCount)
+	}
+	for _, n := range []int{0, 1, maxSaneTokenCount, maxSaneTokenCount + 1, -500, math.MaxInt64, math.MinInt64} {
+		if got, want := clampTokenCount(n), util.ClampTokenCount(n); got != want {
+			t.Errorf("clampTokenCount(%d) = %d, want util's %d", n, got, want)
 		}
 	}
 }
@@ -191,28 +188,29 @@ func TestHandleNonStreamingResponse_OverflowUsageCappedEverywhere(t *testing.T) 
 	if len(charged) != 1 || charged[0].tokens != maxSaneTokenCount {
 		t.Errorf("charge = %+v, want one call at the ceiling %d", charged, maxSaneTokenCount)
 	}
-	// The body is re-encoded to the caller, so the whole usage block must be
-	// in range: a prompt that was clamped beside a total that was not is a
-	// body no provider ever sent.
+	// The caller's body is NOT rewritten. The bound is on what becomes this
+	// gateway's state; the provider's own block goes through as it was sent,
+	// because a partial rewrite of a nine-member block hands the caller an
+	// arithmetic no provider produced, and the gateway has no standing to
+	// restate someone else's usage report.
 	var served struct {
 		Usage struct {
-			PromptTokens            int `json:"prompt_tokens"`
-			CompletionTokens        int `json:"completion_tokens"`
-			TotalTokens             int `json:"total_tokens"`
+			PromptTokens            int64 `json:"prompt_tokens"`
+			TotalTokens             int64 `json:"total_tokens"`
 			CompletionTokensDetails *struct {
-				ReasoningTokens int `json:"reasoning_tokens"`
+				ReasoningTokens int64 `json:"reasoning_tokens"`
 			} `json:"completion_tokens_details"`
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(clientBody, &served); err != nil {
 		t.Fatalf("client body did not decode: %v; body: %.200s", err, clientBody)
 	}
-	if served.Usage.PromptTokens != maxSaneTokenCount || served.Usage.CompletionTokens != maxSaneTokenCount || served.Usage.TotalTokens != maxSaneTokenCount {
-		t.Errorf("client usage = (%d, %d, total %d), want all at the ceiling %d",
-			served.Usage.PromptTokens, served.Usage.CompletionTokens, served.Usage.TotalTokens, maxSaneTokenCount)
+	if served.Usage.PromptTokens != math.MaxInt64 || served.Usage.TotalTokens != math.MaxInt64 {
+		t.Errorf("client usage = (prompt %d, total %d), want the provider's own figures untouched",
+			served.Usage.PromptTokens, served.Usage.TotalTokens)
 	}
-	if served.Usage.CompletionTokensDetails == nil || served.Usage.CompletionTokensDetails.ReasoningTokens != maxSaneTokenCount {
-		t.Errorf("client reasoning detail = %+v, want the ceiling %d", served.Usage.CompletionTokensDetails, maxSaneTokenCount)
+	if served.Usage.CompletionTokensDetails == nil || served.Usage.CompletionTokensDetails.ReasoningTokens != math.MaxInt64 {
+		t.Errorf("client reasoning detail = %+v, want the provider's own figure untouched", served.Usage.CompletionTokensDetails)
 	}
 }
 
@@ -299,11 +297,16 @@ func TestHandleNativeNonStreaming_NegativeUsageNeverCredits(t *testing.T) {
 	}
 }
 
-// TestEmitRawData_ClampsNativeStreamFigures covers the native streaming
-// reader: message_start's prompt figure is a sum of three members the decoder
-// bounded one at a time, and message_delta's output figure used to be
-// assigned verbatim.
-func TestEmitRawData_ClampsNativeStreamFigures(t *testing.T) {
+// TestEmitRawData_RefusesOutOfRangeNativeStreamFigures pins that the native
+// stream judges a usage member exactly as the translated stream's observer
+// does: an out-of-range figure is REFUSED, not clamped.
+//
+// The distinction is the whole point. Clamping here let a message_delta
+// carrying MaxInt64 charge the ceiling on /v1/messages while the byte-identical
+// figure on an OpenAI-shaped stream was discarded and the estimator charged
+// the delivered bytes: the same attack, two answers, depending only on which
+// dialect the caller used.
+func TestEmitRawData_RefusesOutOfRangeNativeStreamFigures(t *testing.T) {
 	h := &Handler{}
 	sink := newStreamSink(httptest.NewRecorder())
 	st := &streamState{}
@@ -315,21 +318,44 @@ func TestEmitRawData_ClampsNativeStreamFigures(t *testing.T) {
 		}
 	}
 
-	emit(`{"type":"message_start","message":{"usage":{"input_tokens":2147483647,"cache_read_input_tokens":2147483647,"cache_creation_input_tokens":2147483647,"output_tokens":5}}}`)
-	if st.promptTokens != maxSaneTokenCount || st.promptCacheHitTokens != maxSaneTokenCount || st.promptCacheMissTokens != maxSaneTokenCount {
-		t.Errorf("summed prompt figures not clamped: prompt=%d hit=%d miss=%d", st.promptTokens, st.promptCacheHitTokens, st.promptCacheMissTokens)
+	// A real reading lands.
+	emit(`{"type":"message_start","message":{"usage":{"input_tokens":100,"cache_read_input_tokens":40,"output_tokens":5}}}`)
+	if st.promptTokens != 140 || st.completionTokens != 5 {
+		t.Fatalf("a real reading did not land: prompt=%d completion=%d", st.promptTokens, st.completionTokens)
 	}
-	if st.completionTokens != 5 {
-		t.Fatalf("message_start output = %d, want 5", st.completionTokens)
-	}
-
-	emit(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":-700}}`)
-	if st.completionTokens != 5 {
-		t.Errorf("a negative message_delta output replaced the reading: %d", st.completionTokens)
+	if st.promptCacheHitTokens != 40 || st.promptCacheMissTokens != 100 {
+		t.Fatalf("cache split = (%d, %d), want (40, 100)", st.promptCacheHitTokens, st.promptCacheMissTokens)
 	}
 
-	emit(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9223372036854775807}}`)
-	if st.completionTokens != maxSaneTokenCount {
-		t.Errorf("an absurd message_delta output was not clamped: %d", st.completionTokens)
+	// A prompt summed past the bound from members the decoder each accepted is
+	// not a reading, so the earlier one stands. Each member is judged on its
+	// own, exactly as the translated observer judges them, so this event's
+	// in-range output IS a reading and replaces the earlier 5.
+	emit(`{"type":"message_start","message":{"usage":{"input_tokens":2147483647,"cache_read_input_tokens":2147483647,"cache_creation_input_tokens":2147483647,"output_tokens":7}}}`)
+	if st.promptTokens != 140 {
+		t.Errorf("an out-of-range summed prompt replaced the reading: %d", st.promptTokens)
+	}
+	if st.completionTokens != 7 {
+		t.Errorf("an in-range output beside a refused prompt was dropped: %d", st.completionTokens)
+	}
+
+	// Neither a negative nor an absurd output figure is a reading.
+	for _, payload := range []string{
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":-700}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9223372036854775807}}`,
+	} {
+		emit(payload)
+		if st.completionTokens != 7 {
+			t.Errorf("%s replaced the reading: %d", payload, st.completionTokens)
+		}
+	}
+
+	// The same figures through the translated observer reach the same verdict.
+	other := &streamState{}
+	other.observeUsage(&Usage{PromptTokens: 140, CompletionTokens: 7})
+	other.observeUsage(&Usage{PromptTokens: math.MaxInt64, CompletionTokens: math.MaxInt64})
+	if other.promptTokens != st.promptTokens || other.completionTokens != st.completionTokens {
+		t.Errorf("dialects disagree: native (%d, %d) vs translated (%d, %d)",
+			st.promptTokens, st.completionTokens, other.promptTokens, other.completionTokens)
 	}
 }

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -255,6 +255,50 @@ func TestHandleNativeNonStreaming_ClampsUsage(t *testing.T) {
 	}
 }
 
+// TestHandleNativeNonStreaming_NegativeUsageNeverCredits is the other
+// direction at the same site: with no overflowing addend to swamp them, the
+// negative members must fold to zero rather than through it.
+func TestHandleNativeNonStreaming_NegativeUsageNeverCredits(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	body := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":-500,"cache_read_input_tokens":10,"output_tokens":-100}}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	native := true
+	aw := newAnthropicResponseWriter(httptest.NewRecorder(), "msg_ignored", "m")
+	aw.bindNativeFlag(&native)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", http.NoBody)
+	logData := &requestLogData{id: uuid.New().String(), modelID: "claude-x", virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming"}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+		t.Fatalf("outcome = %v, want outcomeServed", outcome)
+	}
+	aw.Finalize()
+
+	// prompt is -500 + 10 = -490, miss is -500, completion is -100: every one
+	// folds to zero, and none of the five columns goes negative.
+	for name, got := range map[string]int{
+		"tokensPrompt":          logData.tokensPrompt,
+		"tokensCompletion":      logData.tokensCompletion,
+		"tokensPromptCacheMiss": logData.tokensPromptCacheMiss,
+	} {
+		if got != 0 {
+			t.Errorf("%s = %d, want 0", name, got)
+		}
+	}
+	if logData.tokensPromptCacheHit != 10 {
+		t.Errorf("tokensPromptCacheHit = %d, want the real reading 10", logData.tokensPromptCacheHit)
+	}
+	if len(vkRepo.addTokensCalls) != 1 || vkRepo.addTokensCalls[0].tokens < 0 {
+		t.Errorf("charge = %+v, want one non-negative call", vkRepo.addTokensCalls)
+	}
+}
+
 // TestEmitRawData_ClampsNativeStreamFigures covers the native streaming
 // reader: message_start's prompt figure is a sum of three members the decoder
 // bounded one at a time, and message_delta's output figure used to be

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -1,0 +1,253 @@
+package proxy
+
+import (
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Provider-reported usage is the one input on the metering path the gateway
+// does not author. Before the clamp a negative member drew tokens_used down, a
+// member at 2^31 put an owner's TPM bucket weeks in debt, and a plain JSON
+// integer near 2^63 wrapped the charge sum and failed the int4 request-log
+// UPDATE. These tests pin the bound at every reader and at the charge.
+
+func TestClampTokenCount(t *testing.T) {
+	for _, tc := range []struct{ in, want int }{
+		{0, 0},
+		{1, 1},
+		{75_000_000, 75_000_000},
+		{maxSaneTokenCount, maxSaneTokenCount},
+		{maxSaneTokenCount + 1, maxSaneTokenCount},
+		{-1, 0},
+		{-500, 0},
+		{math.MaxInt32, maxSaneTokenCount},
+		{math.MaxInt64, maxSaneTokenCount},
+		{math.MinInt64, 0},
+	} {
+		if got := clampTokenCount(tc.in); got != tc.want {
+			t.Errorf("clampTokenCount(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeUsageCounts(t *testing.T) {
+	p, c, r := sanitizeUsageCounts(-500, math.MaxInt64, 7)
+	if p != 0 || c != maxSaneTokenCount || r != 7 {
+		t.Errorf("got (%d, %d, %d), want (0, %d, 7)", p, c, r, maxSaneTokenCount)
+	}
+}
+
+func TestIsTokenReading(t *testing.T) {
+	for _, tc := range []struct {
+		in   int
+		want bool
+	}{
+		{0, false}, {-1, false}, {1, true}, {maxSaneTokenCount, true}, {maxSaneTokenCount + 1, false}, {math.MaxInt64, false},
+	} {
+		if got := isTokenReading(tc.in); got != tc.want {
+			t.Errorf("isTokenReading(%d) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The decoder accepts a quoted count and a quoted negative; the bound must
+// hold for whatever spelling the decoder let through.
+func TestSanitizeUsageCounts_SpelledForms(t *testing.T) {
+	var u Usage
+	if err := u.UnmarshalJSON([]byte(`{"prompt_tokens":"-500","completion_tokens":"2147483647","total_tokens":0}`)); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	p, c, _ := sanitizeUsageCounts(u.PromptTokens, u.CompletionTokens, 0)
+	if p != 0 || c != maxSaneTokenCount {
+		t.Errorf("got (%d, %d), want (0, %d)", p, c, maxSaneTokenCount)
+	}
+}
+
+func TestRecordTokenUsage_ClampsTheCharge(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+	logData := &requestLogData{virtualKeyName: "test-key"}
+
+	h.recordTokenUsage("test-hash", logData, -500, -100, 0)
+	if n := len(vkRepo.addTokensCalls); n != 1 || vkRepo.addTokensCalls[0].tokens != 0 {
+		t.Fatalf("negative members: calls=%+v, want one call charging 0", vkRepo.addTokensCalls)
+	}
+
+	vkRepo.addTokensCalls = nil
+	h.recordTokenUsage("test-hash", logData, math.MaxInt64, math.MaxInt64, math.MaxInt64)
+	if n := len(vkRepo.addTokensCalls); n != 1 || vkRepo.addTokensCalls[0].tokens != maxSaneTokenCount {
+		t.Fatalf("overflowing members: calls=%+v, want one call charging the ceiling %d", vkRepo.addTokensCalls, maxSaneTokenCount)
+	}
+
+	vkRepo.addTokensCalls = nil
+	h.recordTokenUsage("test-hash", logData, 60_000_000, 60_000_000, 0)
+	if vkRepo.addTokensCalls[0].tokens != maxSaneTokenCount {
+		t.Errorf("in-range members whose sum is over the ceiling charged %d, want %d", vkRepo.addTokensCalls[0].tokens, maxSaneTokenCount)
+	}
+
+	vkRepo.addTokensCalls = nil
+	h.recordTokenUsage("test-hash", logData, 50, 25, 5)
+	if vkRepo.addTokensCalls[0].tokens != 80 {
+		t.Errorf("a real charge changed: %d, want 80", vkRepo.addTokensCalls[0].tokens)
+	}
+}
+
+func TestObserveUsage_RefusesOutOfRangeMembers(t *testing.T) {
+	st := &streamState{}
+	st.observeUsage(&Usage{PromptTokens: 12, CompletionTokens: 34, CompletionTokensDetails: &CompletionTokensDetails{ReasoningTokens: 3}})
+	if st.promptTokens != 12 || st.completionTokens != 34 || st.reasoningTokens != 3 {
+		t.Fatalf("a real reading did not land: %+v", st)
+	}
+	st.observeUsage(&Usage{PromptTokens: -500, CompletionTokens: -100, CompletionTokensDetails: &CompletionTokensDetails{ReasoningTokens: -7}})
+	st.observeUsage(&Usage{PromptTokens: math.MaxInt32, CompletionTokens: math.MaxInt64, CompletionTokensDetails: &CompletionTokensDetails{ReasoningTokens: maxSaneTokenCount + 1}})
+	if st.promptTokens != 12 || st.completionTokens != 34 || st.reasoningTokens != 3 {
+		t.Errorf("an out-of-range member replaced a good reading: %+v", st)
+	}
+}
+
+func TestExtractCacheTokens_Clamps(t *testing.T) {
+	hit, miss := extractCacheTokens(Usage{PromptTokens: math.MaxInt64, PromptCacheHitTokens: math.MaxInt64})
+	if hit != maxSaneTokenCount || miss != 0 {
+		t.Errorf("OpenAI split = (%d, %d), want (%d, 0)", hit, miss, maxSaneTokenCount)
+	}
+	hit, miss = extractCacheTokens(Usage{PromptTokens: -5, CacheReadInputTokens: 10})
+	if hit != 10 || miss != 0 {
+		t.Errorf("negative prompt with a cache read = (%d, %d), want (10, 0)", hit, miss)
+	}
+	hit, miss = extractCacheTokens(Usage{PromptTokens: 100, PromptTokensDetails: &PromptTokensDetails{CachedTokens: 40}})
+	if hit != 40 || miss != 60 {
+		t.Errorf("a real split changed: (%d, %d), want (40, 60)", hit, miss)
+	}
+	if hit, miss = extractCacheTokens(Usage{PromptTokens: 100}); hit != 0 || miss != 0 {
+		t.Errorf("no cache members = (%d, %d), want (0, 0)", hit, miss)
+	}
+}
+
+func TestExtractPassthroughUsage_Clamps(t *testing.T) {
+	p, c := extractPassthroughUsage([]byte(`{"usage":{"prompt_tokens":-5,"completion_tokens":9223372036854775807}}`))
+	if p != 0 || c != maxSaneTokenCount {
+		t.Errorf("got (%d, %d), want (0, %d)", p, c, maxSaneTokenCount)
+	}
+	if p, c = extractPassthroughUsage([]byte(`{"usage":{"input_tokens":7,"output_tokens":3}}`)); p != 7 || c != 3 {
+		t.Errorf("a real block changed: (%d, %d), want (7, 3)", p, c)
+	}
+}
+
+// nonStreamingUsageFixture drives handleNonStreamingResponse with a 200 whose
+// usage block is under test and returns the row figures and the charge.
+func nonStreamingUsageFixture(t *testing.T, usage string) (logData *requestLogData, charged []addTokensCall) {
+	t.Helper()
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandlerIntegration(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	body := `{"id":"chatcmpl_x","object":"chat.completion","created":1,"model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi there"},"finish_reason":"stop"}],"usage":` + usage + `}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	req := withAuthContext(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", http.NoBody))
+	logData = &requestLogData{modelID: "m", providerName: "p", virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "pending"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	return logData, vkRepo.addTokensCalls
+}
+
+func TestHandleNonStreamingResponse_NegativeUsageNeverCredits(t *testing.T) {
+	logData, charged := nonStreamingUsageFixture(t, `{"prompt_tokens":-500,"completion_tokens":-100,"total_tokens":-600}`)
+	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
+		t.Errorf("row recorded negative figures: prompt=%d completion=%d", logData.tokensPrompt, logData.tokensCompletion)
+	}
+	if len(charged) != 1 || charged[0].tokens < 0 {
+		t.Fatalf("charge = %+v, want one non-negative call", charged)
+	}
+	// The completion was delivered, so the estimator charges for it rather
+	// than letting a negative report make the answer free.
+	if charged[0].tokens == 0 {
+		t.Errorf("a delivered answer with a negative report was charged nothing")
+	}
+}
+
+func TestHandleNonStreamingResponse_OverflowUsageCappedEverywhere(t *testing.T) {
+	logData, charged := nonStreamingUsageFixture(t, `{"prompt_tokens":9223372036854775807,"completion_tokens":"2147483647","total_tokens":1}`)
+	if logData.tokensPrompt != maxSaneTokenCount || logData.tokensCompletion != maxSaneTokenCount {
+		t.Errorf("row = (%d, %d), want both at the ceiling %d", logData.tokensPrompt, logData.tokensCompletion, maxSaneTokenCount)
+	}
+	if len(charged) != 1 || charged[0].tokens != maxSaneTokenCount {
+		t.Errorf("charge = %+v, want one call at the ceiling %d", charged, maxSaneTokenCount)
+	}
+}
+
+func TestHandleNativeNonStreaming_ClampsUsage(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	vkRepo := &mockVirtualKeyRepo{}
+	h.virtualKeyRepo = vkRepo
+
+	body := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":-9,"output_tokens":9223372036854775807}}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	native := true
+	aw := newAnthropicResponseWriter(httptest.NewRecorder(), "msg_ignored", "m")
+	aw.bindNativeFlag(&native)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", http.NoBody)
+	logData := &requestLogData{id: uuid.New().String(), modelID: "claude-x", virtualKeyName: "test-key", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "streaming"}
+	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+	h.insertRequestLogAsync(logData)
+	time.Sleep(100 * time.Millisecond)
+
+	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+		t.Fatalf("outcome = %v, want outcomeServed", outcome)
+	}
+	aw.Finalize()
+
+	if logData.tokensPrompt != 0 || logData.tokensCompletion != maxSaneTokenCount {
+		t.Errorf("row = (%d, %d), want (0, %d)", logData.tokensPrompt, logData.tokensCompletion, maxSaneTokenCount)
+	}
+	if len(vkRepo.addTokensCalls) != 1 || vkRepo.addTokensCalls[0].tokens != maxSaneTokenCount {
+		t.Errorf("charge = %+v, want one call at the ceiling", vkRepo.addTokensCalls)
+	}
+}
+
+// TestEmitRawData_ClampsNativeStreamFigures covers the native streaming
+// reader: message_start's prompt figure is a sum of three members the decoder
+// bounded one at a time, and message_delta's output figure used to be
+// assigned verbatim.
+func TestEmitRawData_ClampsNativeStreamFigures(t *testing.T) {
+	h := &Handler{}
+	sink := newStreamSink(httptest.NewRecorder())
+	st := &streamState{}
+	logData := &requestLogData{}
+	emit := func(payload string) {
+		t.Helper()
+		if stop := h.emitRawData(sink, st, sseEvent{raw: []byte("data: " + payload), payload: payload}, 1, logData); stop {
+			t.Fatalf("emitRawData stopped on %s", payload)
+		}
+	}
+
+	emit(`{"type":"message_start","message":{"usage":{"input_tokens":2147483647,"cache_read_input_tokens":2147483647,"cache_creation_input_tokens":2147483647,"output_tokens":5}}}`)
+	if st.promptTokens != maxSaneTokenCount || st.promptCacheHitTokens != maxSaneTokenCount || st.promptCacheMissTokens != maxSaneTokenCount {
+		t.Errorf("summed prompt figures not clamped: prompt=%d hit=%d miss=%d", st.promptTokens, st.promptCacheHitTokens, st.promptCacheMissTokens)
+	}
+	if st.completionTokens != 5 {
+		t.Fatalf("message_start output = %d, want 5", st.completionTokens)
+	}
+
+	emit(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":-700}}`)
+	if st.completionTokens != 5 {
+		t.Errorf("a negative message_delta output replaced the reading: %d", st.completionTokens)
+	}
+
+	emit(`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9223372036854775807}}`)
+	if st.completionTokens != maxSaneTokenCount {
+		t.Errorf("an absurd message_delta output was not clamped: %d", st.completionTokens)
+	}
+}

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"io"
 	"math"
 	"net/http"
@@ -143,11 +144,12 @@ func TestExtractPassthroughUsage_Clamps(t *testing.T) {
 }
 
 // nonStreamingUsageFixture drives handleNonStreamingResponse with a 200 whose
-// usage block is under test and returns the row figures and the charge.
-func nonStreamingUsageFixture(t *testing.T, usage string) (logData *requestLogData, charged []addTokensCall) {
+// usage block is under test and returns the row figures, the charge, and the
+// body the caller was served.
+func nonStreamingUsageFixture(t *testing.T, usage string) (logData *requestLogData, charged []addTokensCall, clientBody []byte) {
 	t.Helper()
 	h := newIntegrationHandler()
-	t.Cleanup(func() { stopUnitHandlerIntegration(h) })
+	t.Cleanup(func() { stopUnitHandler(h) })
 	vkRepo := &mockVirtualKeyRepo{}
 	h.virtualKeyRepo = vkRepo
 
@@ -158,12 +160,13 @@ func nonStreamingUsageFixture(t *testing.T, usage string) (logData *requestLogDa
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-	return logData, vkRepo.addTokensCalls
+	rec := httptest.NewRecorder()
+	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
+	return logData, vkRepo.addTokensCalls, rec.Body.Bytes()
 }
 
 func TestHandleNonStreamingResponse_NegativeUsageNeverCredits(t *testing.T) {
-	logData, charged := nonStreamingUsageFixture(t, `{"prompt_tokens":-500,"completion_tokens":-100,"total_tokens":-600}`)
+	logData, charged, _ := nonStreamingUsageFixture(t, `{"prompt_tokens":-500,"completion_tokens":-100,"total_tokens":-600}`)
 	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
 		t.Errorf("row recorded negative figures: prompt=%d completion=%d", logData.tokensPrompt, logData.tokensCompletion)
 	}
@@ -178,12 +181,38 @@ func TestHandleNonStreamingResponse_NegativeUsageNeverCredits(t *testing.T) {
 }
 
 func TestHandleNonStreamingResponse_OverflowUsageCappedEverywhere(t *testing.T) {
-	logData, charged := nonStreamingUsageFixture(t, `{"prompt_tokens":9223372036854775807,"completion_tokens":"2147483647","total_tokens":1}`)
+	logData, charged, clientBody := nonStreamingUsageFixture(t, `{"prompt_tokens":9223372036854775807,"completion_tokens":"2147483647","total_tokens":9223372036854775807,"completion_tokens_details":{"reasoning_tokens":9223372036854775807}}`)
 	if logData.tokensPrompt != maxSaneTokenCount || logData.tokensCompletion != maxSaneTokenCount {
 		t.Errorf("row = (%d, %d), want both at the ceiling %d", logData.tokensPrompt, logData.tokensCompletion, maxSaneTokenCount)
 	}
+	if logData.tokensCompletionReasoning != maxSaneTokenCount {
+		t.Errorf("row reasoning = %d, want the ceiling %d", logData.tokensCompletionReasoning, maxSaneTokenCount)
+	}
 	if len(charged) != 1 || charged[0].tokens != maxSaneTokenCount {
 		t.Errorf("charge = %+v, want one call at the ceiling %d", charged, maxSaneTokenCount)
+	}
+	// The body is re-encoded to the caller, so the whole usage block must be
+	// in range: a prompt that was clamped beside a total that was not is a
+	// body no provider ever sent.
+	var served struct {
+		Usage struct {
+			PromptTokens            int `json:"prompt_tokens"`
+			CompletionTokens        int `json:"completion_tokens"`
+			TotalTokens             int `json:"total_tokens"`
+			CompletionTokensDetails *struct {
+				ReasoningTokens int `json:"reasoning_tokens"`
+			} `json:"completion_tokens_details"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(clientBody, &served); err != nil {
+		t.Fatalf("client body did not decode: %v; body: %.200s", err, clientBody)
+	}
+	if served.Usage.PromptTokens != maxSaneTokenCount || served.Usage.CompletionTokens != maxSaneTokenCount || served.Usage.TotalTokens != maxSaneTokenCount {
+		t.Errorf("client usage = (%d, %d, total %d), want all at the ceiling %d",
+			served.Usage.PromptTokens, served.Usage.CompletionTokens, served.Usage.TotalTokens, maxSaneTokenCount)
+	}
+	if served.Usage.CompletionTokensDetails == nil || served.Usage.CompletionTokensDetails.ReasoningTokens != maxSaneTokenCount {
+		t.Errorf("client reasoning detail = %+v, want the ceiling %d", served.Usage.CompletionTokensDetails, maxSaneTokenCount)
 	}
 }
 
@@ -193,7 +222,10 @@ func TestHandleNativeNonStreaming_ClampsUsage(t *testing.T) {
 	vkRepo := &mockVirtualKeyRepo{}
 	h.virtualKeyRepo = vkRepo
 
-	body := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":-9,"output_tokens":9223372036854775807}}`
+	// input_tokens, cache_read_input_tokens and cache_creation_input_tokens are
+	// summed into the prompt figure and differenced into the cache split, so
+	// all five columns this path writes are under test at once.
+	body := `{"id":"msg_up","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":-9,"cache_read_input_tokens":2147483647,"cache_creation_input_tokens":2147483647,"output_tokens":9223372036854775807}}`
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
 	native := true
 	aw := newAnthropicResponseWriter(httptest.NewRecorder(), "msg_ignored", "m")
@@ -209,8 +241,14 @@ func TestHandleNativeNonStreaming_ClampsUsage(t *testing.T) {
 	}
 	aw.Finalize()
 
-	if logData.tokensPrompt != 0 || logData.tokensCompletion != maxSaneTokenCount {
-		t.Errorf("row = (%d, %d), want (0, %d)", logData.tokensPrompt, logData.tokensCompletion, maxSaneTokenCount)
+	if logData.tokensPrompt != maxSaneTokenCount || logData.tokensCompletion != maxSaneTokenCount {
+		t.Errorf("row = (%d, %d), want both at the ceiling %d", logData.tokensPrompt, logData.tokensCompletion, maxSaneTokenCount)
+	}
+	// The cache split is written from the same parse and lands in two more
+	// int4 columns: an unclamped miss (input + cache_creation) failed the
+	// whole terminal UPDATE and stranded the row.
+	if logData.tokensPromptCacheHit != maxSaneTokenCount || logData.tokensPromptCacheMiss != maxSaneTokenCount {
+		t.Errorf("cache split = (%d, %d), want both at the ceiling %d", logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss, maxSaneTokenCount)
 	}
 	if len(vkRepo.addTokensCalls) != 1 || vkRepo.addTokensCalls[0].tokens != maxSaneTokenCount {
 		t.Errorf("charge = %+v, want one call at the ceiling", vkRepo.addTokensCalls)

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -188,11 +188,11 @@ func TestHandleNonStreamingResponse_OverflowUsageCappedEverywhere(t *testing.T) 
 	if len(charged) != 1 || charged[0].tokens != maxSaneTokenCount {
 		t.Errorf("charge = %+v, want one call at the ceiling %d", charged, maxSaneTokenCount)
 	}
-	// The caller's body is NOT rewritten. The bound is on what becomes this
-	// gateway's state; the provider's own block goes through as it was sent,
-	// because a partial rewrite of a nine-member block hands the caller an
-	// arithmetic no provider produced, and the gateway has no standing to
-	// restate someone else's usage report.
+	// The caller's body is NOT rewritten by the bound. (It still goes through
+	// a decode and re-encode, so a quoted count comes back unquoted; what the
+	// bound must not do is restate the figures.) A partial rewrite of a
+	// nine-member block hands the caller an arithmetic no provider produced,
+	// and the gateway has no standing to restate someone else's usage report.
 	var served struct {
 		Usage struct {
 			PromptTokens            int64 `json:"prompt_tokens"`

--- a/internal/util/tokencount.go
+++ b/internal/util/tokencount.go
@@ -1,0 +1,29 @@
+package util
+
+// MaxSaneTokenCount is the largest token figure one provider response may
+// contribute to metering or the request log. A count is bounded by a context
+// window, and no window ever shipped is within 50x of this number, so no
+// figure a real provider reports is touched. Past it a value is not a count in
+// another spelling; it is a different kind of wrong, and DecodeCounts, which
+// tolerates spellings, never judged plausibility. The upstream is configured
+// by the operator but its response body is the one input on the metering path
+// the gateway does not author, and before this bound a negative member drew a
+// key's tokens_used DOWN, a member at 2^31 put the owner's TPM bucket weeks in
+// debt, and a plain JSON integer near 2^63 wrapped the charge sum into a
+// credit while failing the int4 request-log UPDATE outright. The ceiling sits
+// far enough below both column widths that no member, and no per-request sum
+// of members, can reach one.
+const MaxSaneTokenCount = 100_000_000
+
+// ClampTokenCount folds one provider figure into the range a real count can
+// occupy: at least zero, at most MaxSaneTokenCount.
+//
+// A negative folds to zero rather than rejecting the block: zero is what a
+// provider that omitted the member reports, and the proxy's estimate fallback
+// then fills it from the sizes the gateway measured itself, which is the
+// honest charge for a figure that was never a reading. One definition, here,
+// because the proxy and the dashboard's model test both write these figures
+// into the same int4 columns.
+func ClampTokenCount(n int) int {
+	return min(max(n, 0), MaxSaneTokenCount)
+}

--- a/internal/util/tokencount.go
+++ b/internal/util/tokencount.go
@@ -15,10 +15,18 @@ package util
 // second, so the ceiling is how long one bogus response can hold an owner's
 // keys at 429: ten million against the default 60k TPM is under three hours,
 // where a hundred million was more than a day. It still sits ~9x above the
-// largest context window in the catalogs (1,050,000), which bounds any figure
-// a provider can honestly report for a request it actually served, and far
-// enough below int4 that no member, and no per-request sum of members, can
-// reach the column limit.
+// largest context window in the catalogs (1,050,000), and far enough below
+// int4 that no member, and no per-request sum of members, can reach the
+// column limit.
+//
+// A context window bounds what a CHAT response can honestly report, because
+// the estimate only runs on a response the provider actually served. It does
+// not bound the batch families: an embeddings request is capped by
+// MAX_REQUEST_SIZE (50 MB by default), whose estimate is ~12.5M tokens, and a
+// self-hosted embeddings server can honestly report more than the ceiling. So
+// this bound is a deliberate trade rather than a free one: a very large batch
+// meters at the ceiling instead of its true size, and three hours of blast
+// radius is worth more than exact metering of a 40 MB batch.
 //
 // It bounds the blast radius rather than removing it: debt still accumulates
 // across responses, which is the limiter's own contract and a separate fix.

--- a/internal/util/tokencount.go
+++ b/internal/util/tokencount.go
@@ -1,19 +1,28 @@
 package util
 
 // MaxSaneTokenCount is the largest token figure one provider response may
-// contribute to metering or the request log. A count is bounded by a context
-// window, and no window ever shipped is within 50x of this number, so no
-// figure a real provider reports is touched. Past it a value is not a count in
+// contribute to metering or the request log. Past it a value is not a count in
 // another spelling; it is a different kind of wrong, and DecodeCounts, which
 // tolerates spellings, never judged plausibility. The upstream is configured
 // by the operator but its response body is the one input on the metering path
 // the gateway does not author, and before this bound a negative member drew a
 // key's tokens_used DOWN, a member at 2^31 put the owner's TPM bucket weeks in
 // debt, and a plain JSON integer near 2^63 wrapped the charge sum into a
-// credit while failing the int4 request-log UPDATE outright. The ceiling sits
-// far enough below both column widths that no member, and no per-request sum
-// of members, can reach one.
-const MaxSaneTokenCount = 100_000_000
+// credit while failing the int4 request-log UPDATE outright.
+//
+// The number is chosen from what a clamped charge COSTS, not from column
+// width. A charge lands in the TPM bucket as debt that drains at tpm/60 per
+// second, so the ceiling is how long one bogus response can hold an owner's
+// keys at 429: ten million against the default 60k TPM is under three hours,
+// where a hundred million was more than a day. It still sits ~9x above the
+// largest context window in the catalogs (1,050,000), which bounds any figure
+// a provider can honestly report for a request it actually served, and far
+// enough below int4 that no member, and no per-request sum of members, can
+// reach the column limit.
+//
+// It bounds the blast radius rather than removing it: debt still accumulates
+// across responses, which is the limiter's own contract and a separate fix.
+const MaxSaneTokenCount = 10_000_000
 
 // ClampTokenCount folds one provider figure into the range a real count can
 // occupy: at least zero, at most MaxSaneTokenCount.

--- a/internal/util/tokencount_test.go
+++ b/internal/util/tokencount_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"math"
+	"testing"
+)
+
+// The clamp is the shared definition two packages write int4 token columns
+// through, so it is pinned here rather than only through its callers.
+func TestClampTokenCount(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero", 0, 0},
+		{"one", 1, 1},
+		{"an ordinary count", 12_345, 12_345},
+		{"a large but real count", 2_000_000, 2_000_000},
+		{"the ceiling itself", MaxSaneTokenCount, MaxSaneTokenCount},
+		{"one past the ceiling", MaxSaneTokenCount + 1, MaxSaneTokenCount},
+		{"minus one", -1, 0},
+		{"a negative count", -500, 0},
+		{"int32 max", math.MaxInt32, MaxSaneTokenCount},
+		{"int64 max", math.MaxInt64, MaxSaneTokenCount},
+		{"int64 min", math.MinInt64, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClampTokenCount(tc.in); got != tc.want {
+				t.Errorf("ClampTokenCount(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The ceiling has to stay clear of both column widths a clamped figure can
+// land in, with room for a per-request sum of several members.
+func TestMaxSaneTokenCount_FitsTheColumns(t *testing.T) {
+	if MaxSaneTokenCount*4 > math.MaxInt32 {
+		t.Errorf("four clamped members sum to %d, past the int4 column limit %d", MaxSaneTokenCount*4, math.MaxInt32)
+	}
+	if MaxSaneTokenCount < 2_000_000 {
+		t.Errorf("ceiling %d is below the largest context windows in the catalog", MaxSaneTokenCount)
+	}
+}

--- a/internal/util/tokencount_test.go
+++ b/internal/util/tokencount_test.go
@@ -16,7 +16,7 @@ func TestClampTokenCount(t *testing.T) {
 		{"zero", 0, 0},
 		{"one", 1, 1},
 		{"an ordinary count", 12_345, 12_345},
-		{"a large but real count", 2_000_000, 2_000_000},
+		{"the largest catalogued context window", 1_050_000, 1_050_000},
 		{"the ceiling itself", MaxSaneTokenCount, MaxSaneTokenCount},
 		{"one past the ceiling", MaxSaneTokenCount + 1, MaxSaneTokenCount},
 		{"minus one", -1, 0},
@@ -33,13 +33,24 @@ func TestClampTokenCount(t *testing.T) {
 	}
 }
 
-// The ceiling has to stay clear of both column widths a clamped figure can
-// land in, with room for a per-request sum of several members.
-func TestMaxSaneTokenCount_FitsTheColumns(t *testing.T) {
+// largestCatalogueContextWindow is the biggest context length in the provider
+// catalogs, which bounds any figure a provider can honestly report for a
+// request it actually served.
+const largestCatalogueContextWindow = 1_050_000
+
+// The ceiling has to stay clear of the int4 columns a clamped figure lands in,
+// with room for a per-request sum of members, while staying comfortably above
+// anything an honest response can report.
+func TestMaxSaneTokenCount_FitsTheColumnsAndRealTraffic(t *testing.T) {
 	if MaxSaneTokenCount*4 > math.MaxInt32 {
 		t.Errorf("four clamped members sum to %d, past the int4 column limit %d", MaxSaneTokenCount*4, math.MaxInt32)
 	}
-	if MaxSaneTokenCount < 2_000_000 {
-		t.Errorf("ceiling %d is below the largest context windows in the catalog", MaxSaneTokenCount)
+	if MaxSaneTokenCount < 4*largestCatalogueContextWindow {
+		t.Errorf("ceiling %d leaves less than 4x headroom over the largest context window %d", MaxSaneTokenCount, largestCatalogueContextWindow)
+	}
+	// The cost of the ceiling is how long one clamped charge holds a default
+	// 60k-TPM bucket at 429. Keep it inside a working day.
+	if hours := float64(MaxSaneTokenCount) / (60_000.0 / 60.0) / 3600.0; hours > 8 {
+		t.Errorf("one clamped charge holds a 60k TPM bucket for %.1fh, want <= 8h", hours)
 	}
 }

--- a/internal/virtualkey/addtokens_guard_test.go
+++ b/internal/virtualkey/addtokens_guard_test.go
@@ -18,6 +18,7 @@ func TestRepository_AddTokens_RefusesNonPositive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() setup failed: %v", err)
 	}
+	defer func() { _ = repo.Delete(ctx, created.ID) }()
 	if err := repo.AddTokens(ctx, created.KeyHash, 100); err != nil {
 		t.Fatalf("AddTokens(100) failed: %v", err)
 	}

--- a/internal/virtualkey/addtokens_guard_test.go
+++ b/internal/virtualkey/addtokens_guard_test.go
@@ -1,0 +1,36 @@
+package virtualkey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// tokens_used only ever grows. A non-positive charge is refused at the
+// repository as well as at the proxy's metering boundary, so no caller can
+// draw a key's counter down.
+func TestRepository_AddTokens_RefusesNonPositive(t *testing.T) {
+	ctx := context.Background()
+	repo := NewRepository(testDB.Pool())
+	suffix := uuid.New().String()[:8]
+	created, err := repo.Create(ctx, "integration-addtokens-guard-"+suffix, "hash-addtokens-guard-"+suffix, "sk-...ag", nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Create() setup failed: %v", err)
+	}
+	if err := repo.AddTokens(ctx, created.KeyHash, 100); err != nil {
+		t.Fatalf("AddTokens(100) failed: %v", err)
+	}
+	for _, n := range []int{0, -1, -600} {
+		if err := repo.AddTokens(ctx, created.KeyHash, n); err != nil {
+			t.Fatalf("AddTokens(%d) returned an error, want a silent refusal: %v", n, err)
+		}
+	}
+	updated, err := repo.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get() failed: %v", err)
+	}
+	if updated.TokensUsed != 100 {
+		t.Errorf("TokensUsed = %d after non-positive charges, want 100", updated.TokensUsed)
+	}
+}

--- a/internal/virtualkey/virtualkey.go
+++ b/internal/virtualkey/virtualkey.go
@@ -178,7 +178,15 @@ func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 }
 
 // AddTokens increments the token usage counters for a virtual key.
+//
+// A non-positive charge is refused here as well as at the proxy's metering
+// boundary, the same fence TPMLimiter.Debit has always had: tokens_used is a
+// running total that only ever grows, and a caller handing it a negative
+// figure would draw it down, which is a credit the caller has no way to grant.
 func (r *Repository) AddTokens(ctx context.Context, keyHash string, tokens int) error {
+	if tokens <= 0 {
+		return nil
+	}
 	_, err := r.pool.Exec(ctx,
 		`UPDATE virtual_keys SET tokens_used = tokens_used + $1, last_used_at = now() WHERE key_hash = $2`,
 		tokens, keyHash)


### PR DESCRIPTION
## What

Holds every provider-reported token figure to `[0, 10_000_000]` before it becomes gateway state: the meter, the TPM buckets, the virtual key's `tokens_used` counter, and the request log's five int4 token columns.

## Why

Strix 2026-08-31 vuln-0005 (CWE-1284, medium), verified against the code and demonstrated live against a local gateway. Usage figures parsed from an upstream response reached metering with no sign, magnitude or sum check. The decode layer tolerates spellings but never judged plausibility, and three shapes did real damage:

- **negative members** decremented `virtual_keys.tokens_used` (0 → -600 on one request). `estimateMissingUsage` only replaces a *zero*, so a negative passed downstream as authoritative.
- **a quoted `2147483647`** charged the key and debited the owner's aggregate TPM bucket by 2^31: at the default 60k TPM that is ~25 days of 429s for **every key of that owner**, while a control key of a different owner kept serving.
- **a plain `9223372036854775807`** wrapped the charge sum to a large negative credit, after which every further metered request for that key failed with `bigint out of range`; the int4 request-log UPDATE also failed, stranding completed rows at `state='pending'`.

Downstream, `GET /api/stats` returned negative totals and one aggregate errored with SQLSTATE 22003.

## How

`util.ClampTokenCount` / `util.MaxSaneTokenCount` (one definition, shared by the proxy and the dashboard's model-test probe). Every reader clamps, so the log row and the charge agree:

- `handleNonStreamingResponse` — once, into locals, before the TPS math, the row, the estimate and the charge. The caller's body is **not** rewritten: clamping three of a nine-member usage block would hand the caller an arithmetic no provider produced, and the native path's verbatim forwarding is the right precedent. The bound belongs on what becomes the gateway's own state.
- both streaming readers — a *range* guard (`isTokenReading`): an out-of-range member neither replaces an earlier reading nor becomes one, matching the existing "a chunk saying zero says nothing" rule. The native Anthropic stream refuses on the same terms as the translated one, so the same figure cannot be answered two ways depending on the caller's dialect.
- `extractCacheTokens`, `extractPassthroughUsage` (and `extractPassthroughSSEUsage` through it).
- both native-Anthropic readers, whose prompt figure is a sum of three members and whose cache miss is a difference of two — the shape the per-member decode bound cannot catch.
- `recordTokenUsage` clamps again at the charge and caps the per-request total, so no path reaching the meter can skip the bound.
- `anthropic.InspectStreamEvent` `message_delta` gets the positive-output guard `message_start` always had.
- `virtualkey.AddTokens` refuses a non-positive charge, the fence `TPMLimiter.Debit` already had. (`last_used_at` is unaffected: the auth middleware's `TouchLastUsed` already stamps every keyed request.)
- `parseTestModelResponse` clamps, so the admin probe cannot write out-of-range figures into the same columns.

A negative folds to zero rather than rejecting the block: zero is what a provider that omitted the member reports, and the estimator then charges from the sizes the gateway measured itself. No path is made free by this — verified on all four charge paths, and the log row keeps the provider's figures (estimates charge quota, never the row).

The ceiling is chosen from what a clamped charge **costs**, not from column width: a charge lands in the TPM bucket as debt draining at `tpm/60` per second, so 10M holds an owner's keys at 429 for under three hours where 100M was more than a day. It still sits ~9x above the largest context window in the catalogs (1,050,000), and four clamped members sum well inside int4. It bounds the blast radius rather than removing it: debt still accumulates across responses, which is the limiter's own contract and a separate fix (see Follow-up).

A rewritten figure is no longer silent: one `warn` per response carries the reported and recorded figures, so an operator can see a provider poisoning their metering instead of reading a clamped row as an honest one.

## Tests

22 new tests across five packages: the clamp and the range guard directly; the charge (negative members, overflowing members, in-range members whose *sum* exceeds the ceiling); the streaming observer keeping an earlier good reading; the cache split; the passthrough extractor; both native-Anthropic paths including the sum-of-three prompt and the cache split across all five columns; the non-streaming path asserting the row, the charge, and that the caller's body is left as the provider sent it; the two stream dialects reaching the same verdict on identical figures; the `message_delta` guard; the `AddTokens` fence; the model-test probe. `internal/proxy`, `internal/anthropic`, `internal/virtualkey`, `internal/util`, `internal/api`: 5,030 pass. Lint clean, size gate OK, diff coverage 57/57 = 100%.

Verified live against the dev stack with a hostile mock upstream: an honest block meters exactly, a negative block never credits, the 2^31 and int64 figures are capped without wrapping or stranding the row, and the key still works afterwards (pre-fix it was bricked with `bigint out of range`).

## Review

Three adversarial subagent review rounds (Opus), each verified after the fixes.

The first two found: the native non-streaming path still wrote two unclamped cache columns (the same stranded-row failure this closes), the model-test probe was unclamped, and the clamp sat in `failRequest` rather than at the sink every writer passes through.

A third, independent pass (fresh reviewer, told to assume the earlier rounds had missed something) found three more, all real and all verified in source before acting:

1. **The availability half was reduced, not closed.** `burst == tpm` and the TPM limiter accumulates unbounded debt, so the original 100M ceiling still meant ~27.8 hours of 429s for every key of an owner, per bogus response. Ceiling lowered to 10M (~2.8h) with a test that fails if it ever implies more than 8h on a default bucket.
2. **The attack survived on one dialect.** The native Anthropic stream *clamped* where the translated observer *rejects* — and its comment claimed otherwise — so `MaxInt64` charged the ceiling on `/v1/messages` but was discarded on an OpenAI-shaped stream. Both refuse now, with a test asserting the two dialects reach the same verdict.
3. **A signed wrap in the cache split**: the difference was computed before the clamp, so `MinInt64` beside a cache hit wrapped *positive* and the clamp rounded it into a plausible-looking ceiling figure. Inputs are clamped before the subtraction.

Its accepted trade, stated in the code: 10M can under-meter a very large batch-embeddings request, which is bounded by `MAX_REQUEST_SIZE` rather than by a context window. Three hours of blast radius is worth more than exact metering of a 40 MB batch.

## Follow-up (not in this PR)

- **Bound the accumulated TPM debt.** `debitBucket` reserves in burst-sized chunks with no floor, so debt stacks linearly across responses and a clamped charge still costs ~2.8h on a default bucket. Capping the deficit is the actual fix for the availability half; it changes the limiter's own contract, so it belongs in its own PR.
- A `CHECK` constraint on `virtual_keys.tokens_used >= 0` and the request-log token columns would make any future regression in this class fail loudly at the write instead of surfacing as negative dashboard totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S2nsLenYbQm6235Sv8o55
