### PR TITLE
test(proxy): give the hedged-race loser a margin over the winner

### DIFF
--- a/internal/proxy/attempt_trail_test.go
+++ b/internal/proxy/attempt_trail_test.go
@@ -317,9 +317,14 @@ func TestAttemptTrail_HedgedRace(t *testing.T) {
 	h := newIntegrationHandler()
 	defer stopUnitHandler(h)
 
+	// The loser must resolve before the winner, or the orchestrator cancels
+	// it and records it as superseded rather than failed. The winner launches
+	// one hedge delay after the loser, so equal probe delays left the order to
+	// the scheduler and the race detector on a loaded runner flipped it; the
+	// winner is given a margin no scheduler hiccup closes.
 	hh := newHedgeHarness([]fakeProbeSpec{
-		{delay: 5 * time.Millisecond, reqErr: reqError{Kind: KindProviderError, Attempt: 0, Provider: "a", Detail: "HTTP 503"}},
-		{delay: 5 * time.Millisecond, won: true},
+		{delay: time.Millisecond, reqErr: reqError{Kind: KindProviderError, Attempt: 0, Provider: "a", Detail: "HTTP 503"}},
+		{delay: 50 * time.Millisecond, won: true},
 	})
 	st, logData := newHedgeState(time.Millisecond)
 	logData.id = uuid.New().String()


### PR DESCRIPTION
Master went red on the #866 merge in Go Race: `TestAttemptTrail_HedgedRace` scripted both hedged probes at 5ms with the winner launching one 1ms hedge delay after the loser, so which resolved first was the scheduler's call. On a loaded race-detector runner the winner fired first, the orchestrator cancelled the loser, and the trail recorded it as `superseded by the winner while in flight` instead of the 503 the test expects. Nothing in #866 touched that path.

The loser now resolves at 1ms and the winner at 50ms. Passes 40 consecutive runs under `-race` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6