### PR TITLE
test(util): stop the Google fixture tripping GitHub's secret scanner

### DIFF
--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -22,7 +22,12 @@ func TestMaskKeyShapedTokens(t *testing.T) {
 		{"huggingface", "hf_abcdefghij1234567890abcd", true},
 		{"fireworks", "fw_abcdefghij1234567890abcd", true},
 		{"replicate", "r8_abcdefghij1234567890abcd", true},
-		{"google", "AIzaSyA1234567890abcdefghijklmnopqrstuv", true},
+		// 31 characters after the prefix, deliberately. Our rule needs 30 or
+		// more, so this exercises it; GitHub's own google_api_key scanner wants
+		// exactly 35, and a 35-character dummy here raised a secret-scanning
+		// alert against this very file. Do not "correct" the length to a
+		// realistic 35: it tests nothing extra and cries wolf on every clone.
+		{"google", "AIzaSyDUMMY0123456789abcdefghijklmn", true},
 		{"aws access key id", "AKIA1234567890ABCDEF", true},
 		{"bare jwt", "eyJhbGciOiJIUzI1.eyJzdWIiOiIxMjM0.SflKxwRJSMeKK", true},
 		{"bearer token", "Authorization: Bearer abcdefghij1234567890", true},


### PR DESCRIPTION
## What

Shortens one test fixture so it stops raising a GitHub secret-scanning alert.

## Why

Secret-scanning alert #1 (Google API Key) fired on `internal/util/credential_test.go:25`, from #836. **No credential was exposed.** The flagged value is the dummy that proves the credential-shape rule fires on Google keys:

```go
{"google", "AIzaSyA1234567890abcdefghijklmnopqrstuv", true},
```

Sequential digits followed by the alphabet. The scanner reported `validity: unknown` because there is nothing to validate, and `push_protection_bypassed: false`.

It tripped because GitHub's `google_api_key` detector wants `AIza` plus **exactly 35** characters, and the dummy happened to be exactly that. Our own rule needs 30 or more, so the fixture never had to be that long. The irony is that the file it flagged is the test suite for the leak-prevention code.

## How

31 characters after the prefix: still exercises the alternative it is there for, no longer matches GitHub's pattern. A comment records why the length is what it is, so nobody restores a realistic 35 and re-raises the alert.

Every other credential-shaped literal in the Go sources was audited: the rest are either pre-existing (`sk-test-*`, `sk-proj-STANDARDKEY...`) or the AWS and JWT fixtures added alongside this one, and none has alerted.

Alert #1 is dismissed as `used in tests` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S2nsLenYbQm6235Sv8o55