### PR TITLE
fix(proxy): make the per-attempt dial timing race-free

### DIFF
--- a/internal/ctxkeys/keys.go
+++ b/internal/ctxkeys/keys.go
@@ -40,12 +40,12 @@ const RequestBodyKey contextKey = "request_body"
 // Use AddSettingsReadMs to safely add to the accumulated total.
 const SettingsReadMsKey contextKey = "settings_read_ms"
 
-// DialMsKey is the context key under which the proxy handler stores a
-// *float64 pointer for capturing per-request upstream dial timing
-// (DNS resolution + TCP connect). The SafeDialer's DialContext writes
-// the total dial duration into this pointer so the handler can read it
-// after the upstream request completes, avoiding cross-request race
-// conditions from a shared atomic.
+// DialMsKey is the context key under which the proxy handler stores its
+// per-request dial-timing slot (an atomic; the proxy package owns the type)
+// for capturing upstream dial time (DNS resolution + TCP connect). The
+// SafeDialer's DialContext stores the total dial duration into it and the
+// handler swaps it out after the upstream request completes. Atomic because
+// the transport's dial goroutine can outlive the request that started it.
 const DialMsKey contextKey = "dial_ms"
 
 // VirtualKeyRateLimitRPSKey is the context key under which the proxy's

--- a/internal/proxy/anthropic_thinking_retry.go
+++ b/internal/proxy/anthropic_thinking_retry.go
@@ -81,7 +81,7 @@ func (h *Handler) retryLearnableMessages400(
 	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/messages")
 	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
 	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
-	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
+	retryCtx, retryDial := withDialTiming(retryCtx)
 	res.streamCancelOrigin = "retry_timeout"
 
 	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
@@ -100,6 +100,7 @@ func (h *Handler) retryLearnableMessages400(
 	}
 	//nolint:bodyclose // retry resp.Body is consumed by the caller's dispatch
 	retryResp, doErr := (&http.Client{Transport: h.upstreamTransport, CheckRedirect: checkRedirect}).Do(retryReq)
+	*dialMs += retryDial.take()
 	if doErr != nil {
 		rc()
 		debuglog.Warn("proxy: anthropic thinking dialect retry failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", doErr)

--- a/internal/proxy/dial_timing.go
+++ b/internal/proxy/dial_timing.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+)
+
+// dialTiming is the per-attempt slot the SafeDialer writes DNS+TCP time into
+// and the attempt reads back. It is atomic because the writer and the reader
+// are different goroutines with no ordering between them: http.Transport
+// dials on its own goroutine, and that goroutine can outlive the Do call
+// that started it. A request cancelled mid-dial returns from Do at once while
+// the dial goroutine finishes a moment later and records its time; a spare
+// connection the transport raced against an idle one lands the same way. A
+// plain *float64 in the context was a data race on exactly that shape, which
+// the race detector caught on master in the client-disconnect-during-backoff
+// test. A late write after take() is attributed nowhere, which is right: it
+// was not this attempt's wait.
+type dialTiming struct {
+	bits atomic.Uint64
+}
+
+// set records the dial time in milliseconds.
+func (d *dialTiming) set(ms float64) {
+	if d == nil {
+		return
+	}
+	d.bits.Store(math.Float64bits(ms))
+}
+
+// take returns the recorded dial time and clears the slot, so an attempt that
+// dials more than once (the transient-retry loop) sums the dials it waited for
+// and never re-counts one.
+func (d *dialTiming) take() float64 {
+	if d == nil {
+		return 0
+	}
+	return math.Float64frombits(d.bits.Swap(0))
+}
+
+// withDialTiming hands a request context its own timing slot under
+// ctxkeys.DialMsKey and returns the slot for the caller to read after Do.
+func withDialTiming(ctx context.Context) (context.Context, *dialTiming) {
+	dt := &dialTiming{}
+	return context.WithValue(ctx, ctxkeys.DialMsKey, dt), dt
+}
+
+// recordDialMs is the dialer's side: store the time elapsed since start into
+// the request's slot, if the request carries one.
+func recordDialMs(ctx context.Context, start time.Time) {
+	if dt, ok := ctx.Value(ctxkeys.DialMsKey).(*dialTiming); ok {
+		dt.set(float64(time.Since(start).Microseconds()) / 1000.0)
+	}
+}

--- a/internal/proxy/dial_timing_test.go
+++ b/internal/proxy/dial_timing_test.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
+)
+
+// The slot's contract: set/take round-trips, take clears, a nil slot is
+// inert, and a context without a slot is ignored by the dialer's recorder.
+func TestDialTiming_SetTakeClears(t *testing.T) {
+	var slot *dialTiming
+	slot.set(1)
+	if slot.take() != 0 {
+		t.Fatal("nil slot returned a value")
+	}
+	ctx, dt := withDialTiming(context.Background())
+	if _, ok := ctx.Value(ctxkeys.DialMsKey).(*dialTiming); !ok {
+		t.Fatal("the context does not carry the slot under DialMsKey")
+	}
+	dt.set(12.5)
+	if got := dt.take(); got != 12.5 {
+		t.Errorf("take = %v, want 12.5", got)
+	}
+	if got := dt.take(); got != 0 {
+		t.Errorf("second take = %v, want the slot cleared", got)
+	}
+	recordDialMs(context.Background(), time.Now()) // no slot: nothing to do, no panic
+	recordDialMs(ctx, time.Now().Add(-40*time.Millisecond))
+	if got := dt.take(); got < 40 {
+		t.Errorf("recorded %v ms, want at least the 40ms elapsed", got)
+	}
+}
+
+// The shape the race detector caught on master: the transport's dial
+// goroutine records its time after the request goroutine has already moved
+// on to read the slot. With a plain pointer that is a data race; the slot
+// makes both sides safe whichever lands first, and a late write is simply
+// not this attempt's wait.
+func TestDialTiming_LateDialWriteDoesNotRaceTheReader(t *testing.T) {
+	ctx, dt := withDialTiming(context.Background())
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			recordDialMs(ctx, time.Now())
+		}()
+		go func() {
+			defer wg.Done()
+			_ = dt.take()
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/proxy/openai_responses.go
+++ b/internal/proxy/openai_responses.go
@@ -125,7 +125,7 @@ func (h *Handler) retryWithResponses(
 
 	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
 	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
-	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
+	retryCtx, retryDial := withDialTiming(retryCtx)
 	res.streamCancelOrigin = "retry_timeout"
 	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
 	if retryErr != nil {
@@ -143,6 +143,7 @@ func (h *Handler) retryWithResponses(
 	}
 	//nolint:bodyclose // retry resp.Body is consumed by the caller's dispatch
 	retryResp, retryErr := (&http.Client{Transport: h.upstreamTransport, CheckRedirect: checkRedirect}).Do(retryReq)
+	*dialMs += retryDial.take()
 	if retryErr != nil {
 		rc()
 		debuglog.Warn("proxy: responses api retry failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -181,7 +181,7 @@ func (h *Handler) issueParamRetry(
 	rebuilt := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, strip, learnedScopeFor(candidate))
 	retryCtx, rc := context.WithTimeout(r.Context(), st.failoverTimeout)
 	retryCtx = context.WithValue(retryCtx, ctxkeys.CancelOriginKey, "retry_timeout")
-	retryCtx = context.WithValue(retryCtx, ctxkeys.DialMsKey, dialMs)
+	retryCtx, retryDial := withDialTiming(retryCtx)
 	retryReq, retryErr := newRequestWithContext(retryCtx, "POST", targetURL, bytes.NewReader(rebuilt))
 	if retryErr != nil {
 		rc()
@@ -196,6 +196,7 @@ func (h *Handler) issueParamRetry(
 	retryClient := &http.Client{Transport: h.upstreamTransport, CheckRedirect: retryCheckRedirect}
 	//nolint:bodyclose // retryResp.Body is returned to the caller, which consumes and closes it
 	retryResp, retryErr := retryClient.Do(retryReq)
+	*dialMs += retryDial.take()
 	if retryErr != nil {
 		rc() // no body to consume on retry error
 		debuglog.Warn("proxy: auto-retry request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", retryErr)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -674,10 +674,11 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	// per request. A fresh Transport spawns persistent readLoop/writeLoop
 	// goroutines per connection that only die after IdleConnTimeout, so
 	// creating one per request causes unbounded goroutine growth.
-	// Inject per-request dial timing pointer so SafeDialer writes
-	// DNS resolution time into this request's own variable, avoiding
-	// cross-request race conditions on a shared atomic.
-	dialCtx := context.WithValue(ctx, ctxkeys.DialMsKey, dialMs)
+	// Hand the request its own dial-timing slot for SafeDialer to write DNS
+	// and TCP time into. A slot rather than the caller's *dialMs, because the
+	// transport's dial goroutine can outlive Do (see dialTiming); the time is
+	// swapped out into *dialMs once Do has returned.
+	dialCtx, dialTimer := withDialTiming(ctx)
 
 	var checkRedirect func(req *http.Request, via []*http.Request) error
 	if h.safeDialer != nil {
@@ -719,6 +720,7 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		}
 		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
 		resp, err = upstreamClient.Do(tryReq)
+		*dialMs += dialTimer.take()
 		st.timings.dialMs += *dialMs
 		*dialMs = 0
 		if err == nil || try == maxTransientRetries || !isRetryableUpstreamError(err, wroteRequest.Load()) {

--- a/internal/proxy/safe_dialer.go
+++ b/internal/proxy/safe_dialer.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -90,25 +89,18 @@ func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net
 	if s.hosts[strings.ToLower(host)] {
 		dialStart := time.Now()
 		conn, err := s.d.DialContext(ctx, network, addr)
-		if v := ctx.Value(ctxkeys.DialMsKey); v != nil {
-			if p, ok := v.(*float64); ok {
-				*p = float64(time.Since(dialStart).Microseconds()) / 1000.0
-			}
-		}
+		recordDialMs(ctx, dialStart)
 		return conn, err
 	}
 
 	// Resolve the host to IP addresses (timed).
 	dnsStart := time.Now()
 	ips, err := s.resolver.LookupIPAddr(ctx, host)
-	// Write per-request dial timing if the caller provided a pointer.
-	// This captures DNS resolution only when the dial fails before TCP;
-	// successful dials overwrite this with the full DNS+TCP time below.
-	if v := ctx.Value(ctxkeys.DialMsKey); v != nil {
-		if p, ok := v.(*float64); ok {
-			*p = float64(time.Since(dnsStart).Microseconds()) / 1000.0
-		}
-	}
+	// Record the per-request dial timing if the caller provided a slot (see
+	// dialTiming for why it is not a plain pointer). This captures DNS
+	// resolution only when the dial fails before TCP; successful dials
+	// overwrite it with the full DNS+TCP time below.
+	recordDialMs(ctx, dnsStart)
 	if err != nil {
 		// Resolution failure: return the DNS error directly rather than
 		// falling through to an unchecked dial. A host that can't be
@@ -149,12 +141,8 @@ func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net
 			continue
 		}
 		debuglog.Debug("proxy: SafeDialer connected", "host", host, "ip", ip.IP, "total_ms", float64(time.Since(dnsStart).Microseconds())/1000.0)
-		// Overwrite the timing with full DNS+TCP duration.
-		if v := ctx.Value(ctxkeys.DialMsKey); v != nil {
-			if p, ok := v.(*float64); ok {
-				*p = float64(time.Since(dnsStart).Microseconds()) / 1000.0
-			}
-		}
+		// Overwrite the timing with the full DNS+TCP duration.
+		recordDialMs(ctx, dnsStart)
 		return conn, nil
 	}
 

--- a/internal/proxy/safe_dialer_test.go
+++ b/internal/proxy/safe_dialer_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -242,13 +241,12 @@ func TestSafeDialer_NoPortInAddr(t *testing.T) {
 
 func TestSafeDialer_DialTimingContext(t *testing.T) {
 	sd := NewSafeDialer(nil, nil)
-	var dialMs float64
-	ctx := context.WithValue(context.Background(), ctxkeys.DialMsKey, &dialMs)
+	ctx, slot := withDialTiming(context.Background())
 
 	// This will fail to connect but should set the timing value
 	_, _ = sd.DialContext(ctx, "tcp", "127.0.0.1:80")
 	// dialMs should be >= 0 (DNS resolution was attempted, even for IP)
-	if dialMs < 0 {
+	if dialMs := slot.take(); dialMs < 0 {
 		t.Errorf("expected dialMs >= 0, got %f", dialMs)
 	}
 }
@@ -403,15 +401,14 @@ func TestSafeDialer_DialByIP(t *testing.T) {
 func TestSafeDialer_DialTimingSetOnRealDNS(t *testing.T) {
 	t.Parallel()
 	sd := NewSafeDialer(nil, nil)
-	var dialMs float64
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	ctx = context.WithValue(ctx, ctxkeys.DialMsKey, &dialMs)
+	ctx, slot := withDialTiming(ctx)
 
 	// Dial a real public host - connection may fail but DNS should resolve
 	_, _ = sd.DialContext(ctx, "tcp", "example.com:80")
 
-	if dialMs <= 0 {
+	if dialMs := slot.take(); dialMs <= 0 {
 		t.Errorf("expected dialMs > 0 after DNS resolution, got %f", dialMs)
 	}
 }


### PR DESCRIPTION
Hotfix for master: the post-merge CI of #842 went red on `Go Race` in `TestChatCompletions_ClientDisconnectDuringBackoff` (run 33489275855).

## What the race was

The per-attempt dial timing was a plain `*float64` handed to `SafeDialer` through the request context. `http.Transport` dials on its own goroutine, and that goroutine can outlive the `Do` call that started it: a request cancelled mid-dial returns from `Do` at once while the dial finishes a moment later and writes its time, and a spare connection the transport raced against an idle one lands the same way. Meanwhile `doUpstream` (and the three learnable-400 retry helpers, which share the pattern) read and reset the same pointer right after `Do`. Two goroutines, one `float64`, no ordering: the race detector caught the write from `SafeDialer.DialContext` against the write in `doUpstream` on the client-disconnect-during-backoff path, where the cancel makes the window wide. It is latent and older than #842; the PR's own Go Race run happened to miss it.

## Fix

`dialTiming` (`internal/proxy/dial_timing.go`): an atomic slot the dialer stores into (`recordDialMs`) and the attempt swaps out (`take`) after `Do`, per request context (`withDialTiming`). Same accounting as before: the taken value goes into `*dialMs` and then `st.timings.dialMs`, the transient-retry loop sums the dials it waited for, and a write that lands after `take()` is attributed nowhere, which is right: it was not this attempt's wait. All four `Do` sites use it; the three `*float64` writes in `SafeDialer` are gone. `ctxkeys.DialMsKey`'s doc no longer promises a `*float64`.

## Testing

- `go test -race` on the failing test plus the dialer and slot tests, five times: green (it failed on master's run).
- New: the slot's set/take/clear/nil contract, and a concurrent late-write-vs-take test in the shape the detector caught.
- Full `internal/proxy` and `internal/ctxkeys` suites green, `golangci-lint` 0 issues, size gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
