### PR TITLE
fix(provider): scrub the shared discovery and quota helpers of the credential they carry

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -64,6 +64,15 @@ through the attempt's credential masker. A provider quoting the prompt back
 cannot fit; a key cannot survive. The no-content rule of section 6 applies to it
 unchanged.
 
+Provider discovery and quota polling scrub the same way. The shared HTTP helpers in
+`internal/provider/discovery.go` never receive the key as a value, so they read it back off the
+request they are sending (the credential headers, and the credential-bearing query parameters one
+family authenticates with) and mask it exactly, then by shape, then bound the text, in that order so a
+key straddling the cut is still redacted whole. This covers upstream error bodies, retryable-status
+bodies and transport errors that quote the URL, in what is logged, returned to the dashboard, and
+stored as a provider's quota failure. The vendor-specific paths that talk to an upstream directly run
+`util.MaskCredential` over its answer for the same reason.
+
 `phrase` is what the daily phrase-staleness report reads
 (`internal/proxy/phrase_staleness.go`): a rate-limit phrase-table entry that has
 matched no attempt in 90 days, and was added more than 90 days ago, is named in a

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -497,7 +497,7 @@ func (h *Handler) TestModel(w http.ResponseWriter, r *http.Request) {
 		// string is returned to the dashboard AND persisted to
 		// request_logs.error_message. The key was decrypted for the probe just
 		// above, so the exact match covers shapes the regex cannot.
-		errMsg := util.MaskCredential(apiKey, util.SanitizeLogBody(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)), 10000))
+		errMsg := util.MaskCredentialBounded(apiKey, fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)), 10000)
 		h.logTestModelHTTPError(r.Context(), m, reqHash, resp.StatusCode, float64(duration), proxyOverheadMs, keyDecryptMs, errMsg, clientip.From(r))
 		writeJSON(w, TestModelResponse{DurationMs: duration, Error: errMsg})
 		return

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -115,7 +115,15 @@ func secretsOf(h http.Header, u *url.URL) []string {
 	if u == nil {
 		return secrets
 	}
-	for _, seg := range strings.Split(u.RawQuery, "&") {
+	return append(secrets, querySecrets(u.RawQuery)...)
+}
+
+// querySecrets is the query half of secretsOf, over a raw query string, so a
+// URL that failed to parse (and whose error therefore prints it whole) can
+// still be scrubbed from the text after its '?'.
+func querySecrets(rawQuery string) []string {
+	var secrets []string
+	for _, seg := range strings.Split(rawQuery, "&") {
 		name, raw, ok := strings.Cut(seg, "=")
 		if !ok || !credentialQueryParams[strings.ToLower(name)] {
 			continue
@@ -123,6 +131,16 @@ func secretsOf(h http.Header, u *url.URL) []string {
 		secrets = append(secrets, seg, raw)
 		if dec, err := url.QueryUnescape(raw); err == nil && dec != raw {
 			secrets = append(secrets, dec, url.QueryEscape(dec))
+		}
+		// A key pasted with a stray newline or space is what makes the URL
+		// unparseable in the first place, and the parse error renders that
+		// byte escaped (%q prints "\n"), so the exact match on the raw value
+		// misses the visible key body. The trimmed value is what shows.
+		if trimmed := strings.TrimSpace(raw); trimmed != raw {
+			secrets = append(secrets, trimmed)
+			if dec, err := url.QueryUnescape(trimmed); err == nil && dec != trimmed {
+				secrets = append(secrets, dec)
+			}
 		}
 	}
 	return secrets
@@ -254,11 +272,13 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, rawURL string, 
 		// here with last == nil, and its error quotes the URL. Scrub from the
 		// inputs this function was handed instead of from a request.
 		if last == nil {
-			if u, perr := url.Parse(rawURL); perr == nil {
-				err = &maskedError{text: util.MaskCredentialsBounded(secretsOf(headers, u), err.Error(), 500), cause: err}
-			} else {
-				err = &maskedError{text: util.MaskCredentialsBounded(secretsOf(headers, nil), err.Error(), 500), cause: err}
+			// url.Parse fails for the same reason NewRequest did, and the error
+			// prints the raw URL whole, so the query is split off by hand.
+			secrets := secretsOf(headers, nil)
+			if _, q, ok := strings.Cut(rawURL, "?"); ok {
+				secrets = append(secrets, querySecrets(q)...)
 			}
+			err = &maskedError{text: util.MaskCredentialsBounded(secrets, err.Error(), 500), cause: err}
 		}
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -71,45 +71,77 @@ func (d *DiscoveryService) SetRetryBaseDelay(dur time.Duration) {
 // maxDiscoveryRetries bounds attempts for a single discovery HTTP call.
 const maxDiscoveryRetries = 3
 
-// requestSecrets collects every credential a discovery request carries, so
-// text the upstream sends back (or a transport error that quotes the URL) can
-// be scrubbed of it exactly, before the shape layer. The helpers below never
-// receive the key as a value: the caller has already folded it into the
-// Authorization header, an API-key header, or the query string (one family
-// authenticates by ?key=). Reading it back off the request is what lets the
-// shared path cover every family, including the custom and self-hosted
-// gateways whose key format no prefix regex anticipates, and the vendor paths
-// that each fixed this for themselves left this shared one uncovered (Strix
-// vuln-0005, 2026-09-01, the fourth site of the #836 class).
+// credentialHeaders are the request headers a discovery family folds its key
+// into. secretsOf reads the key back off these, so the shared helpers can
+// scrub what an upstream says back without ever being handed the key as a
+// value. A family that authenticates through another header must add it here
+// AND to TestRequestSecrets_CoversEveryCredentialHeader.
+var credentialHeaders = []string{"Authorization", "X-Api-Key", "Api-Key", "X-Goog-Api-Key"}
+
+// credentialQueryParams are the query parameter names a key may travel in
+// (one family authenticates by ?key=). Only these are treated as secrets: a
+// sweep of every query value would redact Azure's ?api-version=... out of the
+// one diagnostic an operator needs when a version is refused.
+var credentialQueryParams = map[string]bool{
+	"key": true, "api_key": true, "apikey": true, "api-key": true,
+	"token": true, "access_token": true, "secret": true, "password": true,
+}
+
+// secretsOf collects every credential the given headers and URL carry, so text
+// the upstream sends back (or a transport error that quotes the URL) can be
+// scrubbed of it exactly, before the shape layer. The helpers below never
+// receive the key as a value: the caller has already folded it into a header
+// or the query string. Reading it back is what lets the shared path cover
+// every family, including the custom and self-hosted gateways whose key
+// format no prefix regex anticipates; the vendor paths that each fixed this
+// for themselves had left this shared one uncovered (Strix vuln-0005,
+// 2026-09-01, the fourth site of the #836 class).
 //
-// Both the raw header value and its bearer-stripped form are listed, since an
-// upstream may quote either. Short values fall out inside MaskCredentials.
-func requestSecrets(req *http.Request) []string {
-	if req == nil {
-		return nil
-	}
+// A header value is listed raw and, for a bearer, stripped, since an upstream
+// may quote either. A query value is listed decoded, percent-escaped, and as
+// its raw "name=value" segment, because a url.Error quotes the URL exactly as
+// it was sent while Query() hands back the decoded form. Short values fall
+// out inside the mask.
+func secretsOf(h http.Header, u *url.URL) []string {
 	var secrets []string
-	for _, name := range []string{"Authorization", "X-Api-Key", "Api-Key"} {
-		for _, v := range req.Header.Values(name) {
+	for _, name := range credentialHeaders {
+		for _, v := range h.Values(name) {
 			secrets = append(secrets, v)
-			if stripped := strings.TrimSpace(strings.TrimPrefix(v, "Bearer ")); stripped != v {
-				secrets = append(secrets, stripped)
+			if f := strings.Fields(v); len(f) == 2 && strings.EqualFold(f[0], "bearer") {
+				secrets = append(secrets, f[1])
 			}
 		}
 	}
-	if req.URL != nil {
-		for _, vs := range req.URL.Query() {
-			secrets = append(secrets, vs...)
+	if u == nil {
+		return secrets
+	}
+	for _, seg := range strings.Split(u.RawQuery, "&") {
+		name, raw, ok := strings.Cut(seg, "=")
+		if !ok || !credentialQueryParams[strings.ToLower(name)] {
+			continue
+		}
+		secrets = append(secrets, seg, raw)
+		if dec, err := url.QueryUnescape(raw); err == nil && dec != raw {
+			secrets = append(secrets, dec, url.QueryEscape(dec))
 		}
 	}
 	return secrets
 }
 
+// requestSecrets is secretsOf for a built request.
+func requestSecrets(req *http.Request) []string {
+	if req == nil {
+		return nil
+	}
+	return secretsOf(req.Header, req.URL)
+}
+
 // maskRequestSecrets scrubs text of everything req carried, then of anything
-// key-shaped. Used for every upstream body or transport error the shared
-// helpers turn into an error or a log line.
+// key-shaped, then bounds it: in that order, so a key straddling the cut is
+// still redacted whole. Used for every upstream body or transport error the
+// shared helpers turn into an error or a log line.
 func maskRequestSecrets(req *http.Request, text string, maxLen int) string {
-	return util.MaskCredentials(requestSecrets(req), util.SanitizeLogBody(text, maxLen))
+	return util.MaskCredentialsBounded(requestSecrets(req), text, maxLen)
 }
 
 // doDiscoveryRequest executes a discovery HTTP request with retries for
@@ -165,20 +197,28 @@ func (d *DiscoveryService) doDiscoveryRequest(ctx context.Context, newReq func()
 	return nil, fmt.Errorf("discovery fetch failed after %d attempts: %w", maxDiscoveryRetries, lastErr)
 }
 
-// maskedRequestError returns err with everything req carried scrubbed out of
-// its text. When nothing needed scrubbing the original error is returned as
-// is, so a caller's errors.Is / errors.As on a transport error (a cancelled
-// context, a timeout) keeps working; only an error that would have leaked is
-// flattened to its masked text.
+// maskedError is a transport error whose text has been scrubbed of what the
+// request carried, with the original still reachable through Unwrap. So
+// errors.Is on a cancelled context or a deadline, and errors.As on a net.Error,
+// keep working for every caller, while nothing that prints the error (%v, %s,
+// slog, a stored column) can reach the unscrubbed text: those all go through
+// Error(). The masked text is computed once, at construction.
+type maskedError struct {
+	text  string
+	cause error
+}
+
+func (e *maskedError) Error() string { return e.text }
+func (e *maskedError) Unwrap() error { return e.cause }
+
+// maskedRequestError wraps err so its text is scrubbed of everything req
+// carried (a url.Error quotes the request URL, and one family authenticates
+// by query parameter) and of anything key-shaped, bounded to 500 runes.
 func maskedRequestError(req *http.Request, err error) error {
 	if err == nil {
 		return nil
 	}
-	masked := maskRequestSecrets(req, err.Error(), 500)
-	if masked == err.Error() {
-		return err
-	}
-	return errors.New(masked)
+	return &maskedError{text: maskRequestSecrets(req, err.Error(), 500), cause: err}
 }
 
 // doDiscoveryRequestPrebuilt retries a prebuilt body-less request (GETs).
@@ -192,13 +232,12 @@ func (d *DiscoveryService) doDiscoveryRequestPrebuilt(ctx context.Context, req *
 // response body, and checks for a 200 OK status. Returns the response body
 // bytes on success. The caller is responsible for unmarshaling the result.
 // Transient network errors and 429/5xx are retried via doDiscoveryRequest.
-func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, headers http.Header) ([]byte, error) {
-	//nolint:gocritic // url variable shadows import but context makes it clear
+func (d *DiscoveryService) fetchURL(ctx context.Context, method, rawURL string, headers http.Header) ([]byte, error) {
 	// The last request built is kept for the scrub below: the credential is in
 	// its headers or URL, and this function never sees it any other way.
 	var last *http.Request
 	resp, err := d.doDiscoveryRequest(ctx, func() (*http.Request, error) {
-		req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
+		req, err := http.NewRequestWithContext(ctx, method, rawURL, http.NoBody)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
@@ -211,6 +250,16 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, hea
 		return req, nil
 	})
 	if err != nil {
+		// A request that never got built (a URL that fails to parse) reaches
+		// here with last == nil, and its error quotes the URL. Scrub from the
+		// inputs this function was handed instead of from a request.
+		if last == nil {
+			if u, perr := url.Parse(rawURL); perr == nil {
+				err = &maskedError{text: util.MaskCredentialsBounded(secretsOf(headers, u), err.Error(), 500), cause: err}
+			} else {
+				err = &maskedError{text: util.MaskCredentialsBounded(secretsOf(headers, nil), err.Error(), 500), cause: err}
+			}
+		}
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -596,20 +645,23 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
+			// Same scrub as doDiscoveryRequest, for the same reason, and with a
+			// worse sink: this error is persisted as the provider's quota
+			// failure and rendered on the dashboard, not only logged.
 			if isTransientNetworkError(err) {
-				lastErr = err
+				lastErr = maskedRequestError(req, err)
 				continue
 			}
 			if opened := circuit.recordFailure(); opened {
 				debuglog.Warn("discovery: circuit breaker opened for quota fetch", "type", providerType, "provider", providerName, "provider_id", providerID, "threshold", quotaBreakerThreshold)
 			}
-			return nil, err
+			return nil, maskedRequestError(req, err)
 		}
 		// Retry on 429 (rate-limited) and 5xx (server error) responses.
 		if isRetryableStatus(resp.StatusCode) {
 			body, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			lastErr = fmt.Errorf("retryable HTTP %d: %s", resp.StatusCode, util.SanitizeLogBody(string(body), 200))
+			lastErr = fmt.Errorf("retryable HTTP %d: %s", resp.StatusCode, maskRequestSecrets(req, string(body), 200))
 			debuglog.Info("discovery: retryable HTTP status for quota fetch", "type", providerType, "provider", providerName, "provider_id", providerID, "status", resp.StatusCode, "attempt", attempt+1)
 			continue
 		}

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -71,6 +71,47 @@ func (d *DiscoveryService) SetRetryBaseDelay(dur time.Duration) {
 // maxDiscoveryRetries bounds attempts for a single discovery HTTP call.
 const maxDiscoveryRetries = 3
 
+// requestSecrets collects every credential a discovery request carries, so
+// text the upstream sends back (or a transport error that quotes the URL) can
+// be scrubbed of it exactly, before the shape layer. The helpers below never
+// receive the key as a value: the caller has already folded it into the
+// Authorization header, an API-key header, or the query string (one family
+// authenticates by ?key=). Reading it back off the request is what lets the
+// shared path cover every family, including the custom and self-hosted
+// gateways whose key format no prefix regex anticipates, and the vendor paths
+// that each fixed this for themselves left this shared one uncovered (Strix
+// vuln-0005, 2026-09-01, the fourth site of the #836 class).
+//
+// Both the raw header value and its bearer-stripped form are listed, since an
+// upstream may quote either. Short values fall out inside MaskCredentials.
+func requestSecrets(req *http.Request) []string {
+	if req == nil {
+		return nil
+	}
+	var secrets []string
+	for _, name := range []string{"Authorization", "X-Api-Key", "Api-Key"} {
+		for _, v := range req.Header.Values(name) {
+			secrets = append(secrets, v)
+			if stripped := strings.TrimSpace(strings.TrimPrefix(v, "Bearer ")); stripped != v {
+				secrets = append(secrets, stripped)
+			}
+		}
+	}
+	if req.URL != nil {
+		for _, vs := range req.URL.Query() {
+			secrets = append(secrets, vs...)
+		}
+	}
+	return secrets
+}
+
+// maskRequestSecrets scrubs text of everything req carried, then of anything
+// key-shaped. Used for every upstream body or transport error the shared
+// helpers turn into an error or a log line.
+func maskRequestSecrets(req *http.Request, text string, maxLen int) string {
+	return util.MaskCredentials(requestSecrets(req), util.SanitizeLogBody(text, maxLen))
+}
+
 // doDiscoveryRequest executes a discovery HTTP request with retries for
 // transient network errors (DNS flaps, timeouts, connection resets) and
 // retryable HTTP statuses (429, 5xx), so one network hiccup cannot turn into
@@ -99,21 +140,22 @@ func (d *DiscoveryService) doDiscoveryRequest(ctx context.Context, newReq func()
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
 			if isTransientNetworkError(err) {
-				lastErr = err
 				// A transport error quotes the request URL, and one provider
-				// family authenticates by query parameter, so this is scrubbed
-				// like any other upstream text. No decrypted key in scope here:
-				// the shape layer is the whole control at this site.
+				// family authenticates by query parameter, so the key IS in
+				// scope here: it is in the request that just failed. Masked
+				// exactly off that request, then by shape, before it reaches
+				// the log or the caller.
+				lastErr = maskedRequestError(req, err)
 				debuglog.Info("discovery: transient fetch error, will retry",
-					"host", req.URL.Host, "attempt", attempt+1, "error", util.SanitizeLogBody(err.Error(), 500))
+					"host", req.URL.Host, "attempt", attempt+1, "error", lastErr.Error())
 				continue
 			}
-			return nil, err
+			return nil, maskedRequestError(req, err)
 		}
 		if isRetryableStatus(resp.StatusCode) {
 			body, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
-			lastErr = fmt.Errorf("retryable HTTP status %d: %s", resp.StatusCode, util.SanitizeLogBody(string(body), 200))
+			lastErr = fmt.Errorf("retryable HTTP status %d: %s", resp.StatusCode, maskRequestSecrets(req, string(body), 200))
 			debuglog.Info("discovery: retryable fetch status, will retry",
 				"host", req.URL.Host, "status", resp.StatusCode, "attempt", attempt+1)
 			continue
@@ -121,6 +163,22 @@ func (d *DiscoveryService) doDiscoveryRequest(ctx context.Context, newReq func()
 		return resp, nil
 	}
 	return nil, fmt.Errorf("discovery fetch failed after %d attempts: %w", maxDiscoveryRetries, lastErr)
+}
+
+// maskedRequestError returns err with everything req carried scrubbed out of
+// its text. When nothing needed scrubbing the original error is returned as
+// is, so a caller's errors.Is / errors.As on a transport error (a cancelled
+// context, a timeout) keeps working; only an error that would have leaked is
+// flattened to its masked text.
+func maskedRequestError(req *http.Request, err error) error {
+	if err == nil {
+		return nil
+	}
+	masked := maskRequestSecrets(req, err.Error(), 500)
+	if masked == err.Error() {
+		return err
+	}
+	return errors.New(masked)
 }
 
 // doDiscoveryRequestPrebuilt retries a prebuilt body-less request (GETs).
@@ -136,6 +194,9 @@ func (d *DiscoveryService) doDiscoveryRequestPrebuilt(ctx context.Context, req *
 // Transient network errors and 429/5xx are retried via doDiscoveryRequest.
 func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, headers http.Header) ([]byte, error) {
 	//nolint:gocritic // url variable shadows import but context makes it clear
+	// The last request built is kept for the scrub below: the credential is in
+	// its headers or URL, and this function never sees it any other way.
+	var last *http.Request
 	resp, err := d.doDiscoveryRequest(ctx, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, method, url, http.NoBody)
 		if err != nil {
@@ -146,6 +207,7 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, hea
 				req.Header.Add(k, v)
 			}
 		}
+		last = req
 		return req, nil
 	})
 	if err != nil {
@@ -159,7 +221,7 @@ func (d *DiscoveryService) fetchURL(ctx context.Context, method, url string, hea
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, util.SanitizeLogBody(string(bodyBytes), 2000))
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, maskRequestSecrets(last, string(bodyBytes), 2000))
 	}
 
 	return bodyBytes, nil

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -132,14 +133,16 @@ func querySecrets(rawQuery string) []string {
 		if dec, err := url.QueryUnescape(raw); err == nil && dec != raw {
 			secrets = append(secrets, dec, url.QueryEscape(dec))
 		}
-		// A key pasted with a stray newline or space is what makes the URL
-		// unparseable in the first place, and the parse error renders that
-		// byte escaped (%q prints "\n"), so the exact match on the raw value
-		// misses the visible key body. The trimmed value is what shows.
-		if trimmed := strings.TrimSpace(raw); trimmed != raw {
-			secrets = append(secrets, trimmed)
-			if dec, err := url.QueryUnescape(trimmed); err == nil && dec != trimmed {
-				secrets = append(secrets, dec)
+		// A key pasted with a stray control byte (a newline at the end, a
+		// wrap in the middle, a DEL) is what makes a URL unparseable in the
+		// first place, and url.Error renders the URL with %q, so that byte
+		// shows escaped and the exact match on the raw value misses the
+		// visible text. The %q rendering IS the visible text: list it. It
+		// covers any control byte anywhere in the value, which trimming the
+		// ends did not.
+		for _, v := range []string{seg, raw} {
+			if q := strconv.Quote(v); q[1:len(q)-1] != v {
+				secrets = append(secrets, q[1:len(q)-1])
 			}
 		}
 	}

--- a/internal/provider/discovery_anthropic.go
+++ b/internal/provider/discovery_anthropic.go
@@ -49,7 +49,7 @@ func (d *DiscoveryService) discoverAnthropic(ctx context.Context, provider *Prov
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			debuglog.Error("discovery: anthropic returned non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(bodyBytes), 2000))
+			debuglog.Error("discovery: anthropic returned non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
 			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 

--- a/internal/provider/discovery_anthropic.go
+++ b/internal/provider/discovery_anthropic.go
@@ -49,7 +49,7 @@ func (d *DiscoveryService) discoverAnthropic(ctx context.Context, provider *Prov
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			debuglog.Error("discovery: anthropic returned non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+			debuglog.Error("discovery: anthropic returned non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 

--- a/internal/provider/discovery_cohere.go
+++ b/internal/provider/discovery_cohere.go
@@ -78,8 +78,8 @@ func (d *DiscoveryService) fetchCohereModels(ctx context.Context, provider *Prov
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			debuglog.Error("discovery: cohere non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "endpoint", endpoint, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
-			return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+			debuglog.Error("discovery: cohere non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "endpoint", endpoint, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
+			return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 		}
 
 		var cohereResp CohereModelsResponse

--- a/internal/provider/discovery_credential_leak_test.go
+++ b/internal/provider/discovery_credential_leak_test.go
@@ -156,10 +156,12 @@ func assertNoKey(t *testing.T, err error) {
 // the exact pass exists for. The retryable branch bounds at 200, so a JSON
 // error body that quotes the key late is the realistic case.
 func TestFetchURL_RetryableBodyKeyAcrossTheCutIsRedactedWhole(t *testing.T) {
-	// 150 + the 22-byte JSON prefix + the 23-byte phrase puts the key's first
-	// byte at 195 and its last past 200: it straddles the retryable branch's
-	// cut instead of falling wholly before or after it.
-	pad := strings.Repeat("x", 150)
+	// 140 + the 22-byte JSON prefix + the 23-byte phrase puts the key's first
+	// byte at 185 and its last past 200: fifteen bytes of it sit before the
+	// retryable branch's cut, which the inverted order leaves behind (the
+	// second review found the first version of this test placed only six
+	// there, fewer than it asserted on, so it passed on the old code).
+	pad := strings.Repeat("x", 140)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"error":{"message":"` + pad + ` auth failed for token ` + leakedKey + `"}}`))
@@ -177,8 +179,21 @@ func TestFetchURL_RetryableBodyKeyAcrossTheCutIsRedactedWhole(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if strings.Contains(err.Error(), leakedKey[:10]) {
+	if strings.Contains(err.Error(), leakedKey[:5]) {
 		t.Errorf("a prefix of the key survived the cut: %s", err.Error())
+	}
+}
+
+// A URL that fails to parse never becomes a request, and the parse error
+// prints the raw URL whole. The fallback must still scrub the query.
+func TestFetchURL_UnparseableURLDoesNotCarryQueryKey(t *testing.T) {
+	svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, "http://example.invalid/v1beta/models?key="+leakedKey+"\n", http.Header{})
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	if strings.Contains(err.Error(), leakedKey) {
+		t.Errorf("the query key survived the unparseable-URL fallback: %s", err.Error())
 	}
 }
 
@@ -323,10 +338,12 @@ func TestRequestSecrets_CoversEveryCredentialHeader(t *testing.T) {
 	}
 }
 
-// The five quota readers that talk to a fixed vendor host log a non-200 body
-// at Error. They were shape-only too; a sweep for the pattern found them after
-// the vendor listing sites above. Same stub, same custom-format key, the same
-// captured log.
+// The four quota readers that talk to a fixed vendor host log a non-200 body
+// at Error (five sites: OpenRouter has a second, for its key-info call, which
+// this stub never reaches because the credits call fails first; it takes the
+// same one-line fix). They were shape-only too; a sweep for the pattern found
+// them after the vendor listing sites above. Same stub, same custom-format
+// key, the same captured log.
 func TestQuotaNon200Logs_DoNotCarryTheKey(t *testing.T) {
 	const masterKey = "test-master-key-for-testing-only-32bytes!"
 	kp, err := auth.Encrypt(leakedKey, masterKey)

--- a/internal/provider/discovery_credential_leak_test.go
+++ b/internal/provider/discovery_credential_leak_test.go
@@ -2,12 +2,16 @@ package provider
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
 // Discovery decrypts the provider credential to talk to the upstream, and an
@@ -75,5 +79,72 @@ func assertScrubbed(t *testing.T, msg string) {
 	}
 	if !strings.Contains(msg, "[redacted]") {
 		t.Errorf("no redaction marker, so the body was not scrubbed at all: %q", msg)
+	}
+}
+
+// The shared helpers behind every provider family that lists models over a
+// plain OpenAI-shaped endpoint. The vendor-specific paths above each learned
+// to run MaskCredential over what the upstream said back; fetchURL and
+// doDiscoveryRequest, which the openai/custom/azure/deepseek/... families all
+// go through, still scrubbed with the shape layer only. A self-hosted gateway
+// (provider type custom or openai, the arbitrary-endpoint fallback) whose error
+// body quotes the bearer back therefore put the decrypted key into the returned
+// error, and from there into app_logs, stdout and the discovery SSE event.
+// Strix vuln-0005 (2026-09-01), the fourth site of the #836 class.
+func TestDiscoverOpenAI_Non200DoesNotCarryTheKey(t *testing.T) {
+	srv := httptest.NewServer(echoKeyHandler(http.StatusUnauthorized))
+	defer srv.Close()
+	svc := &DiscoveryService{httpClient: srv.Client()}
+
+	_, err := svc.discoverOpenAI(context.Background(), &Provider{ID: uuid.New(), BaseURL: srv.URL}, leakedKey)
+
+	assertNoKey(t, err)
+}
+
+// A retryable status (429/5xx) is read into lastErr on every attempt and the
+// final error wraps it, so the key rode out through a different string than the
+// non-200 branch and needs its own assertion.
+func TestFetchURL_RetryableStatusDoesNotCarryTheKey(t *testing.T) {
+	srv := httptest.NewServer(echoKeyHandler(http.StatusServiceUnavailable))
+	defer srv.Close()
+	svc := &DiscoveryService{httpClient: srv.Client()} // zero retryBaseDelay: instant backoffs
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+leakedKey)
+
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, srv.URL+"/models", headers)
+
+	assertNoKey(t, err)
+}
+
+// A transport error quotes the request URL, and one provider family (Google)
+// authenticates by query parameter. The site logged that error at Info with the
+// shape layer alone and returned it verbatim when it was not transient, so a
+// custom-format key in ?key= reached the log line and the caller's error text.
+func TestDoDiscoveryRequest_TransportErrorDoesNotCarryQueryKey(t *testing.T) {
+	var logged strings.Builder
+	prev := slog.Default()
+	debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	defer slog.SetDefault(prev)
+
+	// 127.0.0.1:1 refuses immediately on every platform CI runs on.
+	svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, "http://127.0.0.1:1/v1beta/models?key="+leakedKey, http.Header{})
+
+	assertNoKey(t, err)
+	if strings.Contains(logged.String(), leakedKey) {
+		t.Errorf("the query-parameter key reached the discovery log:\n%s", logged.String())
+	}
+}
+
+func assertNoKey(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error from the upstream refusal")
+	}
+	if strings.Contains(err.Error(), leakedKey) {
+		t.Errorf("error carries the decrypted key: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Errorf("error should show the key was redacted, not silently dropped: %s", err.Error())
 	}
 }

--- a/internal/provider/discovery_credential_leak_test.go
+++ b/internal/provider/discovery_credential_leak_test.go
@@ -156,8 +156,8 @@ func assertNoKey(t *testing.T, err error) {
 // the exact pass exists for. The retryable branch bounds at 200, so a JSON
 // error body that quotes the key late is the realistic case.
 func TestFetchURL_RetryableBodyKeyAcrossTheCutIsRedactedWhole(t *testing.T) {
-	// 140 + the 22-byte JSON prefix + the 23-byte phrase puts the key's first
-	// byte at 185 and its last past 200: fifteen bytes of it sit before the
+	// 140 + the 21-byte JSON prefix + the 23-byte phrase puts the key's first
+	// byte at 184 and its last past 200: sixteen bytes of it sit before the
 	// retryable branch's cut, which the inverted order leaves behind (the
 	// second review found the first version of this test placed only six
 	// there, fewer than it asserted on, so it passed on the old code).
@@ -187,13 +187,25 @@ func TestFetchURL_RetryableBodyKeyAcrossTheCutIsRedactedWhole(t *testing.T) {
 // A URL that fails to parse never becomes a request, and the parse error
 // prints the raw URL whole. The fallback must still scrub the query.
 func TestFetchURL_UnparseableURLDoesNotCarryQueryKey(t *testing.T) {
-	svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
-	_, err := svc.fetchURL(context.Background(), http.MethodGet, "http://example.invalid/v1beta/models?key="+leakedKey+"\n", http.Header{})
-	if err == nil {
-		t.Fatal("expected a parse error")
-	}
-	if strings.Contains(err.Error(), leakedKey) {
-		t.Errorf("the query key survived the unparseable-URL fallback: %s", err.Error())
+	// Three ways a pasted key breaks the URL: a trailing newline, a trailing
+	// DEL (which no whitespace trim touches), and a wrap in the middle of the
+	// key (the realistic one for a long key). The visible text is the %q
+	// rendering, so the assertion is on the readable halves, not the raw key.
+	for name, key := range map[string]string{
+		"trailing newline": leakedKey + "\n",
+		"trailing DEL":     leakedKey + "\x7f",
+		"wrapped":          leakedKey[:12] + "\n" + leakedKey[12:],
+	} {
+		t.Run(name, func(t *testing.T) {
+			svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+			_, err := svc.fetchURL(context.Background(), http.MethodGet, "http://example.invalid/v1beta/models?key="+key, http.Header{})
+			if err == nil {
+				t.Fatal("expected a parse error")
+			}
+			if strings.Contains(err.Error(), leakedKey[:12]) || strings.Contains(err.Error(), leakedKey[12:]) {
+				t.Errorf("a readable part of the key survived the unparseable-URL fallback: %s", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/provider/discovery_credential_leak_test.go
+++ b/internal/provider/discovery_credential_leak_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
@@ -146,5 +148,237 @@ func assertNoKey(t *testing.T, err error) {
 	}
 	if !strings.Contains(err.Error(), "[redacted]") {
 		t.Errorf("error should show the key was redacted, not silently dropped: %s", err.Error())
+	}
+}
+
+// The review of the first cut found that masking AFTER SanitizeLogBody's cut
+// left the head of a key that straddled it, for exactly the custom-format keys
+// the exact pass exists for. The retryable branch bounds at 200, so a JSON
+// error body that quotes the key late is the realistic case.
+func TestFetchURL_RetryableBodyKeyAcrossTheCutIsRedactedWhole(t *testing.T) {
+	// 150 + the 22-byte JSON prefix + the 23-byte phrase puts the key's first
+	// byte at 195 and its last past 200: it straddles the retryable branch's
+	// cut instead of falling wholly before or after it.
+	pad := strings.Repeat("x", 150)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"` + pad + ` auth failed for token ` + leakedKey + `"}}`))
+	}))
+	defer srv.Close()
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+leakedKey)
+
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, srv.URL+"/models", headers)
+
+	// Not assertNoKey: the "[redacted]" marker can itself sit across the cut,
+	// so its presence is not the property. The property is that no run of the
+	// key survives, head included.
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), leakedKey[:10]) {
+		t.Errorf("a prefix of the key survived the cut: %s", err.Error())
+	}
+}
+
+// A url.Error quotes the URL as sent, so a query key with characters that
+// Query() decodes ('+' to a space, %2F to '/') must be matched in its raw
+// rendering too.
+func TestDoDiscoveryRequest_TransportErrorDoesNotCarryRawQueryKey(t *testing.T) {
+	const rawKey = "selfhosted+gateway%2Fsecret-abcdefghij"
+	svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, "http://127.0.0.1:1/v1beta/models?key="+rawKey, http.Header{})
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if strings.Contains(err.Error(), rawKey) || strings.Contains(err.Error(), "selfhosted+gateway") {
+		t.Errorf("the raw query rendering of the key leaked: %s", err.Error())
+	}
+}
+
+// Only credential-bearing query parameters are secrets. Azure lists deployments
+// with ?api-version=..., and redacting that out of a "version not supported"
+// body would destroy the one diagnostic the operator needs.
+func TestFetchURL_NonCredentialQueryValueIsNotRedacted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"api-version 2023-03-15-preview is not supported"}`))
+	}))
+	defer srv.Close()
+	svc := &DiscoveryService{httpClient: srv.Client()}
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+leakedKey)
+
+	_, err := svc.fetchURL(context.Background(), http.MethodGet, srv.URL+"/deployments?api-version=2023-03-15-preview", headers)
+	if err == nil || !strings.Contains(err.Error(), "2023-03-15-preview") {
+		t.Errorf("a non-credential query value must survive in the diagnostic, got %v", err)
+	}
+}
+
+// The masked transport error keeps its cause reachable, so callers can still
+// tell a cancelled context or a timeout apart from a refusal, even when the
+// text was rewritten (a UUID in the path is enough to rewrite it).
+func TestMaskedRequestError_KeepsTheCauseForErrorsIs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+	_, err := svc.fetchURL(ctx, http.MethodGet, "http://127.0.0.1:1/orgs/793ac38b-0211-43e6-baa7-aa7054c39931/v1/models?key="+leakedKey, http.Header{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(context.Canceled) must survive the mask, got %v", err)
+	}
+	if strings.Contains(err.Error(), leakedKey) || strings.Contains(err.Error(), "793ac38b-0211-43e6-baa7-aa7054c39931") {
+		t.Errorf("masked text must carry neither the key nor the UUID: %s", err.Error())
+	}
+}
+
+// The quota helper is the same pre-fix code as doDiscoveryRequest with a worse
+// sink: its error is persisted as the provider's quota failure and rendered on
+// the dashboard. Both of its sites.
+func TestDoQuotaRequestWithRetry_DoesNotCarryTheKey(t *testing.T) {
+	t.Run("retryable body", func(t *testing.T) {
+		srv := httptest.NewServer(echoKeyHandler(http.StatusServiceUnavailable))
+		defer srv.Close()
+		svc := &DiscoveryService{httpClient: srv.Client()}
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/quota", http.NoBody)
+		req.Header.Set("Authorization", "Bearer "+leakedKey)
+
+		_, err := svc.doQuotaRequestWithRetry(context.Background(), req, uuid.NewString(), "prov", "openrouter")
+
+		assertNoKey(t, err)
+	})
+	t.Run("transport error quoting a query key", func(t *testing.T) {
+		svc := &DiscoveryService{httpClient: &http.Client{Timeout: 2 * time.Second}}
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:1/v1beta/quota?key="+leakedKey, http.NoBody)
+
+		_, err := svc.doQuotaRequestWithRetry(context.Background(), req, uuid.NewString(), "prov", "google")
+
+		assertNoKey(t, err)
+	})
+}
+
+// Three vendor non-200 log sites were still shape-only. Each logs the body at
+// Error; the swapped handler captures what would have reached app_logs.
+func TestVendorNon200Logs_DoNotCarryTheKey(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(svc *DiscoveryService, base string) error
+	}{
+		{"anthropic", func(svc *DiscoveryService, base string) error {
+			_, err := svc.discoverAnthropic(context.Background(), &Provider{ID: uuid.New(), Name: "a", BaseURL: base}, leakedKey)
+			return err
+		}},
+		{"opencode-go", func(svc *DiscoveryService, base string) error {
+			_, err := svc.discoverOpenCodeGo(context.Background(), &Provider{ID: uuid.New(), Name: "o", BaseURL: base}, leakedKey)
+			return err
+		}},
+		{"xai", func(svc *DiscoveryService, base string) error {
+			_, err := svc.discoverXAI(context.Background(), &Provider{ID: uuid.New(), Name: "x", BaseURL: base}, leakedKey)
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logged strings.Builder
+			prev := slog.Default()
+			debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			defer slog.SetDefault(prev)
+			srv := httptest.NewServer(echoKeyHandler(http.StatusUnauthorized))
+			defer srv.Close()
+			svc := &DiscoveryService{httpClient: srv.Client()}
+
+			err := tc.run(svc, srv.URL)
+
+			if err == nil {
+				t.Fatal("expected the 401 to surface as an error")
+			}
+			if strings.Contains(logged.String(), leakedKey) || strings.Contains(err.Error(), leakedKey) {
+				t.Errorf("key reached the log or the error:\nlog: %s\nerr: %v", logged.String(), err)
+			}
+		})
+	}
+}
+
+// Every header a discovery family folds its key into must be in
+// credentialHeaders, or a refactor of that family onto the shared helpers would
+// silently un-cover it. The list here is the one the discoverers use today;
+// add to both when a family authenticates through a new header.
+func TestRequestSecrets_CoversEveryCredentialHeader(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "bearer  "+leakedKey) // lowercase and a double space still strip
+	h.Set("X-Api-Key", "anthropic-"+leakedKey)
+	h.Set("Api-Key", "azure-"+leakedKey)
+	h.Set("X-Goog-Api-Key", "vertex-"+leakedKey)
+	got := strings.Join(secretsOf(h, nil), "\n")
+	for _, want := range []string{leakedKey, "anthropic-" + leakedKey, "azure-" + leakedKey, "vertex-" + leakedKey} {
+		if !strings.Contains(got, want) {
+			t.Errorf("secretsOf missed %q; collected:\n%s", want, got)
+		}
+	}
+	if lines := strings.Split(got, "\n"); lines[0] != "bearer  "+leakedKey || lines[1] != leakedKey {
+		t.Errorf("a bearer must be listed raw first, then stripped, got %v", lines[:2])
+	}
+}
+
+// The five quota readers that talk to a fixed vendor host log a non-200 body
+// at Error. They were shape-only too; a sweep for the pattern found them after
+// the vendor listing sites above. Same stub, same custom-format key, the same
+// captured log.
+func TestQuotaNon200Logs_DoNotCarryTheKey(t *testing.T) {
+	const masterKey = "test-master-key-for-testing-only-32bytes!"
+	kp, err := auth.Encrypt(leakedKey, masterKey)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	cases := []struct {
+		name, baseURL string
+		run           func(svc *DiscoveryService, p *Provider) error
+	}{
+		{"kimi-code", "https://api.kimi.com/coding/v1", func(svc *DiscoveryService, p *Provider) error {
+			_, err := svc.GetKimiCodeQuota(context.Background(), p, masterKey)
+			return err
+		}},
+		{"zai-coding", "https://api.z.ai", func(svc *DiscoveryService, p *Provider) error {
+			_, err := svc.GetZAICodingQuota(context.Background(), p, masterKey)
+			return err
+		}},
+		{"openrouter", "https://openrouter.ai/api/v1", func(svc *DiscoveryService, p *Provider) error {
+			_, err := svc.GetOpenRouterBalance(context.Background(), p, masterKey)
+			return err
+		}},
+		{"neuralwatt", "https://api.neuralwatt.com/v1", func(svc *DiscoveryService, p *Provider) error {
+			_, err := svc.GetNeuralWattQuota(context.Background(), p, masterKey)
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logged strings.Builder
+			prev := slog.Default()
+			debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			defer slog.SetDefault(prev)
+			// A 400, not a 401: the readers route an auth refusal to their own
+			// (already masked) "quota rejected" site, and the non-200 site under
+			// test is what every other refusal reaches.
+			srv := httptest.NewServer(echoKeyHandler(http.StatusBadRequest))
+			defer srv.Close()
+			svc := &DiscoveryService{httpClient: &http.Client{Transport: &testTransport{url: srv.URL}}}
+			p := &Provider{ID: uuid.New(), Name: tc.name, BaseURL: tc.baseURL, EncryptedKey: kp.Ciphertext, KeyNonce: kp.Nonce, KeySalt: kp.Salt}
+
+			err := tc.run(svc, p)
+
+			if err == nil {
+				t.Fatal("expected the 400 to surface as an error")
+			}
+			if strings.Contains(logged.String(), leakedKey) || strings.Contains(err.Error(), leakedKey) {
+				t.Errorf("key reached the log or the error:\nlog: %s\nerr: %v", logged.String(), err)
+			}
+			if !strings.Contains(logged.String(), "non-200") {
+				t.Errorf("the non-200 log site was not reached, so this case proves nothing:\nerr: %v\nlog: %s", err, logged.String())
+			}
+		})
 	}
 }

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"slices"
 	"strings"
 
@@ -32,7 +33,7 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	// x-goog-api-key header (which vertex-express already uses) would remove
 	// the class rather than mask it, and is worth doing separately, where the
 	// change can be exercised against the live API.
-	url := fmt.Sprintf("%s/models?key=%s", nativeBaseURL, apiKey)
+	url := fmt.Sprintf("%s/models?key=%s", nativeBaseURL, neturl.QueryEscape(apiKey))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
@@ -56,7 +57,7 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: google non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+		debuglog.Error("discovery: google non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 		return nil, fmt.Errorf("google: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_kimi.go
+++ b/internal/provider/discovery_kimi.go
@@ -141,7 +141,7 @@ func (d *DiscoveryService) GetKimiCodeQuota(ctx context.Context, provider *Provi
 		if authErr := quotaAuthError("kimi-code", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: kimi-code quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: kimi-code quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("kimi-code: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_kimi.go
+++ b/internal/provider/discovery_kimi.go
@@ -141,7 +141,7 @@ func (d *DiscoveryService) GetKimiCodeQuota(ctx context.Context, provider *Provi
 		if authErr := quotaAuthError("kimi-code", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: kimi-code quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.SanitizeLogBody(string(body), 2000))
+		debuglog.Error("discovery: kimi-code quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
 		return nil, fmt.Errorf("kimi-code: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_koboldcpp.go
+++ b/internal/provider/discovery_koboldcpp.go
@@ -170,7 +170,7 @@ func (d *DiscoveryService) koboldcppLoadedModel(ctx context.Context, baseURL, ap
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("status %d: %s", resp.StatusCode, util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, util.MaskCredentialBounded(apiKey, string(body), 2000))
 	}
 
 	var modelsResp KoboldCPPModelsResponse

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -82,7 +82,7 @@ func (d *DiscoveryService) discoverLMStudioNative(ctx context.Context, provider 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("lmstudio: native endpoint status %d for provider %s: %s", resp.StatusCode, provider.Name, util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		return nil, fmt.Errorf("lmstudio: native endpoint status %d for provider %s: %s", resp.StatusCode, provider.Name, util.MaskCredentialBounded(apiKey, string(body), 2000))
 	}
 
 	var modelsResp LMStudioV0ModelsResponse
@@ -184,7 +184,7 @@ func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("lmstudio: unexpected status %d for provider %s: %s", resp.StatusCode, provider.Name, util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		return nil, fmt.Errorf("lmstudio: unexpected status %d for provider %s: %s", resp.StatusCode, provider.Name, util.MaskCredentialBounded(apiKey, string(body), 2000))
 	}
 
 	var modelsResp LMStudioModelsResponse

--- a/internal/provider/discovery_neuralwatt.go
+++ b/internal/provider/discovery_neuralwatt.go
@@ -47,7 +47,7 @@ func (d *DiscoveryService) GetNeuralWattQuota(ctx context.Context, provider *Pro
 		if authErr := quotaAuthError("neuralwatt", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: neuralwatt quota non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(body), 2000))
+		debuglog.Error("discovery: neuralwatt quota non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
 		return nil, fmt.Errorf("neuralwatt: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_neuralwatt.go
+++ b/internal/provider/discovery_neuralwatt.go
@@ -47,7 +47,7 @@ func (d *DiscoveryService) GetNeuralWattQuota(ctx context.Context, provider *Pro
 		if authErr := quotaAuthError("neuralwatt", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: neuralwatt quota non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: neuralwatt quota non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("neuralwatt: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_ollama.go
+++ b/internal/provider/discovery_ollama.go
@@ -37,7 +37,7 @@ func (d *DiscoveryService) discoverOllama(ctx context.Context, provider *Provide
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		debuglog.Error("discovery: ollama unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: ollama unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("ollama: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 
@@ -141,7 +141,7 @@ func (d *DiscoveryService) ollamaShowModel(ctx context.Context, apiBase, apiKey,
 		// Sanitized like every sibling discovery path: an upstream that quotes
 		// the operator's key back in an auth failure would otherwise put it in
 		// app_logs verbatim, and from there into the OTLP export.
-		debuglog.Error("discovery: ollama show model failed with status", "model", modelName, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(respBody), 2000)))
+		debuglog.Error("discovery: ollama show model failed with status", "model", modelName, "status", resp.StatusCode, "body", util.MaskCredentialBounded(apiKey, string(respBody), 2000))
 		return nil, fmt.Errorf("show failed for %s: status %d", modelName, resp.StatusCode)
 	}
 
@@ -258,7 +258,7 @@ func (d *DiscoveryService) GetOllamaCloudAccount(ctx context.Context, provider *
 		if authErr := quotaAuthError("ollama-cloud", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: ollama cloud account non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: ollama cloud account non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("ollama-cloud: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_opencode_go.go
+++ b/internal/provider/discovery_opencode_go.go
@@ -49,7 +49,7 @@ func (d *DiscoveryService) discoverOpenCodeGo(ctx context.Context, provider *Pro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: opencode-go unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+		debuglog.Error("discovery: opencode-go unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 		return nil, fmt.Errorf("opencode-go: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_opencode_go.go
+++ b/internal/provider/discovery_opencode_go.go
@@ -49,7 +49,7 @@ func (d *DiscoveryService) discoverOpenCodeGo(ctx context.Context, provider *Pro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: opencode-go unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.SanitizeLogBody(string(bodyBytes), 2000))
+		debuglog.Error("discovery: opencode-go unexpected status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
 		return nil, fmt.Errorf("opencode-go: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_openrouter.go
+++ b/internal/provider/discovery_openrouter.go
@@ -176,7 +176,7 @@ func (d *DiscoveryService) GetOpenRouterBalance(ctx context.Context, provider *P
 		if authErr := quotaAuthError("openrouter", apiKey, provider, creditsResp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: openrouter credits non-200 status", "status", creditsResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: openrouter credits non-200 status", "status", creditsResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("openrouter: unexpected status code %d from credits endpoint for provider %s", creditsResp.StatusCode, provider.Name)
 	}
 
@@ -205,7 +205,7 @@ func (d *DiscoveryService) GetOpenRouterBalance(ctx context.Context, provider *P
 		if authErr := quotaAuthError("openrouter", apiKey, provider, keyResp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: openrouter key info non-200 status", "status", keyResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: openrouter key info non-200 status", "status", keyResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("openrouter: unexpected status code %d from key endpoint for provider %s", keyResp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_openrouter.go
+++ b/internal/provider/discovery_openrouter.go
@@ -176,7 +176,7 @@ func (d *DiscoveryService) GetOpenRouterBalance(ctx context.Context, provider *P
 		if authErr := quotaAuthError("openrouter", apiKey, provider, creditsResp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: openrouter credits non-200 status", "status", creditsResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(body), 2000))
+		debuglog.Error("discovery: openrouter credits non-200 status", "status", creditsResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
 		return nil, fmt.Errorf("openrouter: unexpected status code %d from credits endpoint for provider %s", creditsResp.StatusCode, provider.Name)
 	}
 
@@ -205,7 +205,7 @@ func (d *DiscoveryService) GetOpenRouterBalance(ctx context.Context, provider *P
 		if authErr := quotaAuthError("openrouter", apiKey, provider, keyResp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: openrouter key info non-200 status", "status", keyResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(body), 2000))
+		debuglog.Error("discovery: openrouter key info non-200 status", "status", keyResp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
 		return nil, fmt.Errorf("openrouter: unexpected status code %d from key endpoint for provider %s", keyResp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_quota.go
+++ b/internal/provider/discovery_quota.go
@@ -31,7 +31,7 @@ func quotaAuthError(label, apiKey string, p *Provider, status int, body []byte) 
 	}
 	debuglog.Warn("discovery: "+label+" quota rejected: provider key invalid or inactive",
 		"status", status, "provider", p.Name, "provider_id", p.ID,
-		"body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		"body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 	return fmt.Errorf("%s: %w for provider %s (status %d)", label, ErrProviderKeyInvalid, p.Name, status)
 }
 
@@ -67,7 +67,7 @@ func (d *DiscoveryService) fetchQuotaJSON(ctx context.Context, provider *Provide
 		if authErr := quotaAuthError(label, apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return authErr
 		}
-		debuglog.Error("discovery: "+label+" "+resource+" non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: "+label+" "+resource+" non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return fmt.Errorf("%s: unexpected status code %d for provider %s", label, resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_vertex.go
+++ b/internal/provider/discovery_vertex.go
@@ -87,7 +87,10 @@ func (d *DiscoveryService) vertexCountTokensProbe(ctx context.Context, baseURL, 
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		return 0, err
+		// Off the shared helpers, so scrubbed here: the key is header-only
+		// today, but a transport error quotes the URL and this is the one
+		// probe whose URL a future change could carry it in.
+		return 0, maskedRequestError(req, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/provider/discovery_xai.go
+++ b/internal/provider/discovery_xai.go
@@ -118,7 +118,7 @@ func (d *DiscoveryService) discoverXAILanguageModels(ctx context.Context, provid
 		return nil, &httpError{StatusCode: resp.StatusCode}
 	}
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: xai language-models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+		debuglog.Error("discovery: xai language-models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 		return nil, fmt.Errorf("xAI: unexpected status %d for provider %s", resp.StatusCode, provider.Name)
 	}
 
@@ -279,7 +279,7 @@ func (d *DiscoveryService) discoverXAIMinimalModels(ctx context.Context, provide
 		return nil, &httpError{StatusCode: resp.StatusCode}
 	}
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: xai minimal models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
+		debuglog.Error("discovery: xai minimal models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
 		return nil, fmt.Errorf("xAI: unexpected status %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_xai.go
+++ b/internal/provider/discovery_xai.go
@@ -118,7 +118,7 @@ func (d *DiscoveryService) discoverXAILanguageModels(ctx context.Context, provid
 		return nil, &httpError{StatusCode: resp.StatusCode}
 	}
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: xai language-models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(bodyBytes), 2000))
+		debuglog.Error("discovery: xai language-models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
 		return nil, fmt.Errorf("xAI: unexpected status %d for provider %s", resp.StatusCode, provider.Name)
 	}
 
@@ -279,7 +279,7 @@ func (d *DiscoveryService) discoverXAIMinimalModels(ctx context.Context, provide
 		return nil, &httpError{StatusCode: resp.StatusCode}
 	}
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: xai minimal models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.SanitizeLogBody(string(bodyBytes), 2000))
+		debuglog.Error("discovery: xai minimal models non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(bodyBytes), 2000)))
 		return nil, fmt.Errorf("xAI: unexpected status %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_zai.go
+++ b/internal/provider/discovery_zai.go
@@ -177,7 +177,7 @@ func (d *DiscoveryService) GetZAICodingQuota(ctx context.Context, provider *Prov
 		if authErr := quotaAuthError("zai-coding", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: zai-coding quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
+		debuglog.Error("discovery: zai-coding quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredentialBounded(apiKey, string(body), 2000))
 		return nil, fmt.Errorf("zai-coding: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_zai.go
+++ b/internal/provider/discovery_zai.go
@@ -177,7 +177,7 @@ func (d *DiscoveryService) GetZAICodingQuota(ctx context.Context, provider *Prov
 		if authErr := quotaAuthError("zai-coding", apiKey, provider, resp.StatusCode, body); authErr != nil {
 			return nil, authErr
 		}
-		debuglog.Error("discovery: zai-coding quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.SanitizeLogBody(string(body), 2000))
+		debuglog.Error("discovery: zai-coding quota fetch non-200 status", "provider", provider.Name, "provider_id", provider.ID, "status", resp.StatusCode, "body", util.MaskCredential(apiKey, util.SanitizeLogBody(string(body), 2000)))
 		return nil, fmt.Errorf("zai-coding: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -134,15 +134,27 @@ func MaskCredentialsBounded(secrets []string, body string, maxLen int) string {
 	if strings.HasSuffix(out, "…") {
 		out, suffix = strings.TrimSuffix(out, "…"), "…"
 	}
+	// The longest matching head across ALL secrets, stripped once. Taking the
+	// first secret that matches and stopping would let a second secret's head
+	// survive whenever an earlier secret's prefix is a suffix of it.
+	longest := 0
 	for _, secret := range secrets {
 		if len(secret) < CredentialMinLen {
 			continue
 		}
-		for k := min(len(secret)-1, len(out)); k >= CredentialMinLen; k-- {
+		for k := min(len(secret)-1, len(out)); k > longest && k >= CredentialMinLen; k-- {
 			if strings.HasSuffix(out, secret[:k]) {
-				out = out[:len(out)-k] + "[redacted]"
+				longest = k
 				break
 			}
+		}
+	}
+	if longest > 0 {
+		out = out[:len(out)-longest] + "[redacted]"
+		// "[redacted]" is ten bytes, so a head of eight or nine grew the text
+		// past the bound this function promises. Cut back and say so.
+		if len(out) > maxLen {
+			out, suffix = out[:maxLen], "…"
 		}
 	}
 	return out + suffix

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -122,7 +122,38 @@ func MaskCredentialsBounded(secrets []string, body string, maxLen int) string {
 	if len(body) > maxLen+scrubMargin {
 		body = body[:maxLen+scrubMargin]
 	}
-	return SanitizeLogBody(maskExact(secrets, body), maxLen)
+	out := SanitizeLogBody(maskExact(secrets, body), maxLen)
+	// The window cut above can leave the head of a secret at its very end, and
+	// masking SHRINKS the text ("[redacted]" is shorter than a key), so enough
+	// earlier occurrences pull that cut head down below maxLen where the final
+	// truncation no longer removes it. Nothing before this point can know how
+	// far the text moved, so the tail is checked last: a proper prefix of any
+	// listed secret, of credential length, is redacted too. Only the tail can
+	// hold one, since a whole occurrence anywhere was already replaced.
+	suffix := ""
+	if strings.HasSuffix(out, "…") {
+		out, suffix = strings.TrimSuffix(out, "…"), "…"
+	}
+	for _, secret := range secrets {
+		if len(secret) < CredentialMinLen {
+			continue
+		}
+		for k := min(len(secret)-1, len(out)); k >= CredentialMinLen; k-- {
+			if strings.HasSuffix(out, secret[:k]) {
+				out = out[:len(out)-k] + "[redacted]"
+				break
+			}
+		}
+	}
+	return out + suffix
+}
+
+// MaskCredentialBounded is MaskCredentialsBounded for a caller that holds one
+// key. It is the form every vendor path that logs or returns an upstream body
+// uses; MaskCredential over an already-sanitized body is the inverted order
+// and must not be written.
+func MaskCredentialBounded(secret, body string, maxLen int) string {
+	return MaskCredentialsBounded([]string{secret}, body, maxLen)
 }
 
 // maskExact replaces every listed secret of credential length. It runs the

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -96,8 +96,21 @@ func MaskKeyShapedTokens(body []byte) []byte {
 // they are talking to an upstream, and this is the function to run over
 // anything that upstream says back.
 func MaskCredential(secret, body string) string {
-	if len(secret) >= CredentialMinLen && strings.Contains(body, secret) {
-		body = strings.ReplaceAll(body, secret, "[redacted]")
+	return MaskCredentials([]string{secret}, body)
+}
+
+// MaskCredentials is MaskCredential for a caller that holds more than one
+// candidate secret, or none it can name: the exact pass runs for every entry,
+// then the shape layer runs once. It exists for the shared discovery helpers,
+// which never receive the key as a value, only inside the headers and URL of
+// the request they are about to send, and so mask with everything that request
+// carries (each bearer, each query value) rather than with one named key.
+// Entries shorter than CredentialMinLen are skipped for the reason given there.
+func MaskCredentials(secrets []string, body string) string {
+	for _, secret := range secrets {
+		if len(secret) >= CredentialMinLen && strings.Contains(body, secret) {
+			body = strings.ReplaceAll(body, secret, "[redacted]")
+		}
 	}
 	return string(MaskKeyShapedTokens([]byte(body)))
 }

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -107,10 +107,32 @@ func MaskCredential(secret, body string) string {
 // carries (each bearer, each query value) rather than with one named key.
 // Entries shorter than CredentialMinLen are skipped for the reason given there.
 func MaskCredentials(secrets []string, body string) string {
+	return string(MaskKeyShapedTokens([]byte(maskExact(secrets, body))))
+}
+
+// MaskCredentialsBounded is MaskCredentials followed by SanitizeLogBody, in the
+// one order that is safe: the exact pass runs BEFORE the truncation, over the
+// same maxLen+scrubMargin window SanitizeLogBody scans. Running it after (over
+// text already cut at maxLen) leaves the head of a key that straddles the cut,
+// and a custom-format key gets nothing from the shape pass behind it either.
+// This is the same rule SanitizeLogBody documents for its own shape pass; a
+// caller that has a body to bound and secrets to name uses this, not the two
+// in sequence.
+func MaskCredentialsBounded(secrets []string, body string, maxLen int) string {
+	if len(body) > maxLen+scrubMargin {
+		body = body[:maxLen+scrubMargin]
+	}
+	return SanitizeLogBody(maskExact(secrets, body), maxLen)
+}
+
+// maskExact replaces every listed secret of credential length. It runs the
+// list in order, so a caller that lists a superset ("Bearer X") before its
+// subset ("X") has the whole token consumed first.
+func maskExact(secrets []string, body string) string {
 	for _, secret := range secrets {
 		if len(secret) >= CredentialMinLen && strings.Contains(body, secret) {
 			body = strings.ReplaceAll(body, secret, "[redacted]")
 		}
 	}
-	return string(MaskKeyShapedTokens([]byte(body)))
+	return body
 }

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -247,3 +247,30 @@ func TestMaskCredentialBounded_IsTheSingleSecretForm(t *testing.T) {
 		t.Errorf("got %q", got)
 	}
 }
+
+// The tail strip must take the longest head across every listed secret. The
+// third review round broke the per-secret version with two secrets where the
+// first's prefix is a suffix of the second's cut head.
+func TestMaskCredentialsBounded_TailStripTakesTheLongestHeadAcrossSecrets(t *testing.T) {
+	a := "12345678abcdefghij"
+	b := "wxyzZZZZ12345678QQQQRRRRSS"
+	got := MaskCredentialsBounded([]string{a, b}, "oops wxyzZZZZ12345678", 100)
+	if got != "oops [redacted]" {
+		t.Errorf("got %q, want the whole head of the second secret stripped", got)
+	}
+}
+
+// A stripped head of eight or nine bytes is replaced by a ten-byte marker,
+// which would push the text past maxLen; the function stays bounded and marks
+// the cut.
+func TestMaskCredentialsBounded_StripStaysWithinMaxLen(t *testing.T) {
+	secret := "abcdefghijklmnop"
+	body := strings.Repeat("x", 192) + secret[:8] // 200 bytes, ends in an 8-byte head
+	got := MaskCredentialsBounded([]string{secret}, body, 200)
+	if strings.Contains(got, secret[:8]) {
+		t.Errorf("head survived: %q", got)
+	}
+	if n := len(strings.TrimSuffix(got, "…")); n > 200 {
+		t.Errorf("result is %d bytes, over maxLen 200", n)
+	}
+}

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -200,3 +200,21 @@ func TestMaskCredentials_NoSecretsStillRunsTheShapeLayer(t *testing.T) {
 		t.Errorf("shape layer must run even with no exact secrets: %s", got)
 	}
 }
+
+// A key that straddles the truncation boundary must still be redacted whole.
+// Truncating first leaves its head behind, which the shape pass cannot see for
+// a custom-format key; this is the order SanitizeLogBody itself documents.
+func TestMaskCredentialsBounded_KeyAcrossTheCutIsRedactedWhole(t *testing.T) {
+	const key = "selfhosted-gateway-secret-abcdefghij"
+	pad := strings.Repeat("x", 190) // the key starts 10 runes before a 200-rune cut
+	got := MaskCredentialsBounded([]string{key}, pad+key+" trailing", 200)
+	if strings.Contains(got, key[:12]) {
+		t.Errorf("a prefix of the key survived the cut: %s", got)
+	}
+	if !strings.Contains(got, "[redacted]") {
+		t.Errorf("want the key redacted, got %s", got)
+	}
+	if len(got) > 200+len("[redacted]")+3 {
+		t.Errorf("result must still be bounded near maxLen, got %d runes", len(got))
+	}
+}

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -179,3 +179,24 @@ func TestSanitizeLogBody_LeavesModelIdsIntact(t *testing.T) {
 		}
 	}
 }
+
+func TestMaskCredentials_EveryEntryIsRedacted(t *testing.T) {
+	body := `refused: bearer "gateway-secret-alpha-1234" and param "gateway-secret-beta-5678"; tiny "ab"`
+	got := MaskCredentials([]string{"gateway-secret-alpha-1234", "ab", "gateway-secret-beta-5678", ""}, body)
+	if strings.Contains(got, "gateway-secret-alpha-1234") || strings.Contains(got, "gateway-secret-beta-5678") {
+		t.Errorf("a listed secret survived: %s", got)
+	}
+	if strings.Count(got, "[redacted]") != 2 {
+		t.Errorf("want exactly the two real secrets redacted (the short and empty entries must be skipped), got %s", got)
+	}
+	if !strings.Contains(got, `tiny "ab"`) {
+		t.Errorf("an entry below CredentialMinLen must not be rewritten: %s", got)
+	}
+}
+
+func TestMaskCredentials_NoSecretsStillRunsTheShapeLayer(t *testing.T) {
+	got := MaskCredentials(nil, "Incorrect API key provided: sk-abcdefghijklmnop1234")
+	if strings.Contains(got, "sk-abcdefghijklmnop1234") {
+		t.Errorf("shape layer must run even with no exact secrets: %s", got)
+	}
+}

--- a/internal/util/credential_test.go
+++ b/internal/util/credential_test.go
@@ -218,3 +218,32 @@ func TestMaskCredentialsBounded_KeyAcrossTheCutIsRedactedWhole(t *testing.T) {
 		t.Errorf("result must still be bounded near maxLen, got %d runes", len(got))
 	}
 }
+
+// Masking shrinks the text, so many earlier copies of the key can pull a copy
+// that the window cut in half down below maxLen, where the final truncation
+// no longer removes its head. Found by the second review round with this
+// exact shape: maxLen 2000, a 51-byte key echoed 100 times, then a straddle.
+func TestMaskCredentialsBounded_ShrinkCannotDragACutHeadIntoView(t *testing.T) {
+	key := strings.Repeat("qwertyuiop", 5) + "Z" // 51 bytes, no digit: shapeless
+	body := strings.Repeat(key+" ", 100)
+	// Place one more copy so that it straddles the maxLen+scrubMargin window.
+	const maxLen = 2000
+	gap := maxLen + 4096 - len(body) - 20
+	if gap < 0 {
+		t.Fatalf("test geometry: body already past the window (%d)", len(body))
+	}
+	body += strings.Repeat("-", gap) + key + " tail"
+	got := MaskCredentialsBounded([]string{key}, body, maxLen)
+	for k := len(key) - 1; k >= CredentialMinLen; k-- {
+		if strings.Contains(got, key[:k]) {
+			t.Fatalf("a %d-byte head of the key survived: ...%s", k, got[max(0, len(got)-80):])
+		}
+	}
+}
+
+func TestMaskCredentialBounded_IsTheSingleSecretForm(t *testing.T) {
+	got := MaskCredentialBounded("selfhosted-gateway-secret", "refused selfhosted-gateway-secret now", 100)
+	if got != "refused [redacted] now" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
Closes Strix vuln-0005 (2026-09-01 run, MEDIUM, CWE-532): the shared discovery helpers put a provider's decrypted key into `app_logs`, container stdout and the discovery event whenever a self-hosted upstream quoted it back.

## The hole

After #836 every vendor-specific discovery path runs `util.MaskCredential` over what the upstream says back. The shared helpers they all sit on, `fetchURL` and `doDiscoveryRequest` (openai, custom, azure, deepseek, kimi, minimax, nanogpt, opencode, openrouter, zai, bedrock), were left with the shape layer alone. A self-hosted gateway of type `custom` or `openai`, the arbitrary-endpoint fallback, that answers `401 {"error":{"message":"Incorrect API key provided: <key>"}}` with a key of a format no prefix regex anticipates therefore leaked it three ways:

1. `fetchURL`'s non-200 body into the returned error.
2. The retryable-status (`429`/`5xx`) body into `lastErr`, which the final error wraps.
3. A transport error into an Info log line **and** the caller's error: a `url.Error` quotes the request URL, and one family authenticates by `?key=`. The old comment at that site said "no decrypted key in scope here". It was in the request that had just failed.

This is the fourth site of the #836 class: each vendor path fixed itself and the shared one stayed uncovered.

## The fix

The helpers never receive the key as a value, only inside the request they are about to send, so they now read it back off that request: every `Authorization` value (raw and bearer-stripped, case-insensitively), the API-key headers (`X-Api-Key`, `Api-Key`, `X-Goog-Api-Key`, pinned by a test), and the credential-bearing query parameters (`key`, `api_key`, `token`, ... listed raw, decoded and re-escaped, because a `url.Error` quotes the URL as sent). `util.MaskCredentialsBounded` bounds the text, masks exactly, then sanitises, in that order so a key straddling the cut is still redacted whole. Applied at every shared site in **both** helpers, listing and quota, so every family that goes through them, and any future one, is covered without touching a caller.

A masked transport error keeps its cause reachable through `Unwrap`, so `errors.Is` on a cancelled context or a timeout still works through the retry loop, while nothing that prints the error can reach the unscrubbed text.

## What the review round changed

An adversarial review of the first cut (fresh model, told to assume the author was careless) reproduced nine findings, two of them disqualifying. Everything below is fixed in the second commit:

- **The identical pre-fix code sat 400 lines lower** in `doQuotaRequestWithRetry`, nine callers, and a *worse* sink: its error is persisted as the provider's quota failure and shown on the dashboard. Same three sites, same scrub.
- **My helper sanitised before the exact pass**, so a key straddling the 200-rune cut of the retryable branch left its head behind, reintroducing a leak class the repo had already solved and documented in `SanitizeLogBody`. Fixed by ordering, with a straddle test.
- **Query secrets were collected URL-decoded** while `url.Error` quotes them raw (`+`, `%2F`); now listed in every rendering.
- **Every query value was treated as a secret**, which redacted Azure's `?api-version=...` out of the one diagnostic a refused version produces. Only credential-bearing names count now; a test keeps the version string in the error.
- **`maskedRequestError`'s comment promised `errors.Is` still worked and it did not** (a UUID in the path was enough to flatten a cancelled request). Now a proper error type with `Unwrap`.
- **Nine vendor log sites were still shape-only**, contradicting the first commit's own message: the anthropic, opencode-go and two xai listing sites (the fourth found by the test, not the review), plus the kimi, zai, openrouter (x2) and neuralwatt quota non-200 sites, found by a sweep for the pattern afterwards. Each now masks the body it logs, with tests through a captured log for all of them.
- `X-Goog-Api-Key` added to the header list; the `newReq()` failure path in `fetchURL` scrubbed too; `doc/logging.md` now states where discovery and quota scrubbing happen and in what order.

## What the second review round changed

A second reviewer, told to attack the first round's *fixes*, found that they carried the bug they were fixing:

- **The nine vendor sites I had masked used truncate-then-exact** (`MaskCredential` over an already-sanitized body), the very order the shared path had just abolished; reproduced leaking 30 bytes of a shapeless key across the 2000-rune cut. Twelve more pre-existing sites had the same shape, one of them the model-test endpoint whose string is *returned to the dashboard*. All 21 now use `util.MaskCredentialBounded`, and a grep for the inverted form finds nothing.
- **`MaskCredentialsBounded` itself still leaked**: masking shrinks the text, so enough earlier echoes of a key drag a window-cut copy's head below `maxLen`, where the final truncation no longer removes it. The tail is now checked last for a credential-length proper prefix of any listed secret; the reviewer's shape (a 51-byte key echoed 100 times) is a test.
- **My straddle test was vacuous** (six bytes of the key before the cut, asserting on ten); it now places fifteen and asserts on five, and fails on the old order.
- The unparseable-URL fallback never saw the query (it re-parsed the URL that had just failed to parse); the query is split off by hand, and a whitespace-trimmed rendering is listed because a stray newline is what makes such a URL unparseable and `%q` prints it escaped. Google's `?key=` is escaped; Vertex's probe scrubs its transport error.

## What the third review round changed

A third reviewer, scoped to the round-two fixes only, found three more: my whitespace-trim for the parse-error path covered exactly one shape (a trailing newline) while any control byte anywhere in a pasted key still showed its readable halves through `url.Error`'s `%q` rendering, so the `%q` rendering itself is now listed; the tail strip stopped after the first matching secret, so a second secret's head could survive when the first's prefix was a suffix of it, so it now takes the longest head across all secrets; and the strip could push the text past `maxLen` without an ellipsis. Each has a test that fails on the round-two code.

## Verification

**Live A/B on the dev stack**, same stub upstream (a container answering 401 and echoing the bearer), same `custom` provider, same custom-format key, discovery triggered by hand:

| | pre-fix build (master) | this branch |
|---|---|---|
| `app_logs` rows carrying the key | 2 | **0** |
| `app_logs` rows with `[redacted]` | 0 | **2** |
| container stdout lines with the key | 3 | **0** (3 redacted) |

**Tests**: three new ones in `discovery_credential_leak_test.go` pin each site with a key the shape layer cannot see (`selfhosted-gateway-secret`, no prefix, no digit); the transport case asserts the captured log output as well as the error. All three fail on master. `util.MaskCredentials` has its own tests (every entry redacted, short/empty entries skipped, shape layer still runs with no secrets). Full `internal/provider` and `internal/util` suites pass; golangci-lint 0 issues; size gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
