### PR TITLE
fix(frontdesk): bound the liveness probe, on its own budget

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -131,19 +131,19 @@ func main() {
 	// One TRUSTED_PROXIES parse feeds both consumers: the login rate limiter
 	// and the server's client-IP resolution for logs and session metadata.
 	trustedProxies := config.LoadTrustedProxies()
-	ipLimiter := ratelimit.NewIPLimiter(defaultIPRPS, defaultIPBurst, trustedProxies, nil)
+	ipLimiter := ratelimit.NewIPLimiter(defaultIPRPS, defaultIPBurst, trustedProxies, nil).Named("login")
 	// A separate budget for the liveness probe, so a flood of it cannot spend
 	// the allowance pairing and login need from the same address. Sized for a
 	// probe rather than for a person: the container HEALTHCHECK polls every
 	// 30 seconds, so two per second with a burst of five leaves room for a
 	// monitoring poller and a human curl beside it and still bounds the store
 	// reads each hit performs.
-	healthzLimiter := ratelimit.NewIPLimiter(defaultHealthzRPS, defaultHealthzBurst, trustedProxies, nil)
+	healthzLimiter := ratelimit.NewIPLimiter(defaultHealthzRPS, defaultHealthzBurst, trustedProxies, nil).Named("healthz")
 	// And one for the ungated Traefik poll, which is the costlier sibling.
 	// Traefik polls every 5 seconds (0.2 rps) from the compose network, so this
 	// is ten times its cadence and, being per-address, cannot be spent by
 	// anyone else's traffic.
-	traefikLimiter := ratelimit.NewIPLimiter(defaultTraefikRPS, defaultTraefikBurst, trustedProxies, nil)
+	traefikLimiter := ratelimit.NewIPLimiter(defaultTraefikRPS, defaultTraefikBurst, trustedProxies, nil).Named("traefik-config")
 
 	srv := frontdesk.NewServer(frontdesk.ServerConfig{
 		Store:          store,

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -132,6 +132,13 @@ func main() {
 	// and the server's client-IP resolution for logs and session metadata.
 	trustedProxies := config.LoadTrustedProxies()
 	ipLimiter := ratelimit.NewIPLimiter(defaultIPRPS, defaultIPBurst, trustedProxies, nil)
+	// A separate budget for the liveness probe, so a flood of it cannot spend
+	// the allowance pairing and login need from the same address. Sized for a
+	// probe rather than for a person: the container HEALTHCHECK polls every
+	// 30 seconds, so two per second with a burst of five leaves room for a
+	// monitoring poller and a human curl beside it and still bounds the store
+	// reads each hit performs.
+	healthzLimiter := ratelimit.NewIPLimiter(defaultHealthzRPS, defaultHealthzBurst, trustedProxies, nil)
 
 	srv := frontdesk.NewServer(frontdesk.ServerConfig{
 		Store:          store,
@@ -141,6 +148,7 @@ func main() {
 		MasterKey:      masterKey,
 		RelyingParty:   rp,
 		IPLimiter:      ipLimiter,
+		HealthzLimiter: healthzLimiter,
 		TrustedProxies: trustedProxies,
 		UI:             frontdesk.EmbeddedUI(),
 		// Dedicated Prometheus scrape bearer; when unset, /metrics falls back to
@@ -230,6 +238,10 @@ func main() {
 const (
 	defaultIPRPS   = 5
 	defaultIPBurst = 10
+	// The liveness probe's own budget. Generous against a 30-second
+	// HEALTHCHECK, tight against line-rate anonymous probing.
+	defaultHealthzRPS   = 2
+	defaultHealthzBurst = 5
 )
 
 // announceGeneratedToken writes a freshly generated login token to w and logs

--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -139,6 +139,11 @@ func main() {
 	// monitoring poller and a human curl beside it and still bounds the store
 	// reads each hit performs.
 	healthzLimiter := ratelimit.NewIPLimiter(defaultHealthzRPS, defaultHealthzBurst, trustedProxies, nil)
+	// And one for the ungated Traefik poll, which is the costlier sibling.
+	// Traefik polls every 5 seconds (0.2 rps) from the compose network, so this
+	// is ten times its cadence and, being per-address, cannot be spent by
+	// anyone else's traffic.
+	traefikLimiter := ratelimit.NewIPLimiter(defaultTraefikRPS, defaultTraefikBurst, trustedProxies, nil)
 
 	srv := frontdesk.NewServer(frontdesk.ServerConfig{
 		Store:          store,
@@ -149,6 +154,7 @@ func main() {
 		RelyingParty:   rp,
 		IPLimiter:      ipLimiter,
 		HealthzLimiter: healthzLimiter,
+		TraefikLimiter: traefikLimiter,
 		TrustedProxies: trustedProxies,
 		UI:             frontdesk.EmbeddedUI(),
 		// Dedicated Prometheus scrape bearer; when unset, /metrics falls back to
@@ -242,6 +248,9 @@ const (
 	// HEALTHCHECK, tight against line-rate anonymous probing.
 	defaultHealthzRPS   = 2
 	defaultHealthzBurst = 5
+	// The ungated Traefik poll's own budget: ten times its 5-second cadence.
+	defaultTraefikRPS   = 2
+	defaultTraefikBurst = 5
 )
 
 // announceGeneratedToken writes a freshly generated login token to w and logs

--- a/contrib/crowdsec/README.md
+++ b/contrib/crowdsec/README.md
@@ -391,7 +391,10 @@ docker restart <crowdsec-container>
   DO reach the container log. Successful requests to it are therefore visible, apart from the
   reads the dashboard repeats on a timer (the member and device lists, per-member traffic, quota,
   the event stream) and the machine probes (`/healthz`, `/traefik/config`, `/metrics`), which are
-  logged at debug on purpose so an idle browser tab does not fill the log.
+  logged at debug on purpose so an idle browser tab does not fill the log. A probe that is
+  REFUSED is a different matter: `/healthz` and the ungated `/traefik/config` carry their own
+  per-IP budgets, and a 429 is logged at warning like any other 4xx, so a flood of either is
+  visible in the log even though the served polls are not.
 
 - **Front Desk's access log is opt-in like the gateway's.** Front Desk writes the same
   `access: request` line the gateway does, but the parser that maps it onto `http_access-log` is

--- a/internal/frontdesk/healthz_limit_test.go
+++ b/internal/frontdesk/healthz_limit_test.go
@@ -1,0 +1,104 @@
+package frontdesk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/ratelimit"
+)
+
+// probe drives GET /healthz from one address and returns the status.
+func probe(t *testing.T, srv *Server, addr string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	req.RemoteAddr = addr
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// The probe runs the same two store reads a Traefik config poll does, on an
+// unauthenticated route, so line-rate anonymous probing is a way to spend the
+// control plane's CPU — and the cost grows with the fleet's member count.
+func TestHealthz_IsRateLimited(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(0.001, 2, nil, nil))
+
+	served, throttled := 0, 0
+	for range 10 {
+		if probe(t, srv, "203.0.113.10:5000") == http.StatusOK {
+			served++
+		} else {
+			throttled++
+		}
+	}
+	if throttled == 0 {
+		t.Errorf("10 probes from one address were all served: the route is unlimited")
+	}
+	if served == 0 {
+		t.Errorf("no probe was served at all: the limiter is not letting the burst through")
+	}
+}
+
+// The container HEALTHCHECK polls every 30 seconds, so the real cadence has to
+// sit far inside the budget. A burst-sized run of probes must all succeed.
+func TestHealthz_ContainerCadenceIsUnaffected(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(2, 5, nil, nil))
+	for i := range 5 {
+		if code := probe(t, srv, "203.0.113.11:5000"); code != http.StatusOK {
+			t.Fatalf("probe %d of a burst of 5 got %d, want 200", i+1, code)
+		}
+	}
+}
+
+// Each address gets its own budget, so one noisy prober cannot deny the probe
+// to an orchestrator polling from somewhere else.
+func TestHealthz_LimitIsPerAddress(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(0.001, 1, nil, nil))
+	if code := probe(t, srv, "203.0.113.12:5000"); code != http.StatusOK {
+		t.Fatalf("first address got %d, want 200", code)
+	}
+	if code := probe(t, srv, "203.0.113.12:5001"); code == http.StatusOK {
+		t.Fatal("the same address should have exhausted its own budget")
+	}
+	if code := probe(t, srv, "203.0.113.13:5000"); code != http.StatusOK {
+		t.Errorf("a different address got %d, want its own budget", code)
+	}
+}
+
+// The probe's budget is deliberately NOT the login limiter's. Sharing one
+// would turn an anonymous probe flood into a pairing and login outage for
+// every client behind the same address, which is a worse failure than the one
+// the limit exists to prevent.
+func TestHealthz_FloodDoesNotSpendTheLoginBudget(t *testing.T) {
+	login := ratelimit.NewIPLimiter(0.001, 2, nil, nil)
+	srv, _ := newTestServerCfgFull(t, nil, login, ratelimit.NewIPLimiter(0.001, 2, nil, nil), "")
+
+	// Exhaust the probe's budget from one address.
+	for range 10 {
+		probe(t, srv, "203.0.113.14:5000")
+	}
+
+	// The login-limited surface must still answer that same address. A 429
+	// here would mean the two budgets are the same bucket; any other status
+	// (400/401 for a malformed pairing attempt) means the limiter let it
+	// through, which is what this asserts.
+	req := httptest.NewRequest(http.MethodPost, "/api/pair", http.NoBody)
+	req.RemoteAddr = "203.0.113.14:5001"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code == http.StatusTooManyRequests {
+		t.Error("a /healthz flood exhausted the login limiter's budget for the same address")
+	}
+}
+
+// A nil limiter leaves the probe unlimited, which is what a server built
+// without one gets. The route must still be mounted and answer.
+func TestHealthz_NilLimiterLeavesTheRouteWorking(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, nil)
+	for range 20 {
+		if code := probe(t, srv, "203.0.113.15:5000"); code != http.StatusOK {
+			t.Fatalf("probe got %d with no limiter configured, want 200", code)
+		}
+	}
+}

--- a/internal/frontdesk/healthz_limit_test.go
+++ b/internal/frontdesk/healthz_limit_test.go
@@ -74,19 +74,26 @@ func TestHealthz_LimitIsPerAddress(t *testing.T) {
 	}
 }
 
-// The container HEALTHCHECK polls every 30 seconds against a budget of two per
-// second, so the real cadence has to sit far inside it. Pinned at both ends:
-// the burst is served AND the request past it is refused, so this fails both
-// on a revert and on a budget tightened below the cadence.
-func TestHealthz_ContainerCadenceIsInsideTheBudget(t *testing.T) {
-	srv, _ := newTestServerHealthzLimited(t, probeLimiterFor(t))
-	for i := range probeBurst {
-		if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.11:5000", ""); rec.Code != http.StatusOK {
-			t.Fatalf("probe %d of %d got %d, want 200", i+1, probeBurst, rec.Code)
-		}
+// The groups carry their limiter and nothing else does. Without this, an
+// over-scoping regression would be invisible: every other route in the test
+// server has a budget no test can reach, so they would keep answering 200
+// whether or not a limiter had been wrapped around them.
+func TestProbeLimiters_DoNotCoverTheOtherRoutes(t *testing.T) {
+	srv, _ := newTestServerCfgTraefikLimited(t, probeLimiterFor(t), probeLimiterFor(t), "")
+
+	const addr = "203.0.113.30:5000"
+	for range probeBurst + 3 {
+		get(t, srv, http.MethodGet, "/healthz", addr, "")
+		get(t, srv, http.MethodGet, "/traefik/config", addr, "")
 	}
-	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.11:5000", ""); rec.Code != http.StatusTooManyRequests {
-		t.Errorf("past the burst returned %d, want %d", rec.Code, http.StatusTooManyRequests)
+	// Both budgets for this address are now spent.
+	if rec := get(t, srv, http.MethodGet, "/healthz", addr, ""); rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("the probe budget was not spent (%d): this test proves nothing", rec.Code)
+	}
+	for _, path := range []string{"/api/totp/status", "/api/auth/oidc/status"} {
+		if rec := get(t, srv, http.MethodGet, path, addr, ""); rec.Code == http.StatusTooManyRequests {
+			t.Errorf("%s was refused: a probe limiter is covering more than its own route", path)
+		}
 	}
 }
 

--- a/internal/frontdesk/healthz_limit_test.go
+++ b/internal/frontdesk/healthz_limit_test.go
@@ -3,92 +3,180 @@ package frontdesk
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/hugalafutro/model-hotel/internal/ratelimit"
 )
 
-// probe drives GET /healthz from one address and returns the status.
-func probe(t *testing.T, srv *Server, addr string) int {
+// probeBurst is the burst the probe limiter is given in these tests: small
+// enough to exhaust deterministically, large enough to show the admitted half.
+const probeBurst = 3
+
+// probeLimiterFor builds a probe limiter tight enough to observe and stops its
+// cleanup goroutine with the test, matching limiterFor in the login suite.
+func probeLimiterFor(t *testing.T) *ratelimit.IPLimiter {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	lim := ratelimit.NewIPLimiter(0.01, probeBurst, nil, nil)
+	t.Cleanup(lim.Stop)
+	return lim
+}
+
+// get drives one request from a chosen address and returns the recorder.
+func get(t *testing.T, srv *Server, method, path, addr, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, http.NoBody)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.RemoteAddr = addr
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
-	return rec.Code
+	return rec
 }
 
 // The probe runs the same two store reads a Traefik config poll does, on an
 // unauthenticated route, so line-rate anonymous probing is a way to spend the
-// control plane's CPU — and the cost grows with the fleet's member count.
-func TestHealthz_IsRateLimited(t *testing.T) {
-	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(0.001, 2, nil, nil))
+// control plane's CPU, and the cost grows with the fleet's member count.
+//
+// Admitted-then-refused, the shape the login suite uses: asserting only that
+// something is refused would pass if the route were broken, and asserting only
+// that something is served would pass on a full revert.
+func TestHealthz_RidesItsOwnPerIPLimiter(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, probeLimiterFor(t))
 
-	served, throttled := 0, 0
-	for range 10 {
-		if probe(t, srv, "203.0.113.10:5000") == http.StatusOK {
-			served++
-		} else {
-			throttled++
+	for i := range probeBurst {
+		if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.10:5000", ""); rec.Code != http.StatusOK {
+			t.Fatalf("probe %d of the burst returned %d, want 200: the limiter is tighter than the burst it was given", i+1, rec.Code)
 		}
 	}
-	if throttled == 0 {
-		t.Errorf("10 probes from one address were all served: the route is unlimited")
-	}
-	if served == 0 {
-		t.Errorf("no probe was served at all: the limiter is not letting the burst through")
-	}
-}
-
-// The container HEALTHCHECK polls every 30 seconds, so the real cadence has to
-// sit far inside the budget. A burst-sized run of probes must all succeed.
-func TestHealthz_ContainerCadenceIsUnaffected(t *testing.T) {
-	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(2, 5, nil, nil))
-	for i := range 5 {
-		if code := probe(t, srv, "203.0.113.11:5000"); code != http.StatusOK {
-			t.Fatalf("probe %d of a burst of 5 got %d, want 200", i+1, code)
-		}
+	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.10:5001", ""); rec.Code != http.StatusTooManyRequests {
+		t.Errorf("a probe past the burst returned %d, want %d: the route is not behind a limiter", rec.Code, http.StatusTooManyRequests)
 	}
 }
 
 // Each address gets its own budget, so one noisy prober cannot deny the probe
 // to an orchestrator polling from somewhere else.
 func TestHealthz_LimitIsPerAddress(t *testing.T) {
-	srv, _ := newTestServerHealthzLimited(t, ratelimit.NewIPLimiter(0.001, 1, nil, nil))
-	if code := probe(t, srv, "203.0.113.12:5000"); code != http.StatusOK {
-		t.Fatalf("first address got %d, want 200", code)
+	srv, _ := newTestServerHealthzLimited(t, probeLimiterFor(t))
+
+	for range probeBurst + 1 {
+		get(t, srv, http.MethodGet, "/healthz", "203.0.113.12:5000", "")
 	}
-	if code := probe(t, srv, "203.0.113.12:5001"); code == http.StatusOK {
-		t.Fatal("the same address should have exhausted its own budget")
+	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.12:5001", ""); rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("the flooding address got %d, want it to have spent its own budget", rec.Code)
 	}
-	if code := probe(t, srv, "203.0.113.13:5000"); code != http.StatusOK {
-		t.Errorf("a different address got %d, want its own budget", code)
+	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.13:5000", ""); rec.Code != http.StatusOK {
+		t.Errorf("a different address got %d, want its own budget", rec.Code)
+	}
+}
+
+// The container HEALTHCHECK polls every 30 seconds against a budget of two per
+// second, so the real cadence has to sit far inside it. Pinned at both ends:
+// the burst is served AND the request past it is refused, so this fails both
+// on a revert and on a budget tightened below the cadence.
+func TestHealthz_ContainerCadenceIsInsideTheBudget(t *testing.T) {
+	srv, _ := newTestServerHealthzLimited(t, probeLimiterFor(t))
+	for i := range probeBurst {
+		if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.11:5000", ""); rec.Code != http.StatusOK {
+			t.Fatalf("probe %d of %d got %d, want 200", i+1, probeBurst, rec.Code)
+		}
+	}
+	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.11:5000", ""); rec.Code != http.StatusTooManyRequests {
+		t.Errorf("past the burst returned %d, want %d", rec.Code, http.StatusTooManyRequests)
 	}
 }
 
 // The probe's budget is deliberately NOT the login limiter's. Sharing one
 // would turn an anonymous probe flood into a pairing and login outage for
-// every client behind the same address, which is a worse failure than the one
-// the limit exists to prevent.
+// every client behind the same address — and FRONTDESK_TRUSTED_PROXIES ships
+// empty, so under the documented nginx topology that is every operator at
+// once.
+//
+// Both halves are asserted: the flood really is refused (so the test cannot
+// pass on a revert that leaves the probe unlimited), and the login route still
+// answers its own status for the same address afterwards, with its own limiter
+// still live (a 429 arrives once ITS burst is spent, so "not 429" is not being
+// satisfied by a dead route).
 func TestHealthz_FloodDoesNotSpendTheLoginBudget(t *testing.T) {
-	login := ratelimit.NewIPLimiter(0.001, 2, nil, nil)
-	srv, _ := newTestServerCfgFull(t, nil, login, ratelimit.NewIPLimiter(0.001, 2, nil, nil), "")
+	login := limiterFor(t)
+	srv, _ := newTestServerCfgFull(t, nil, login, probeLimiterFor(t), "")
 
-	// Exhaust the probe's budget from one address.
-	for range 10 {
-		probe(t, srv, "203.0.113.14:5000")
+	refused := 0
+	for range probeBurst + 5 {
+		if get(t, srv, http.MethodGet, "/healthz", "203.0.113.14:5000", "").Code == http.StatusTooManyRequests {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatal("the probe flood was never refused: the probe limiter is not in play, so this proves nothing about the login budget")
 	}
 
-	// The login-limited surface must still answer that same address. A 429
-	// here would mean the two budgets are the same bucket; any other status
-	// (400/401 for a malformed pairing attempt) means the limiter let it
-	// through, which is what this asserts.
-	req := httptest.NewRequest(http.MethodPost, "/api/pair", http.NoBody)
-	req.RemoteAddr = "203.0.113.14:5001"
+	// The same address must still reach the pairing exchange and get its own
+	// verdict on the payload rather than a rate-limit refusal.
+	rec := get(t, srv, http.MethodPost, "/api/pair", "203.0.113.14:5001", `{"code":"nope"}`)
+	if rec.Code == http.StatusTooManyRequests {
+		t.Fatal("a /healthz flood exhausted the login limiter's budget for the same address")
+	}
+	if rec.Code != http.StatusBadRequest && rec.Code != http.StatusUnauthorized {
+		t.Errorf("pairing returned %d, want the route's own rejection of a bad code (400 or 401)", rec.Code)
+	}
+
+	// And the login limiter is genuinely live, so the assertion above is not
+	// being satisfied by a route that can never be refused.
+	for range loginBurst + 1 {
+		rec = get(t, srv, http.MethodPost, "/api/pair", "203.0.113.14:5002", `{"code":"nope"}`)
+	}
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("the login limiter never refused past its burst (%d): it is not bounding this route at all", rec.Code)
+	}
+}
+
+// The ungated Traefik poll is the costlier sibling of the probe: the same two
+// store reads plus BuildTraefikConfig and a member-sized marshal, and its body
+// discloses member URLs and settings. It carries its own budget, so a flood of
+// one endpoint cannot starve the other.
+func TestTraefikConfig_UngatedRidesItsOwnLimiter(t *testing.T) {
+	traefik := probeLimiterFor(t)
+	srv, _ := newTestServerCfgTraefikLimited(t, probeLimiterFor(t), traefik, "")
+
+	for i := range probeBurst {
+		if rec := get(t, srv, http.MethodGet, "/traefik/config", "203.0.113.20:5000", ""); rec.Code != http.StatusOK {
+			t.Fatalf("poll %d of the burst returned %d, want 200", i+1, rec.Code)
+		}
+	}
+	if rec := get(t, srv, http.MethodGet, "/traefik/config", "203.0.113.20:5001", ""); rec.Code != http.StatusTooManyRequests {
+		t.Errorf("an ungated poll past the burst returned %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+	// The probe keeps its own budget: Traefik's poll is the data plane's
+	// lifeline and the two must not share a bucket.
+	if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.20:5002", ""); rec.Code != http.StatusOK {
+		t.Errorf("a /traefik/config flood spent the probe's budget for the same address: got %d", rec.Code)
+	}
+}
+
+// Once the token gates it, an unauthenticated caller is refused before any of
+// the work happens, so the limiter is skipped and Traefik's own polling is
+// never throttled by someone else's rejected traffic.
+func TestTraefikConfig_GatedSkipsTheLimiter(t *testing.T) {
+	srv, _ := newTestServerCfgTraefikLimited(t, probeLimiterFor(t), probeLimiterFor(t), "traefik-token")
+
+	for range probeBurst + 5 {
+		if rec := get(t, srv, http.MethodGet, "/traefik/config", "203.0.113.21:5000", ""); rec.Code == http.StatusTooManyRequests {
+			t.Fatal("a gated poll was rate-limited: the cheap auth refusal should run instead")
+		}
+	}
+	// And the real Traefik still gets through after all of that.
+	req := httptest.NewRequest(http.MethodGet, "/traefik/config", http.NoBody)
+	req.RemoteAddr = "203.0.113.21:5001"
+	req.Header.Set("Authorization", "Bearer traefik-token")
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
-	if rec.Code == http.StatusTooManyRequests {
-		t.Error("a /healthz flood exhausted the login limiter's budget for the same address")
+	if rec.Code != http.StatusOK {
+		t.Errorf("the token-carrying poll returned %d, want 200", rec.Code)
 	}
 }
 
@@ -96,9 +184,9 @@ func TestHealthz_FloodDoesNotSpendTheLoginBudget(t *testing.T) {
 // without one gets. The route must still be mounted and answer.
 func TestHealthz_NilLimiterLeavesTheRouteWorking(t *testing.T) {
 	srv, _ := newTestServerHealthzLimited(t, nil)
-	for range 20 {
-		if code := probe(t, srv, "203.0.113.15:5000"); code != http.StatusOK {
-			t.Fatalf("probe got %d with no limiter configured, want 200", code)
+	for range probeBurst + 10 {
+		if rec := get(t, srv, http.MethodGet, "/healthz", "203.0.113.15:5000", ""); rec.Code != http.StatusOK {
+			t.Fatalf("probe got %d with no limiter configured, want 200", rec.Code)
 		}
 	}
 }

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -52,11 +52,18 @@ type ServerConfig struct {
 	MasterKey    string                        // encrypts the TOTP secret at rest
 	RelyingParty *gowa.WebAuthn                // WebAuthn RP (from PUBLIC_ORIGIN); nil disables passkeys
 	IPLimiter    adminauth.IPLimiterMiddleware // per-IP limit on login routes
-	UI           fs.FS                         // embedded SPA; nil disables the UI mount
-	MetricsToken string                        // FRONTDESK_METRICS_TOKEN; bearer for /metrics scrapes (falls back to admin auth when empty)
-	TraefikToken string                        // FRONTDESK_TRAEFIK_TOKEN; bearer Traefik's HTTP provider sends when polling /traefik/config (endpoint stays open when empty)
-	LBPort       string                        // host port of the LB (Traefik "web"); shown in the wizard's Done step. Defaults to 8080.
-	Version      string                        // running build, stamped via ldflags; surfaced read-only over GET /api/version. Defaults to "dev".
+	// HealthzLimiter bounds the unauthenticated liveness probe. It is separate
+	// from IPLimiter on purpose: sharing one budget would let an anonymous
+	// flood of /healthz exhaust the same IP's allowance for pairing and login,
+	// which turns a probe flood into a login outage. Nil leaves the probe
+	// unlimited, which is the old behaviour and what the tests without a
+	// limiter get.
+	HealthzLimiter adminauth.IPLimiterMiddleware
+	UI             fs.FS  // embedded SPA; nil disables the UI mount
+	MetricsToken   string // FRONTDESK_METRICS_TOKEN; bearer for /metrics scrapes (falls back to admin auth when empty)
+	TraefikToken   string // FRONTDESK_TRAEFIK_TOKEN; bearer Traefik's HTTP provider sends when polling /traefik/config (endpoint stays open when empty)
+	LBPort         string // host port of the LB (Traefik "web"); shown in the wizard's Done step. Defaults to 8080.
+	Version        string // running build, stamped via ldflags; surfaced read-only over GET /api/version. Defaults to "dev".
 	// CookieSecure controls the Secure attribute on Front Desk auth cookies:
 	// "always" (default), "auto", or "never" for plain-http LAN.
 	CookieSecure string
@@ -87,6 +94,7 @@ type Server struct {
 	alertDisp      *alert.Dispatcher
 	pairing        *pairingCodes                 // one-time Bellhop pairing codes (in-memory)
 	ipLimiter      adminauth.IPLimiterMiddleware // per-IP limit reused on the public /api/pair exchange
+	healthzLimiter adminauth.IPLimiterMiddleware // separate budget for the unauthenticated liveness probe
 	trustedProxies []*net.IPNet                  // gates XFF trust for logged/stored client addresses
 	settingsMu     sync.Mutex                    // serializes the settings-row read-merge-write
 	// rearmMu guards rearmCh, the in-process rearm broadcast. rearmCh is closed (and
@@ -257,6 +265,7 @@ func NewServer(cfg ServerConfig) *Server {
 		cookieSecure:    cookieSecure,
 		pairing:         newPairingCodes(),
 		ipLimiter:       cfg.IPLimiter,
+		healthzLimiter:  cfg.HealthzLimiter,
 		trustedProxies:  cfg.TrustedProxies,
 		rearmCh:         make(chan struct{}),
 		syncHeld:        make(map[string]bool),
@@ -485,7 +494,26 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 	// purpose: it must keep answering when FRONTDESK_TRAEFIK_TOKEN gates the
 	// config endpoint, so it discloses nothing and only proves the server and
 	// its store answer.
-	r.Get("/healthz", s.handleHealthz)
+	//
+	// It is also not free: each hit runs the same two store reads a Traefik
+	// config poll does (see handleHealthz), deliberately, so the probe fails
+	// exactly when a poll would. That makes line-rate anonymous probing a way
+	// to spend the control plane's CPU, and the cost grows with the fleet's
+	// member count. Its own per-IP budget bounds that. The budget is separate
+	// from the login limiter's so a probe flood cannot spend the allowance
+	// pairing and login need from the same address, and it is far above the
+	// 30-second container HEALTHCHECK cadence.
+	//
+	// Throttling rather than caching: the gateway's /health caches for two
+	// seconds, but TestHealthzTracksTraefikConfigDependencies pins per-request
+	// freshness here, and a cached answer would delay a degraded-store report
+	// past the point a Traefik poll would have failed.
+	r.Group(func(r chi.Router) {
+		if s.healthzLimiter != nil {
+			r.Use(s.healthzLimiter.Middleware)
+		}
+		r.Get("/healthz", s.handleHealthz)
+	})
 
 	// Prometheus scrape endpoint. Outside /api (matching the main server's
 	// mount) and never rate-limited by IP so scrapers aren't throttled; auth

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -59,6 +59,16 @@ type ServerConfig struct {
 	// unlimited, which is the old behaviour and what the tests without a
 	// limiter get.
 	HealthzLimiter adminauth.IPLimiterMiddleware
+	// TraefikLimiter bounds /traefik/config while it is UNGATED. That endpoint
+	// is the more expensive sibling of the liveness probe: the same two store
+	// reads, plus building and marshalling a member-sized config, and its body
+	// discloses member URLs and settings. It gets its own budget rather than
+	// the probe's, because Traefik's poll is the data plane's lifeline and a
+	// flood of one endpoint must not starve the other. Per-address, so an
+	// attacker's traffic cannot spend the budget Traefik itself polls on.
+	// Ignored once FRONTDESK_TRAEFIK_TOKEN is set: a caller without the token
+	// is then refused before any of the work happens.
+	TraefikLimiter adminauth.IPLimiterMiddleware
 	UI             fs.FS  // embedded SPA; nil disables the UI mount
 	MetricsToken   string // FRONTDESK_METRICS_TOKEN; bearer for /metrics scrapes (falls back to admin auth when empty)
 	TraefikToken   string // FRONTDESK_TRAEFIK_TOKEN; bearer Traefik's HTTP provider sends when polling /traefik/config (endpoint stays open when empty)
@@ -95,6 +105,7 @@ type Server struct {
 	pairing        *pairingCodes                 // one-time Bellhop pairing codes (in-memory)
 	ipLimiter      adminauth.IPLimiterMiddleware // per-IP limit reused on the public /api/pair exchange
 	healthzLimiter adminauth.IPLimiterMiddleware // separate budget for the unauthenticated liveness probe
+	traefikLimiter adminauth.IPLimiterMiddleware // separate budget for /traefik/config while it is ungated
 	trustedProxies []*net.IPNet                  // gates XFF trust for logged/stored client addresses
 	settingsMu     sync.Mutex                    // serializes the settings-row read-merge-write
 	// rearmMu guards rearmCh, the in-process rearm broadcast. rearmCh is closed (and
@@ -266,6 +277,7 @@ func NewServer(cfg ServerConfig) *Server {
 		pairing:         newPairingCodes(),
 		ipLimiter:       cfg.IPLimiter,
 		healthzLimiter:  cfg.HealthzLimiter,
+		traefikLimiter:  cfg.TraefikLimiter,
 		trustedProxies:  cfg.TrustedProxies,
 		rearmCh:         make(chan struct{}),
 		syncHeld:        make(map[string]bool),
@@ -488,26 +500,33 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 	// value into Traefik's provider headers); without one the endpoint stays
 	// open for compose-internal use, relying on the deployment boundary and
 	// the reverse-proxy 404 block the HA wiki prescribes.
-	r.Get("/traefik/config", s.traefikAuth(s.handleTraefikConfig))
+	//
+	// Ungated it also rides a per-IP budget of its own: it is the costlier
+	// sibling of the probe below (the same two store reads plus a member-sized
+	// config build) and its body discloses member URLs. Not the probe's budget,
+	// because Traefik's poll is what keeps the data plane routable and a flood
+	// of one must not starve the other. Once the token is set an unauthenticated
+	// caller is refused before any of that work, so the limiter is skipped.
+	r.Group(func(r chi.Router) {
+		if s.traefikLimiter != nil && s.traefikToken == "" {
+			r.Use(s.traefikLimiter.Middleware)
+		}
+		r.Get("/traefik/config", s.traefikAuth(s.handleTraefikConfig))
+	})
 
 	// Container liveness probe (the image's HEALTHCHECK). Unauthenticated on
 	// purpose: it must keep answering when FRONTDESK_TRAEFIK_TOKEN gates the
 	// config endpoint, so it discloses nothing and only proves the server and
 	// its store answer.
 	//
-	// It is also not free: each hit runs the same two store reads a Traefik
-	// config poll does (see handleHealthz), deliberately, so the probe fails
-	// exactly when a poll would. That makes line-rate anonymous probing a way
-	// to spend the control plane's CPU, and the cost grows with the fleet's
-	// member count. Its own per-IP budget bounds that. The budget is separate
-	// from the login limiter's so a probe flood cannot spend the allowance
-	// pairing and login need from the same address, and it is far above the
-	// 30-second container HEALTHCHECK cadence.
-	//
-	// Throttling rather than caching: the gateway's /health caches for two
-	// seconds, but TestHealthzTracksTraefikConfigDependencies pins per-request
-	// freshness here, and a cached answer would delay a degraded-store report
-	// past the point a Traefik poll would have failed.
+	// Not free, though: each hit runs the same two store reads a Traefik poll
+	// does (see handleHealthz), so line-rate anonymous probing spends the
+	// control plane's CPU, and the cost grows with the fleet. Its own per-IP
+	// budget bounds that, separate from the login limiter's so a probe flood
+	// cannot spend what pairing and login need from the same address, and far
+	// above the 30-second container HEALTHCHECK cadence. Throttled rather than
+	// cached because TestHealthzTracksTraefikConfigDependencies pins per-request
+	// freshness: a cached answer would delay a degraded-store report.
 	r.Group(func(r chi.Router) {
 		if s.healthzLimiter != nil {
 			r.Use(s.healthzLimiter.Middleware)

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -333,7 +333,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// reaches the endpoint keeps that watchdog quiet, and a real Traefik that
 	// died is never reported. Said once, at construction, because a default
 	// whose consequence is a monitor that stops monitoring should not be silent.
-	if s.traefikToken == "" {
+	if !s.traefikGated() {
 		debuglog.Warn("frontdesk: /traefik/config is unauthenticated, set FRONTDESK_TRAEFIK_TOKEN to gate it",
 			"consequence", "any caller that reaches it resets the Traefik staleness watchdog")
 	}
@@ -508,7 +508,7 @@ func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHa
 	// of one must not starve the other. Once the token is set an unauthenticated
 	// caller is refused before any of that work, so the limiter is skipped.
 	r.Group(func(r chi.Router) {
-		if s.traefikLimiter != nil && s.traefikToken == "" {
+		if s.traefikLimiter != nil && !s.traefikGated() {
 			r.Use(s.traefikLimiter.Middleware)
 		}
 		r.Get("/traefik/config", s.traefikAuth(s.handleTraefikConfig))
@@ -730,9 +730,16 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 // open: Traefik polls credential-less, so unlike /metrics there is no
 // admin-auth fallback — gating an unconfigured fleet would 401 its own data
 // plane and take the front door down on the next Traefik restart.
+// traefikGated reports whether /traefik/config requires the bearer. One
+// predicate for all three readers (the startup warning, the router's decision
+// to mount a limiter, and this gate), because the router decides once at build
+// time and the gate decides per request: two spellings of the same condition
+// is how a future reloadable token would leave the router silently stale.
+func (s *Server) traefikGated() bool { return s.traefikToken != "" }
+
 func (s *Server) traefikAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if s.traefikToken == "" {
+		if !s.traefikGated() {
 			next(w, r)
 			return
 		}

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -89,16 +89,38 @@ func newTestServerTraefikToken(t *testing.T, token string) (*Server, *Store) {
 // does not spend the login limiter's allowance.
 func newTestServerHealthzLimited(t *testing.T, healthz adminauth.IPLimiterMiddleware) (*Server, *Store) {
 	t.Helper()
-	return newTestServerCfgFull(t, nil, ratelimit.NewIPLimiter(1000, 1000, nil, nil), healthz, "")
+	return newTestServerCfgFull(t, nil, unlimitedLimiter(t), healthz, "")
+}
+
+// newTestServerCfgTraefikLimited builds a server with chosen probe and Traefik
+// budgets, and an optional Traefik token, for the tests that assert the ungated
+// poll is bounded and the gated one is not.
+func newTestServerCfgTraefikLimited(t *testing.T, healthz, traefik adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
+	t.Helper()
+	return newTestServerCfgAll(t, nil, unlimitedLimiter(t), healthz, traefik, traefikToken)
+}
+
+// unlimitedLimiter is a budget no test can reach, so unrelated suites never see
+// a 429. Stopped with the test, like limiterFor.
+func unlimitedLimiter(t *testing.T) *ratelimit.IPLimiter {
+	t.Helper()
+	lim := ratelimit.NewIPLimiter(1000, 1000, nil, nil)
+	t.Cleanup(lim.Stop)
+	return lim
 }
 
 func newTestServerCfg(t *testing.T, ui fs.FS, limiter adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
 	t.Helper()
-	// A probe limit no unrelated test can reach.
-	return newTestServerCfgFull(t, ui, limiter, ratelimit.NewIPLimiter(1000, 1000, nil, nil), traefikToken)
+	// Probe and Traefik limits no unrelated test can reach.
+	return newTestServerCfgFull(t, ui, limiter, unlimitedLimiter(t), traefikToken)
 }
 
 func newTestServerCfgFull(t *testing.T, ui fs.FS, limiter, healthz adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
+	t.Helper()
+	return newTestServerCfgAll(t, ui, limiter, healthz, unlimitedLimiter(t), traefikToken)
+}
+
+func newTestServerCfgAll(t *testing.T, ui fs.FS, limiter, healthz, traefik adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
 	t.Helper()
 	store := newTestStore(t)
 	bus := events.NewBus()
@@ -121,6 +143,7 @@ func newTestServerCfgFull(t *testing.T, ui fs.FS, limiter, healthz adminauth.IPL
 		RelyingParty:   rp,
 		IPLimiter:      limiter,
 		HealthzLimiter: healthz,
+		TraefikLimiter: traefik,
 		UI:             ui,
 		TraefikToken:   traefikToken,
 	})

--- a/internal/frontdesk/server_test.go
+++ b/internal/frontdesk/server_test.go
@@ -84,7 +84,21 @@ func newTestServerTraefikToken(t *testing.T, token string) (*Server, *Store) {
 	return newTestServerCfg(t, nil, ratelimit.NewIPLimiter(1000, 1000, nil, nil), token)
 }
 
+// newTestServerHealthzLimited builds a server whose liveness probe has its own
+// budget, for the tests that assert the probe is bounded and that its flood
+// does not spend the login limiter's allowance.
+func newTestServerHealthzLimited(t *testing.T, healthz adminauth.IPLimiterMiddleware) (*Server, *Store) {
+	t.Helper()
+	return newTestServerCfgFull(t, nil, ratelimit.NewIPLimiter(1000, 1000, nil, nil), healthz, "")
+}
+
 func newTestServerCfg(t *testing.T, ui fs.FS, limiter adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
+	t.Helper()
+	// A probe limit no unrelated test can reach.
+	return newTestServerCfgFull(t, ui, limiter, ratelimit.NewIPLimiter(1000, 1000, nil, nil), traefikToken)
+}
+
+func newTestServerCfgFull(t *testing.T, ui fs.FS, limiter, healthz adminauth.IPLimiterMiddleware, traefikToken string) (*Server, *Store) {
 	t.Helper()
 	store := newTestStore(t)
 	bus := events.NewBus()
@@ -99,15 +113,16 @@ func newTestServerCfg(t *testing.T, ui fs.FS, limiter adminauth.IPLimiterMiddlew
 		t.Fatalf("NewRelyingParty: %v", err)
 	}
 	srv := NewServer(ServerConfig{
-		Store:        store,
-		Poller:       poller,
-		Bus:          bus,
-		AdminMgr:     adminMgr,
-		MasterKey:    testMasterKey,
-		RelyingParty: rp,
-		IPLimiter:    limiter,
-		UI:           ui,
-		TraefikToken: traefikToken,
+		Store:          store,
+		Poller:         poller,
+		Bus:            bus,
+		AdminMgr:       adminMgr,
+		MasterKey:      testMasterKey,
+		RelyingParty:   rp,
+		IPLimiter:      limiter,
+		HealthzLimiter: healthz,
+		UI:             ui,
+		TraefikToken:   traefikToken,
 	})
 	// Drain any detached background goroutine (e.g. an auto-sync kick) before
 	// the store and its temp dir are torn down. Registered here so it runs

--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -28,11 +28,12 @@ type ipEntry struct {
 	burst    int
 	lastUsed time.Time
 	throttle throttleState // edge-triggered throttle logging (see throttle.go)
+	budget   string        // copied from the owning limiter for the log line
 }
 
 // throttleCtx builds the per-IP logging context for the shared throttleState.
 func (e *ipEntry) throttleCtx(ip string) throttleLogCtx {
-	return throttleLogCtx{prefix: "ratelimit-ip", label: "ip", id: ip, rps: e.rps, burst: e.burst}
+	return throttleLogCtx{prefix: "ratelimit-ip", label: "ip", id: ip, budget: e.budget, rps: e.rps, burst: e.burst}
 }
 
 func (e *ipEntry) noteRejected(ip string) {
@@ -66,6 +67,18 @@ type IPLimiter struct {
 	stopCh         chan struct{}
 	trustedProxies []*net.IPNet
 	settings       SettingsReader
+	// budget names this limiter in its throttle log lines. Front Desk runs
+	// three (login, liveness probe, ungated Traefik poll), two of them with
+	// identical numbers, so the line has to say which one fired.
+	budget string
+}
+
+// Named labels this limiter's throttle log lines and returns it, so a
+// deployment running several can tell them apart. Set at construction, before
+// the limiter is shared.
+func (l *IPLimiter) Named(budget string) *IPLimiter {
+	l.budget = budget
+	return l
 }
 
 // NewIPLimiter creates an IP rate limiter. The rps and burst parameters
@@ -202,6 +215,7 @@ func (l *IPLimiter) getLimiter(ctx context.Context, ip string) *ipEntry {
 			rps:      rps,
 			burst:    burst,
 			lastUsed: time.Now(),
+			budget:   l.budget,
 		}
 		l.limiters[ip] = entry
 	} else {

--- a/internal/ratelimit/named_budget_test.go
+++ b/internal/ratelimit/named_budget_test.go
@@ -1,0 +1,76 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+)
+
+// A deployment can run several IP limiters at once (Front Desk runs three, two
+// of them with identical rps and burst). Without a name their throttle lines
+// are byte-identical apart from the address, and "a prober was refused" is not
+// the same event as "the data plane may be losing its config source".
+func TestThrottleLogCtx_LogAttrs(t *testing.T) {
+	unnamed := throttleLogCtx{label: "ip", id: "203.0.113.1", rps: 2, burst: 5}
+	got := unnamed.logAttrs()
+	if slices.Contains(got, "budget") {
+		t.Errorf("an unnamed limiter should not carry a budget attr: %v", got)
+	}
+	if len(got) != 6 || got[0] != "ip" || got[1] != "203.0.113.1" {
+		t.Errorf("logAttrs() = %v, want the identity then the limits", got)
+	}
+
+	named := throttleLogCtx{label: "ip", id: "203.0.113.1", budget: "healthz", rps: 2, burst: 5}
+	got = named.logAttrs()
+	i := slices.Index(got, "budget")
+	if i < 0 || got[i+1] != "healthz" {
+		t.Fatalf("logAttrs() = %v, want a budget=healthz pair", got)
+	}
+	// The identity still leads and the limits still trail, so the line reads
+	// the same way with or without a name.
+	if got[0] != "ip" || got[1] != "203.0.113.1" || !slices.Contains(got, "rps") || !slices.Contains(got, "burst") {
+		t.Errorf("logAttrs() = %v, want identity first and limits last", got)
+	}
+}
+
+func TestIPLimiter_Named(t *testing.T) {
+	lim := NewIPLimiter(1, 1, nil, nil)
+	defer lim.Stop()
+
+	if got := lim.Named("healthz"); got != lim {
+		t.Error("Named should return the same limiter so it can be used at construction")
+	}
+	if lim.budget != "healthz" {
+		t.Errorf("budget = %q, want healthz", lim.budget)
+	}
+}
+
+// The name has to reach the per-address entry, which is what actually builds
+// the log context, or naming the limiter would have no effect on its output.
+func TestIPLimiter_NamePropagatesToTheThrottledEntry(t *testing.T) {
+	lim := NewIPLimiter(0.01, 1, nil, nil).Named("traefik-config")
+	defer lim.Stop()
+
+	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	for range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/traefik/config", http.NoBody)
+		req.RemoteAddr = "203.0.113.44:5000"
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	lim.mu.Lock()
+	entry, ok := lim.limiters["203.0.113.44"]
+	lim.mu.Unlock()
+	if !ok {
+		t.Fatal("no entry was created for the flooding address")
+	}
+	if entry.budget != "traefik-config" {
+		t.Errorf("entry budget = %q, want the limiter's name", entry.budget)
+	}
+	if got := entry.throttleCtx("203.0.113.44").budget; got != "traefik-config" {
+		t.Errorf("throttleCtx budget = %q, want the limiter's name", got)
+	}
+}

--- a/internal/ratelimit/throttle.go
+++ b/internal/ratelimit/throttle.go
@@ -31,8 +31,23 @@ type throttleLogCtx struct {
 	prefix string // "ratelimit" or "ratelimit-ip"
 	label  string // "key" or "ip"
 	id     string // the key hash or client IP
+	// budget names WHICH limiter throttled, for deployments running several of
+	// them. Two IP limiters with the same rps and burst otherwise produce
+	// byte-identical log lines, and "a prober was refused" and "Traefik may be
+	// losing its config source" are not the same event. Empty for a lone
+	// limiter, which is what the gateway has.
+	budget string
 	rps    float64
 	burst  int
+}
+
+// logAttrs renders the identity and limits of one throttle episode.
+func (c throttleLogCtx) logAttrs() []any {
+	attrs := []any{c.label, c.id}
+	if c.budget != "" {
+		attrs = append(attrs, "budget", c.budget)
+	}
+	return append(attrs, "rps", c.rps, "burst", c.burst)
 }
 
 // noteRejected records a 429 and logs "throttling started" on the first
@@ -45,8 +60,7 @@ func (s *throttleState) noteRejected(c throttleLogCtx) {
 		s.throttledAt = time.Now()
 		s.rejectedN = 1
 		s.mu.Unlock()
-		debuglog.Warn(c.prefix+": throttling started",
-			c.label, c.id, "rps", c.rps, "burst", c.burst)
+		debuglog.Warn(c.prefix+": throttling started", c.logAttrs()...)
 		return
 	}
 	s.rejectedN++

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -447,11 +447,24 @@ server {
     location /traefik/ { return 404; }
 
     # `/healthz` stays reachable through the catch-all below, on purpose: it is
-    # the container liveness probe and discloses nothing. It is bounded at
-    # 2 requests per second per resolved client address, as is `/traefik/config`
-    # while FRONTDESK_TRAEFIK_TOKEN is unset. Set FRONTDESK_TRUSTED_PROXIES to
-    # this proxy's address, or every client behind it shares one budget and one
-    # noisy prober can exhaust it for the rest.
+    # the container liveness probe and discloses nothing. It is bounded at 2
+    # requests per second per resolved client address, as is `/traefik/config`
+    # while FRONTDESK_TRAEFIK_TOKEN is unset.
+    #
+    # Those budgets are a fallback, not the control. FRONTDESK_TRAEFIK_TOKEN is
+    # the control: with it set, an unauthenticated poll is refused before any
+    # work happens and the limiter is not mounted at all. Set it.
+    #
+    # If you set FRONTDESK_TRUSTED_PROXIES, set it to the address Front Desk
+    # actually sees as the TCP peer, which with a published port and Docker's
+    # userland proxy is the bridge gateway rather than this nginx. Be aware of
+    # what that buys and costs: trusting the bridge means anything reaching the
+    # published port chooses its own X-Forwarded-For, and therefore its own rate
+    # -limit bucket. It can then key a flood into the bucket Traefik polls on,
+    # or the one the container healthcheck uses. Leaving it unset is safe but
+    # coarse: every client behind this proxy shares one budget, so one noisy
+    # prober can exhaust it for the rest. Either way, gate the endpoint with the
+    # token and do not publish the port beyond where it is needed.
 
     location / {
         proxy_pass http://HA_HOST:8090;

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -446,6 +446,13 @@ server {
     location = /traefik/config { return 404; }
     location /traefik/ { return 404; }
 
+    # `/healthz` stays reachable through the catch-all below, on purpose: it is
+    # the container liveness probe and discloses nothing. It is bounded at
+    # 2 requests per second per resolved client address, as is `/traefik/config`
+    # while FRONTDESK_TRAEFIK_TOKEN is unset. Set FRONTDESK_TRUSTED_PROXIES to
+    # this proxy's address, or every client behind it shares one budget and one
+    # noisy prober can exhaust it for the rest.
+
     location / {
         proxy_pass http://HA_HOST:8090;
         proxy_set_header Host $host;


### PR DESCRIPTION
## What

Bounds Front Desk's unauthenticated `GET /healthz` with a per-IP rate limiter, **its own**, not the one the login ceremonies share.

## Why

Strix 2026-08-31 vuln-0003 (CWE-770, medium), verified against the code.

`/healthz` is unauthenticated by design: it must keep answering when `FRONTDESK_TRAEFIK_TOKEN` gates the config endpoint. But it is mounted on the root router, outside every rate-limit group, and each hit runs the same two store reads a Traefik config poll performs (`ListMembers`, then `GetSettings`): deliberately, so the probe fails exactly when a poll would.

That makes line-rate anonymous probing a way to spend the control plane's CPU, and the cost scales with the fleet:

- **2,757-3,045 req/s** sustained from a single serial client against an empty members table, every response 200, zero throttling;
- **612 req/s at 104% of one core** with 500 members seeded, where one anonymous client saturates the process.

The HA compose file publishes the port (`${FRONTDESK_PORT:-8090}:8090`) and the project's own documented nginx snippet blocks only `location /traefik/`, so its catch-all `location /` passes `/healthz` straight through to the anonymous internet client the wiki models.

Impact is availability of the control plane only. The data plane and member gateways are untouched, and the response body is a constant `{"status":"ok"}`, so nothing is disclosed.

## How

The route rides a per-IP limiter at 2 rps / burst 5. The container `HEALTHCHECK` polls every 30 seconds, so the real cadence sits far inside that, with room for a monitoring poller and a human `curl` beside it.

**The limiter is a new one, not `s.ipLimiter`.** Reusing the login limiter is the obvious move and the wrong one: its budget is shared per IP with the pairing exchange, the admin token exchange and the login ceremonies, so an anonymous flood of an *unauthenticated* probe would exhaust the same address's allowance for *authentication*. That converts a probe flood into a login outage, which is a worse failure than the one being fixed. The review made this sharper than I had it: `FRONTDESK_TRUSTED_PROXIES` ships **empty**, so under the documented nginx topology every external client already collapses into one bucket, and a shared budget would have meant any anonymous flood locking out every operator at once. A nil limiter leaves the probe unlimited, which is the old behaviour.

**Its sibling on the same port is bounded too.** `/traefik/config` runs the same two store reads *plus* `BuildTraefikConfig` and a member-sized marshal, and unlike the probe its body discloses member URLs and settings, and `FRONTDESK_TRAEFIK_TOKEN` defaults to empty. It was left unlimited by the first draft of this PR: strictly more expensive, data-disclosing, unauthenticated, right next to the endpoint being fixed. It now carries its own budget while ungated. Its own, again: Traefik's poll is what keeps the data plane routable, so a flood of the probe must not starve it. Once the token is set the gate refuses an unauthenticated caller before any of the work, so the limiter is skipped and Traefik is never throttled by traffic that was going to be rejected anyway.

**Throttling, not caching.** The gateway binary's own `/health` caches its probe for 2 seconds, and that was the first thing I tried here. It breaks `TestHealthzTracksTraefikConfigDependencies`, which pins per-request freshness: a cached answer would delay a degraded-store report past the point at which a Traefik poll would already have failed. Throttling preserves the parity the endpoint exists for.

Untouched: `/metrics`, which is already token-gated and deliberately never IP-limited so scrapers are not throttled.

## Residual risk, stated plainly

The bound is **per IP, not global**. Using this PR's own measurement, roughly 300 distinct addresses each pacing at 2 rps still saturates a core, which is trivial for a botnet or an IPv6 client rotating a /64. The limiter also publishes the exact budget in `X-RateLimit-*` on the success path, so a client can pace under it. This closes the reported single-client finding; it does not close the class. The per-source state the limiter now allocates on a publicly reachable endpoint is the same exposure `/api/pair` already carries.

## Tests

Admitted-then-refused throughout, the shape the login suite already uses, because the first draft's tests passed on a full revert: the probe's burst is served and the request past it is refused; the budget is per address, so one noisy prober cannot deny the probe to an orchestrator elsewhere; the ungated Traefik poll is bounded on its own budget while a probe flood leaves it alone; the gated poll is not limited at all and the token-carrying poll still succeeds; a `/healthz` flood does not spend the login limiter's budget, proven by asserting the flood really was refused, that pairing returns its own verdict on the payload, and that the login limiter is live by spending its burst too; and a nil limiter leaves the route working.

Mutation-checked: removing both limiter groups fails five of these tests. `internal/frontdesk` + `internal/ratelimit`: 753 pass, including the existing Traefik-parity test. Lint clean, size gate OK, diff coverage 12/12 = 100%.

## Review

Adversarial subagent review (Opus), with the reviewer asked to argue the other side of the separate-limiter decision and to check the one failure mode that would make this worse than the disease: whether a flood could 429 the container's own HEALTHCHECK into a restart loop. It could not, and the reviewer verified why (the probe runs from inside the container against loopback, which no external client can share; BusyBox `wget --spider` issues a GET, so it does hit the limited route; and compose does not restart on unhealthy).

The round found the unbounded `/traefik/config` sibling and that three of five tests passed on a revert. Both fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S2nsLenYbQm6235Sv8o55
