### PR TITLE
fix(proxy): recognise Z.ai code 1310 as a spent usage window

### DIFF
--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -177,7 +177,13 @@ var rateLimitPhrases = []rateLimitPhrase{
 	// prod while the quota advisor was already pinning the same circuit; the
 	// cost of missing it was an "unrecognised" cause on every surface, a
 	// class="unknown" metric and a dependence on that advisor.
-	{phrase: "limit exhausted", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
+	//
+	// "limit exhausted" alone would be the broadest phrase here, and it runs
+	// ahead of every saturated entry, so it also requires the body to name a
+	// reset: a spent window says when it comes back, a busy provider says
+	// "retry shortly", and "concurrency limit exhausted" must keep reaching
+	// the saturated entries below (a table case holds that line).
+	{phrase: "limit exhausted", also: "reset", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
 	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "session usage limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "usage limit", also: "upgrade", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud (\"you have reached your session usage limit, upgrade for higher limits\")", observed: "2026-08-31"},

--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -167,8 +167,17 @@ var rateLimitPhrases = []rateLimitPhrase{
 	{phrase: "exceeded your current quota", class: rateLimitExhausted, pinHint: pinHintUntilPaid, entitled: true, provider: "OpenAI", observed: "2026-08-31"},
 	{phrase: "billing hard limit", class: rateLimitExhausted, pinHint: pinHintUntilPaid, entitled: true, provider: "OpenAI", observed: "2026-08-31"},
 	{phrase: "credit balance is too low", class: rateLimitExhausted, pinHint: pinHintUntilPaid, entitled: true, provider: "Anthropic", observed: "2026-08-31"},
-	// Usage windows: time fixes these. The weekly entry must precede the
+	// Usage windows: time fixes these. The weekly entries must precede the
 	// session/generic ones so the longer pin is not shadowed.
+	//
+	// Z.ai's code 1310 names the reset to the second ("Your limit will reset
+	// at 2026-09-03 18:01:05"); the weekly pin, re-pinned toward that instant
+	// on each open by the advisor when the usage API agrees, is the safe
+	// reading of a body whose date format nothing here parses. Seen live on
+	// prod while the quota advisor was already pinning the same circuit; the
+	// cost of missing it was an "unrecognised" cause on every surface, a
+	// class="unknown" metric and a dependence on that advisor.
+	{phrase: "limit exhausted", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
 	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "session usage limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "usage limit", also: "upgrade", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud (\"you have reached your session usage limit, upgrade for higher limits\")", observed: "2026-08-31"},

--- a/internal/proxy/rate_limit_classify_test.go
+++ b/internal/proxy/rate_limit_classify_test.go
@@ -75,6 +75,16 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantPin:   pinHintWeekly,
 		},
 		{
+			// Holds the line the entry above could have crossed: "exhausted"
+			// beside a concurrency limit is a busy provider, and it must reach
+			// the saturated entries rather than open a circuit with a 2h pin.
+			name:      "concurrency limit exhausted stays saturated (no reset named)",
+			status:    429,
+			body:      `{"error":{"message":"Concurrency limit exhausted, retry shortly"}}`,
+			wantClass: rateLimitSaturated,
+			wantRetry: defaultSaturatedRetryAfter,
+		},
+		{
 			name:       "OpenAI insufficient_quota",
 			status:     429,
 			body:       `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota"}}`,

--- a/internal/proxy/rate_limit_classify_test.go
+++ b/internal/proxy/rate_limit_classify_test.go
@@ -65,6 +65,16 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantEntitl: true,
 		},
 		{
+			// Verbatim from prod, 2026-09-01 16:42 UTC, glm-5.3 on the Coding Plan:
+			// a weekly/monthly cap with a dated reset. Time fixes it (not
+			// entitled), and the pin is the weekly one.
+			name:      "Z.ai coding plan code 1310 weekly/monthly limit exhausted",
+			status:    429,
+			body:      `{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-09-03 18:01:05"}}`,
+			wantClass: rateLimitExhausted,
+			wantPin:   pinHintWeekly,
+		},
+		{
 			name:       "OpenAI insufficient_quota",
 			status:     429,
 			body:       `{"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota"}}`,


### PR DESCRIPTION
One phrase-table entry. Z.ai's code 1310 was the one 429 body the 2026-09-01 `hotel/glm53` Strix run produced that the classifier did not recognise:

```
{"error":{"code":"1310","message":"Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-09-03 18:01:05"}}
```

The Z.ai entries cover code 1113 (a balance a person tops up) and the window entries cover Ollama's "usage limit" wording; "Weekly/Monthly **Limit Exhausted**" matched neither.

## What it cost

Nothing was mis-routed: the circuit opened on the ordinary failure charge and the quota advisor, reading Z.ai's usage API at 100%, pinned it. The cost was the diagnosis, on every surface, on every fleet member:

- circuit ledger, Front Desk circuits column and breaker-open event: `upstream status 429 (unrecognised)`
- metric: `modelhotel_upstream_rate_limit_total{class="unknown"}`
- request log: `error_kind=provider_error` rather than `provider_quota_exhausted`
- and a pin that existed only because the usage API happened to be readable at that moment; had it not been, the circuit would have half-opened and probed on the ordinary cooldown for two days.

## The entry

`"limit exhausted"` **and** `"reset"` → exhausted, weekly pin, not entitled (the body names a reset, so time fixes it). Placed ahead of the generic window entries so the longer pin is not shadowed. The verbatim body is a table case.

The second word is the review's doing: `"limit exhausted"` alone would have been the broadest phrase in the table, running ahead of every *saturated* entry, so a body like `"Concurrency limit exhausted, retry shortly"` would have read as spent and opened a circuit on one 429 with a two-hour pin. A spent window says when it comes back; a busy provider says retry shortly. A table case holds that concurrency wording on the saturated side.

## Verification

`go test ./internal/proxy/` (full package), the classifier table and the phrase-provenance tests pass; golangci-lint 0 issues; size gate clean.

**Live, on the dev stack rebuilt from this branch**, a `custom` provider backed by a stub that lists one model and answers every chat completion with the verbatim 1310 body; one request through `/api/chat/completions`:

| surface | before (prod, this morning) | now |
|---|---|---|
| client answer | 502 after the failure threshold | `429 … the provider's usage quota is exhausted; retry after it resets` on the first response |
| circuit ledger | `upstream status 429 (unrecognised)`, plain cooldown | `upstream status 429 (exhausted)`, `pinned=true`, `pin_source=response` |
| request log | `error_kind=provider_error` | `error_kind=provider_quota_exhausted`, trail `phrase="limit exhausted"` |
| cap ledger | nothing | `{"phrase":"limit exhausted","model":"glm-stub"}` |

Re-run after the `also: "reset"` narrowing with the same result. The stub provider was removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
