### PR TITLE
fix(web): the failover card's live count on its own line

### DIFF
--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -271,8 +271,7 @@ export function FailoverGroupCard({
 					{formatTokens(group.total_tokens)} {t("common.tokens")}
 					{group.group_enabled && summary.total > 0 && (
 						<>
-							{" "}
-							•{" "}
+							<br />
 							{summary.allDark ? (
 								<span
 									className="text-red-400 font-medium"


### PR DESCRIPTION
The "X of Y entries live" / "all entries dark" summary on the failover group card now starts on its own line under the active/tokens line instead of following it after a dot. Requested after the #854 card shipped to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
