### PR TITLE
fix(frontdesk): a hold judged against an old primary cannot condemn the fleet

### DIFF
--- a/internal/frontdesk/autosync_divergence_test.go
+++ b/internal/frontdesk/autosync_divergence_test.go
@@ -275,7 +275,7 @@ func TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed(t *testing.T) {
 	srv, store := newTestServer(t)
 	m := &Member{ID: "m1", Name: "m1"}
 	srv.syncHeldMu.Lock()
-	srv.syncHeld[m.ID] = "dev@old"
+	srv.syncHeld[m.ID] = memberBuild{Version: "dev", Commit: "old"}.key()
 	srv.holdLogChecked[m.ID] = true
 	srv.syncHeldMu.Unlock()
 

--- a/internal/frontdesk/autosync_divergence_test.go
+++ b/internal/frontdesk/autosync_divergence_test.go
@@ -275,7 +275,7 @@ func TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed(t *testing.T) {
 	srv, store := newTestServer(t)
 	m := &Member{ID: "m1", Name: "m1"}
 	srv.syncHeldMu.Lock()
-	srv.syncHeld[m.ID] = true
+	srv.syncHeld[m.ID] = "dev@old"
 	srv.holdLogChecked[m.ID] = true
 	srv.syncHeldMu.Unlock()
 
@@ -286,7 +286,7 @@ func TestAutoSync_FailedRecoveredEmitIsNotMemoisedAsClosed(t *testing.T) {
 
 	srv.syncHeldMu.Lock()
 	checked := srv.holdLogChecked[m.ID]
-	held := srv.syncHeld[m.ID]
+	_, held := srv.syncHeld[m.ID]
 	srv.syncHeldMu.Unlock()
 	if checked {
 		t.Error("a failed config.sync_recovered persist stayed memoised as closed; the next pass must re-read the log and retry")

--- a/internal/frontdesk/autosync_hold.go
+++ b/internal/frontdesk/autosync_hold.go
@@ -44,8 +44,11 @@ func (s *Server) warnIfBuildGateDegraded(primary memberBuild) {
 // push; this only tracks and reports it.
 func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primary, member memberBuild) {
 	s.syncHeldMu.Lock()
-	already := s.syncHeld[m.ID]
-	s.syncHeld[m.ID] = true
+	_, already := s.syncHeld[m.ID]
+	// Record the primary build this verdict was reached against. A hold means
+	// "this member differs from the primary", which stops being a claim about
+	// anything the moment the primary is a different build; see heldSnapshot.
+	s.syncHeld[m.ID] = primary.key()
 	s.syncHeldMu.Unlock()
 	if already {
 		return
@@ -90,7 +93,7 @@ func (s *Server) holdMemberForSkew(ctx context.Context, m *Member, primary, memb
 // leading the sentence, or a " to <name>" target).
 func (s *Server) closeSyncHold(ctx context.Context, m *Member, message string) {
 	s.syncHeldMu.Lock()
-	was := s.syncHeld[m.ID]
+	_, was := s.syncHeld[m.ID]
 	delete(s.syncHeld, m.ID)
 	s.syncHeldMu.Unlock()
 	if !was && !s.heldPerLog(ctx, m) {

--- a/internal/frontdesk/autosync_hold_test.go
+++ b/internal/frontdesk/autosync_hold_test.go
@@ -166,7 +166,7 @@ func TestAutoSync_ClosesHoldAcrossRestart(t *testing.T) {
 
 	// Simulate a restart: the in-memory hold state is gone, the event log is not.
 	srv.syncHeldMu.Lock()
-	srv.syncHeld = make(map[string]bool)
+	srv.syncHeld = make(map[string]string)
 	srv.holdLogChecked = make(map[string]bool)
 	srv.syncHeldMu.Unlock()
 
@@ -227,7 +227,7 @@ func TestAutoSync_StillHeldAfterRestartDoesNotRealert(t *testing.T) {
 
 	// Simulate a restart with the member still skewed.
 	srv.syncHeldMu.Lock()
-	srv.syncHeld = make(map[string]bool)
+	srv.syncHeld = make(map[string]string)
 	srv.holdLogChecked = make(map[string]bool)
 	srv.syncHeldMu.Unlock()
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -766,7 +766,7 @@ func TestDeleteMemberForgetsItsInMemoryState(t *testing.T) {
 		t.Fatalf("create gone: %v", err)
 	}
 
-	srv.syncHeld[gone.ID] = "dev@old"
+	srv.syncHeld[gone.ID] = memberBuild{Version: "dev", Commit: "old"}.key()
 	srv.syncIncomplete[gone.ID] = incompleteState{diverged: true, lastAttempt: time.Now()}
 	srv.backupStale[gone.ID] = true
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -766,7 +766,7 @@ func TestDeleteMemberForgetsItsInMemoryState(t *testing.T) {
 		t.Fatalf("create gone: %v", err)
 	}
 
-	srv.syncHeld[gone.ID] = true
+	srv.syncHeld[gone.ID] = "dev@old"
 	srv.syncIncomplete[gone.ID] = incompleteState{diverged: true, lastAttempt: time.Now()}
 	srv.backupStale[gone.ID] = true
 
@@ -775,7 +775,7 @@ func TestDeleteMemberForgetsItsInMemoryState(t *testing.T) {
 		t.Fatalf("delete member = %d (%s)", rec.Code, rec.Body.String())
 	}
 
-	if srv.syncHeld[gone.ID] {
+	if _, stillHeld := srv.syncHeld[gone.ID]; stillHeld {
 		t.Error("skew hold survived the member's removal")
 	}
 	if _, ok := srv.syncIncomplete[gone.ID]; ok {

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -79,6 +79,21 @@ type memberFleetFacts struct {
 	Drained  bool
 	Syncable bool
 	Held     bool
+	// HeldCurrent is Held AND judged against the build the primary is running
+	// now. The distinction exists because a hold is a claim ("this member
+	// differs from the primary") that the primary changing invalidates: the
+	// verdict was reached against a build nothing is running any more, and no
+	// pass has re-checked it yet.
+	//
+	// It matters only for the escalation. A rolling rebuild always produces a
+	// window where the member rebuilt BEFORE the primary is still flagged from
+	// when it disagreed with the OLD primary, while the members rebuilt after
+	// it are freshly flagged against the new one. Counting the stale flag made
+	// that read as "every candidate disagrees", which is the one condition that
+	// escalates to faulty, so a routine rebuild reported the fleet broken for
+	// as long as the next auto-sync pass took to catch up. A stale hold still
+	// degrades the fleet; it just cannot condemn it.
+	HeldCurrent bool
 	// Incomplete marks a member that applied a config without materialising all
 	// of it.
 	Incomplete bool
@@ -99,7 +114,7 @@ type fleetStateInput struct {
 // live reads happen in the Server wrapper (fleetStateNow), keeping this
 // exhaustively table-testable.
 func computeFleetState(in fleetStateInput) (FleetState, []string) {
-	var down, held, syncable, drained, incomplete int
+	var down, held, heldCurrent, syncable, drained, incomplete int
 	for _, m := range in.Members {
 		if m.Known && !m.Healthy {
 			down++
@@ -114,6 +129,9 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 			syncable++
 			if m.Held {
 				held++
+			}
+			if m.HeldCurrent {
+				heldCurrent++
 			}
 		}
 	}
@@ -138,7 +156,12 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 	switch {
 	// With a single candidate there is no way to tell which side of the skew is
 	// the odd one out, so it stays a per-member degradation.
-	case syncable >= 2 && held == syncable:
+	//
+	// Escalating needs every candidate to be held ON CURRENT INFORMATION. A
+	// hold carried over from a previous primary build has not been re-judged,
+	// so it cannot be part of the evidence that the whole fleet disagrees; see
+	// memberFleetFacts.HeldCurrent.
+	case syncable >= 2 && heldCurrent == syncable:
 		reasons = append(reasons, reasonAllSyncHeld)
 	case held > 0:
 		reasons = append(reasons, reasonSyncHeld)
@@ -180,10 +203,10 @@ const fleetStateInterval = 5 * time.Second
 // sync_held / all_sync_held. That direction is deliberate: a stale hold degrades
 // the fleet state, it never reports a false ok, and it clears when auto-sync
 // resumes or the skew resolves.
-func (s *Server) heldSnapshot() map[string]bool {
+func (s *Server) heldSnapshot() map[string]string {
 	s.syncHeldMu.Lock()
 	defer s.syncHeldMu.Unlock()
-	out := make(map[string]bool, len(s.syncHeld))
+	out := make(map[string]string, len(s.syncHeld))
 	maps.Copy(out, s.syncHeld)
 	return out
 }
@@ -253,15 +276,22 @@ func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg Auto
 	held := s.heldSnapshot()
 	incomplete := s.incompleteSnapshot()
 	facts := make([]memberFleetFacts, 0, len(members))
+	// The build the primary is running right now, as last read by the poller.
+	// A hold judged against a different one has not been re-checked since, so it
+	// cannot say anything about the current primary; see memberFleetFacts.
+	primarySt := statuses[cfg.PrimaryID]
+	primaryBuild := memberBuild{Version: primarySt.Version, Commit: primarySt.Commit}.key()
 	for _, m := range members {
 		st := statuses[m.ID]
+		heldAgainst, wasHeld := held[m.ID]
 		facts = append(facts, memberFleetFacts{
-			Known:      st.Health.Known,
-			Healthy:    st.Health.Healthy,
-			Drained:    m.State == StateDrained,
-			Syncable:   m.HasToken && m.ID != cfg.PrimaryID,
-			Held:       held[m.ID],
-			Incomplete: incomplete[m.ID],
+			Known:       st.Health.Known,
+			Healthy:     st.Health.Healthy,
+			Drained:     m.State == StateDrained,
+			Syncable:    m.HasToken && m.ID != cfg.PrimaryID,
+			Held:        heldAgainst != "" || wasHeld,
+			HeldCurrent: wasHeld && heldAgainst == primaryBuild,
+			Incomplete:  incomplete[m.ID],
 		})
 	}
 	return computeFleetState(fleetStateInput{

--- a/internal/frontdesk/fleetstate.go
+++ b/internal/frontdesk/fleetstate.go
@@ -85,6 +85,12 @@ type memberFleetFacts struct {
 	// verdict was reached against a build nothing is running any more, and no
 	// pass has re-checked it yet.
 	//
+	// The cost is latency: a hold is re-judged only by an auto-sync pass, so a
+	// primary that really is the odd one out is condemned up to one pass late
+	// (~15s), and longer while passes are not completing at all. The fleet
+	// still reports degraded throughout, never ok, so the delay costs an
+	// escalation's urgency rather than its correctness.
+	//
 	// It matters only for the escalation. A rolling rebuild always produces a
 	// window where the member rebuilt BEFORE the primary is still flagged from
 	// when it disagreed with the OLD primary, while the members rebuilt after
@@ -130,7 +136,7 @@ func computeFleetState(in fleetStateInput) (FleetState, []string) {
 			if m.Held {
 				held++
 			}
-			if m.HeldCurrent {
+			if m.Held && m.HeldCurrent {
 				heldCurrent++
 			}
 		}
@@ -272,15 +278,20 @@ func fleetStateSeverity(st FleetState) int {
 // those reads pass them in so the polled /api/fleet/autosync endpoint does not
 // re-query the store.
 func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg AutoSyncConfig, lastSync time.Time, haveSync bool) (FleetState, []string) {
-	statuses := s.poller.Snapshot()
+	// Holds first, then the poller. The two snapshots are taken at different
+	// instants, and this order keeps the only possible skew in the safe
+	// direction: the primary build can be newer than the holds (which reads
+	// them as stale, degrading), never older (which would read fresh holds as
+	// stale and could miss an escalation for a tick).
 	held := s.heldSnapshot()
+	statuses := s.poller.Snapshot()
 	incomplete := s.incompleteSnapshot()
 	facts := make([]memberFleetFacts, 0, len(members))
 	// The build the primary is running right now, as last read by the poller.
 	// A hold judged against a different one has not been re-checked since, so it
 	// cannot say anything about the current primary; see memberFleetFacts.
 	primarySt := statuses[cfg.PrimaryID]
-	primaryBuild := memberBuild{Version: primarySt.Version, Commit: primarySt.Commit}.key()
+	primaryBuild := buildOf(primarySt).key()
 	for _, m := range members {
 		st := statuses[m.ID]
 		heldAgainst, wasHeld := held[m.ID]
@@ -289,7 +300,7 @@ func (s *Server) fleetStateFrom(ctx context.Context, members []*Member, cfg Auto
 			Healthy:     st.Health.Healthy,
 			Drained:     m.State == StateDrained,
 			Syncable:    m.HasToken && m.ID != cfg.PrimaryID,
-			Held:        heldAgainst != "" || wasHeld,
+			Held:        wasHeld,
 			HeldCurrent: wasHeld && heldAgainst == primaryBuild,
 			Incomplete:  incomplete[m.ID],
 		})

--- a/internal/frontdesk/fleetstate_rollout_test.go
+++ b/internal/frontdesk/fleetstate_rollout_test.go
@@ -26,9 +26,11 @@ func TestFleetState_RollingRebuildDoesNotEscalateOnAStaleHold(t *testing.T) {
 	srv, store := newTestServer(t)
 	ctx := t.Context()
 
-	const (
-		oldBuild = "dev@b59259c5ceb1"
-		newBuild = "dev@02c834188570"
+	// Derived, never spelled: the key's format is memberBuild's business, and a
+	// test that hardcodes the separator silently stops matching when it changes.
+	var (
+		oldBuild = memberBuild{Version: "dev", Commit: "b59259c5ceb1"}.key()
+		newBuild = memberBuild{Version: "dev", Commit: "02c834188570"}.key()
 	)
 	mk := func(name, url string) *Member {
 		t.Helper()
@@ -47,8 +49,11 @@ func TestFleetState_RollingRebuildDoesNotEscalateOnAStaleHold(t *testing.T) {
 
 	// Everything starts on the old build, healthy, in sync.
 	for _, m := range append([]*Member{primary, first}, rest...) {
-		setMemberBuild(srv, m.ID, "dev", "b59259c5ceb1")
+		// Health first: setHealth assigns a whole MemberStatus and would wipe
+		// the build if it ran second, leaving the fleet on an unknown build and
+		// the first hold stale from birth rather than fresh.
 		setHealth(srv, m.ID, true)
+		setMemberBuild(srv, m.ID, "dev", "b59259c5ceb1")
 	}
 	if state, reasons := fleetStateFor(ctx, t, srv); state != FleetOK {
 		t.Fatalf("a fleet on one build should be ok, got %s %v", state, reasons)

--- a/internal/frontdesk/fleetstate_rollout_test.go
+++ b/internal/frontdesk/fleetstate_rollout_test.go
@@ -1,0 +1,125 @@
+package frontdesk
+
+import (
+	"context"
+	"testing"
+)
+
+// A rolling rebuild replays this exact sequence, and it used to report the
+// fleet FAULTY partway through. Observed on the live fleet 2026-08-31:
+//
+//	19:48:09  MH2 held        (MH2 rebuilt new, primary still old, so it differs)
+//	19:48:22  primary drained (the primary starts its own rebuild)
+//	19:49:10  MH3, MH4 held   (primary now new, they are still old)
+//	19:49:11  primary active  (MH2 now agrees with it again)
+//	19:49:14  FAULTY          <- all three candidates still flagged held
+//	19:49:25  MH2 recovered   (the next auto-sync pass finally clears it)
+//
+// Nothing was wrong with the fleet at 19:49:14. MH2's flag was 76 seconds old
+// and had been judged against a build no member was running any more; clearing
+// it is a polled operation, so for one window every candidate carried a hold
+// and the escalation read that as "the whole fleet disagrees with the primary".
+//
+// The escalation now needs holds judged against the CURRENT primary build, so
+// the window degrades rather than condemns.
+func TestFleetState_RollingRebuildDoesNotEscalateOnAStaleHold(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := t.Context()
+
+	const (
+		oldBuild = "dev@b59259c5ceb1"
+		newBuild = "dev@02c834188570"
+	)
+	mk := func(name, url string) *Member {
+		t.Helper()
+		m, err := store.CreateMember(ctx, name, url, "tok-"+name)
+		if err != nil {
+			t.Fatalf("CreateMember %s: %v", name, err)
+		}
+		return m
+	}
+	primary := mk("primary", "https://p.example")
+	first := mk("rebuilt-first", "https://f.example")
+	rest := []*Member{mk("rest-1", "https://r1.example"), mk("rest-2", "https://r2.example")}
+	if err := store.SetAutoSync(ctx, true, primary.ID); err != nil {
+		t.Fatalf("SetAutoSync: %v", err)
+	}
+
+	// Everything starts on the old build, healthy, in sync.
+	for _, m := range append([]*Member{primary, first}, rest...) {
+		setMemberBuild(srv, m.ID, "dev", "b59259c5ceb1")
+		setHealth(srv, m.ID, true)
+	}
+	if state, reasons := fleetStateFor(ctx, t, srv); state != FleetOK {
+		t.Fatalf("a fleet on one build should be ok, got %s %v", state, reasons)
+	}
+
+	// The first member is rebuilt: it now differs from the still-old primary.
+	setMemberBuild(srv, first.ID, "dev", "02c834188570")
+	holdFor(srv, first.ID, oldBuild)
+	if state, _ := fleetStateFor(ctx, t, srv); state != FleetDegraded {
+		t.Fatalf("one held member should degrade, got %s", state)
+	}
+
+	// The primary is rebuilt. The two not yet rebuilt are judged against the
+	// new primary and held; the first member now agrees with it again, but its
+	// flag has not been re-checked yet.
+	setMemberBuild(srv, primary.ID, "dev", "02c834188570")
+	for _, m := range rest {
+		holdFor(srv, m.ID, newBuild)
+	}
+
+	state, reasons := fleetStateFor(ctx, t, srv)
+	if state == FleetFaulty {
+		t.Errorf("the rebuild window reported the fleet faulty on a stale hold: %s %v", state, reasons)
+	}
+	if state != FleetDegraded {
+		t.Errorf("state = %s %v, want degraded", state, reasons)
+	}
+	for _, r := range reasons {
+		if r == reasonAllSyncHeld {
+			t.Errorf("reasons %v carry %q while one candidate's hold predates the current primary", reasons, reasonAllSyncHeld)
+		}
+	}
+
+	// The genuine condition still escalates: once the stale flag is re-judged
+	// against the current primary and stands, every candidate really does
+	// disagree.
+	holdFor(srv, first.ID, newBuild)
+	if state, reasons := fleetStateFor(ctx, t, srv); state != FleetFaulty {
+		t.Errorf("state = %s %v, want faulty once every hold is judged against the current primary", state, reasons)
+	}
+
+	// And the ordinary recovery clears it.
+	releaseHold(srv, first.ID)
+	for _, m := range rest {
+		releaseHold(srv, m.ID)
+	}
+	if state, reasons := fleetStateFor(ctx, t, srv); state != FleetOK {
+		t.Errorf("state = %s %v, want ok once the fleet is on one build", state, reasons)
+	}
+}
+
+// fleetStateFor computes the current state the way the background loop does.
+func fleetStateFor(ctx context.Context, t *testing.T, s *Server) (FleetState, []string) {
+	t.Helper()
+	state, reasons, _, err := s.fleetStateNow(ctx)
+	if err != nil {
+		t.Fatalf("fleetStateNow: %v", err)
+	}
+	return state, reasons
+}
+
+// holdFor records a skew hold judged against a given primary build, which is
+// what the auto-sync pass does when it finds a member that differs.
+func holdFor(s *Server, memberID, primaryBuild string) {
+	s.syncHeldMu.Lock()
+	s.syncHeld[memberID] = primaryBuild
+	s.syncHeldMu.Unlock()
+}
+
+func releaseHold(s *Server, memberID string) {
+	s.syncHeldMu.Lock()
+	delete(s.syncHeld, memberID)
+	s.syncHeldMu.Unlock()
+}

--- a/internal/frontdesk/fleetstate_test.go
+++ b/internal/frontdesk/fleetstate_test.go
@@ -11,7 +11,18 @@ import (
 func TestComputeFleetState(t *testing.T) {
 	up := memberFleetFacts{Known: true, Healthy: true}
 	down := memberFleetFacts{Known: true, Healthy: false}
-	heldOf := func(f memberFleetFacts) memberFleetFacts { f.Syncable = true; f.Held = true; return f }
+	// heldOf is a hold judged against the build the primary is running now, the
+	// ordinary case. staleHeldOf is one carried over from a previous primary
+	// build, which a rolling rebuild always produces and which must not be part
+	// of the evidence for an all_sync_held escalation.
+	heldOf := func(f memberFleetFacts) memberFleetFacts {
+		f.Syncable, f.Held, f.HeldCurrent = true, true, true
+		return f
+	}
+	staleHeldOf := func(f memberFleetFacts) memberFleetFacts {
+		f.Syncable, f.Held, f.HeldCurrent = true, true, false
+		return f
+	}
 	incompleteOf := func(f memberFleetFacts) memberFleetFacts { f.Syncable = true; f.Incomplete = true; return f }
 	syncable := func(f memberFleetFacts) memberFleetFacts { f.Syncable = true; return f }
 	drainedOf := func(f memberFleetFacts) memberFleetFacts { f.Drained = true; return f }
@@ -41,6 +52,15 @@ func TestComputeFleetState(t *testing.T) {
 		{"all held (2+) is faulty: primary is the odd one out",
 			fleetStateInput{Members: []memberFleetFacts{up, heldOf(up), heldOf(up)}},
 			FleetFaulty, []string{"all_sync_held"}},
+		{"a stale hold degrades but cannot escalate: it was judged against a primary build nothing runs now",
+			fleetStateInput{Members: []memberFleetFacts{up, staleHeldOf(up), heldOf(up)}},
+			FleetDegraded, []string{"sync_held"}},
+		{"every candidate stale is still only a degradation",
+			fleetStateInput{Members: []memberFleetFacts{up, staleHeldOf(up), staleHeldOf(up)}},
+			FleetDegraded, []string{"sync_held"}},
+		{"the rolling-rebuild window: one member re-checked, the rest flagged against the old primary",
+			fleetStateInput{Members: []memberFleetFacts{up, staleHeldOf(up), heldOf(up), heldOf(up)}},
+			FleetDegraded, []string{"sync_held"}},
 		{"single held candidate cannot prove the primary is odd",
 			fleetStateInput{Members: []memberFleetFacts{up, heldOf(up)}},
 			FleetDegraded, []string{"sync_held"}},
@@ -340,7 +360,7 @@ func simulateFleetStateRestart(s *Server) {
 	s.poller.lastConfigPollAt = time.Time{}
 	s.poller.mu.Unlock()
 	s.syncHeldMu.Lock()
-	s.syncHeld = make(map[string]bool)
+	s.syncHeld = make(map[string]string)
 	s.syncHeldMu.Unlock()
 	s.syncIncompleteMu.Lock()
 	s.syncIncomplete = make(map[string]incompleteState)

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -155,7 +155,13 @@ func (p *Poller) Snapshot() map[string]MemberStatus {
 func (p *Poller) memberBuildOf(id string) memberBuild {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	st := p.statuses[id]
+	return buildOf(p.statuses[id])
+}
+
+// buildOf reads a member's build out of a polled status. One extraction, so a
+// caller working from an already-taken snapshot cannot drift from
+// memberBuildOf if a third build field is ever added.
+func buildOf(st MemberStatus) memberBuild {
 	return memberBuild{Version: st.Version, Commit: st.Commit}
 }
 

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -121,7 +121,10 @@ type Server struct {
 	// previous process announced is still closed out, and a still-held member is
 	// not re-alerted.
 	syncHeldMu sync.Mutex
-	syncHeld   map[string]bool
+	// syncHeld maps a held member to the primary build its hold was judged
+	// against, so a later pass can tell a hold that still means something from
+	// one that has not been re-checked since the primary itself changed.
+	syncHeld map[string]string
 	// ungatedCommitWarned records that this process already warned that the
 	// primary reports no usable commit, so the warning fires once per transition
 	// rather than every pass. Guarded by syncHeldMu, alongside the hold state it
@@ -280,7 +283,7 @@ func NewServer(cfg ServerConfig) *Server {
 		traefikLimiter:  cfg.TraefikLimiter,
 		trustedProxies:  cfg.TrustedProxies,
 		rearmCh:         make(chan struct{}),
-		syncHeld:        make(map[string]bool),
+		syncHeld:        make(map[string]string),
 		holdLogChecked:  make(map[string]bool),
 		syncIncomplete:  make(map[string]incompleteState),
 		unconfirmedSync: make(map[string]string),

--- a/internal/frontdesk/versionskew.go
+++ b/internal/frontdesk/versionskew.go
@@ -16,8 +16,12 @@ type memberBuild struct {
 
 // key identifies the build for comparing one recorded verdict against another.
 // Both halves, because a fleet whose images all report the "dev" placeholder
-// version is distinguished only by commit. The separator is a byte neither half
-// can contain, so no two different builds can produce the same key.
+// version is distinguished only by commit. The separator is a byte no real
+// version or commit contains, so no two builds a member can honestly report
+// collide. It is not an enforced invariant: both halves are strings a member
+// hands us, and JSON can carry a NUL, so a member that deliberately reported
+// one could collide with another build. That member is already a trusted
+// config target, and the cost is one hold read as fresh when it is stale.
 //
 // Every unknown build shares one key, deliberately. A hold taken while the
 // primary's build could not be read should keep counting for as long as it

--- a/internal/frontdesk/versionskew.go
+++ b/internal/frontdesk/versionskew.go
@@ -18,6 +18,12 @@ type memberBuild struct {
 // when that is all there is, "dev (d18a96d1f84d)" when a commit backs it. An
 // unknown build reads as "unknown" rather than an empty string, so a message
 // naming it does not trail off.
+// key identifies the build for comparing one recorded verdict against another.
+// Both halves, so a fleet whose images all report the "dev" placeholder version
+// is still distinguished by commit, and an unknown build gets its own value
+// rather than colliding with every other unknown.
+func (b memberBuild) key() string { return b.Version + "@" + b.Commit }
+
 func (b memberBuild) describe() string {
 	switch {
 	case b.Version == "":

--- a/internal/frontdesk/versionskew.go
+++ b/internal/frontdesk/versionskew.go
@@ -14,16 +14,22 @@ type memberBuild struct {
 	Commit  string
 }
 
+// key identifies the build for comparing one recorded verdict against another.
+// Both halves, because a fleet whose images all report the "dev" placeholder
+// version is distinguished only by commit. The separator is a byte neither half
+// can contain, so no two different builds can produce the same key.
+//
+// Every unknown build shares one key, deliberately. A hold taken while the
+// primary's build could not be read should keep counting for as long as it
+// still cannot be read; it is the CHANGE from one known build to another that
+// makes a hold stale. Reading the two sides through the same fields is what
+// makes that symmetric.
+func (b memberBuild) key() string { return b.Version + "\x00" + b.Commit }
+
 // describe renders the build for an operator-facing event: the version alone
 // when that is all there is, "dev (d18a96d1f84d)" when a commit backs it. An
 // unknown build reads as "unknown" rather than an empty string, so a message
 // naming it does not trail off.
-// key identifies the build for comparing one recorded verdict against another.
-// Both halves, so a fleet whose images all report the "dev" placeholder version
-// is still distinguished by commit, and an unknown build gets its own value
-// rather than colliding with every other unknown.
-func (b memberBuild) key() string { return b.Version + "@" + b.Commit }
-
 func (b memberBuild) describe() string {
 	switch {
 	case b.Version == "":


### PR DESCRIPTION
## What

A hold recorded against one primary build can no longer escalate the fleet to FAULTY after the primary has become a different build.

## Why

Every rolling rebuild reported the fleet FAULTY partway through. Caught on the live fleet during the 2026-08-31 rebuild:

```
19:48:09  MH2 held        (MH2 rebuilt new, primary still old, so it differs)
19:48:22  primary drained (the primary starts its own rebuild)
19:49:10  MH3, MH4 held   (primary now new, they are still old)
19:49:11  primary active  (MH2 agrees with it again)
19:49:14  FAULTY          <- all three candidates still flagged held
19:49:25  MH2 recovered   (the next auto-sync pass clears it)
```

Nothing was wrong at 19:49:14. MH2's flag was 76 seconds old and had been judged against a build no member was running any more. Clearing a hold is a *polled* operation, so for one window every sync candidate carried one, and `all_sync_held` read that as "the whole fleet disagrees with the primary" and escalated.

The rebuild tool already orders the primary second specifically to dodge this, on the reasoning that some member always agrees with it. That reasoning is true of the **builds** and false of the **recorded state** for as long as the next pass takes: whichever member is rebuilt before the primary stays flagged until it is re-checked, and the members rebuilt after it are freshly flagged. No ordering closes that window, which is why the fix belongs here and not in the tool. Any operator doing a rolling restart by hand hit the same thing.

Impact was a red fleet in Bellhop (and now an alert) for ~15s per rebuild, self-clearing, with no data-plane effect.

## How

A hold records which primary build it was judged against (`memberBuild.key()`, version and commit, so a fleet whose images all report the `dev` placeholder is still distinguished). `computeFleetState` counts two things now:

- **held** (any hold, fresh or stale) still drives `sync_held`, so a stale hold degrades the fleet and nothing can report a false ok;
- **heldCurrent** (judged against the build the primary is running *now*) is what `all_sync_held` requires.

The genuine condition is unchanged: once every candidate has been re-judged against the current primary and still disagrees, it escalates.

## Tests

Table cases for a stale hold beside a fresh one, every candidate stale, and the exact rolling-rebuild shape. Plus an end-to-end test replaying the production sequence above through `fleetStateNow`, which asserts the window degrades, that the escalation still fires once the stale flag is re-judged and stands, and that ordinary recovery returns to ok.

Mutation-checked: restoring the old rule (`held == syncable`) makes the end-to-end test fail with exactly the production symptom, `faulty [all_sync_held]`.

`internal/frontdesk` + `internal/util`: 1,153 pass. Lint clean, size gate OK, diff coverage 22/22 = 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S2nsLenYbQm6235Sv8o55
