### PR TITLE
feat(failover): every circuit remembers why it last changed

### DIFF
--- a/cmd/server/background_test.go
+++ b/cmd/server/background_test.go
@@ -693,7 +693,7 @@ func TestQuotaPollLoop_DisabledSpanReleasesQuotaPins(t *testing.T) {
 	cb.Cooldown = time.Minute
 	cb.SetQuotaAdvisor(quotaPinAdvisor{at: time.Now().Add(6 * time.Hour)})
 	providerID := uuid.New()
-	cb.RecordFailure(providerID, "pinned-provider", "")
+	cb.RecordFailure(providerID, "pinned-provider", "", failover.Cause{})
 	if !quotaPinnedFor(cb, providerID) {
 		t.Fatal("setup: a 6h deadline against a 1m cooldown must pin the circuit")
 	}
@@ -756,7 +756,7 @@ func TestQuotaPollLoop_DisabledSpanReleasesQuotaPins(t *testing.T) {
 	// below is unambiguously the second span's doing.
 	time.Sleep(50 * time.Millisecond)
 	cb.Reset(providerID)
-	cb.RecordFailure(providerID, "pinned-provider", "")
+	cb.RecordFailure(providerID, "pinned-provider", "", failover.Cause{})
 	if !quotaPinnedFor(cb, providerID) {
 		t.Fatal("setup: the circuit must carry a pin again before the second disable")
 	}

--- a/internal/api/failover_circuitbreaker.go
+++ b/internal/api/failover_circuitbreaker.go
@@ -13,6 +13,9 @@ import (
 // CircuitBreakerReader provides read-only access to circuit breaker status.
 type CircuitBreakerReader interface {
 	Status() []failover.ProviderStatus
+	// StatusDetail is Status with every row's circuits[] filled in; only the
+	// detail response pays for it.
+	StatusDetail() []failover.ProviderStatus
 }
 
 // CircuitBreakerResetter clears breaker state so an operator can force a
@@ -102,7 +105,11 @@ func (h *FailoverHandler) CircuitBreakerStatus(w http.ResponseWriter, r *http.Re
 	resp := CircuitBreakerStatusResponse{}
 	trackedProviders := make([]failover.ProviderStatus, 0)
 	if h.cb != nil {
-		trackedProviders = h.cb.Status()
+		if wantDetail {
+			trackedProviders = h.cb.StatusDetail()
+		} else {
+			trackedProviders = h.cb.Status()
+		}
 		for _, s := range trackedProviders {
 			switch s.State {
 			case failover.StateClosed.String():

--- a/internal/api/failover_circuitbreaker_reset_test.go
+++ b/internal/api/failover_circuitbreaker_reset_test.go
@@ -38,7 +38,7 @@ func newTestHandlerWithBreaker(t *testing.T) (*Handler, chi.Router, *failover.Ci
 func openCircuit(t *testing.T, cb *failover.CircuitBreaker, providerID uuid.UUID) {
 	t.Helper()
 	for i := 0; i < cb.Threshold; i++ {
-		cb.RecordFailure(providerID, "test-provider", "")
+		cb.RecordFailure(providerID, "test-provider", "", failover.Cause{})
 	}
 	if !cb.IsOpen(providerID, "test-provider", "") {
 		t.Fatalf("setup: circuit for %s should be open after %d failures", providerID, cb.Threshold)
@@ -131,8 +131,8 @@ func TestResetCircuitBreaker_ClosedCircuitReportsNoChange(t *testing.T) {
 	_, r, cb := newTestHandlerWithBreaker(t)
 
 	tracked := uuid.New()
-	cb.RecordFailure(tracked, "test-provider", "") // one failure: circuit exists, still closed
-	untracked := uuid.New()                        // never routed, so no circuit at all
+	cb.RecordFailure(tracked, "test-provider", "", failover.Cause{}) // one failure: circuit exists, still closed
+	untracked := uuid.New()                                          // never routed, so no circuit at all
 
 	for name, providerID := range map[string]uuid.UUID{"tracked but closed": tracked, "never tracked": untracked} {
 		t.Run(name, func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestResetAllCircuitBreakers_ClearsEveryCircuit(t *testing.T) {
 	openA, openB, healthy := uuid.New(), uuid.New(), uuid.New()
 	openCircuit(t, cb, openA)
 	openCircuit(t, cb, openB)
-	cb.RecordFailure(healthy, "test-provider", "") // tracked, below threshold, still closed
+	cb.RecordFailure(healthy, "test-provider", "", failover.Cause{}) // tracked, below threshold, still closed
 
 	code, body := doAdminRequest(r, http.MethodPost, "/failover-groups/circuit-breaker/reset")
 	if code != http.StatusOK {

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -913,6 +913,11 @@ func TestCircuitBreakerStatus_DetailCarriesProviderOpenAndOpenModels(t *testing.
 				ConsecutiveFails: 5,
 				ProviderOpen:     true,
 				OpenModels:       []string{"model-a", "model-b"},
+				Circuits: []failover.CircuitStatus{
+					{Model: "model-a", State: "open", ConsecutiveFails: 5, LastCause: "upstream status 429 (saturated)", LastStatus: 429, LastAt: "2026-08-31T14:48:37Z"},
+					{Model: "model-b", State: "open", ConsecutiveFails: 5, LastCause: "upstream status 503", LastStatus: 503},
+					{Model: "model-c", State: "closed", LastCause: "success"},
+				},
 			},
 			{
 				ProviderID:       uuid.New().String(),
@@ -952,6 +957,20 @@ func TestCircuitBreakerStatus_DetailCarriesProviderOpenAndOpenModels(t *testing.
 	if got := decodeOpenModels(t, indicted); !slices.Equal(got, []string{"model-a", "model-b"}) {
 		t.Errorf("open_models = %v, want both models the verdict rests on", got)
 	}
+	// The circuits behind the row ride along verbatim, verdict included: this
+	// is the list that says WHY each model is dark.
+	circuits, _ := indicted["circuits"].([]any)
+	if len(circuits) != 3 {
+		t.Fatalf("circuits = %v, want the three circuits the row is built from", indicted["circuits"])
+	}
+	first, _ := circuits[0].(map[string]any)
+	if first["model"] != "model-a" || first["last_cause"] != "upstream status 429 (saturated)" || first["last_status"] != float64(429) || first["last_at"] != "2026-08-31T14:48:37Z" {
+		t.Errorf("circuits[0] = %v", first)
+	}
+	third, _ := circuits[2].(map[string]any)
+	if _, present := third["last_status"]; present {
+		t.Errorf("circuits[2] = %v: a verdict with no status must omit last_status, not send 0", third)
+	}
 
 	single, _ := providers[1].(map[string]any)
 	raw, present := single["provider_open"]
@@ -963,6 +982,9 @@ func TestCircuitBreakerStatus_DetailCarriesProviderOpenAndOpenModels(t *testing.
 	}
 	if got := decodeOpenModels(t, single); !slices.Equal(got, []string{"model-a"}) {
 		t.Errorf("open_models = %v, want the single open model", got)
+	}
+	if _, present := single["circuits"]; present {
+		t.Errorf("circuits present on a row that reported none: an older member's row must decode the same way")
 	}
 }
 

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -725,6 +725,9 @@ func TestDeleteFailoverGroup_NonExistent(t *testing.T) {
 // reads instead of trusting a call counter.
 type mockCircuitBreaker struct {
 	statuses []failover.ProviderStatus
+	// detailCalls counts StatusDetail reads, so a test can pin that the
+	// aggregate poll never pays for the per-circuit list.
+	detailCalls int
 }
 
 func (m *mockCircuitBreaker) Status() []failover.ProviderStatus {
@@ -732,6 +735,7 @@ func (m *mockCircuitBreaker) Status() []failover.ProviderStatus {
 }
 
 func (m *mockCircuitBreaker) StatusDetail() []failover.ProviderStatus {
+	m.detailCalls++
 	return m.statuses
 }
 
@@ -840,6 +844,11 @@ func TestCircuitBreakerStatus_WithDetail(t *testing.T) {
 		}
 		if _, exists := resp["providers"]; exists {
 			t.Error("expected no providers field without ?detail=1")
+		}
+		// The aggregate poll reads only the counts, so it must take the lean
+		// Status and never build the per-circuit list.
+		if mockCB.detailCalls != 0 {
+			t.Errorf("StatusDetail called %d times without ?detail=1, want 0", mockCB.detailCalls)
 		}
 	})
 

--- a/internal/api/handler_failover_test.go
+++ b/internal/api/handler_failover_test.go
@@ -731,6 +731,10 @@ func (m *mockCircuitBreaker) Status() []failover.ProviderStatus {
 	return m.statuses
 }
 
+func (m *mockCircuitBreaker) StatusDetail() []failover.ProviderStatus {
+	return m.statuses
+}
+
 func (m *mockCircuitBreaker) Reset(providerID uuid.UUID) failover.State {
 	id := providerID.String()
 	for i, s := range m.statuses {

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -20,7 +20,8 @@ import (
 // instead of silently passing.
 type fakeBreakerReader struct{ statuses []failover.ProviderStatus }
 
-func (f fakeBreakerReader) Status() []failover.ProviderStatus { return f.statuses }
+func (f fakeBreakerReader) Status() []failover.ProviderStatus       { return f.statuses }
+func (f fakeBreakerReader) StatusDetail() []failover.ProviderStatus { return f.statuses }
 
 func (f fakeBreakerReader) Reset(uuid.UUID) failover.State {
 	panic("metrics must never reset the circuit breaker")

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -473,7 +473,8 @@ type pinReleaseRecorder struct {
 	allCalls int
 }
 
-func (p *pinReleaseRecorder) Status() []failover.ProviderStatus { return nil }
+func (p *pinReleaseRecorder) Status() []failover.ProviderStatus       { return nil }
+func (p *pinReleaseRecorder) StatusDetail() []failover.ProviderStatus { return nil }
 
 func (p *pinReleaseRecorder) Reset(uuid.UUID) failover.State {
 	panic("the quota refresh must never reset a circuit")

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -656,7 +656,7 @@ func TestRefreshQuotaAdvice_ReleasesPinsOnlyOnFreshRecoveryEvidence(t *testing.T
 				}
 			}
 		}
-		cb.RecordFailure(ids[i], c.name, "")
+		cb.RecordFailure(ids[i], c.name, "", failover.Cause{})
 	}
 
 	pinned := pinnedByProvider(cb)
@@ -751,7 +751,7 @@ func TestRefreshQuotaAdvice_FleetImportedFailureMarkerRetainsPin(t *testing.T) {
 			t.Fatalf("import %s: want 200, got %d: %s", c.name, rr.Code, rr.Body.String())
 		}
 
-		cb.RecordFailure(ids[i], c.name, "")
+		cb.RecordFailure(ids[i], c.name, "", failover.Cause{})
 	}
 
 	pinned := pinnedByProvider(cb)
@@ -798,7 +798,7 @@ func TestDisableQuotaAdvice_ReleasesPinsThatARefreshWouldKeep(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed exhausted snapshot: %v", err)
 	}
-	cb.RecordFailure(spentID, "zai-still-spent", "")
+	cb.RecordFailure(spentID, "zai-still-spent", "", failover.Cause{})
 
 	// While polling runs, this provider's pin survives every refresh: it is
 	// still exhausted, which is affirmative evidence in the other direction.
@@ -1160,7 +1160,7 @@ func TestNudgeQuotaPoll_RetargetsAnAlreadyOpenCircuit(t *testing.T) {
 	// The advisor is empty until the nudge refreshes it, so this open is
 	// necessarily unpinned and lands on the 60s default cooldown.
 	for i := 0; i < 5; i++ {
-		cb.RecordFailure(id, "zai-repin", "")
+		cb.RecordFailure(id, "zai-repin", "", failover.Cause{})
 	}
 
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/failover/circuit_backoff_test.go
+++ b/internal/failover/circuit_backoff_test.go
@@ -28,7 +28,7 @@ func failProbe(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
 	if cb.IsOpen(id, "test-provider", "") {
 		t.Fatal("setup: the circuit is still dark, no probe to fail")
 	}
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 	if got := cb.GetState(id, ""); got != StateOpen {
 		t.Fatalf("setup: after a failed probe got state %v, want open", got)
 	}
@@ -163,7 +163,7 @@ func TestCircuitBreaker_AProbeThatSucceedsResetsTheBackoff(t *testing.T) {
 	}
 
 	// The next open is a fresh incident and starts from the base again.
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 	if s := onlyStatus(t, cb); s.CooldownMs != backoffTestBase.Milliseconds() || s.BackedOff || s.FailedProbes != 0 {
 		t.Errorf("after recovery and a new open: cooldown %dms backed_off=%v failed_probes=%d, want base/false/0",
 			s.CooldownMs, s.BackedOff, s.FailedProbes)
@@ -341,14 +341,14 @@ func TestCircuitBreaker_SwitchReadsDoNotScaleWithBackedOffCircuits(t *testing.T)
 		id := uuid.New()
 		for i := range circuits {
 			model := fmt.Sprintf("model-%02d", i)
-			cb.RecordFailure(id, "test-provider", model)
+			cb.RecordFailure(id, "test-provider", model, Cause{})
 			cb.mu.Lock()
 			cb.circuits[id.String()][model].openedAt = time.Now().Add(-24 * time.Hour)
 			cb.mu.Unlock()
 			if cb.IsOpen(id, "test-provider", model) {
 				t.Fatalf("setup: %s still dark past its cooldown", model)
 			}
-			cb.RecordFailure(id, "test-provider", model)
+			cb.RecordFailure(id, "test-provider", model, Cause{})
 		}
 		settings.reset()
 		s := onlyStatus(t, cb)
@@ -402,7 +402,7 @@ func TestCircuitBreaker_BackoffSuffixOnlyWhenTheBackoffGoverns(t *testing.T) {
 
 	cb := newTestCB(1, backoffTestBase)
 	id := uuid.New()
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 	waitForOpenEvent(t, sub, id)
 	cb.mu.Lock()
 	cb.circuits[id.String()][modelA].openedAt = time.Now().Add(-24 * time.Hour)
@@ -411,7 +411,7 @@ func TestCircuitBreaker_BackoffSuffixOnlyWhenTheBackoffGoverns(t *testing.T) {
 		t.Fatal("setup: no probe handed out past the cooldown")
 	}
 	cb.SetQuotaAdvisor(stubAdvisor{at: time.Now().Add(10 * time.Hour), ok: true})
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	ev := waitForOpenEvent(t, sub, id)
 	pinned, _ := ev.Metadata["quota_pinned"].(bool)
@@ -458,7 +458,7 @@ func TestCircuitBreaker_OpenEventCarriesModelIDAndTheBackoff(t *testing.T) {
 
 	cb := newTestCB(1, backoffTestBase)
 	id := uuid.New()
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	ev := waitForOpenEvent(t, sub, id)
 	if got, _ := ev.Metadata["model_id"].(string); got != modelA {
@@ -486,7 +486,7 @@ func TestCircuitBreaker_OpenEventCarriesModelIDAndTheBackoff(t *testing.T) {
 	if cb.IsOpen(id, "test-provider", modelA) {
 		t.Fatal("setup: no probe handed out past the cooldown")
 	}
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	ev = waitForOpenEvent(t, sub, id)
 	if got, _ := ev.Metadata["backed_off"].(bool); !got {
@@ -539,7 +539,7 @@ func TestCircuitBreaker_OpenEventDropsModelIDOnceTheProviderIsSkipped(t *testing
 	cb := newTestCB(1, backoffTestBase)
 	cb.SpanModels = 1 // the first open indicts the provider
 	id := uuid.New()
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	ev := waitForOpenEvent(t, sub, id)
 	if open, _ := ev.Metadata["provider_open"].(bool); !open {
@@ -563,11 +563,11 @@ func TestCircuitBreaker_ClosedEventCarriesModelID(t *testing.T) {
 	cb := newTestCB(1, 0)
 	cb.SpanModels = 1
 	id := uuid.New()
-	cb.RecordFailure(id, "test-provider", modelB) // the sibling holds the verdict
+	cb.RecordFailure(id, "test-provider", modelB, Cause{}) // the sibling holds the verdict
 	cb.mu.Lock()
 	cb.circuits[id.String()][modelB].openedAt = time.Now().Add(time.Hour) // still dark for an hour
 	cb.mu.Unlock()
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 	cb.mu.Lock()
 	cb.circuits[id.String()][modelA].state = StateHalfOpen // owed its probe
 	cb.mu.Unlock()

--- a/internal/failover/circuit_cause_test.go
+++ b/internal/failover/circuit_cause_test.go
@@ -1,0 +1,274 @@
+package failover
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/events"
+)
+
+// lastVerdict reads a circuit's remembered verdict straight off the ledger.
+func lastVerdict(t *testing.T, cb *CircuitBreaker, id uuid.UUID, model string) (string, int, time.Time) {
+	t.Helper()
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	c, ok := cb.circuits[id.String()][model]
+	if !ok {
+		t.Fatalf("no circuit tracked for %s/%s", id, model)
+	}
+	return c.lastCause, c.lastStatus, c.lastAt
+}
+
+func TestUpstreamStatus(t *testing.T) {
+	if got := UpstreamStatus(503, ""); got.Status != 503 || got.Reason != "upstream status 503" {
+		t.Errorf("UpstreamStatus(503) = %+v", got)
+	}
+	if got := UpstreamStatus(429, "saturated"); got.Status != 429 || got.Reason != "upstream status 429 (saturated)" {
+		t.Errorf("UpstreamStatus(429, saturated) = %+v", got)
+	}
+}
+
+// Every verdict site leaves its cause on the circuit: what the breaker saw,
+// the status behind it, and when. This is the memory the detail endpoint and
+// the open event read, so a site that forgot to stamp would show an operator
+// the PREVIOUS verdict under the current state.
+func TestCircuitRemembersItsLastVerdict(t *testing.T) {
+	cb := newTestCB(3, time.Minute)
+	id := uuid.New()
+	before := time.Now()
+
+	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
+	cause, status, at := lastVerdict(t, cb, id, "m")
+	if cause != "upstream status 503" || status != 503 || at.Before(before) {
+		t.Errorf("after a 503 charge: cause=%q status=%d at=%v", cause, status, at)
+	}
+
+	cb.RecordSuccess(id, "p", "m")
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != causeSuccess || status != 0 {
+		t.Errorf("after a success: cause=%q status=%d", cause, status)
+	}
+
+	cb.RecordAlive(id, "p", "m", 400)
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != "upstream status 400 (alive)" || status != 400 {
+		t.Errorf("after a 400: cause=%q status=%d", cause, status)
+	}
+
+	cb.RecordRateLimited(id, "p", "m", UpstreamStatus(429, "unrecognised"))
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != "upstream status 429 (unrecognised)" || status != 429 {
+		t.Errorf("after an unrecognised 429: cause=%q status=%d", cause, status)
+	}
+
+	cb.RecordFailure(id, "p", "m", Cause{Reason: "upstream request failed"})
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != "upstream request failed" || status != 0 {
+		t.Errorf("after a connection failure: cause=%q status=%d, want no status", cause, status)
+	}
+
+	cb.RecordExhausted(id, "p", "m2", 0)
+	if cause, status, _ := lastVerdict(t, cb, id, "m2"); cause != "upstream status 429 (exhausted)" || status != 429 {
+		t.Errorf("after an exhausted 429: cause=%q status=%d", cause, status)
+	}
+}
+
+// A saturated 429 is remembered without being charged or credited: the
+// circuit's counters and state are exactly what they were, only the verdict
+// changes. That is what lets a status row say "busy" about a closed circuit.
+func TestRecordSaturated_RemembersWithoutCharging(t *testing.T) {
+	cb := newTestCB(3, time.Minute)
+	id := uuid.New()
+	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
+	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
+
+	cb.RecordSaturated(id, "p", "m")
+
+	cause, status, _ := lastVerdict(t, cb, id, "m")
+	if cause != "upstream status 429 (saturated)" || status != 429 {
+		t.Errorf("cause=%q status=%d", cause, status)
+	}
+	if got := cb.GetState(id, "m"); got != StateClosed {
+		t.Errorf("state = %v, want closed: a saturated 429 must not charge", got)
+	}
+	cb.mu.RLock()
+	fails := cb.circuits[id.String()]["m"].consecutiveFails
+	cb.mu.RUnlock()
+	if fails != 2 {
+		t.Errorf("consecutiveFails = %d, want the 2 earlier charges untouched (neither charged nor reset)", fails)
+	}
+	// And a fresh pair gets a circuit, so the verdict has somewhere to live.
+	other := uuid.New()
+	cb.RecordSaturated(other, "p", "m")
+	if cause, _, _ := lastVerdict(t, cb, other, "m"); cause != "upstream status 429 (saturated)" {
+		t.Errorf("untracked pair after RecordSaturated: cause=%q", cause)
+	}
+}
+
+// The quota poller's retarget and the two releases are transitions with no
+// request behind them; each records itself as the verdict and keeps the
+// status of the response that opened the circuit.
+func TestQuotaPinTransitionsRecordTheirCause(t *testing.T) {
+	cb := newTestCB(1, time.Minute)
+	id := uuid.New()
+	cb.RecordFailure(id, "p", "m", UpstreamStatus(429, "unrecognised"))
+	if cb.GetState(id, "m") != StateOpen {
+		t.Fatal("setup: circuit not open")
+	}
+
+	if n := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(2 * time.Hour)}); n != 1 {
+		t.Fatalf("retargeted %d, want 1", n)
+	}
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != causePinRetargeted || status != 429 {
+		t.Errorf("after retarget: cause=%q status=%d", cause, status)
+	}
+
+	if n := cb.ReleaseQuotaPins(map[uuid.UUID]struct{}{id: {}}); n != 1 {
+		t.Fatalf("released %d, want 1", n)
+	}
+	if cause, status, _ := lastVerdict(t, cb, id, "m"); cause != causePinReleasedQuota || status != 429 {
+		t.Errorf("after release: cause=%q status=%d", cause, status)
+	}
+
+	cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(2 * time.Hour)})
+	if n := cb.ReleaseAllQuotaPins(); n != 1 {
+		t.Fatalf("released all %d, want 1", n)
+	}
+	if cause, _, _ := lastVerdict(t, cb, id, "m"); cause != causePinReleasedOff {
+		t.Errorf("after release-all: cause=%q", cause)
+	}
+}
+
+// The detail row lists every circuit it is built from, sorted, each with its
+// state and verdict, and the open ones are exactly open_models: two readings
+// of the same ledger must never disagree.
+func TestStatus_CircuitsMatchOpenModels(t *testing.T) {
+	cb := newTestCB(2, time.Minute)
+	id := uuid.New()
+	cb.RecordFailure(id, "p", "b-open", UpstreamStatus(503, ""))
+	cb.RecordFailure(id, "p", "b-open", UpstreamStatus(503, ""))
+	cb.RecordFailure(id, "p", "a-closed", UpstreamStatus(502, ""))
+	cb.RecordSuccess(id, "p", "c-served")
+
+	s := onlyStatus(t, cb)
+	if len(s.Circuits) != 3 {
+		t.Fatalf("circuits = %+v, want 3", s.Circuits)
+	}
+	for i, want := range []string{"a-closed", "b-open", "c-served"} {
+		if s.Circuits[i].Model != want {
+			t.Errorf("circuits[%d].Model = %q, want %q (sorted)", i, s.Circuits[i].Model, want)
+		}
+	}
+	var open []string
+	for _, c := range s.Circuits {
+		if c.State == StateOpen.String() {
+			open = append(open, c.Model)
+		}
+	}
+	if len(open) != 1 || open[0] != "b-open" || len(s.OpenModels) != 1 || s.OpenModels[0] != "b-open" {
+		t.Errorf("open circuits %v vs open_models %v", open, s.OpenModels)
+	}
+
+	byModel := map[string]CircuitStatus{}
+	for _, c := range s.Circuits {
+		byModel[c.Model] = c
+	}
+	o := byModel["b-open"]
+	if o.LastCause != "upstream status 503" || o.LastStatus != 503 || o.LastAt == "" {
+		t.Errorf("open circuit verdict = %+v", o)
+	}
+	if o.ConsecutiveFails != 2 || o.OpenedAt == "" || o.CooldownMs != time.Minute.Milliseconds() || o.NextRetryAt == "" {
+		t.Errorf("open circuit wait = %+v", o)
+	}
+	c := byModel["a-closed"]
+	if c.ConsecutiveFails != 1 || c.LastStatus != 502 || c.OpenedAt != "" || c.CooldownMs != 0 || c.NextRetryAt != "" {
+		t.Errorf("closed circuit = %+v, want a charge and no wait", c)
+	}
+	if byModel["c-served"].LastCause != causeSuccess {
+		t.Errorf("served circuit verdict = %+v", byModel["c-served"])
+	}
+
+	// A circuit owed a probe keeps its opened_at and its verdict, so the row
+	// can still say how long it was dark and why.
+	backdateOpenModel(t, cb, id, "b-open", 2*time.Minute)
+	s = onlyStatus(t, cb)
+	for _, c := range s.Circuits {
+		if c.Model != "b-open" {
+			continue
+		}
+		if c.State != StateHalfOpen.String() || c.OpenedAt == "" || c.NextRetryAt != "" || c.LastCause != "upstream status 503" {
+			t.Errorf("half-open circuit = %+v", c)
+		}
+	}
+	if len(s.OpenModels) != 0 {
+		t.Errorf("open_models = %v after the cooldown elapsed", s.OpenModels)
+	}
+}
+
+// The open event and the open log line carry the verdict that produced them,
+// and the event's sentence names it, because the message is all an outbound
+// alert renders. The close carries its own verdict too.
+func TestOpenEventAndLogCarryTheCause(t *testing.T) {
+	capt := captureLogs(t)
+	sub := events.Subscribe()
+	defer events.Unsubscribe(sub)
+
+	cb := newTestCB(1, time.Minute)
+	id := uuid.New()
+	cb.RecordFailure(id, "zai", "glm-5.3", UpstreamStatus(429, "unrecognised"))
+
+	ev := waitForOpenEvent(t, sub, id)
+	if got, _ := ev.Metadata["cause"].(string); got != "upstream status 429 (unrecognised)" {
+		t.Errorf("event cause = %q", got)
+	}
+	if got, _ := ev.Metadata["status"].(int); got != 429 {
+		t.Errorf("event status = %v", ev.Metadata["status"])
+	}
+	want := "Provider zai circuit breaker: open for model glm-5.3: upstream status 429 (unrecognised)"
+	if ev.Message != want {
+		t.Errorf("event message = %q, want %q", ev.Message, want)
+	}
+
+	var opened *capturedLog
+	for _, r := range capt.forProvider(id) {
+		if r.msg == "circuit-breaker: model state=closed→open" {
+			rec := r
+			opened = &rec
+		}
+	}
+	if opened == nil {
+		t.Fatal("no open log line for the provider")
+	}
+	if got, _ := opened.attrs["cause"].(string); got != "upstream status 429 (unrecognised)" {
+		t.Errorf("log cause = %q", got)
+	}
+	// slog widens an int attribute to int64; the rendered value is what matters.
+	if got := fmt.Sprint(opened.attrs["status"]); got != "429" {
+		t.Errorf("log status = %v", opened.attrs["status"])
+	}
+
+	// Close it: the cooldown elapses, IsOpen moves the circuit to half-open
+	// and lets the probe through, and the probe succeeds.
+	backdateOpenModel(t, cb, id, "glm-5.3", 2*time.Minute)
+	if cb.IsOpen(id, "zai", "glm-5.3") {
+		t.Fatal("setup: circuit still blocking after its cooldown elapsed")
+	}
+	cb.RecordSuccess(id, "zai", "glm-5.3")
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-sub:
+			if ev.Type != "circuit_breaker.closed" {
+				continue
+			}
+			if got, _ := ev.Metadata["cause"].(string); got != causeSuccess {
+				t.Errorf("closed event cause = %q", got)
+			}
+			if ev.Message != "Provider zai circuit breaker: closed for model glm-5.3" {
+				t.Errorf("closed message = %q: a recovery names only what recovered", ev.Message)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no circuit_breaker.closed event")
+		}
+	}
+}

--- a/internal/failover/circuit_cause_test.go
+++ b/internal/failover/circuit_cause_test.go
@@ -81,7 +81,7 @@ func TestRecordSaturated_RemembersWithoutCharging(t *testing.T) {
 	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
 	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
 
-	cb.RecordSaturated(id, "p", "m")
+	cb.RecordSaturated(id, "m")
 
 	cause, status, _ := lastVerdict(t, cb, id, "m")
 	if cause != "upstream status 429 (saturated)" || status != 429 {
@@ -98,9 +98,17 @@ func TestRecordSaturated_RemembersWithoutCharging(t *testing.T) {
 	}
 	// And a fresh pair gets a circuit, so the verdict has somewhere to live.
 	other := uuid.New()
-	cb.RecordSaturated(other, "p", "m")
+	cb.RecordSaturated(other, "m")
 	if cause, _, _ := lastVerdict(t, cb, other, "m"); cause != "upstream status 429 (saturated)" {
 		t.Errorf("untracked pair after RecordSaturated: cause=%q", cause)
+	}
+	// Nothing landed, so nothing moves the eviction clock: a circuit that
+	// exists only for this stamp ranks first for eviction.
+	cb.mu.RLock()
+	stamped := cb.circuits[other.String()]["m"].lastCharged
+	cb.mu.RUnlock()
+	if !stamped.IsZero() {
+		t.Errorf("lastCharged = %v after a saturated stamp, want untouched", stamped)
 	}
 }
 
@@ -149,7 +157,7 @@ func TestStatus_CircuitsMatchOpenModels(t *testing.T) {
 	cb.RecordFailure(id, "p", "a-closed", UpstreamStatus(502, ""))
 	cb.RecordSuccess(id, "p", "c-served")
 
-	s := onlyStatus(t, cb)
+	s := onlyDetail(t, cb)
 	if len(s.Circuits) != 3 {
 		t.Fatalf("circuits = %+v, want 3", s.Circuits)
 	}
@@ -190,7 +198,7 @@ func TestStatus_CircuitsMatchOpenModels(t *testing.T) {
 	// A circuit owed a probe keeps its opened_at and its verdict, so the row
 	// can still say how long it was dark and why.
 	backdateOpenModel(t, cb, id, "b-open", 2*time.Minute)
-	s = onlyStatus(t, cb)
+	s = onlyDetail(t, cb)
 	for _, c := range s.Circuits {
 		if c.Model != "b-open" {
 			continue
@@ -270,5 +278,28 @@ func TestOpenEventAndLogCarryTheCause(t *testing.T) {
 		case <-deadline:
 			t.Fatal("no circuit_breaker.closed event")
 		}
+	}
+}
+
+func onlyDetail(t *testing.T, cb *CircuitBreaker) ProviderStatus {
+	t.Helper()
+	statuses := cb.StatusDetail()
+	if len(statuses) != 1 {
+		t.Fatalf("got %d detail statuses, want 1", len(statuses))
+	}
+	return statuses[0]
+}
+
+// The row alone never carries the list: Status is what the scrape and the
+// aggregate poll read, and neither looks past the row.
+func TestStatus_OmitsCircuitsWithoutDetail(t *testing.T) {
+	cb := newTestCB(1, time.Minute)
+	id := uuid.New()
+	cb.RecordFailure(id, "p", "m", UpstreamStatus(503, ""))
+	if s := onlyStatus(t, cb); s.Circuits != nil {
+		t.Errorf("Status() carried circuits: %+v", s.Circuits)
+	}
+	if s := onlyDetail(t, cb); len(s.Circuits) != 1 {
+		t.Errorf("StatusDetail() circuits = %+v, want one", s.Circuits)
 	}
 }

--- a/internal/failover/circuit_events.go
+++ b/internal/failover/circuit_events.go
@@ -1,0 +1,174 @@
+package failover
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/events"
+)
+
+// The breaker's SSE event and the sentence an alert renders from it. Split out
+// of circuitbreaker.go when that file reached the size ceiling.
+
+// publishEvent fires an SSE event for circuit breaker state transitions. r is
+// the walk the caller already started, so the flags here are the ones its log
+// line reported. Must be called with cb.mu held.
+func (cb *CircuitBreaker) publishEvent(providerID uuid.UUID, providerName, state, model string, c *circuit, r *cooldownReads) {
+	// quota_pinned and backed_off report the overrides currently governing this
+	// circuit, not a claim about whether the circuit is blocking traffic right
+	// now — the same predicates ProviderStatus uses. With the default
+	// HalfOpenMaxProbes of 1 the distinction never surfaces, but a half-open
+	// circuit that has banked a probe still carries its override until
+	// RecordSuccess closes it.
+	pinned := cb.quotaPinnedForWith(c, r)
+	backedOff := cb.backedOffForWith(c, r)
+	cooldown := cb.effectiveCooldownForWith(c, r)
+	providerOpen := cb.providerOpen(cb.circuits[providerID.String()])
+	meta := map[string]any{
+		"provider_id": providerID.String(),
+		"provider":    providerName,
+		"model":       model,
+		"state":       state,
+		// cause and status are the verdict that produced this transition: why
+		// the circuit opened ("upstream status 429 (saturated)") or what closed
+		// it ("success"), and the upstream status behind it, 0 when none was
+		// seen. They are what an alert has to say for an operator to act on it
+		// without opening a terminal.
+		"cause":  c.lastCause,
+		"status": c.lastStatus,
+		// pin_source tells a measured pin ("advisor") from one inferred out of
+		// the exhausted response itself ("response"); empty when no pin governs.
+		"pin_source": cb.pinSourceForWith(c, r),
+		// provider_open is the derived verdict as it stands after this
+		// transition. The event names one model, and at the default span of 2 the
+		// first model to open leaves the provider serving everything else, so
+		// without this flag a consumer would have to re-derive the verdict from a
+		// span setting it cannot see and circuits it is not shown.
+		"provider_open":     providerOpen,
+		"consecutive_fails": c.consecutiveFails,
+		"quota_pinned":      pinned,
+		// backed_off and failed_probes explain a cooldown longer than the
+		// setting: the flag is what governs, the count is what happened.
+		"backed_off":    backedOff,
+		"failed_probes": c.failedProbes,
+	}
+	// model_id is the identity the alert dispatcher debounces on. An open
+	// carries it only while the provider is still serving: then the event is
+	// about one model, and keying it on the provider would let the first model
+	// to fail suppress every sibling that fails beside it. Once the verdict says
+	// the provider itself is skipped, an open is about the provider: the verdict
+	// lapses every time a blocking circuit's cooldown elapses, which lets one
+	// more sibling through to fail and open, and a fifty-model provider outage
+	// keyed per model would notify fifty times inside one alert window for what
+	// is one fact. Without the key the dispatcher falls back to provider_id. A
+	// close always carries it: a recovery is about the model that recovered
+	// whatever the verdict still says about its siblings, and two models coming
+	// back inside one window are two recoveries, not one.
+	if state != "open" || !providerOpen {
+		meta["model_id"] = model
+	}
+	if state == "open" {
+		// cooldown_ms is the wait actually enforced. next_retry_at accompanies
+		// it whenever something other than the configured cooldown governs, so
+		// a consumer never has to add the two itself, and it is deliberately not
+		// called "resets_at": under a pin it is openedAt plus the ceiling-clamped
+		// and jittered pin, exactly the instant the status API publishes under
+		// that name, not the provider's quota reset, which on a weekly plan lies
+		// days beyond a 24h-capped pin.
+		meta["cooldown_ms"] = cooldown.Milliseconds()
+		if pinned || backedOff {
+			meta["next_retry_at"] = c.openedAt.Add(cooldown).Format(time.RFC3339)
+		}
+	}
+	msg := breakerEventMessage(providerName, state, model, providerOpen, c.lastCause)
+	// The suffix attributes the wait to the backoff, so it is added only when
+	// the backoff is the value in force. A circuit can be backed off and pinned
+	// at once, and when the pin reaches further it is quota, not failed retries,
+	// that holds the circuit; saying "backing off, next retry in 10h" there
+	// would blame the model for a provider's spent window.
+	if state == "open" && backedOff && cooldown == c.cooldownBackoff {
+		msg += backoffSuffix(cooldown, c.failedProbes)
+	}
+	events.Publish(events.Event{
+		Type:     "circuit_breaker." + state,
+		Severity: cb.severityForState(state),
+		Source:   "failover",
+		Message:  msg,
+		Metadata: meta,
+	})
+}
+
+// backoffSuffix extends the open message when the probe backoff governs. The
+// message is all an outbound alert renders, so without it the notification for
+// a circuit fifteen minutes from its next retry is byte-identical to one sixty
+// seconds from it, and the operator has no way to tell a blip from a model that
+// has been failing its retries all afternoon.
+func backoffSuffix(cooldown time.Duration, failedProbes int) string {
+	noun := "retries"
+	if failedProbes == 1 {
+		noun = "retry"
+	}
+	return fmt.Sprintf(" (backing off after %d failed %s, next retry in %s)", failedProbes, noun, shortDuration(cooldown))
+}
+
+// shortDuration renders a cooldown the way an operator reads it: "4m" rather
+// than Duration.String's "4m0s", "1h30m" rather than "1h30m0s" or "90m", and
+// never "0s" for a cooldown that is merely short.
+func shortDuration(d time.Duration) string {
+	if d < time.Second || d%time.Second != 0 {
+		return d.String()
+	}
+	if d%time.Minute != 0 {
+		return d.Round(time.Second).String()
+	}
+	h, m := d/time.Hour, (d%time.Hour)/time.Minute
+	switch {
+	case h == 0:
+		return fmt.Sprintf("%dm", m)
+	case m == 0:
+		return fmt.Sprintf("%dh", h)
+	default:
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+}
+
+// breakerEventMessage is the sentence an operator reads in a dashboard toast and
+// in an Apprise alert. It names the model because the breaker charges one model
+// circuit at a time: at the default span of 2 the first model to open leaves the
+// provider serving everything else, and "Provider X circuit breaker: open" alone
+// reports an outage that is not happening. The provider-wide verdict is spelled
+// out when it flips, because that is the transition that takes the remaining
+// models out of rotation, and it is the part worth acting on.
+//
+// An open names its cause after a colon ("open for model glm-5.3: upstream
+// status 429 (saturated)"), because the message is all an alert renders and
+// "open" alone sent the operator to a terminal on 2026-08-31. The model id goes
+// before it, and the closed form deliberately says nothing about the verdict or
+// the cause: a recovery says only what recovered.
+func breakerEventMessage(providerName, state, model string, providerOpen bool, cause string) string {
+	msg := fmt.Sprintf("Provider %s circuit breaker: %s", providerName, state)
+	if model == "" {
+		return msg
+	}
+	msg += " for model " + model
+	if state == "open" && providerOpen {
+		msg += " (provider skipped)"
+	}
+	if state == "open" && cause != "" {
+		msg += ": " + cause
+	}
+	return msg
+}
+
+func (cb *CircuitBreaker) severityForState(state string) string {
+	switch state {
+	case "open":
+		return "warning"
+	case "closed":
+		return "success"
+	default:
+		return "info"
+	}
+}

--- a/internal/failover/circuit_quota.go
+++ b/internal/failover/circuit_quota.go
@@ -126,7 +126,7 @@ func (cb *CircuitBreaker) ReleaseQuotaPins(recovered map[uuid.UUID]struct{}) int
 			if c.cooldownOverride == 0 {
 				continue
 			}
-			cb.releasePin("circuit-breaker: quota pin released (provider no longer exhausted)", id, model, c, r)
+			cb.releasePin(causePinReleasedQuota, id, model, c, r)
 			released++
 		}
 	}
@@ -203,6 +203,10 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 			}
 			c.cooldownOverride = d
 			c.pinSource = pinSourceAdvisor
+			// A transition with no request behind it: the wait changed, and the
+			// status the open recorded stays, so the row still says what opened
+			// the circuit as well as what is now holding it.
+			c.note(time.Now(), Cause{Status: c.lastStatus, Reason: causePinRetargeted})
 			retargeted++
 			// The open transition already logged a cooldown_ms that is now wrong,
 			// and the corrected one can mean hours of darkness, so an operator gets
@@ -242,17 +246,18 @@ func (cb *CircuitBreaker) ReleaseAllQuotaPins() int {
 			if c.cooldownOverride == 0 {
 				continue
 			}
-			cb.releasePin("circuit-breaker: quota pin released (quota polling disabled)", id, model, c, r)
+			cb.releasePin(causePinReleasedOff, id, model, c, r)
 			released++
 		}
 	}
 	return released
 }
 
-// releasePin drops one circuit's quota override and logs it. The message names
-// the reason rather than being assembled from parts: an operator reading "pin
-// released" needs to know whether the provider recovered or whether the poller
-// was switched off, because only one of those means the window is actually back.
+// releasePin drops one circuit's quota override, logs it and records it as the
+// circuit's last verdict. The reason is a named phrase rather than being
+// assembled from parts: an operator reading "pin released" needs to know
+// whether the provider recovered or whether the poller was switched off,
+// because only one of those means the window is actually back.
 //
 // The open transition logged a cooldown_ms that may have promised hours of
 // darkness, so the line that says it ended early is logged at the same Info
@@ -260,8 +265,9 @@ func (cb *CircuitBreaker) ReleaseAllQuotaPins() int {
 // falls back to, which is its backoff when one is in force: a recovered quota
 // does not undo the probes that failed. Routing metadata only — never payload
 // or credentials. Must be called with cb.mu held.
-func (cb *CircuitBreaker) releasePin(msg, providerID, model string, c *circuit, r *cooldownReads) {
+func (cb *CircuitBreaker) releasePin(reason, providerID, model string, c *circuit, r *cooldownReads) {
 	c.cooldownOverride = 0
 	c.pinSource = ""
-	debuglog.Info(msg, "provider_id", providerID, "state", cb.logicalStateWith(c, r).String(), "cooldown_ms", cb.unpinnedCooldownWith(c, r).Milliseconds(), "model", model)
+	c.note(time.Now(), Cause{Status: c.lastStatus, Reason: reason})
+	debuglog.Info("circuit-breaker: "+reason, "provider_id", providerID, "state", cb.logicalStateWith(c, r).String(), "cooldown_ms", cb.unpinnedCooldownWith(c, r).Milliseconds(), "model", model)
 }

--- a/internal/failover/circuit_ratelimit_test.go
+++ b/internal/failover/circuit_ratelimit_test.go
@@ -151,18 +151,18 @@ func TestRecordRateLimited_ThirdOpenLiftsBackoffCeiling(t *testing.T) {
 	id := uuid.New()
 
 	// Open 1 (closed → open): streak 1, no probes failed yet.
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 	// Open 2 (failed probe): streak 2, backoff 2m — the ordinary ceiling.
 	backdateOpenModel(t, cb, id, "m", 2*time.Minute)
 	cb.IsOpen(id, "p", "m") // transitions to half-open
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 	if got := exhaustedCircuit(t, cb, id, "m").cooldownBackoff; got != 2*time.Minute {
 		t.Fatalf("backoff after second 429 open = %v, want the ordinary ceiling of 2m", got)
 	}
 	// Open 3: streak 3 = escalated, and the doubling may pass the old ceiling.
 	backdateOpenModel(t, cb, id, "m", 3*time.Minute)
 	cb.IsOpen(id, "p", "m")
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 
 	if got := exhaustedCircuit(t, cb, id, "m").cooldownBackoff; got != 4*time.Minute {
 		t.Errorf("backoff after third 429 open = %v, want 4m (1m doubled twice, past the 2m backoff_max, under the 5h pin ceiling)", got)
@@ -173,14 +173,14 @@ func TestRecordRateLimited_NonRateLimitOpenResetsEscalation(t *testing.T) {
 	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: time.Minute, backoffMax: 2 * time.Minute, pinMax: 5 * time.Hour})
 	id := uuid.New()
 
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 	backdateOpenModel(t, cb, id, "m", 2*time.Minute)
 	cb.IsOpen(id, "p", "m")
 	// A 5xx-caused open in between: different failure, streak resets.
-	cb.RecordFailure(id, "p", "m")
+	cb.RecordFailure(id, "p", "m", Cause{})
 	backdateOpenModel(t, cb, id, "m", 3*time.Minute)
 	cb.IsOpen(id, "p", "m")
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 
 	c := exhaustedCircuit(t, cb, id, "m")
 	if c.opens429Streak != 1 {
@@ -194,7 +194,7 @@ func TestRecordRateLimited_NonRateLimitOpenResetsEscalation(t *testing.T) {
 func TestRecordSuccess_ClosingProbeClearsEscalation(t *testing.T) {
 	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: time.Minute})
 	id := uuid.New()
-	cb.RecordRateLimited(id, "p", "m")
+	cb.RecordRateLimited(id, "p", "m", Cause{})
 	backdateOpenModel(t, cb, id, "m", 2*time.Minute)
 	cb.IsOpen(id, "p", "m")
 
@@ -225,14 +225,14 @@ func TestLastSuccessWithin(t *testing.T) {
 		t.Error("a success 61s ago is inside a 60s window")
 	}
 	// A failure does not refresh the success stamp.
-	cb.RecordFailure(id, "p", "m")
+	cb.RecordFailure(id, "p", "m", Cause{})
 	if cb.LastSuccessWithin(id, "m", time.Minute) {
 		t.Error("RecordFailure refreshed the success stamp")
 	}
 	// Neither does an alive-but-served-nothing credit (a plain 400): a client's
 	// own malformed payloads must not keep the fallback reading a spent window
 	// as busy.
-	cb.RecordAlive(id, "p", "m")
+	cb.RecordAlive(id, "p", "m", 400)
 	if cb.LastSuccessWithin(id, "m", time.Minute) {
 		t.Error("RecordAlive stamped a serve the provider never made")
 	}
@@ -250,7 +250,7 @@ func TestBlockedUntil(t *testing.T) {
 	}
 
 	// The model's own blocking circuit: retry at openedAt+cooldown, unpinned.
-	cb.RecordFailure(id, "p", "m")
+	cb.RecordFailure(id, "p", "m", Cause{})
 	retryAt, pinned, ok := cb.BlockedUntil(id, "m")
 	if !ok || pinned {
 		t.Fatalf("own blocking circuit: ok=%v pinned=%v, want blocked and unpinned", ok, pinned)

--- a/internal/failover/circuit_status.go
+++ b/internal/failover/circuit_status.go
@@ -1,0 +1,149 @@
+package failover
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+)
+
+// Cause is why a circuit is being charged or credited: a short operator-facing
+// reason and the upstream HTTP status behind it, 0 when no response was seen (a
+// connection that never completed, a stream that died before its status meant
+// anything). The circuit remembers its most recent one as its last verdict, the
+// open transition publishes it, and the detail endpoint lists it per circuit,
+// so a status row, an SSE event and an outbound alert can all say what the
+// breaker SAW rather than only what it did. Diagnosing the 2026-08-31 incident
+// took an hour of polling because none of them could.
+//
+// Routing metadata only. The reason is always a fixed phrase chosen by the
+// caller, never text copied from a provider response, so it can never carry a
+// prompt echo or a credential into a status page or an alert.
+type Cause struct {
+	Status int
+	Reason string
+}
+
+// UpstreamStatus is the cause for a response whose status alone decided the
+// verdict: "upstream status 503". qualifier names a refinement of a status
+// that has several readings, so a 429 reports which one the classifier reached:
+// "upstream status 429 (saturated)".
+func UpstreamStatus(status int, qualifier string) Cause {
+	reason := fmt.Sprintf("upstream status %d", status)
+	if qualifier != "" {
+		reason += " (" + qualifier + ")"
+	}
+	return Cause{Status: status, Reason: reason}
+}
+
+// The verdicts the breaker stamps itself, where the caller has nothing more
+// specific to say than which method it called.
+const (
+	causeSuccess          = "success"
+	causeSaturated        = "saturated"
+	causeExhausted        = "exhausted"
+	causeUnrecognised429  = "unrecognised"
+	causeAlive            = "alive"
+	causePinRetargeted    = "quota pin retargeted (advisor)"
+	causePinReleasedQuota = "quota pin released (provider no longer exhausted)"
+	causePinReleasedOff   = "quota pin released (quota polling disabled)"
+)
+
+// note records the verdict that just landed on this circuit.
+func (c *circuit) note(now time.Time, cause Cause) {
+	c.lastCause = cause.Reason
+	c.lastStatus = cause.Status
+	c.lastAt = now
+}
+
+// RecordSaturated remembers a 429 the classifier read as load rather than a
+// spent window. It is deliberately NOT a charge and not a credit: a provider at
+// its concurrency ceiling is alive, and benching it benches the slots that are
+// all busy serving (see recordRateLimitOutcome in the proxy). What it does is
+// leave the verdict on the circuit, so a status row can say "busy" about a
+// provider whose circuit is closed but whose last three answers were 429s,
+// which on 2026-08-31 was the whole story and was visible nowhere.
+func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, providerName, model string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	c := cb.getOrCreate(providerID.String(), model)
+	c.lastCharged = time.Now()
+	c.note(c.lastCharged, UpstreamStatus(429, causeSaturated))
+	debuglog.Debug("circuit-breaker: saturated 429 noted, circuit not charged", "provider", providerName, "provider_id", providerID, "model", model)
+}
+
+// CircuitStatus is one (provider, resolved upstream model) circuit as the
+// detail endpoint reports it: the same fields the provider row carries, at the
+// level the breaker actually keeps them, plus the last verdict that landed on
+// it. The provider row is built from the most degraded of these, so a row
+// saying "open" while the model an operator cares about reads "closed" here is
+// not a contradiction: it is the per-model keying made visible.
+type CircuitStatus struct {
+	Model            string `json:"model"`
+	State            string `json:"state"`
+	ConsecutiveFails int    `json:"consecutive_fails"`
+	OpenedAt         string `json:"opened_at,omitempty"`
+	CooldownMs       int64  `json:"cooldown_ms,omitempty"`
+	NextRetryAt      string `json:"next_retry_at,omitempty"`
+	// QuotaPinned, PinSource and BackedOff describe the overrides governing
+	// THIS circuit's cooldown, unlike the row's QuotaPinned, which is the
+	// verdict's "any blocking circuit is pinned" arm.
+	QuotaPinned  bool   `json:"quota_pinned,omitempty"`
+	PinSource    string `json:"pin_source,omitempty"`
+	BackedOff    bool   `json:"backed_off,omitempty"`
+	FailedProbes int    `json:"failed_probes,omitempty"`
+	// LastCause is the reason of the most recent verdict on this circuit,
+	// LastStatus the upstream status behind it (0 when none was seen) and
+	// LastAt when it landed. For an open circuit this is why it opened, until a
+	// quota pin retarget or release records that it changed the wait.
+	LastCause  string `json:"last_cause,omitempty"`
+	LastStatus int    `json:"last_status,omitempty"`
+	LastAt     string `json:"last_at,omitempty"`
+}
+
+// circuitStatuses lists a provider's circuits for the detail endpoint, sorted
+// by model so a polling UI never sees them reshuffle. r is the walk the caller
+// already started, so every circuit is judged by the same cooldown reads as the
+// row built from them. Must be called with cb.mu held (read lock suffices).
+func (cb *CircuitBreaker) circuitStatuses(models modelCircuits, r *cooldownReads) []CircuitStatus {
+	out := make([]CircuitStatus, 0, len(models))
+	for model, c := range models {
+		state := cb.logicalStateWith(c, r)
+		s := CircuitStatus{
+			Model:            model,
+			State:            state.String(),
+			ConsecutiveFails: c.consecutiveFails,
+			QuotaPinned:      cb.quotaPinnedForWith(c, r),
+			PinSource:        cb.pinSourceForWith(c, r),
+			BackedOff:        cb.backedOffForWith(c, r),
+			FailedProbes:     c.failedProbes,
+			LastCause:        c.lastCause,
+			LastStatus:       c.lastStatus,
+		}
+		if !c.lastAt.IsZero() {
+			s.LastAt = c.lastAt.Format(time.RFC3339)
+		}
+		// The same rule the provider row applies to its dominant circuit: the
+		// wait is reported only while it is being enforced, and a circuit owed
+		// a probe keeps its opened_at so the row can say how long it was dark.
+		if state == StateOpen && !c.openedAt.IsZero() {
+			cooldown := cb.effectiveCooldownForWith(c, r)
+			s.OpenedAt = c.openedAt.Format(time.RFC3339)
+			s.CooldownMs = cooldown.Milliseconds()
+			s.NextRetryAt = c.openedAt.Add(cooldown).Format(time.RFC3339)
+		}
+		if state == StateHalfOpen && !c.openedAt.IsZero() {
+			s.OpenedAt = c.openedAt.Format(time.RFC3339)
+		}
+		out = append(out, s)
+	}
+	slices.SortFunc(out, func(a, b CircuitStatus) int {
+		return strings.Compare(a.Model, b.Model)
+	})
+	return out
+}

--- a/internal/failover/circuit_status.go
+++ b/internal/failover/circuit_status.go
@@ -5,11 +5,11 @@ import (
 	"slices"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
-
-	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
+
+// The circuit's last verdict: the Cause a caller hands the breaker, the stamp
+// that remembers it on the circuit, and the per-circuit status rows the detail
+// endpoint builds from it.
 
 // Cause is why a circuit is being charged or credited: a short operator-facing
 // reason and the upstream HTTP status behind it, 0 when no response was seen (a
@@ -46,7 +46,6 @@ const (
 	causeSuccess          = "success"
 	causeSaturated        = "saturated"
 	causeExhausted        = "exhausted"
-	causeUnrecognised429  = "unrecognised"
 	causeAlive            = "alive"
 	causePinRetargeted    = "quota pin retargeted (advisor)"
 	causePinReleasedQuota = "quota pin released (provider no longer exhausted)"
@@ -58,23 +57,6 @@ func (c *circuit) note(now time.Time, cause Cause) {
 	c.lastCause = cause.Reason
 	c.lastStatus = cause.Status
 	c.lastAt = now
-}
-
-// RecordSaturated remembers a 429 the classifier read as load rather than a
-// spent window. It is deliberately NOT a charge and not a credit: a provider at
-// its concurrency ceiling is alive, and benching it benches the slots that are
-// all busy serving (see recordRateLimitOutcome in the proxy). What it does is
-// leave the verdict on the circuit, so a status row can say "busy" about a
-// provider whose circuit is closed but whose last three answers were 429s,
-// which on 2026-08-31 was the whole story and was visible nowhere.
-func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, providerName, model string) {
-	cb.mu.Lock()
-	defer cb.mu.Unlock()
-
-	c := cb.getOrCreate(providerID.String(), model)
-	c.lastCharged = time.Now()
-	c.note(c.lastCharged, UpstreamStatus(429, causeSaturated))
-	debuglog.Debug("circuit-breaker: saturated 429 noted, circuit not charged", "provider", providerName, "provider_id", providerID, "model", model)
 }
 
 // CircuitStatus is one (provider, resolved upstream model) circuit as the

--- a/internal/failover/circuit_unstable_test.go
+++ b/internal/failover/circuit_unstable_test.go
@@ -105,14 +105,14 @@ func TestCircuitBreaker_ReportsAModelThatKeepsReopening(t *testing.T) {
 	// unconditional report passing this test: without it, publishing on every
 	// open looks identical to publishing on the third.
 	for range opensBeforeEscalation - 1 {
-		cb.RecordFailure(id, "test-provider", modelA)
+		cb.RecordFailure(id, "test-provider", modelA, Cause{})
 		cb.IsOpen(id, "test-provider", modelA)
 		if ev, ok := drainUnstable(sub, id); ok {
 			t.Fatalf("reported after fewer than %d opens: %s", opensBeforeEscalation, ev.Message)
 		}
 	}
 
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	ev := waitForUnstableEvent(t, sub, id)
 	if got, _ := ev.Metadata["model"].(string); got != modelA {

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -355,6 +355,9 @@ func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, mo
 // It does not touch lastCharged: nothing landed, so the circuit ranks for
 // eviction exactly as it did, and a circuit that exists only because of this
 // stamp ranks first, behind every circuit a charge or credit ever reached.
+// That is also what keeps the creation here harmless at the cap: a burst of
+// saturated 429s across many untracked models evicts its own zero-stamped
+// entries first, never a circuit a charge ever reached.
 func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, model string) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -84,6 +84,11 @@ type ProviderStatus struct {
 	// models a verdict rests on. Circuits owed a probe are not in it: they are no
 	// longer blocking anything.
 	OpenModels []string `json:"open_models,omitempty"`
+	// Circuits lists every circuit the row above is built from, sorted by
+	// model, each with its own state, cooldown and last verdict. Additive: the
+	// row and OpenModels stay what the dashboard keys on, and an older member
+	// in a mixed-version fleet simply omits this.
+	Circuits []CircuitStatus `json:"circuits,omitempty"`
 }
 
 // SettingsReader provides dynamic configuration for the circuit breaker.
@@ -259,26 +264,33 @@ func (cb *CircuitBreaker) IsOpen(providerID uuid.UUID, providerName, model strin
 //   - Half-open: immediately re-opens the circuit with a fresh cooldown, doubled
 //     for every probe that has failed since the circuit last closed.
 //   - Open: no-op.
-func (cb *CircuitBreaker) RecordFailure(providerID uuid.UUID, providerName, model string) {
-	cb.recordFailure(providerID, providerName, model, false)
+//
+// cause is remembered as the circuit's last verdict and published with the open
+// it may produce; see Cause for what it must and must not carry.
+func (cb *CircuitBreaker) RecordFailure(providerID uuid.UUID, providerName, model string, cause Cause) {
+	cb.recordFailure(providerID, providerName, model, false, cause)
 }
 
 // RecordRateLimited is RecordFailure for an UNCLASSIFIED 429: it charges
 // identically, and additionally feeds the rate-limit-open streak so a circuit
 // that only ever opens on 429s escalates to exhausted handling without any
 // provider phrase saying so (see circuit.note429Open). The classified cases
-// never come here: a saturated 429 is a breaker no-op at the call site, and an
-// exhausted one goes through RecordExhausted.
-func (cb *CircuitBreaker) RecordRateLimited(providerID uuid.UUID, providerName, model string) {
-	cb.recordFailure(providerID, providerName, model, true)
+// never come here: a saturated 429 is a breaker no-op at the call site
+// (RecordSaturated remembers it), and an exhausted one goes through
+// RecordExhausted. cause says which reading of the 429 the caller reached.
+func (cb *CircuitBreaker) RecordRateLimited(providerID uuid.UUID, providerName, model string, cause Cause) {
+	cb.recordFailure(providerID, providerName, model, true, cause)
 }
 
-func (cb *CircuitBreaker) recordFailure(providerID uuid.UUID, providerName, model string, by429 bool) {
+func (cb *CircuitBreaker) recordFailure(providerID uuid.UUID, providerName, model string, by429 bool, cause Cause) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
 	c := cb.getOrCreate(providerID.String(), model)
 	c.lastCharged = time.Now()
+	// Stamped before the switch so the open transition below logs and
+	// publishes the verdict that produced it.
+	c.note(c.lastCharged, cause)
 
 	switch c.state {
 	case StateClosed:
@@ -315,6 +327,7 @@ func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, mo
 
 	c := cb.getOrCreate(providerID.String(), model)
 	c.lastCharged = time.Now()
+	c.note(c.lastCharged, UpstreamStatus(429, causeExhausted))
 
 	switch c.state {
 	case StateClosed:
@@ -416,7 +429,7 @@ func (cb *CircuitBreaker) openCircuit(msg string, providerID uuid.UUID, provider
 	cb.applyQuotaPin(providerID, c, exhaustHint)
 	// One walk for the log line and the event, so the two cannot disagree.
 	r := cb.cooldowns()
-	debuglog.Warn(msg, "provider", providerName, "provider_id", providerID, "consecutive_failures", c.consecutiveFails, "cooldown_ms", cb.effectiveCooldownForWith(c, r).Milliseconds(), "quota_pinned", cb.quotaPinnedForWith(c, r), "backed_off", cb.backedOffForWith(c, r), "failed_probes", c.failedProbes, "model", model)
+	debuglog.Warn(msg, "provider", providerName, "provider_id", providerID, "cause", c.lastCause, "status", c.lastStatus, "consecutive_failures", c.consecutiveFails, "cooldown_ms", cb.effectiveCooldownForWith(c, r).Milliseconds(), "quota_pinned", cb.quotaPinnedForWith(c, r), "backed_off", cb.backedOffForWith(c, r), "failed_probes", c.failedProbes, "model", model)
 	cb.publishEvent(providerID, providerName, "open", model, c, r)
 	if c.noteOpen(now) {
 		cb.reportUnstable(providerID, providerName, model, c.opens)
@@ -481,7 +494,7 @@ func (cb *CircuitBreaker) reportUnstable(providerID uuid.UUID, providerName, mod
 //   - Half-open: increments the probe counter. Closes the circuit if
 //     enough probes succeed.
 func (cb *CircuitBreaker) RecordSuccess(providerID uuid.UUID, providerName, model string) {
-	cb.recordSuccess(providerID, providerName, model, true)
+	cb.recordSuccess(providerID, providerName, model, true, Cause{Reason: causeSuccess})
 }
 
 // RecordAlive is RecordSuccess for a response that proves the provider ALIVE
@@ -490,16 +503,18 @@ func (cb *CircuitBreaker) RecordSuccess(providerID uuid.UUID, providerName, mode
 // lastSuccess, because the 429 behavioural fallback reads that stamp as "this
 // model SERVED moments ago, so the window cannot be spent" — and a client's
 // own malformed payloads must not keep classifying a spent window as busy.
-func (cb *CircuitBreaker) RecordAlive(providerID uuid.UUID, providerName, model string) {
-	cb.recordSuccess(providerID, providerName, model, false)
+// status is that response's status, remembered as the verdict.
+func (cb *CircuitBreaker) RecordAlive(providerID uuid.UUID, providerName, model string, status int) {
+	cb.recordSuccess(providerID, providerName, model, false, UpstreamStatus(status, causeAlive))
 }
 
-func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, model string, served bool) {
+func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, model string, served bool, cause Cause) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
 	c := cb.getOrCreate(providerID.String(), model)
 	c.lastCharged = time.Now()
+	c.note(c.lastCharged, cause)
 	if served {
 		c.lastSuccess = c.lastCharged
 	}
@@ -524,154 +539,6 @@ func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, mode
 			debuglog.Info("circuit-breaker: model state=half-open→closed (probe succeeded)", "provider", providerName, "provider_id", providerID, "model", model)
 			cb.publishEvent(providerID, providerName, "closed", model, c, cb.cooldowns())
 		}
-	}
-}
-
-// publishEvent fires an SSE event for circuit breaker state transitions. r is
-// the walk the caller already started, so the flags here are the ones its log
-// line reported. Must be called with cb.mu held.
-func (cb *CircuitBreaker) publishEvent(providerID uuid.UUID, providerName, state, model string, c *circuit, r *cooldownReads) {
-	// quota_pinned and backed_off report the overrides currently governing this
-	// circuit, not a claim about whether the circuit is blocking traffic right
-	// now — the same predicates ProviderStatus uses. With the default
-	// HalfOpenMaxProbes of 1 the distinction never surfaces, but a half-open
-	// circuit that has banked a probe still carries its override until
-	// RecordSuccess closes it.
-	pinned := cb.quotaPinnedForWith(c, r)
-	backedOff := cb.backedOffForWith(c, r)
-	cooldown := cb.effectiveCooldownForWith(c, r)
-	providerOpen := cb.providerOpen(cb.circuits[providerID.String()])
-	meta := map[string]any{
-		"provider_id": providerID.String(),
-		"provider":    providerName,
-		"model":       model,
-		"state":       state,
-		// pin_source tells a measured pin ("advisor") from one inferred out of
-		// the exhausted response itself ("response"); empty when no pin governs.
-		"pin_source": cb.pinSourceForWith(c, r),
-		// provider_open is the derived verdict as it stands after this
-		// transition. The event names one model, and at the default span of 2 the
-		// first model to open leaves the provider serving everything else, so
-		// without this flag a consumer would have to re-derive the verdict from a
-		// span setting it cannot see and circuits it is not shown.
-		"provider_open":     providerOpen,
-		"consecutive_fails": c.consecutiveFails,
-		"quota_pinned":      pinned,
-		// backed_off and failed_probes explain a cooldown longer than the
-		// setting: the flag is what governs, the count is what happened.
-		"backed_off":    backedOff,
-		"failed_probes": c.failedProbes,
-	}
-	// model_id is the identity the alert dispatcher debounces on. An open
-	// carries it only while the provider is still serving: then the event is
-	// about one model, and keying it on the provider would let the first model
-	// to fail suppress every sibling that fails beside it. Once the verdict says
-	// the provider itself is skipped, an open is about the provider: the verdict
-	// lapses every time a blocking circuit's cooldown elapses, which lets one
-	// more sibling through to fail and open, and a fifty-model provider outage
-	// keyed per model would notify fifty times inside one alert window for what
-	// is one fact. Without the key the dispatcher falls back to provider_id. A
-	// close always carries it: a recovery is about the model that recovered
-	// whatever the verdict still says about its siblings, and two models coming
-	// back inside one window are two recoveries, not one.
-	if state != "open" || !providerOpen {
-		meta["model_id"] = model
-	}
-	if state == "open" {
-		// cooldown_ms is the wait actually enforced. next_retry_at accompanies
-		// it whenever something other than the configured cooldown governs, so
-		// a consumer never has to add the two itself, and it is deliberately not
-		// called "resets_at": under a pin it is openedAt plus the ceiling-clamped
-		// and jittered pin, exactly the instant the status API publishes under
-		// that name, not the provider's quota reset, which on a weekly plan lies
-		// days beyond a 24h-capped pin.
-		meta["cooldown_ms"] = cooldown.Milliseconds()
-		if pinned || backedOff {
-			meta["next_retry_at"] = c.openedAt.Add(cooldown).Format(time.RFC3339)
-		}
-	}
-	msg := breakerEventMessage(providerName, state, model, providerOpen)
-	// The suffix attributes the wait to the backoff, so it is added only when
-	// the backoff is the value in force. A circuit can be backed off and pinned
-	// at once, and when the pin reaches further it is quota, not failed retries,
-	// that holds the circuit; saying "backing off, next retry in 10h" there
-	// would blame the model for a provider's spent window.
-	if state == "open" && backedOff && cooldown == c.cooldownBackoff {
-		msg += backoffSuffix(cooldown, c.failedProbes)
-	}
-	events.Publish(events.Event{
-		Type:     "circuit_breaker." + state,
-		Severity: cb.severityForState(state),
-		Source:   "failover",
-		Message:  msg,
-		Metadata: meta,
-	})
-}
-
-// backoffSuffix extends the open message when the probe backoff governs. The
-// message is all an outbound alert renders, so without it the notification for
-// a circuit fifteen minutes from its next retry is byte-identical to one sixty
-// seconds from it, and the operator has no way to tell a blip from a model that
-// has been failing its retries all afternoon.
-func backoffSuffix(cooldown time.Duration, failedProbes int) string {
-	noun := "retries"
-	if failedProbes == 1 {
-		noun = "retry"
-	}
-	return fmt.Sprintf(" (backing off after %d failed %s, next retry in %s)", failedProbes, noun, shortDuration(cooldown))
-}
-
-// shortDuration renders a cooldown the way an operator reads it: "4m" rather
-// than Duration.String's "4m0s", "1h30m" rather than "1h30m0s" or "90m", and
-// never "0s" for a cooldown that is merely short.
-func shortDuration(d time.Duration) string {
-	if d < time.Second || d%time.Second != 0 {
-		return d.String()
-	}
-	if d%time.Minute != 0 {
-		return d.Round(time.Second).String()
-	}
-	h, m := d/time.Hour, (d%time.Hour)/time.Minute
-	switch {
-	case h == 0:
-		return fmt.Sprintf("%dm", m)
-	case m == 0:
-		return fmt.Sprintf("%dh", h)
-	default:
-		return fmt.Sprintf("%dh%dm", h, m)
-	}
-}
-
-// breakerEventMessage is the sentence an operator reads in a dashboard toast and
-// in an Apprise alert. It names the model because the breaker charges one model
-// circuit at a time: at the default span of 2 the first model to open leaves the
-// provider serving everything else, and "Provider X circuit breaker: open" alone
-// reports an outage that is not happening. The provider-wide verdict is spelled
-// out when it flips, because that is the transition that takes the remaining
-// models out of rotation, and it is the part worth acting on.
-//
-// The model id goes last in the sentence, and the closed form deliberately says
-// nothing about the verdict: a recovery says only what recovered.
-func breakerEventMessage(providerName, state, model string, providerOpen bool) string {
-	msg := fmt.Sprintf("Provider %s circuit breaker: %s", providerName, state)
-	if model == "" {
-		return msg
-	}
-	msg += " for model " + model
-	if state == "open" && providerOpen {
-		msg += " (provider skipped)"
-	}
-	return msg
-}
-
-func (cb *CircuitBreaker) severityForState(state string) string {
-	switch state {
-	case "open":
-		return "warning"
-	case "closed":
-		return "success"
-	default:
-		return "info"
 	}
 }
 
@@ -713,6 +580,7 @@ func (cb *CircuitBreaker) Status() []ProviderStatus {
 			FailedProbes: c.failedProbes,
 			ProviderOpen: providerOpen,
 			OpenModels:   openModels,
+			Circuits:     cb.circuitStatuses(models, r),
 		}
 		if state == StateOpen && !c.openedAt.IsZero() {
 			s.OpenedAt = c.openedAt.Format(time.RFC3339)

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -85,9 +85,9 @@ type ProviderStatus struct {
 	// longer blocking anything.
 	OpenModels []string `json:"open_models,omitempty"`
 	// Circuits lists every circuit the row above is built from, sorted by
-	// model, each with its own state, cooldown and last verdict. Additive: the
-	// row and OpenModels stay what the dashboard keys on, and an older member
-	// in a mixed-version fleet simply omits this.
+	// model, each with its own state, cooldown and last verdict. Filled only by
+	// StatusDetail. Additive: the row and OpenModels stay what the dashboard
+	// keys on, and an older member in a mixed-version fleet simply omits this.
 	Circuits []CircuitStatus `json:"circuits,omitempty"`
 }
 
@@ -344,6 +344,24 @@ func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, mo
 	}
 }
 
+// RecordSaturated remembers a 429 the classifier read as load rather than a
+// spent window. It is deliberately NOT a charge and not a credit: a provider at
+// its concurrency ceiling is alive, and benching it benches the slots that are
+// all busy serving (see recordRateLimitOutcome in the proxy). What it does is
+// leave the verdict on the circuit, so a status row can say "busy" about a
+// provider whose circuit is closed but whose last three answers were 429s,
+// which on 2026-08-31 was the whole story and was visible nowhere.
+//
+// It does not touch lastCharged: nothing landed, so the circuit ranks for
+// eviction exactly as it did, and a circuit that exists only because of this
+// stamp ranks first, behind every circuit a charge or credit ever reached.
+func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, model string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.getOrCreate(providerID.String(), model).note(time.Now(), UpstreamStatus(429, causeSaturated))
+}
+
 // BlockedUntil reports when the breaker next lets a request at this
 // (provider, model) pair through, and whether every circuit blocking it is
 // quota-pinned. It answers for the same rule IsOpen enforces: the model's own
@@ -543,8 +561,22 @@ func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, mode
 }
 
 // Status returns the current status of all tracked providers, one row per
-// provider built from its most degraded model circuit.
+// provider built from its most degraded model circuit, without the per-circuit
+// list. This is what the Prometheus scrape and the aggregate status poll read,
+// and both look only at the row.
 func (cb *CircuitBreaker) Status() []ProviderStatus {
+	return cb.status(false)
+}
+
+// StatusDetail is Status with Circuits filled in on every row: one entry per
+// circuit, sorted by model, with its own state, wait and last verdict. Only
+// the detail endpoint asks for it, because building the list allocates per
+// circuit under the lock the request path takes.
+func (cb *CircuitBreaker) StatusDetail() []ProviderStatus {
+	return cb.status(true)
+}
+
+func (cb *CircuitBreaker) status(detail bool) []ProviderStatus {
 	cb.mu.RLock()
 	defer cb.mu.RUnlock()
 
@@ -580,7 +612,9 @@ func (cb *CircuitBreaker) Status() []ProviderStatus {
 			FailedProbes: c.failedProbes,
 			ProviderOpen: providerOpen,
 			OpenModels:   openModels,
-			Circuits:     cb.circuitStatuses(models, r),
+		}
+		if detail {
+			s.Circuits = cb.circuitStatuses(models, r)
 		}
 		if state == StateOpen && !c.openedAt.IsZero() {
 			s.OpenedAt = c.openedAt.Format(time.RFC3339)

--- a/internal/failover/circuitbreaker_404_test.go
+++ b/internal/failover/circuitbreaker_404_test.go
@@ -19,7 +19,7 @@ func TestCircuitBreaker_NoOpPreservesFailureHistory(t *testing.T) {
 
 	// 4 × RecordFailure (simulating 5xx responses)
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 
 	// 404/499: the proxy calls neither RecordFailure nor RecordSuccess.
@@ -28,7 +28,7 @@ func TestCircuitBreaker_NoOpPreservesFailureHistory(t *testing.T) {
 	// consecutiveFails to 0 here.
 
 	// 1 more RecordFailure should open the circuit (counter at 5).
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("no-op should preserve failure count: expected circuit open at 5 failures")
@@ -46,7 +46,7 @@ func TestCircuitBreaker_NoOpInHalfOpenDoesNotCloseCircuit(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit with a single failure
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Fatal("circuit should be open")
 	}
@@ -70,7 +70,7 @@ func TestCircuitBreaker_NoOpInHalfOpenDoesNotCloseCircuit(t *testing.T) {
 	}
 
 	// Verify: a subsequent 5xx failure should re-open the circuit.
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("circuit should have re-opened after 5xx in half-open state")
 	}
@@ -89,7 +89,7 @@ func TestCircuitBreaker_RecordSuccessResetsFailures(t *testing.T) {
 
 	// 4 × RecordFailure (5xx)
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 
 	// RecordSuccess (what we USED to do for 404 — the wrong behavior)
@@ -97,13 +97,13 @@ func TestCircuitBreaker_RecordSuccessResetsFailures(t *testing.T) {
 
 	// Counter was reset to 0 — need 5 MORE failures to open
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("circuit should still be closed — only 4 failures after reset")
 	}
 
-	cb.RecordFailure(pid, "test-provider", "") // 5th after reset → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // 5th after reset → opens
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("circuit should be open after 5 failures post-reset")

--- a/internal/failover/circuitbreaker_coverage_test.go
+++ b/internal/failover/circuitbreaker_coverage_test.go
@@ -41,7 +41,7 @@ func TestCircuitBreaker_IsOpen_ClosedStateViaWriteLock(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	// Transition to half-open via cooldown
 	cb.Cooldown = 1 * time.Millisecond
@@ -66,7 +66,7 @@ func TestCircuitBreaker_IsOpen_HalfOpenViaWriteLock(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	time.Sleep(10 * time.Millisecond)
 
 	// Trigger transition to HalfOpen

--- a/internal/failover/circuitbreaker_harness_test.go
+++ b/internal/failover/circuitbreaker_harness_test.go
@@ -135,7 +135,7 @@ func (s stubAdvisor) ResetsAt(uuid.UUID) (time.Time, bool) { return s.at, s.ok }
 func openBreaker(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
 	t.Helper()
 	for i := 0; i < cb.effectiveThreshold(); i++ {
-		cb.RecordFailure(id, "test-provider", "")
+		cb.RecordFailure(id, "test-provider", "", Cause{})
 	}
 	if got := cb.GetState(id, ""); got != StateOpen {
 		t.Fatalf("setup: got state %v, want open", got)

--- a/internal/failover/circuitbreaker_model_test.go
+++ b/internal/failover/circuitbreaker_model_test.go
@@ -30,8 +30,10 @@ const (
 // chargeToOpen drives one model circuit to Open with real failures.
 func chargeToOpen(t *testing.T, cb *CircuitBreaker, id uuid.UUID, model string) {
 	t.Helper()
+	// A real cause, as every production charge carries one: the message
+	// assertions below must see the sentence production emits.
 	for i := 0; i < cb.effectiveThreshold(); i++ {
-		cb.RecordFailure(id, "test-provider", model, Cause{})
+		cb.RecordFailure(id, "test-provider", model, UpstreamStatus(503, ""))
 	}
 	if got := cb.GetState(id, model); got != StateOpen {
 		t.Fatalf("setup: model %q state %v, want open", model, got)
@@ -444,7 +446,7 @@ func TestModelCircuits_EventMessageNamesTheModelAndTheVerdict(t *testing.T) {
 
 	chargeToOpen(t, cb, id, modelA)
 	ev := waitForOpenEvent(t, sub, id)
-	want := "Provider test-provider circuit breaker: open for model " + modelA
+	want := "Provider test-provider circuit breaker: open for model " + modelA + ": upstream status 503"
 	if ev.Message != want {
 		t.Errorf("first open event message = %q, want %q", ev.Message, want)
 	}
@@ -454,7 +456,7 @@ func TestModelCircuits_EventMessageNamesTheModelAndTheVerdict(t *testing.T) {
 	// model out of rotation.
 	chargeToOpen(t, cb, id, modelB)
 	ev = waitForOpenEvent(t, sub, id)
-	want = "Provider test-provider circuit breaker: open for model " + modelB + " (provider skipped)"
+	want = "Provider test-provider circuit breaker: open for model " + modelB + " (provider skipped): upstream status 503"
 	if ev.Message != want {
 		t.Errorf("second open event message = %q, want %q", ev.Message, want)
 	}

--- a/internal/failover/circuitbreaker_model_test.go
+++ b/internal/failover/circuitbreaker_model_test.go
@@ -31,7 +31,7 @@ const (
 func chargeToOpen(t *testing.T, cb *CircuitBreaker, id uuid.UUID, model string) {
 	t.Helper()
 	for i := 0; i < cb.effectiveThreshold(); i++ {
-		cb.RecordFailure(id, "test-provider", model)
+		cb.RecordFailure(id, "test-provider", model, Cause{})
 	}
 	if got := cb.GetState(id, model); got != StateOpen {
 		t.Fatalf("setup: model %q state %v, want open", model, got)
@@ -119,10 +119,10 @@ func TestModelCircuits_SuccessOnOneModelKeepsTheOtherStreak(t *testing.T) {
 	cb := newTestCB(3, time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", modelA)
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 	cb.RecordSuccess(id, "test-provider", modelB)
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 
 	if got := cb.GetState(id, modelA); got != StateOpen {
 		t.Errorf("model A took 3 failures at threshold 3, state %v, want open", got)
@@ -136,9 +136,9 @@ func TestModelCircuits_FailureOnOneModelKeepsTheOtherStreak(t *testing.T) {
 	cb := newTestCB(3, time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", modelA)
-	cb.RecordFailure(id, "test-provider", modelB)
-	cb.RecordFailure(id, "test-provider", modelB)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
+	cb.RecordFailure(id, "test-provider", modelB, Cause{})
+	cb.RecordFailure(id, "test-provider", modelB, Cause{})
 
 	if got := cb.GetState(id, modelA); got != StateClosed {
 		t.Errorf("model A took 1 of 3 failures, state %v, want closed", got)
@@ -146,7 +146,7 @@ func TestModelCircuits_FailureOnOneModelKeepsTheOtherStreak(t *testing.T) {
 	if got := cb.GetState(id, modelB); got != StateClosed {
 		t.Errorf("model B took 2 of 3 failures, state %v, want closed", got)
 	}
-	cb.RecordFailure(id, "test-provider", modelB)
+	cb.RecordFailure(id, "test-provider", modelB, Cause{})
 	if got := cb.GetState(id, modelB); got != StateOpen {
 		t.Errorf("model B took 3 of 3 failures, state %v, want open", got)
 	}
@@ -172,7 +172,7 @@ func TestModelCircuits_HalfOpenProbeIsPerModel(t *testing.T) {
 		t.Fatalf("model A state %v, want half-open", got)
 	}
 
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 	if got := cb.GetState(id, modelA); got != StateOpen {
 		t.Errorf("model A probe failed, state %v, want open", got)
 	}
@@ -251,7 +251,7 @@ func TestModelCircuits_EvictionNeverDropsAnOpenCircuit(t *testing.T) {
 	// closed and therefore evictable, while model A stays open and must not be.
 	const churn = maxModelCircuitsPerProvider + 50
 	for i := 0; i < churn; i++ {
-		cb.RecordFailure(id, "test-provider", fmt.Sprintf("churn-%03d", i))
+		cb.RecordFailure(id, "test-provider", fmt.Sprintf("churn-%03d", i), Cause{})
 	}
 
 	if got := cb.GetState(id, modelA); got != StateOpen {
@@ -273,14 +273,14 @@ func TestModelCircuits_EvictionDropsTheLeastRecentlyChargedCircuit(t *testing.T)
 
 	// Fill the provider to the cap with closed circuits, one failure each.
 	for i := 0; i < maxModelCircuitsPerProvider; i++ {
-		cb.RecordFailure(id, "test-provider", fmt.Sprintf("m%03d", i))
+		cb.RecordFailure(id, "test-provider", fmt.Sprintf("m%03d", i), Cause{})
 	}
 	// Re-charge the oldest one, which makes the second-oldest the least recently
 	// charged. Ordering by charge time and ordering by creation now disagree,
 	// which is the whole point of the assertion below.
-	cb.RecordFailure(id, "test-provider", "m000")
+	cb.RecordFailure(id, "test-provider", "m000", Cause{})
 
-	cb.RecordFailure(id, "test-provider", "newcomer")
+	cb.RecordFailure(id, "test-provider", "newcomer", Cause{})
 
 	if !hasCircuit(t, cb, id, "m000") {
 		t.Error("m000 was charged most recently of the filled set, want it kept")
@@ -303,12 +303,12 @@ func TestModelCircuits_EvictionDropsTheEmptyModelIDLikeAnyOther(t *testing.T) {
 	cb := newTestCB(5, time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "") // charged first, so the oldest
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // charged first, so the oldest
 	for i := 1; i < maxModelCircuitsPerProvider; i++ {
-		cb.RecordFailure(id, "test-provider", fmt.Sprintf("m%03d", i))
+		cb.RecordFailure(id, "test-provider", fmt.Sprintf("m%03d", i), Cause{})
 	}
 
-	cb.RecordFailure(id, "test-provider", "newcomer")
+	cb.RecordFailure(id, "test-provider", "newcomer", Cause{})
 
 	if hasCircuit(t, cb, id, "") {
 		t.Error("the empty model id was the least recently charged circuit, want it evicted")
@@ -324,7 +324,7 @@ func TestModelCircuits_EvictionKeepsGrowingWhenEveryCircuitIsOpen(t *testing.T) 
 
 	const models = maxModelCircuitsPerProvider + 3
 	for i := 0; i < models; i++ {
-		cb.RecordFailure(id, "test-provider", fmt.Sprintf("open-%03d", i))
+		cb.RecordFailure(id, "test-provider", fmt.Sprintf("open-%03d", i), Cause{})
 	}
 
 	if got := countCircuits(t, cb, id); got != models {
@@ -336,7 +336,7 @@ func TestModelCircuits_StatusReportsTheMostDegradedCircuit(t *testing.T) {
 	cb := newTestCB(2, time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", modelB) // one failure, stays closed
+	cb.RecordFailure(id, "test-provider", modelB, Cause{}) // one failure, stays closed
 	chargeToOpen(t, cb, id, modelA)
 
 	s := onlyStatus(t, cb)
@@ -371,9 +371,9 @@ func TestModelCircuits_StatusReportsTheWorstStreakAmongClosedCircuits(t *testing
 	cb := newTestCB(5, time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", modelA)
+	cb.RecordFailure(id, "test-provider", modelA, Cause{})
 	for i := 0; i < 3; i++ {
-		cb.RecordFailure(id, "test-provider", modelB)
+		cb.RecordFailure(id, "test-provider", modelB, Cause{})
 	}
 
 	s := onlyStatus(t, cb)
@@ -466,6 +466,7 @@ func TestBreakerEventMessage(t *testing.T) {
 		state        string
 		model        string
 		providerOpen bool
+		cause        string
 		want         string
 	}{
 		{
@@ -479,8 +480,13 @@ func TestBreakerEventMessage(t *testing.T) {
 			want: "Provider zai circuit breaker: open for model glm-4.6 (provider skipped)",
 		},
 		{
+			name:  "an open names its cause, after the verdict",
+			state: "open", model: "glm-4.6", providerOpen: true, cause: "upstream status 429 (saturated)",
+			want: "Provider zai circuit breaker: open for model glm-4.6 (provider skipped): upstream status 429 (saturated)",
+		},
+		{
 			name:  "a recovery names the model that recovered and nothing else",
-			state: "closed", model: "glm-4.6", providerOpen: true,
+			state: "closed", model: "glm-4.6", providerOpen: true, cause: "success",
 			want: "Provider zai circuit breaker: closed for model glm-4.6",
 		},
 		{
@@ -491,7 +497,7 @@ func TestBreakerEventMessage(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := breakerEventMessage("zai", tc.state, tc.model, tc.providerOpen)
+			got := breakerEventMessage("zai", tc.state, tc.model, tc.providerOpen, tc.cause)
 			if got != tc.want {
 				t.Errorf("breakerEventMessage() = %q, want %q", got, tc.want)
 			}
@@ -689,7 +695,7 @@ func TestModelCircuits_ResetAllCountsCircuitsNotProviders(t *testing.T) {
 
 	chargeToOpen(t, cb, busy, modelA)
 	chargeToOpen(t, cb, busy, modelB)
-	cb.RecordFailure(other, "test-provider", modelA) // tracked, below threshold, closed
+	cb.RecordFailure(other, "test-provider", modelA, Cause{}) // tracked, below threshold, closed
 
 	cleared, recovered := cb.ResetAll()
 	if cleared != 3 {

--- a/internal/failover/circuitbreaker_quota_test.go
+++ b/internal/failover/circuitbreaker_quota_test.go
@@ -306,7 +306,7 @@ func TestQuotaPin_RepinsAfterFailedProbe(t *testing.T) {
 
 	// Probe fails and quota now reports a long window: half-open to open re-pins.
 	cb.SetQuotaAdvisor(stubAdvisor{at: time.Now().Add(4 * time.Hour), ok: true})
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 
 	if !cb.Status()[0].QuotaPinned {
 		t.Error("half-open to open must apply the pin")
@@ -669,7 +669,7 @@ func TestApplyQuotaPins_RetargetsOpenCircuit(t *testing.T) {
 	cb := newTestCB(1, 3*time.Hour)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "") // opens unpinned: no advice existed yet
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // opens unpinned: no advice existed yet
 	if got := overrideFor(t, cb, id); got != 0 {
 		t.Fatalf("setup: got override %v, want an unpinned circuit", got)
 	}
@@ -712,15 +712,15 @@ func TestApplyQuotaPins_LeavesNonOpenCircuitsAlone(t *testing.T) {
 		{
 			name: "closed",
 			setup: func(_ *testing.T, cb *CircuitBreaker, id uuid.UUID) {
-				cb.RecordFailure(id, "test-provider", "") // one short of the threshold
+				cb.RecordFailure(id, "test-provider", "", Cause{}) // one short of the threshold
 			},
 			why: "a closed circuit is serving traffic and has no cooldown to retarget",
 		},
 		{
 			name: "half-open probe out",
 			setup: func(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
-				cb.RecordFailure(id, "test-provider", "")
-				cb.RecordFailure(id, "test-provider", "") // opens
+				cb.RecordFailure(id, "test-provider", "", Cause{})
+				cb.RecordFailure(id, "test-provider", "", Cause{}) // opens
 				backdateOpen(t, cb, id, time.Second)
 				cb.IsOpen(id, "test-provider", "") // cooldown elapsed: hands out a probe
 			},
@@ -729,9 +729,9 @@ func TestApplyQuotaPins_LeavesNonOpenCircuitsAlone(t *testing.T) {
 		{
 			name: "cooldown elapsed",
 			setup: func(t *testing.T, cb *CircuitBreaker, id uuid.UUID) {
-				cb.RecordFailure(id, "test-provider", "")
-				cb.RecordFailure(id, "test-provider", "") // opens
-				backdateOpen(t, cb, id, time.Second)      // probe due, reads as half-open
+				cb.RecordFailure(id, "test-provider", "", Cause{})
+				cb.RecordFailure(id, "test-provider", "", Cause{}) // opens
+				backdateOpen(t, cb, id, time.Second)               // probe due, reads as half-open
 			},
 			why: "the cooldown already elapsed, so the circuit is due a probe",
 		},
@@ -763,7 +763,7 @@ func TestApplyQuotaPins_NeverShortensExistingPin(t *testing.T) {
 	id := uuid.New()
 	cb.SetQuotaAdvisor(stubAdvisor{at: time.Now().Add(6 * time.Hour), ok: true})
 
-	cb.RecordFailure(id, "test-provider", "") // opens pinned to ~6h
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // opens pinned to ~6h
 	before := overrideFor(t, cb, id)
 	if before == 0 {
 		t.Fatal("setup: expected the open transition to pin the circuit")
@@ -786,7 +786,7 @@ func TestApplyQuotaPins_SkipsWhenPinDisabled(t *testing.T) {
 	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: 60 * time.Second, pinEnabled: &disabled})
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 
 	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(6 * time.Hour)}); got != 0 {
 		t.Errorf("got %d circuits retargeted, want 0 while quota pinning is disabled", got)
@@ -806,7 +806,7 @@ func TestApplyQuotaPins_CeilingCapsRunawayDeadline(t *testing.T) {
 	cb := NewCircuitBreaker(&stubSettings{threshold: 1, cooldown: 60 * time.Second, pinMax: time.Hour})
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 
 	if got := cb.ApplyQuotaPins(map[uuid.UUID]time.Time{id: time.Now().Add(500 * 24 * time.Hour)}); got != 1 {
 		t.Fatalf("got %d circuits retargeted, want 1", got)

--- a/internal/failover/circuitbreaker_race_test.go
+++ b/internal/failover/circuitbreaker_race_test.go
@@ -20,7 +20,7 @@ func TestCircuitBreaker_Concurrent(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			cb.RecordFailure(pid, "test-provider", "")
+			cb.RecordFailure(pid, "test-provider", "", Cause{})
 		}()
 		go func() {
 			defer wg.Done()
@@ -48,7 +48,7 @@ func TestCircuitBreaker_IsOpen_HalfOpenAllowsProbesConcurrently(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	time.Sleep(60 * time.Millisecond)
 	cb.IsOpen(pid, "test-provider", "") // triggers transition to half-open
 
@@ -76,7 +76,7 @@ func TestCircuitBreaker_IsOpen_Concurrent(t *testing.T) {
 
 	// Pre-populate with some failures but not enough to open
 	for range 50 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 
 	var wg sync.WaitGroup
@@ -103,7 +103,7 @@ func TestCircuitBreaker_IsOpen_RaceWithRecordSuccess(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	time.Sleep(60 * time.Millisecond)
 
 	// Trigger transition to half-open
@@ -152,7 +152,7 @@ func TestGetState_ConcurrentReads(t *testing.T) {
 
 	// Pre-populate with some failures
 	for range 50 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 
 	var wg sync.WaitGroup

--- a/internal/failover/circuitbreaker_test.go
+++ b/internal/failover/circuitbreaker_test.go
@@ -26,14 +26,14 @@ func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
 	cb := newTestCB(3, 30*time.Second)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "")
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should not be open after 2 failures (threshold=3)")
 	}
 
-	cb.RecordFailure(pid, "test-provider", "") // 3rd failure → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // 3rd failure → opens
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be open after 3 consecutive failures")
@@ -48,19 +48,19 @@ func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
 	pid := uuid.New()
 
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 	cb.RecordSuccess(pid, "test-provider", "") // resets counter
 
 	// Need 5 more failures to open
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should still be closed — only 4 failures after reset")
 	}
 
-	cb.RecordFailure(pid, "test-provider", "") // 5th → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // 5th → opens
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be open after 5 consecutive failures post-reset")
 	}
@@ -70,7 +70,7 @@ func TestCircuitBreaker_TransitionsToHalfOpen(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // threshold=1 → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // threshold=1 → opens
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Fatal("should be open")
@@ -88,7 +88,7 @@ func TestCircuitBreaker_HalfOpenProbeSuccess(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	time.Sleep(60 * time.Millisecond)
 	cb.IsOpen(pid, "test-provider", "") // triggers Open→HalfOpen
 
@@ -106,11 +106,11 @@ func TestCircuitBreaker_HalfOpenProbeFailure(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	time.Sleep(60 * time.Millisecond)
 	cb.IsOpen(pid, "test-provider", "") // triggers Open→HalfOpen
 
-	cb.RecordFailure(pid, "test-provider", "") // probe fails → re-opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // probe fails → re-opens
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be re-opened after failed probe")
@@ -126,7 +126,7 @@ func TestCircuitBreaker_Reset(t *testing.T) {
 	cb := newTestCB(1, 30*time.Second)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Fatal("should be open")
 	}
@@ -152,7 +152,7 @@ func TestCircuitBreaker_ResetReportsPreResetState(t *testing.T) {
 	}
 
 	belowThreshold := uuid.New()
-	cb.RecordFailure(belowThreshold, "test-provider", "") // 1 of 2: still closed
+	cb.RecordFailure(belowThreshold, "test-provider", "", Cause{}) // 1 of 2: still closed
 	if prev := cb.Reset(belowThreshold); prev != StateClosed {
 		t.Errorf("below-threshold circuit: Reset = %v, want closed", prev)
 	}
@@ -161,7 +161,7 @@ func TestCircuitBreaker_ResetReportsPreResetState(t *testing.T) {
 	// (Status, GetState); Reset must not disagree with them.
 	readyToProbe := uuid.New()
 	cbShort := newTestCB(1, time.Millisecond)
-	cbShort.RecordFailure(readyToProbe, "test-provider", "")
+	cbShort.RecordFailure(readyToProbe, "test-provider", "", Cause{})
 	time.Sleep(5 * time.Millisecond)
 	if prev := cbShort.Reset(readyToProbe); prev != StateHalfOpen {
 		t.Errorf("cooldown-elapsed circuit: Reset = %v, want half-open", prev)
@@ -172,8 +172,8 @@ func TestCircuitBreaker_ResetAll(t *testing.T) {
 	cb := newTestCB(1, 30*time.Second)
 	p1, p2 := uuid.New(), uuid.New()
 
-	cb.RecordFailure(p1, "test-provider", "")
-	cb.RecordFailure(p2, "test-provider", "")
+	cb.RecordFailure(p1, "test-provider", "", Cause{})
+	cb.RecordFailure(p2, "test-provider", "", Cause{})
 
 	cleared, recovered := cb.ResetAll()
 	if cleared != 2 || recovered != 2 {
@@ -192,9 +192,9 @@ func TestCircuitBreaker_ResetAllCountsOnlyBlockingCircuitsAsRecovered(t *testing
 	cb := newTestCB(2, 30*time.Second)
 	open, healthy := uuid.New(), uuid.New()
 
-	cb.RecordFailure(open, "test-provider", "")
-	cb.RecordFailure(open, "test-provider", "") // reaches threshold: opens
-	cb.RecordFailure(healthy, "test-provider", "")
+	cb.RecordFailure(open, "test-provider", "", Cause{})
+	cb.RecordFailure(open, "test-provider", "", Cause{}) // reaches threshold: opens
+	cb.RecordFailure(healthy, "test-provider", "", Cause{})
 
 	if !cb.IsOpen(open, "test-provider", "") {
 		t.Fatal("setup: circuit should be open")
@@ -217,7 +217,7 @@ func TestCircuitBreaker_Status(t *testing.T) {
 	cb := newTestCB(1, 30*time.Second)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 
 	statuses := cb.Status()
 	if len(statuses) != 1 {
@@ -241,7 +241,7 @@ func TestCircuitBreaker_Status_ReportsLogicalHalfOpen(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 
 	// Before cooldown elapses, it reports as open.
 	if statuses := cb.Status(); statuses[0].State != "open" {
@@ -282,7 +282,7 @@ func TestCircuitBreaker_FailureCountAccuracy(t *testing.T) {
 	pid := uuid.New()
 
 	for range 4 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 	statuses := cb.Status()
 	if len(statuses) != 1 {
@@ -303,11 +303,11 @@ func TestCircuitBreaker_SettingsOverrideThreshold(t *testing.T) {
 
 	// Default struct threshold is 5, but settings override to 2.
 	// After 2 failures, the circuit should open.
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should still be closed after 1 failure (threshold=2)")
 	}
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be open after 2 failures (settings threshold=2)")
 	}
@@ -319,7 +319,7 @@ func TestCircuitBreaker_SettingsOverrideCooldown(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit.
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Fatal("should be open after 1 failure")
 	}
@@ -347,14 +347,14 @@ func TestCircuitBreaker_ContextCancellationSkipContract(t *testing.T) {
 	cb := newTestCB(3, 30*time.Second)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "")
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should not be open after 2 failures (threshold=3)")
 	}
 
-	cb.RecordFailure(pid, "test-provider", "") // 3rd failure → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // 3rd failure → opens
 
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be open after 3 consecutive failures")
@@ -364,8 +364,8 @@ func TestCircuitBreaker_ContextCancellationSkipContract(t *testing.T) {
 	// does for context errors) means the circuit stays closed.
 	cb.Reset(pid)
 
-	cb.RecordFailure(pid, "test-provider", "")
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	// 3rd "failure" was a context cancellation → RecordFailure NOT called
 	// So we're at 2 failures, not 3. Circuit should remain closed.
 
@@ -383,12 +383,12 @@ func TestCircuitBreaker_NilSettingsUsesDefaults(t *testing.T) {
 
 	// With nil settings, effective methods should return struct defaults.
 	for range 2 {
-		cb.RecordFailure(pid, "test-provider", "")
+		cb.RecordFailure(pid, "test-provider", "", Cause{})
 	}
 	if cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be closed after 2/3 failures")
 	}
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Error("should be open after 3/3 failures (struct default)")
 	}
@@ -473,7 +473,7 @@ func TestCircuitBreaker_IsOpen_OpenStillWithinCooldown(t *testing.T) {
 	cb := newTestCB(1, 10*time.Second) // long cooldown
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens the circuit
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens the circuit
 
 	// Immediately after opening, cooldown has not elapsed.
 	if !cb.IsOpen(pid, "test-provider", "") {
@@ -495,7 +495,7 @@ func TestCircuitBreaker_IsOpen_HalfOpenState(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 	if !cb.IsOpen(pid, "test-provider", "") {
 		t.Fatal("should be open after 1 failure")
 	}
@@ -527,9 +527,9 @@ func TestCircuitBreaker_IsOpen_MultipleProviders(t *testing.T) {
 	pid3 := uuid.New()
 
 	// Open only pid1
-	cb.RecordFailure(pid1, "test-provider", "")
-	cb.RecordFailure(pid1, "test-provider", "")
-	cb.RecordFailure(pid1, "test-provider", "")
+	cb.RecordFailure(pid1, "test-provider", "", Cause{})
+	cb.RecordFailure(pid1, "test-provider", "", Cause{})
+	cb.RecordFailure(pid1, "test-provider", "", Cause{})
 
 	// pid2 and pid3 should remain closed
 	if !cb.IsOpen(pid1, "test-provider", "") {
@@ -557,7 +557,7 @@ func TestCircuitBreaker_IsOpen_OpenToHalfOpenTransition(t *testing.T) {
 	pid := uuid.New()
 
 	// Open the circuit
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	// Verify it's open
 	if !cb.IsOpen(pid, "test-provider", "") {
@@ -604,7 +604,7 @@ func TestGetState_OpenCircuitBeforeCooldown(t *testing.T) {
 	cb := newTestCB(1, 30*time.Second)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // threshold=1 → opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // threshold=1 → opens
 
 	// Immediately after opening (no cooldown elapsed), GetState should return StateOpen
 	if s := cb.GetState(pid, ""); s != StateOpen {
@@ -617,8 +617,8 @@ func TestGetState_OpenCircuitAfterCooldown(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
-	time.Sleep(60 * time.Millisecond)          // wait for cooldown
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
+	time.Sleep(60 * time.Millisecond)                   // wait for cooldown
 
 	// After cooldown, GetState should return StateHalfOpen (logical transition)
 	if s := cb.GetState(pid, ""); s != StateHalfOpen {
@@ -631,7 +631,7 @@ func TestGetState_DoesNotMutateInternalState(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 
 	// Wait for cooldown
 	time.Sleep(60 * time.Millisecond)
@@ -656,8 +656,8 @@ func TestGetState_ClosedCircuitAfterSuccess(t *testing.T) {
 	pid := uuid.New()
 
 	// Record some failures but not enough to open
-	cb.RecordFailure(pid, "test-provider", "")
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	if s := cb.GetState(pid, ""); s != StateClosed {
 		t.Errorf("expected StateClosed after 2/3 failures, got %v", s)
@@ -669,7 +669,7 @@ func TestGetState_HalfOpenTransitionsToClosedOnSuccess(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	time.Sleep(60 * time.Millisecond)
 
 	// Transition to half-open via IsOpen (which mutates internal state)
@@ -688,14 +688,14 @@ func TestGetState_HalfOpenTransitionsToOpenOnFailure(t *testing.T) {
 	cb := newTestCB(1, 50*time.Millisecond)
 	pid := uuid.New()
 
-	cb.RecordFailure(pid, "test-provider", "") // opens
+	cb.RecordFailure(pid, "test-provider", "", Cause{}) // opens
 	time.Sleep(60 * time.Millisecond)
 
 	// Transition to half-open via IsOpen (which mutates internal state)
 	cb.IsOpen(pid, "test-provider", "")
 
 	// Record failure in half-open state → should re-open
-	cb.RecordFailure(pid, "test-provider", "")
+	cb.RecordFailure(pid, "test-provider", "", Cause{})
 
 	if s := cb.GetState(pid, ""); s != StateOpen {
 		t.Errorf("expected StateOpen after failed probe in half-open, got %v", s)
@@ -754,7 +754,7 @@ func TestOpenTransitionLogsTheGoverningCooldown(t *testing.T) {
 	cb.SetQuotaAdvisor(stubAdvisor{ok: false}) // advice withdrawn; plain cooldown now
 	cb.circuits[id.String()][""].cooldownOverride = 0
 	cb.circuits[id.String()][""].state = StateHalfOpen
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 
 	recs = capt.forProvider(id)
 	if len(recs) != 2 {
@@ -821,8 +821,8 @@ func TestOnOpen_FiresOnClosedToOpen(t *testing.T) {
 	got := make(chan uuid.UUID, 1)
 	cb.SetOnOpen(func(providerID uuid.UUID) { got <- providerID })
 
-	cb.RecordFailure(id, "test-provider", "")
-	cb.RecordFailure(id, "test-provider", "") // threshold reached → opens
+	cb.RecordFailure(id, "test-provider", "", Cause{})
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // threshold reached → opens
 
 	if reported := waitForOnOpen(t, got); reported != id {
 		t.Errorf("callback got provider %s, want %s", reported, id)
@@ -837,7 +837,7 @@ func TestOnOpen_FiresOnHalfOpenToOpen(t *testing.T) {
 	cb := newTestCB(1, 0) // zero cooldown: the first IsOpen call hands out a probe
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "") // closed→open, no callback installed yet
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // closed→open, no callback installed yet
 
 	got := make(chan uuid.UUID, 1)
 	cb.SetOnOpen(func(providerID uuid.UUID) { got <- providerID })
@@ -849,7 +849,7 @@ func TestOnOpen_FiresOnHalfOpenToOpen(t *testing.T) {
 		t.Fatalf("setup: got state %v, want half-open", s)
 	}
 
-	cb.RecordFailure(id, "test-provider", "") // probe fails → half-open→open
+	cb.RecordFailure(id, "test-provider", "", Cause{}) // probe fails → half-open→open
 
 	if reported := waitForOnOpen(t, got); reported != id {
 		t.Errorf("callback got provider %s, want %s", reported, id)
@@ -863,7 +863,7 @@ func TestOnOpen_NoCallbackIsSafe(t *testing.T) {
 	cb := newTestCB(1, 30*time.Second)
 	id := uuid.New()
 
-	cb.RecordFailure(id, "test-provider", "")
+	cb.RecordFailure(id, "test-provider", "", Cause{})
 
 	if s := cb.GetState(id, ""); s != StateOpen {
 		t.Errorf("got state %v, want open", s)

--- a/internal/failover/model_circuits.go
+++ b/internal/failover/model_circuits.go
@@ -54,7 +54,8 @@ type circuit struct {
 	cooldownBackoff time.Duration
 	// lastCharged is when a failure or success last landed on this circuit. It
 	// orders eviction, so the circuits that are dropped when a provider exceeds
-	// the cap are the ones nothing has routed to in the longest time.
+	// the cap are the ones nothing has routed to in the longest time. A
+	// saturated 429 is neither and leaves it alone (see RecordSaturated).
 	lastCharged time.Time
 	// lastSuccess is when a success last landed on this circuit. It backs the
 	// 429 behavioural fallback (LastSuccessWithin): a rate limit from a model

--- a/internal/failover/model_circuits.go
+++ b/internal/failover/model_circuits.go
@@ -65,6 +65,15 @@ type circuit struct {
 	// itself). Empty when no pin is stamped. Observability only; the pin's
 	// mechanics do not read it.
 	pinSource string
+	// lastCause, lastStatus and lastAt are the circuit's most recent verdict:
+	// why it was last charged, credited, pinned or released, the upstream
+	// status behind that (0 when none was seen) and when it landed. Like
+	// pinSource they are observability only; nothing in the breaker's mechanics
+	// reads them. They are what lets a status row, an event and an alert say
+	// WHY a circuit is open rather than only that it is (see Cause).
+	lastCause  string
+	lastStatus int
+	lastAt     time.Time
 	// opens429Streak counts consecutive rate-limit-caused opens inside the
 	// window that began at open429WindowStart. Any open with another cause, or
 	// the window running out, resets it. From the third such open the circuit

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -78,7 +78,7 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
 			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-			h.recordAnswerOutcome(st, candidate, logData, nil)
+			h.recordAnswerOutcome(st, candidate, logData, 200, nil)
 
 			charged := h.circuitBreaker.GetState(providerID, "") == failover.StateOpen
 			if charged != tc.wantCharge {
@@ -109,7 +109,7 @@ func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
 	}
 	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID, failover.Cause{})
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", emptyCompletion: false, providerID: providerID, providerName: "p"}, nil)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", emptyCompletion: false, providerID: providerID, providerName: "p"}, 200, nil)
 
 	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID, failover.Cause{})
 	if h.circuitBreaker.GetState(providerID, candidate.model.ModelID) == failover.StateOpen {
@@ -128,11 +128,52 @@ func TestRecordAnswerOutcome_AFailedAttemptIsCharged(t *testing.T) {
 	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, nil)
+	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, 200, nil)
 
 	if h.circuitBreaker.GetState(providerID, "") != failover.StateOpen {
 		t.Error("a completion that failed after the headers must be charged")
 	}
+	// The verdict carries the status the UPSTREAM answered, the 200 whose body
+	// then failed, never the 502 this gateway goes on to answer the client.
+	assertLastVerdict(t, h.circuitBreaker, providerID, "response failed after headers", 200)
+}
+
+// assertLastVerdict reads the provider's single circuit off the detail status
+// and checks the verdict it remembers.
+func assertLastVerdict(t *testing.T, cb *failover.CircuitBreaker, providerID uuid.UUID, wantCause string, wantStatus int) {
+	t.Helper()
+	for _, s := range cb.StatusDetail() {
+		if s.ProviderID != providerID.String() {
+			continue
+		}
+		if len(s.Circuits) != 1 {
+			t.Fatalf("circuits = %+v, want one", s.Circuits)
+		}
+		if c := s.Circuits[0]; c.LastCause != wantCause || c.LastStatus != wantStatus {
+			t.Errorf("last verdict = %q/%d, want %q/%d", c.LastCause, c.LastStatus, wantCause, wantStatus)
+		}
+		return
+	}
+	t.Fatalf("provider %s not in the breaker status", providerID)
+}
+
+// A body the gateway could not translate is charged with the 2xx the upstream
+// answered: logData carries no status yet at that point, so the caller hands
+// it in, and a 0 here would read as "no response was seen".
+func TestRejectUntranslatableBody_RecordsTheUpstreamStatus(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	withBreakerThresholdOne(t, h)
+
+	providerID := uuid.New()
+	st := &requestState{circuitBreakerEnabled: true, startTime: time.Now()}
+	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
+
+	out := h.rejectUntranslatableBody(st, candidate, &requestLogData{modelID: "m", providerName: "p"}, "gemini", 200, errors.New("not a gemini object"), 0, httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	if out != outcomeFailover {
+		t.Fatalf("outcome = %v, want failover", out)
+	}
+	assertLastVerdict(t, h.circuitBreaker, providerID, "upstream body could not be translated", 200)
 }
 
 // And it stays a no-op when the breaker is off.
@@ -142,7 +183,7 @@ func TestRecordAnswerOutcome_NoOpWhenTheBreakerIsDisabled(t *testing.T) {
 	providerID := uuid.New()
 
 	h.recordAnswerOutcome(&requestState{circuitBreakerEnabled: false}, modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}},
-		&requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, nil)
+		&requestLogData{state: "failed", errorKind: KindProviderError, providerID: providerID, providerName: "p"}, 200, nil)
 
 	if _, seen := cbConsecutiveFails(cb, providerID); seen {
 		t.Error("the disabled breaker was touched")
@@ -296,7 +337,7 @@ func TestHandleNonStreamingResponse_AnInterruptedReadIsNotCharged(t *testing.T) 
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)).WithContext(ctx)
 
 			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-			h.recordAnswerOutcome(st, candidate, logData, req)
+			h.recordAnswerOutcome(st, candidate, logData, 200, req)
 
 			if logData.errorKind != tc.wantKind {
 				t.Errorf("errorKind = %q, want %q", logData.errorKind, tc.wantKind)
@@ -337,7 +378,7 @@ func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
 			st := &requestState{circuitBreakerEnabled: true}
 			candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-			h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: tc.kind, providerID: providerID, providerName: "p"}, nil)
+			h.recordAnswerOutcome(st, candidate, &requestLogData{state: "failed", errorKind: tc.kind, providerID: providerID, providerName: "p"}, 200, nil)
 
 			_, seen := cbConsecutiveFails(cb, providerID)
 			if seen != tc.wantCharge {
@@ -460,7 +501,7 @@ func TestHandleNonStreamingResponse_AnOversizedBodyIsNotTheProvidersFault(t *tes
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(huge)), Header: make(http.Header)}
 
 	h.handleNonStreamingResponse(httptest.NewRecorder(), withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-	h.recordAnswerOutcome(st, candidate, logData, nil)
+	h.recordAnswerOutcome(st, candidate, logData, 200, nil)
 
 	if logData.errorKind != KindProviderBadRequest {
 		t.Errorf("errorKind = %q, want provider_bad_request: refusing a body is this gateway's policy", logData.errorKind)
@@ -683,7 +724,7 @@ func TestRejectUntranslatableBody_AClientHangingUpIsNotCharged(t *testing.T) {
 	st := &requestState{circuitBreakerEnabled: true}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.rejectUntranslatableBody(st, candidate, &requestLogData{modelID: "m", providerName: "p"}, "gemini", errors.New("read: connection reset"), 0, cancelledRequest())
+	h.rejectUntranslatableBody(st, candidate, &requestLogData{modelID: "m", providerName: "p"}, "gemini", 200, errors.New("read: connection reset"), 0, cancelledRequest())
 
 	if _, seen := cbConsecutiveFails(cb, providerID); seen {
 		t.Error("an abandoned request was charged to the provider")
@@ -711,7 +752,7 @@ func TestHandleNonStreamingResponse_ABodyThatDiedOnTheWireIsCharged(t *testing.T
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
 	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-	h.recordAnswerOutcome(st, candidate, logData, nil)
+	h.recordAnswerOutcome(st, candidate, logData, 200, nil)
 
 	if logData.errorKind != KindProviderError {
 		t.Errorf("errorKind = %q, want provider_error: a dead read is not a parse failure", logData.errorKind)
@@ -905,7 +946,7 @@ func TestHandleNonStreamingResponse_ACompleteBodyBehindAnUncleanCloseIsServed(t 
 	w := httptest.NewRecorder()
 
 	h.handleNonStreamingResponse(w, withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, 0, 0, 0, 0, 0, 0, 0, "test-hash", 1)
-	h.recordAnswerOutcome(st, candidate, logData, nil)
+	h.recordAnswerOutcome(st, candidate, logData, 200, nil)
 
 	if !strings.Contains(w.Body.String(), "hello") {
 		t.Errorf("a complete answer was discarded: %q", w.Body.String())

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -107,11 +107,11 @@ func TestRecordAnswerOutcome_AnAnswerClearsTheFailureCount(t *testing.T) {
 		model:    &model.Model{ID: uuid.New(), ModelID: "answering-model"},
 		provider: &provider.Provider{ID: providerID, Name: "p"},
 	}
-	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID)
+	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID, failover.Cause{})
 
 	h.recordAnswerOutcome(st, candidate, &requestLogData{state: "completed", emptyCompletion: false, providerID: providerID, providerName: "p"}, nil)
 
-	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID)
+	h.circuitBreaker.RecordFailure(providerID, "p", candidate.model.ModelID, failover.Cause{})
 	if h.circuitBreaker.GetState(providerID, candidate.model.ModelID) == failover.StateOpen {
 		t.Error("an answered completion recorded no success on the model it answered for, so an old failure was still on the clock")
 	}
@@ -162,7 +162,7 @@ func TestChargeBreaker_UntranslatableBodyIsCharged(t *testing.T) {
 	st := &requestState{circuitBreakerEnabled: true}
 	candidate := modelCandidate{provider: &provider.Provider{ID: providerID, Name: "p"}}
 
-	h.chargeBreaker(st, candidate, "upstream body could not be translated")
+	h.chargeBreaker(st, candidate, 200, "upstream body could not be translated")
 
 	if h.circuitBreaker.GetState(providerID, "") != failover.StateOpen {
 		t.Error("a body the gateway could not translate must be charged to the provider")
@@ -743,7 +743,7 @@ func TestServeBufferedJSONPassthrough_AnEmptyBodilessSuccessIsANoOp(t *testing.T
 	withBreakerThreshold(t, h, "2")
 
 	providerID := uuid.New()
-	h.circuitBreaker.RecordFailure(providerID, "p", "")
+	h.circuitBreaker.RecordFailure(providerID, "p", "", failover.Cause{})
 	st := passthroughState(providerID)
 	candidate := modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
@@ -755,7 +755,7 @@ func TestServeBufferedJSONPassthrough_AnEmptyBodilessSuccessIsANoOp(t *testing.T
 
 	// The earlier failure must still be on the clock: at threshold 2 a second
 	// one opens the circuit, which it cannot do if the 204 credited a success.
-	h.circuitBreaker.RecordFailure(providerID, "p", "")
+	h.circuitBreaker.RecordFailure(providerID, "p", "", failover.Cause{})
 	if h.circuitBreaker.GetState(providerID, "") != failover.StateOpen {
 		t.Error("an empty 204 credited a success and erased the failure before it")
 	}
@@ -1047,12 +1047,12 @@ func TestPassthrough_TheCreditLandsOnTheModelItServed(t *testing.T) {
 				model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
 				provider: &provider.Provider{ID: providerID, Name: "p"},
 			}
-			h.circuitBreaker.RecordFailure(providerID, "p", cand.model.ModelID)
+			h.circuitBreaker.RecordFailure(providerID, "p", cand.model.ModelID, failover.Cause{})
 
 			st := passthroughState(providerID)
 			tc.serve(h, st, cand, tc.resp())
 
-			h.circuitBreaker.RecordFailure(providerID, "p", cand.model.ModelID)
+			h.circuitBreaker.RecordFailure(providerID, "p", cand.model.ModelID, failover.Cause{})
 			if got := h.circuitBreaker.GetState(providerID, cand.model.ModelID); got == failover.StateOpen {
 				t.Error("the pass-through credit missed the model it served: an earlier failure was still on the clock")
 			}
@@ -1110,7 +1110,7 @@ func TestAttemptPassthroughCandidate_ADefiniteErrorCreditsTheModelItAsked(t *tes
 
 	m := &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"}
 	cand := goneCandidateAt(m, "Relay", "http://relay.example.com")
-	h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, m.ModelID)
+	h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, m.ModelID, failover.Cause{})
 
 	st := &requestState{
 		startTime: time.Now(), reqModel: m.ModelID,
@@ -1128,7 +1128,7 @@ func TestAttemptPassthroughCandidate_ADefiniteErrorCreditsTheModelItAsked(t *tes
 	h.insertRequestLogAsync(st.logData)
 	h.attemptPassthroughCandidate(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, 0, 1)
 
-	h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, m.ModelID)
+	h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, m.ModelID, failover.Cause{})
 	if got := h.circuitBreaker.GetState(cand.provider.ID, m.ModelID); got == failover.StateOpen {
 		t.Error("the 400 credited a circuit other than the model it asked for: an earlier failure was still on the clock")
 	}

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -120,7 +120,7 @@ func (h *Handler) recordRateLimitOutcome(ctx context.Context, st *requestState, 
 		// credited; it only remembers the verdict, so the status page can say
 		// "busy" about a closed circuit whose last answers were all 429s.
 		debuglog.Info("proxy: 429 classified saturated, circuit breaker not charged", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "retry_after", rl.retryAfter, "model", candidateModelID(candidate))
-		h.circuitBreaker.RecordSaturated(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+		h.circuitBreaker.RecordSaturated(candidate.provider.ID, candidateModelID(candidate))
 	case rateLimitExhausted:
 		if !h.settingsRepo.GetBool(ctx, "circuit_breaker_open_on_exhaustion", true) {
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "upstream status", "status", http.StatusTooManyRequests, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
@@ -148,7 +148,13 @@ func (h *Handler) recordRateLimitOutcome(ctx context.Context, st *requestState, 
 // body read that died, a body the gateway could not decode, an upstream that
 // sent a success shape behind a failure status. The old code had already
 // credited every one of those before the read was even attempted.
-func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData, r *http.Request) {
+//
+// status is the status the UPSTREAM answered, handed in by the caller rather
+// than read back off logData: a failure handler may have replaced
+// logData.statusCode with the 502 this gateway answers the client, and a
+// translation failure never wrote it at all, and neither is what the
+// provider said.
+func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate, logData *requestLogData, status int, r *http.Request) {
 	if !st.circuitBreakerEnabled {
 		return
 	}
@@ -171,14 +177,14 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 		if !providerAtFault(logData.errorKind) {
 			return
 		}
-		h.chargeBreaker(st, candidate, logData.statusCode, "response failed after headers")
+		h.chargeBreaker(st, candidate, status, "response failed after headers")
 		return
 	}
 	// A completed answer is credited even if the caller has since gone: the body
 	// was read, the provider answered, and withholding the credit leaves older
 	// failures on the clock to open a healthy circuit later.
 	if logData.emptyCompletion {
-		h.chargeBreaker(st, candidate, logData.statusCode, "response completed without delivering content")
+		h.chargeBreaker(st, candidate, status, "response completed without delivering content")
 		return
 	}
 	h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
@@ -210,14 +216,17 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, stat
 // any translation was attempted, and each adapter's own comment already called
 // this a provider fault. Mutation testing then showed two of the three copies
 // had no test behind them.
-func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, err error, attempt int, r *http.Request) candidateOutcome {
+//
+// status is the 2xx the upstream answered before its body failed translation;
+// logData has not been stamped with it at this point.
+func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, status int, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
 	// Both translators read the body with an unbounded ReadAll under the
 	// attempt's context, so an interrupted request arrives here as a translation
 	// failure — a caller hanging up or this gateway's own request_timeout, and
 	// neither is the provider's doing.
 	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
-		h.chargeBreaker(st, candidate, logData.statusCode, "upstream body could not be translated")
+		h.chargeBreaker(st, candidate, status, "upstream body could not be translated")
 	}
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -74,10 +75,10 @@ func (h *Handler) recordBreakerOutcome(ctx context.Context, st *requestState, ca
 				// toward the 429-only escalation. Only while classification
 				// is on — its master switch must restore today's behaviour
 				// bit for bit, escalation included.
-				h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+				h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(statusCode, "unrecognised"))
 				return
 			}
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(statusCode, ""))
 		case breakerActionNoOp:
 			// Model-specific client error (404/499): provider is alive
 			// but rejecting this request. No-op for the breaker — neither
@@ -105,7 +106,7 @@ func (h *Handler) recordBreakerOutcome(ctx context.Context, st *requestState, ca
 	// (same credit) but served nothing, and the 429 behavioural fallback must
 	// not read it as a recent serve.
 	if !servedSuccessStatus(statusCode) {
-		h.circuitBreaker.RecordAlive(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+		h.circuitBreaker.RecordAlive(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), statusCode)
 	}
 }
 
@@ -115,12 +116,15 @@ func (h *Handler) recordRateLimitOutcome(ctx context.Context, st *requestState, 
 	switch rl.class {
 	case rateLimitSaturated:
 		// Info, not warn: the provider is healthy and at capacity, which is a
-		// routing fact, not an incident.
-		debuglog.Info("proxy: 429 classified saturated, circuit breaker untouched", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "retry_after", rl.retryAfter, "model", candidateModelID(candidate))
+		// routing fact, not an incident. The circuit is neither charged nor
+		// credited; it only remembers the verdict, so the status page can say
+		// "busy" about a closed circuit whose last answers were all 429s.
+		debuglog.Info("proxy: 429 classified saturated, circuit breaker not charged", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "retry_after", rl.retryAfter, "model", candidateModelID(candidate))
+		h.circuitBreaker.RecordSaturated(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
 	case rateLimitExhausted:
 		if !h.settingsRepo.GetBool(ctx, "circuit_breaker_open_on_exhaustion", true) {
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "upstream status", "status", http.StatusTooManyRequests, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
-			h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+			h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(http.StatusTooManyRequests, "exhausted, not opened by setting"))
 			return
 		}
 		debuglog.Warn("proxy: recording circuit breaker exhaustion", "reason", "upstream 429 (exhausted)", "status", http.StatusTooManyRequests, "pin_hint_ms", rl.pinHint.Milliseconds(), "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
@@ -167,14 +171,14 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 		if !providerAtFault(logData.errorKind) {
 			return
 		}
-		h.chargeBreaker(st, candidate, "response failed after headers")
+		h.chargeBreaker(st, candidate, logData.statusCode, "response failed after headers")
 		return
 	}
 	// A completed answer is credited even if the caller has since gone: the body
 	// was read, the provider answered, and withholding the credit leaves older
 	// failures on the clock to open a healthy circuit later.
 	if logData.emptyCompletion {
-		h.chargeBreaker(st, candidate, "response completed without delivering content")
+		h.chargeBreaker(st, candidate, logData.statusCode, "response completed without delivering content")
 		return
 	}
 	h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
@@ -186,13 +190,15 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 // "recording circuit breaker failure" warn was added to close.
 //
 // The charge lands on the candidate's resolved upstream model, the same key the
-// success sites and the routing skip use.
-func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, reason string) {
+// success sites and the routing skip use. status is the upstream status the
+// attempt had reached (a 200 whose body then failed is still a 200), 0 when
+// none; it rides with the reason onto the circuit as its last verdict.
+func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, status int, reason string) {
 	if !st.circuitBreakerEnabled {
 		return
 	}
-	debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
-	h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+	debuglog.Warn("proxy: recording circuit breaker failure", "reason", reason, "status", status, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
+	h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: status, Reason: reason})
 }
 
 // rejectUntranslatableBody is the single outcome all three egress adapters have
@@ -211,7 +217,7 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	// failure — a caller hanging up or this gateway's own request_timeout, and
 	// neither is the provider's doing.
 	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
-		h.chargeBreaker(st, candidate, "upstream body could not be translated")
+		h.chargeBreaker(st, candidate, logData.statusCode, "upstream body could not be translated")
 	}
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt

--- a/internal/proxy/breaker_sequence_test.go
+++ b/internal/proxy/breaker_sequence_test.go
@@ -152,8 +152,8 @@ func TestChatCompletions_CircuitBreakerSequence_FailoverThen200(t *testing.T) {
 	// Seeded on model2's resolved upstream id: circuits are keyed per model, so a
 	// seed under any other key is a different circuit and the success under test
 	// would have nothing to reset.
-	cb.RecordFailure(provider2.ID, provider2Name, model2.ModelID)
-	cb.RecordFailure(provider2.ID, provider2Name, model2.ModelID)
+	cb.RecordFailure(provider2.ID, provider2Name, model2.ModelID, failover.Cause{})
+	cb.RecordFailure(provider2.ID, provider2Name, model2.ModelID, failover.Cause{})
 	if f, _ := cbConsecutiveFails(cb, provider2.ID); f != 2 {
 		t.Fatalf("pre-seed sanity: expected provider2 consecutiveFails=2, got %d", f)
 	}
@@ -226,8 +226,8 @@ func TestChatCompletions_CircuitBreakerSequence_400RetryThen200(t *testing.T) {
 	// Pre-seed 2 failures (< threshold 5 → still Closed) so the expected
 	// RecordSuccess on the 200 retry is observable as a reset to 0. env.ModelName
 	// is the resolved upstream model id, which is the circuit the retry credits.
-	cb.RecordFailure(env.ProviderID, env.ProviderName, env.ModelName)
-	cb.RecordFailure(env.ProviderID, env.ProviderName, env.ModelName)
+	cb.RecordFailure(env.ProviderID, env.ProviderName, env.ModelName, failover.Cause{})
+	cb.RecordFailure(env.ProviderID, env.ProviderName, env.ModelName, failover.Cause{})
 
 	body := `{"model": "` + env.ProviderName + `/` + env.ModelName + `", "stream": false, "messages": [{"role": "user", "content": "hi"}], "top_p": 0.9}`
 	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/openairesponses"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -403,7 +404,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, newCredentialMasker(candidate.apiKey), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 		if recordFailure && st.circuitBreakerEnabled {
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "hedged TTFT probe failed", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "attempt", attempt, "kind", string(re.Kind), "duration_ms", elapsed.Milliseconds(), "error", re.Underlying)
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: resp.StatusCode, Reason: "hedged TTFT probe failed"})
 		}
 		res.reqErr = re
 		return res

--- a/internal/proxy/model_gone_probe_test.go
+++ b/internal/proxy/model_gone_probe_test.go
@@ -669,7 +669,7 @@ func TestNoteModelGone_AnOpenCircuitCostsNoClaim(t *testing.T) {
 	// state: this check has to agree with what the routing path sees, and the
 	// threshold is the breaker's to define.
 	for range h.circuitBreaker.Threshold {
-		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, cand.model.ModelID)
+		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, cand.model.ModelID, failover.Cause{})
 	}
 	if state := h.circuitBreaker.GetState(cand.provider.ID, cand.model.ModelID); state != failover.StateOpen {
 		t.Fatalf("fixture: the circuit did not open, state = %v", state)

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -405,7 +405,7 @@ func TestProbeModel_OpenCircuitCostsNoRequest(t *testing.T) {
 	// state: the check has to agree with what the routing path would see, and
 	// the threshold is the breaker's to define.
 	for range h.circuitBreaker.Threshold {
-		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, cand.model.ModelID)
+		h.circuitBreaker.RecordFailure(cand.provider.ID, cand.provider.Name, cand.model.ModelID, failover.Cause{})
 	}
 	if state := h.circuitBreaker.GetState(cand.provider.ID, cand.model.ModelID); state != failover.StateOpen {
 		t.Fatalf("fixture: the circuit did not open, state = %v", state)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -448,7 +448,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	emptyBodyIsFailure := !bodilessSuccessStatus(resp.StatusCode) || !errors.Is(readErr, io.EOF)
 	if n == 0 && readErr != nil && emptyBodyIsFailure {
 		if st.circuitBreakerEnabled && r.Context().Err() == nil {
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: resp.StatusCode, Reason: "response completed without delivering content"})
+			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: resp.StatusCode, Reason: "upstream body read failed"})
 		}
 		debuglog.Warn("proxy: passthrough first-byte read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", readErr)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", readErr))

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -235,7 +236,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		// request_timeout both surface here as a failed read, and neither is the
 		// provider's doing. cancelKind is the package's classifier for that.
 		if _, aborted := cancelKind(r.Context(), err); !aborted {
-			h.chargeBreaker(st, candidate, "upstream body read failed")
+			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough body read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", err)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", err))
@@ -297,7 +298,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
 		}
 	default:
-		h.chargeBreaker(st, candidate, "response completed without delivering content")
+		h.chargeBreaker(st, candidate, resp.StatusCode, "response completed without delivering content")
 	}
 	// Oversized is judged on the bytes read, before masking can shrink a
 	// cap+1 read under the cap and drop the streamed remainder.
@@ -447,7 +448,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	emptyBodyIsFailure := !bodilessSuccessStatus(resp.StatusCode) || !errors.Is(readErr, io.EOF)
 	if n == 0 && readErr != nil && emptyBodyIsFailure {
 		if st.circuitBreakerEnabled && r.Context().Err() == nil {
-			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: resp.StatusCode, Reason: "response completed without delivering content"})
 		}
 		debuglog.Warn("proxy: passthrough first-byte read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", readErr)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", readErr))

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -94,7 +94,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		// not RecordSuccess: nothing was served, so the 429 behavioural
 		// fallback must not count it as a recent serve.
 		if !isFailoverEligible && st.circuitBreakerEnabled {
-			h.circuitBreaker.RecordAlive(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+			h.circuitBreaker.RecordAlive(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), resp.StatusCode)
 		}
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, isFailoverEligible, responseHeaderMs)
 	}

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -1224,7 +1224,7 @@ func TestDispatchStreaming_TheStreamCreditLandsOnTheServedModel(t *testing.T) {
 		provider: &provider.Provider{ID: providerID, Name: "streaming-provider"},
 		apiKey:   "sk-test",
 	}
-	h.circuitBreaker.RecordFailure(providerID, cand.provider.Name, cand.model.ModelID)
+	h.circuitBreaker.RecordFailure(providerID, cand.provider.Name, cand.model.ModelID, failover.Cause{})
 
 	logData := streamingLog()
 	logData.providerName = cand.provider.Name
@@ -1246,7 +1246,7 @@ func TestDispatchStreaming_TheStreamCreditLandsOnTheServedModel(t *testing.T) {
 		t.Fatalf("outcome = %v, want served", got)
 	}
 
-	h.circuitBreaker.RecordFailure(providerID, cand.provider.Name, cand.model.ModelID)
+	h.circuitBreaker.RecordFailure(providerID, cand.provider.Name, cand.model.ModelID, failover.Cause{})
 	if got := h.circuitBreaker.GetState(providerID, cand.model.ModelID); got == failover.StateOpen {
 		t.Errorf("circuit = %s, want closed: the completed stream credited a circuit other than the model it served", got)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -235,7 +235,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		} else if err := translateResponsesResponseBody(resp, st.reqModel); err != nil {
 			// A 200 whose body cannot be read or is not a Responses object is
 			// a provider fault; fail over like any other malformed upstream.
-			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", err, attempt, r)
+			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", resp.StatusCode, err, attempt, r)
 		}
 	}
 	if st.geminiAttempt {
@@ -243,7 +243,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", err, attempt, r)
+			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", resp.StatusCode, err, attempt, r)
 		}
 	}
 	if st.anthropicEgressAttempt {
@@ -251,7 +251,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", err, attempt, r)
+			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", resp.StatusCode, err, attempt, r)
 		}
 	}
 	if st.isStreaming {
@@ -278,7 +278,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// producedOutput is where that line is drawn.
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r.WithContext(failoverCtx), st, resp, attempt, responseHeaderMs)
-		h.recordAnswerOutcome(st, candidate, logData, r)
+		h.recordAnswerOutcome(st, candidate, logData, resp.StatusCode, r)
 		if producedOutput(logData) {
 			h.noteModelServed(candidate.model, logData.endpointType)
 		}
@@ -290,7 +290,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	// bare client request made this gateway's own request_timeout look like the
 	// provider dying.
 	h.handleNonStreamingResponse(w, r.WithContext(failoverCtx), logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
-	h.recordAnswerOutcome(st, candidate, logData, r)
+	h.recordAnswerOutcome(st, candidate, logData, resp.StatusCode, r)
 	if producedOutput(logData) {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/anthropicegress"
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/openairesponses"
 	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
@@ -416,7 +417,7 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			elapsed := time.Since(st.startTime)
 			re, recordFailure := classifyProbeError(probeErr, candidate.provider.Name, newCredentialMasker(candidate.apiKey), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 			if recordFailure && st.circuitBreakerEnabled {
-				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Status: resp.StatusCode, Reason: "TTFT probe failed"})
 			}
 			st.setReqErr(re)
 			logData.failoverAttempt = attempt
@@ -781,7 +782,8 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		// retry never counts against the provider.
 		if !isContextErr {
 			if st.circuitBreakerEnabled {
-				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
+				// No status: the request never completed, so there is none.
+				h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.Cause{Reason: "upstream request failed"})
 			}
 		}
 		return nil, false

--- a/internal/proxy/proxy_failover_test.go
+++ b/internal/proxy/proxy_failover_test.go
@@ -176,9 +176,9 @@ func TestRecordBreakerOutcome_TheCreditLandsOnTheChargedModel(t *testing.T) {
 				provider: &provider.Provider{ID: provID, Name: "p"},
 			}
 
-			cb.RecordFailure(provID, "p", cand.model.ModelID)
+			cb.RecordFailure(provID, "p", cand.model.ModelID, failover.Cause{})
 			h.recordBreakerOutcome(context.Background(), st, cand, tc.status, tc.eligible, rateLimitVerdict{})
-			cb.RecordFailure(provID, "p", cand.model.ModelID)
+			cb.RecordFailure(provID, "p", cand.model.ModelID, failover.Cause{})
 
 			if got := cb.GetState(provID, cand.model.ModelID); got == failover.StateOpen {
 				t.Error("the credit missed the charged model's circuit: an erased failure was still on the clock")

--- a/internal/proxy/proxy_resolve_test.go
+++ b/internal/proxy/proxy_resolve_test.go
@@ -250,7 +250,7 @@ func TestResolveHotelModel_CircuitBreakerOpen_Integration(t *testing.T) {
 	// modelName is the resolved upstream model id, which is the key the skip in
 	// buildFailoverCandidates reads.
 	for range 5 {
-		handler.circuitBreaker.RecordFailure(providerID, "test-provider", modelName)
+		handler.circuitBreaker.RecordFailure(providerID, "test-provider", modelName, failover.Cause{})
 	}
 
 	body := `{"model": "hotel/` + modelName + `", "messages": [{"role": "user", "content": "hello"}], "stream": false}`

--- a/internal/proxy/rate_limit_flow_test.go
+++ b/internal/proxy/rate_limit_flow_test.go
@@ -369,7 +369,7 @@ func TestRecordBreakerOutcome_ClassifiedRateLimits(t *testing.T) {
 		if got := cb.GetState(provID, cand.model.ModelID); got != failover.StateClosed {
 			t.Errorf("state = %v, want closed", got)
 		}
-		statuses := cb.Status()
+		statuses := cb.StatusDetail()
 		if len(statuses) != 1 || len(statuses[0].Circuits) != 1 || statuses[0].Circuits[0].LastCause != "upstream status 429 (saturated)" {
 			t.Errorf("status = %+v, want the saturated verdict remembered on the circuit", statuses)
 		}

--- a/internal/proxy/rate_limit_flow_test.go
+++ b/internal/proxy/rate_limit_flow_test.go
@@ -360,8 +360,18 @@ func TestRecordBreakerOutcome_ClassifiedRateLimits(t *testing.T) {
 
 		h.recordBreakerOutcome(ctx, st, cand, 429, true, rateLimitVerdict{class: rateLimitSaturated, retryAfter: time.Second})
 
-		if _, seen := cbConsecutiveFails(cb, provID); seen {
-			t.Error("a saturated 429 touched the breaker; it must be a no-op")
+		// Neither charged nor credited: the counter is untouched and the
+		// circuit closed. What IS left behind is the verdict, so the status
+		// page can say "busy" about a closed circuit whose last answer was a 429.
+		if fails, seen := cbConsecutiveFails(cb, provID); !seen || fails != 0 {
+			t.Errorf("consecutiveFails = %d (tracked=%v), want a tracked circuit with no charge", fails, seen)
+		}
+		if got := cb.GetState(provID, cand.model.ModelID); got != failover.StateClosed {
+			t.Errorf("state = %v, want closed", got)
+		}
+		statuses := cb.Status()
+		if len(statuses) != 1 || len(statuses[0].Circuits) != 1 || statuses[0].Circuits[0].LastCause != "upstream status 429 (saturated)" {
+			t.Errorf("status = %+v, want the saturated verdict remembered on the circuit", statuses)
 		}
 	})
 
@@ -373,7 +383,7 @@ func TestRecordBreakerOutcome_ClassifiedRateLimits(t *testing.T) {
 		st := &requestState{circuitBreakerEnabled: true}
 		provID := uuid.New()
 		cand := modelCandidateForBreaker(provID)
-		cb.RecordFailure(provID, "p", cand.model.ModelID)
+		cb.RecordFailure(provID, "p", cand.model.ModelID, failover.Cause{})
 		time.Sleep(time.Millisecond)
 		cb.IsOpen(provID, "p", cand.model.ModelID) // cooldown elapsed: half-open
 

--- a/internal/proxy/resolve_test.go
+++ b/internal/proxy/resolve_test.go
@@ -737,7 +737,7 @@ func TestResolveHotelModel_CircuitBreakerOpen(t *testing.T) {
 	// Charged under the model's resolved upstream id, which is the key the skip
 	// in buildFailoverCandidates reads.
 	for range 5 {
-		h.circuitBreaker.RecordFailure(createdProvider.ID, createdProvider.Name, testModel.ModelID)
+		h.circuitBreaker.RecordFailure(createdProvider.ID, createdProvider.Name, testModel.ModelID, failover.Cause{})
 	}
 
 	candidates, _, _, _, err := h.resolveHotelModel(context.Background(), "cb-fg")
@@ -1183,7 +1183,7 @@ func TestBuildFailoverCandidates_CircuitBreakerOpen(t *testing.T) {
 	}
 
 	// Open the circuit breaker
-	cb.RecordFailure(providerID, providerName, models[modelUUID].ModelID)
+	cb.RecordFailure(providerID, providerName, models[modelUUID].ModelID, failover.Cause{})
 
 	candidates, _, _, _ := h.buildFailoverCandidates(fg, models, providers, true, &breakerSkipSummary{})
 
@@ -1223,7 +1223,7 @@ func TestBuildFailoverCandidates_CircuitBreakerOpenButDisabled(t *testing.T) {
 	}
 
 	// Open the circuit breaker
-	cb.RecordFailure(providerID, providerName, models[modelUUID].ModelID)
+	cb.RecordFailure(providerID, providerName, models[modelUUID].ModelID, failover.Cause{})
 
 	// cbEnabled=false → circuit breaker should be skipped
 	candidates, _, _, _ := h.buildFailoverCandidates(fg, models, providers, false, &breakerSkipSummary{})

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/anthropic"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -329,7 +330,7 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	// say and which is otherwise invisible above Debug.
 	if verdict := judgeStreamForBreaker(st, logData, errMsg, opts.circuitBreakerOn); verdict.failureReason != "" {
 		debuglog.Warn("proxy: recording circuit breaker failure", "reason", verdict.failureReason, "provider", opts.providerName, "provider_id", opts.providerID, "attempt", opts.attempt, "chunks", st.chunkCount, "error_chunks", st.errorChunkCount, "duration_ms", totalDuration, "model", opts.model)
-		h.circuitBreaker.RecordFailure(opts.providerID, opts.providerName, opts.model)
+		h.circuitBreaker.RecordFailure(opts.providerID, opts.providerName, opts.model, failover.Cause{Status: statusCode, Reason: verdict.failureReason})
 	} else if verdict.success {
 		h.circuitBreaker.RecordSuccess(opts.providerID, opts.providerName, opts.model)
 	}

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -603,7 +603,7 @@ func TestHandleStreamingResponse_UnreadableFramesTellTheBreakerNothing(t *testin
 			h.insertRequestLogAsync(logData)
 			// One failure on the clock. Only a recorded SUCCESS clears it, so
 			// whether the second failure opens the circuit reports the verdict.
-			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider", "")
+			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider", "", failover.Cause{})
 
 			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(tc.body))}
 			h.handleStreamingResponse(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody), logData, resp, time.Now(), streamOptions{
@@ -618,7 +618,7 @@ func TestHandleStreamingResponse_UnreadableFramesTellTheBreakerNothing(t *testin
 			if got := h.circuitBreaker.GetState(providerID, ""); got == failover.StateOpen {
 				t.Fatal("a frame the gateway forwarded must never be charged to the provider")
 			}
-			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider", "")
+			h.circuitBreaker.RecordFailure(providerID, "wide-shape-provider", "", failover.Cause{})
 			cleared := h.circuitBreaker.GetState(providerID, "") != failover.StateOpen
 			if cleared != tc.wantCleared {
 				t.Errorf("failure streak cleared = %v, want %v", cleared, tc.wantCleared)

--- a/web/src/api/types/failover.ts
+++ b/web/src/api/types/failover.ts
@@ -87,6 +87,36 @@ export interface CircuitBreakerProviderStatus {
 	// counted from; circuits owed a probe are not in it, because they block
 	// nothing.
 	open_models?: string[];
+	// Every circuit the row above is built from, sorted by model, each with its
+	// own state, wait and last verdict. Additive: open_models stays what
+	// entryCircuitStatus keys on, and a member from before this field simply
+	// omits it, so a consumer must fall back to open_models when it is absent.
+	circuits?: CircuitStatus[];
+}
+// One (provider, resolved upstream model) circuit as the detail endpoint
+// reports it. The row-level fields above describe the provider's most
+// degraded circuit; these are the same fields at the level the breaker keeps
+// them, plus the verdict that last landed on the circuit.
+export interface CircuitStatus {
+	model: string;
+	state: "closed" | "open" | "half-open";
+	consecutive_fails: number;
+	opened_at?: string;
+	cooldown_ms?: number;
+	next_retry_at?: string;
+	// The overrides governing THIS circuit's cooldown, unlike the row's
+	// quota_pinned, which is the verdict's "any blocking circuit is pinned" arm.
+	quota_pinned?: boolean;
+	pin_source?: "advisor" | "response";
+	backed_off?: boolean;
+	failed_probes?: number;
+	// Why the circuit was last charged, credited, pinned or released ("upstream
+	// status 429 (saturated)", "success", "quota pin retargeted (advisor)"),
+	// the upstream status behind it (omitted when none was seen) and when. For
+	// an open circuit this is why it opened.
+	last_cause?: string;
+	last_status?: number;
+	last_at?: string;
 }
 // Outcome of an operator forcing one provider's circuit back closed.
 // previous_state is what the breaker reported a moment before the reset, and

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1474,6 +1474,8 @@ Heartbeat comments (`: heartbeat`) are sent every 30 seconds.
 | `model` | string | always | The resolved upstream model id whose circuit changed state (the id sent upstream, never a `hotel/` alias) |
 | `model_id` | string | on `closed` always; on `open` unless `provider_open` is `true` | The same value as `model`, carried separately because it is the identity outbound alerts debounce on, so two models opening on one provider inside the alert cooldown notify separately. Omitted from an `open` once the provider itself is skipped, so a provider outage debounces as one fact on `provider_id` rather than once per model; a `closed` always carries it, so two recoveries are two notifications |
 | `state` | string | always | `open` or `closed` |
+| `cause` | string | always | The verdict that produced the transition: why the circuit opened (`upstream status 503`, `upstream status 429 (saturated)`, `response failed after headers`, ...) or what closed it (`success`). A fixed phrase chosen by the gateway, never provider text; see [Why a circuit is open](Failover-and-Hotel-Routing#why-a-circuit-is-open) |
+| `status` | int | always | The upstream HTTP status behind `cause`; `0` when no response was seen |
 | `provider_open` | bool | always | Whether the provider as a whole is now being skipped. One model's circuit opening does not skip the provider until `circuit_breaker_span_models` of them are open, so this is `false` on most `circuit_breaker.open` events |
 | `consecutive_fails` | int | always | Consecutive failures recorded against that model's circuit |
 | `quota_pinned` | bool | always | Whether a quota reset deadline is in force on this circuit |

--- a/wiki/Alerting.md
+++ b/wiki/Alerting.md
@@ -2,7 +2,7 @@
 
 Model Hotel can push outbound notifications for noteworthy operational events (a provider going down, a circuit breaker tripping, a failover group failing to sync) to wherever you want them: Telegram, email, Discord, Slack, Matrix, a raw webhook, and ~80 other destinations.
 
-It does this through [Apprise](https://github.com/caronc/apprise): you run a small, stateless `apprise-api` container, Model Hotel POSTs a short event summary to it, and Apprise fans the notification out to your chosen service. Model Hotel writes no per-service integration code, ships no Python in its image, and (consistent with its [[Privacy]] stance) **never sends request or response content**, only the event summary (e.g. "Provider openai circuit breaker: open for model gpt-5").
+It does this through [Apprise](https://github.com/caronc/apprise): you run a small, stateless `apprise-api` container, Model Hotel POSTs a short event summary to it, and Apprise fans the notification out to your chosen service. Model Hotel writes no per-service integration code, ships no Python in its image, and (consistent with its [[Privacy]] stance) **never sends request or response content**, only the event summary (e.g. "Provider openai circuit breaker: open for model gpt-5: upstream status 503").
 
 ---
 

--- a/wiki/Failover-and-Hotel-Routing.md
+++ b/wiki/Failover-and-Hotel-Routing.md
@@ -606,6 +606,26 @@ The span default of `2` is the smallest number that requires corroboration: one 
 
 The dashboard reads it the same way. The **red number** in the Failover nav badge counts providers the breaker is skipping - the derived verdict, read off the `provider_open` field of the detail rows - and the amber number beside it counts providers that hold an open or probing circuit but are still routing. The status endpoint's own `closed` / `half_open` / `open` counts are per-circuit-state tallies of the most degraded circuit per provider, which is a different question: a provider serving three models with one dark appears under `open` there and in the **amber** number here.
 
+### Why a circuit is open
+
+Every circuit remembers its last verdict: the reason it was last charged, credited, pinned or released, the upstream HTTP status behind that (0 when no response was seen) and when it landed. The reason is always a fixed phrase chosen by the gateway, never text copied from a provider response, so it can carry neither a prompt echo nor a credential into a status page or an alert.
+
+| Cause | Recorded when |
+|-------|---------------|
+| `upstream status 503` (any status) | A failover-eligible status was charged to the circuit |
+| `upstream status 429 (saturated)` | A 429 the classifier read as load. The circuit is neither charged nor credited, only the verdict is remembered, so a closed circuit whose last answers were all 429s can be told apart from a healthy one |
+| `upstream status 429 (exhausted)` | A 429 the classifier read as a spent window; the circuit opened outright |
+| `upstream status 429 (unrecognised)` | A 429 the classifier could not read, charged like any failure |
+| `upstream status 429 (exhausted, not opened by setting)` | An exhausted 429 charged as an ordinary failure because `circuit_breaker_open_on_exhaustion` is off |
+| `response failed after headers`, `response completed without delivering content`, `upstream body could not be translated`, `upstream body read failed` | A 2xx whose body then failed the gateway's own checks; `status` is the 2xx |
+| `TTFT probe failed`, `hedged TTFT probe failed`, and the stream verdict's own reasons | A stream that stalled before its first token or died on the wire |
+| `upstream request failed` | The request never completed; `status` is 0 |
+| `success` | A completion the breaker credited |
+| `upstream status 400 (alive)` (any non-eligible status) | A response that proved the provider alive without serving anything |
+| `quota pin retargeted (advisor)`, `quota pin released (...)` | The quota poller changed the wait of an already-open circuit; `status` keeps the value of the response that opened it |
+
+`GET /api/failover-groups/circuit-breaker-status?detail=1` lists every circuit behind a provider row under `circuits[]`, sorted by model, each with its own `state`, `consecutive_fails`, `opened_at` / `cooldown_ms` / `next_retry_at` (while the wait is enforced), `quota_pinned` / `pin_source` / `backed_off` / `failed_probes` (the overrides governing that circuit), and `last_cause` / `last_status` / `last_at`. The open entries in `circuits[]` are exactly `open_models`, which stays what the dashboard keys on; a member from before this field simply omits it. The `circuit_breaker.open` event and the `model state=...→open` log line carry the same `cause` and `status`, and the event's message names the cause, so an outbound alert reads `Provider Neuralwatt circuit breaker: open for model glm-5.3: upstream status 429 (saturated)` rather than only `open`.
+
 ### Failover Integration
 
 Blocked candidates are filtered out during provider resolution:
@@ -698,7 +718,7 @@ The circuit breaker publishes real-time events via the SSE event bus:
 
 | Event | When |
 |-------|------|
-| `circuit_breaker.open` | One model circuit transitions from Closed to Open. `provider_open` says whether that also takes the whole provider out |
+| `circuit_breaker.open` | One model circuit transitions from Closed to Open. `provider_open` says whether that also takes the whole provider out, and the message names the cause after a colon (`... open for model glm-5.3: upstream status 429 (saturated)`), which is what an outbound alert renders |
 | `circuit_breaker.closed` | One model circuit recovers (Half-Open → Closed) |
 | `circuit_breaker.unstable` | One model circuit has opened 3 times inside 24 hours, so every cooldown it serves out returns it to service still broken |
 
@@ -732,6 +752,8 @@ These events appear in the real-time sidebar and dashboard.
 | `model` | string | always | The resolved upstream model id whose circuit changed state |
 | `model_id` | string | on `closed` always; on `open` unless `provider_open` is `true` | The same value as `model`, carried separately because it is the identity outbound alerts debounce on: without it two models opening on one provider inside the alert cooldown would collapse to one notification. Omitted from an `open` once the provider itself is skipped, because then the outage is one fact however many models it reaches, and alerts fall back to debouncing on `provider_id`. A `closed` always carries it: a recovery is about the model that recovered |
 | `state` | string | always | `open` or `closed` |
+| `cause` | string | always | The verdict that produced the transition: why the circuit opened (`upstream status 503`, `upstream status 429 (saturated)`, `response failed after headers`, `hedged TTFT probe failed`, ...) or what closed it (`success`). A fixed phrase chosen by the gateway, never text copied from the provider (see [Why a circuit is open](#why-a-circuit-is-open)) |
+| `status` | int | always | The upstream HTTP status behind `cause`; `0` when no response was seen (a connection that never completed) |
 | `provider_open` | bool | always | Whether the provider as a whole is now being skipped, derived from how many of its model circuits are open (see `circuit_breaker_span_models`) |
 | `consecutive_fails` | int | always | Consecutive failures recorded against that model's circuit |
 | `quota_pinned` | bool | always | `true` when a quota reset deadline is in force on this circuit |
@@ -743,12 +765,14 @@ These events appear in the real-time sidebar and dashboard.
 `next_retry_at` is the **retry deadline, not the provider's quota reset time**: under a pin it is the clamped and jittered pin, so a weekly quota that resets days out still yields a `next_retry_at` at the `circuit_breaker_quota_pin_max` ceiling, and under a backoff it is the doubled cooldown. It is the same value the circuit-breaker status API publishes under that name.
 
 ```go
-// internal/failover/circuitbreaker.go:publishEvent
+// internal/failover/circuit_events.go:publishEvent
 meta := map[string]any{
     "provider_id":       providerID.String(),
     "provider":          providerName,
     "model":             model,
     "state":             state,
+    "cause":             c.lastCause,
+    "status":            c.lastStatus,
     "provider_open":     providerOpen,
     "consecutive_fails": c.consecutiveFails,
     "quota_pinned":      pinned,
@@ -764,7 +788,7 @@ if state == "open" {
         meta["next_retry_at"] = c.openedAt.Add(cooldown).Format(time.RFC3339)
     }
 }
-msg := breakerEventMessage(providerName, state, model, providerOpen)
+msg := breakerEventMessage(providerName, state, model, providerOpen, c.lastCause)
 if state == "open" && backedOff {
     msg += backoffSuffix(cooldown, c.failedProbes)
 }

--- a/wiki/Failover-and-Hotel-Routing.md
+++ b/wiki/Failover-and-Hotel-Routing.md
@@ -789,7 +789,7 @@ if state == "open" {
     }
 }
 msg := breakerEventMessage(providerName, state, model, providerOpen, c.lastCause)
-if state == "open" && backedOff {
+if state == "open" && backedOff && cooldown == c.cooldownBackoff {
     msg += backoffSuffix(cooldown, c.failedProbes)
 }
 events.Publish(events.Event{
@@ -801,7 +801,7 @@ events.Publish(events.Event{
 })
 ```
 
-The message names the model, because the event is about one model circuit: `Provider zai circuit breaker: open for model glm-4.6`. When that transition also flips the provider-wide verdict, the message says so as well - `... for model glm-4.6 (provider skipped)` - since that is the moment the remaining models leave rotation. Without the model in the sentence, a toast or an Apprise alert about one sidelined model reads as a whole provider going down.
+The message names the model, because the event is about one model circuit, and the cause after it: `Provider zai circuit breaker: open for model glm-4.6: upstream status 503`. When that transition also flips the provider-wide verdict, the message says so as well - `... for model glm-4.6 (provider skipped): upstream status 503` - since that is the moment the remaining models leave rotation. Without the model in the sentence, a toast or an Apprise alert about one sidelined model reads as a whole provider going down.
 
 A separate `quota.schema_drift` event fires when a provider changes the *shape* of its quota response (the set of key paths, not the values). It carries the added and removed paths and is alert-only: it never opens a circuit, never pins a cooldown, and never affects routing. See [Alerting](Alerting) and the [API Reference](API-Reference) for its metadata.
 


### PR DESCRIPTION
Implements section B of `plans/2026-08-31-failover-observability-design.md` (the first slice of the observability companion spec; sequenced first because it is the smallest change with the biggest payoff for the next incident, and needs no schema).

## Why

Diagnosing the 2026-08-31 `hotel/glm53` run took an hour of ad-hoc API polling because nothing MH exposed could say *why* a circuit was open: `?detail=1` said "open", the event said "open", the alert said "open". The 429 body that explained everything was visible only when it happened to be a request's terminal attempt.

## What

**Every circuit remembers its last verdict** (`internal/failover`): `lastCause`, `lastStatus`, `lastAt`, stamped at every site that charges, credits, pins or releases it. The cause is a `failover.Cause{Status, Reason}` the caller passes to `RecordFailure` / `RecordRateLimited` (and `RecordAlive` takes the status); `RecordExhausted` / `RecordSuccess` stamp their own. The reason is always a fixed phrase chosen by the gateway, never text copied from a provider response, so it can carry neither a prompt echo nor a credential into a status page or an alert.

- **`RecordSaturated`** (new): a saturated 429 stays neither a charge nor a credit, but the circuit now remembers it, so a closed circuit whose last answers were all 429s can be told apart from a healthy one. This is what the "busy" chip in section D will read.
- The quota poller's retarget and both releases record themselves as the verdict and keep the status of the response that opened the circuit.

**`?detail=1` gains `circuits[]`** per provider row: every circuit the row is built from, sorted by model, each with its own state, wait, overrides and `last_cause` / `last_status` / `last_at`. Additive; `open_models` stays what the dashboard keys on, and a member from before this field omits it (mixed-version fleet safe). Built by a new `StatusDetail()`; `Status()`, which the Prometheus scrape and the aggregate poll read under the request path's lock, stays as lean as it was.

**Event, log and alert carry the cause**: `circuit_breaker.open` / `.closed` metadata gains `cause` and `status`; the `model state=...→open` log line carries both; and the open message names the cause after a colon, so an Apprise alert reads `Provider Neuralwatt circuit breaker: open for model glm-5.3: upstream status 429 (saturated)` instead of `open`.

Proxy side: the eight breaker charge sites pass the reason they already logged (`response failed after headers`, `hedged TTFT probe failed`, `upstream request failed`, the stream verdict's own reasons, ...) with the upstream status the attempt had reached. `circuitbreaker.go` had reached the size ceiling, so `publishEvent` and the message helpers moved to `circuit_events.go` unchanged apart from the cause.

Dashboard: `CircuitStatus` type added (`web/src/api/types/failover.ts`); the card itself is section D. Wiki: a "Why a circuit is open" section with the cause table, and the event metadata table gains the two fields.

**One deliberate deviation from the spec**: it lists `applyQuotaPin` among the setters. At the open transition the cause recorded is the response that opened the circuit; the pin stamped in the same transition is already reported by `pin_source`, and overwriting the cause with "quota pin" would lose the more useful fact. The poller's later retarget does record itself, because that transition has no request behind it.

**Two side effects worth knowing**: a saturated 429 now creates a circuit for an untracked (provider, model) pair, so a provider outside every failover group that has only ever answered busy appears in the status counts as closed (it is tracked; the count is honest). The stamp does not move the eviction clock (`lastCharged`), so such a circuit ranks first for eviction behind every circuit a charge or credit ever reached.

## Review

An independent second-opinion round (different model) found two real defects in the first cut, both fixed and pinned by tests: `chargeBreaker` recorded `logData.statusCode` at two sites where that is not the upstream status (0 on a translation failure, since nothing had stamped it yet; the gateway's own 502 on the native-Anthropic read failure), so the status is now handed in by the caller from `resp`; and a message test whose helper passed an empty cause, pinning a sentence production can never emit. It also moved `circuits[]` off the scrape path (above), stopped `RecordSaturated` touching the eviction clock, fixed a misleading reason on the streamed pass-through first-byte failure, and caught three wiki pages that still showed the old message shape.

## Testing

- `internal/failover`: every verdict site stamps (`TestCircuitRemembersItsLastVerdict`), a saturated 429 is remembered without charging (counter and state untouched), the three pin transitions record their cause and keep the status, `circuits[]` is sorted and its open entries equal `open_models` exactly (a circuit owed a probe keeps its `opened_at` and verdict), and the open event + log line carry `cause` / `status` with the message naming it while a close names only what recovered.
- `internal/api`: `?detail=1` carries `circuits[]` verbatim, omits `last_status` when no status was seen, and a row without circuits decodes as before.
- `internal/proxy`: the saturated no-op test now asserts the real contract (tracked, uncharged, closed, verdict remembered); a failed-after-headers charge and an untranslatable body both record the upstream's 200, never a 0 or the gateway's 502.
- Full `go test` on failover / proxy / api / cmd/server green, `golangci-lint` 0 issues, size gate, `tsc -b`, Biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
