### PR TITLE
fix(api,provider): bound an imported max_in_flight like the admin API does

### DIFF
--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -134,8 +134,9 @@ var errInvalidSyncedRateLimit = errors.New("configsync: refusing to apply an inv
 // carries a field the interactive API would reject: a max_in_flight outside
 // 1..10000, which the runtime would read as "no ceiling" (zero or less) rather
 // than reject, silently deleting the operator's cap and then exporting the
-// value to every member on the next sync; or a base_url past the length the
-// admin API accepts. Import maps it to a 400 refusal.
+// value to every member on the next sync; a base_url its SSRF check refuses;
+// an unprintable or over-long name; or a disable date that is not a date.
+// Import maps it to a 400 refusal.
 var errInvalidSyncedProvider = errors.New("configsync: refusing to apply an invalid provider")
 
 // errInvalidSyncedPasswordHash is returned by apply when a user in the envelope

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -130,6 +130,14 @@ var errInvalidSyncedSettingBound = errors.New("configsync: refusing to apply a s
 // maps it to a 400 refusal.
 var errInvalidSyncedRateLimit = errors.New("configsync: refusing to apply an invalid rate limit")
 
+// errInvalidSyncedProvider is returned by apply when a provider in the envelope
+// carries a field the interactive API would reject: a max_in_flight outside
+// 1..10000, which the runtime would read as "no ceiling" (zero or less) rather
+// than reject, silently deleting the operator's cap and then exporting the
+// value to every member on the next sync; or a base_url past the length the
+// admin API accepts. Import maps it to a 400 refusal.
+var errInvalidSyncedProvider = errors.New("configsync: refusing to apply an invalid provider")
+
 // errInvalidSyncedPasswordHash is returned by apply when a user in the envelope
 // carries a password_hash that is not a well-formed argon2id hash. A password
 // hash is the one credential field this member does not compute itself, and

--- a/internal/api/configsync_apply_upserts.go
+++ b/internal/api/configsync_apply_upserts.go
@@ -66,8 +66,27 @@ func providerTypeForImport(p ExportProvider) string {
 	return provider.LegacyTypeFromURL(p.BaseURL)
 }
 
+// validateSyncedProvider applies to an imported provider the bounds the
+// interactive admin API applies on create and update, so a compromised
+// primary cannot write through this path what the dashboard would reject.
+// The URL's shape is checked separately (validateURL below); this is the
+// rest: the in-flight ceiling, through the same rule the admin API uses, and
+// the URL's length.
+func validateSyncedProvider(p ExportProvider) error {
+	if err := provider.ValidateMaxInFlight(p.MaxInFlight); err != nil {
+		return fmt.Errorf("%w: provider %q: %w", errInvalidSyncedProvider, p.Name, err)
+	}
+	if len(p.BaseURL) > maxProviderURLLen {
+		return fmt.Errorf("%w: provider %q: base_url must be at most %d characters", errInvalidSyncedProvider, p.Name, maxProviderURLLen)
+	}
+	return nil
+}
+
 func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider, validateURL func(string) error) error {
 	for _, p := range providers {
+		if err := validateSyncedProvider(p); err != nil {
+			return err
+		}
 		// Defense in depth on the import path: a compromised primary must not be
 		// able to write a provider base_url that the interactive admin API would
 		// reject. validateURL is the same guard CreateProvider/UpdateProvider use
@@ -78,7 +97,9 @@ func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider,
 		// out of the database entirely. Nil validateURL disables the check (tests).
 		if validateURL != nil {
 			if err := validateURL(p.BaseURL); err != nil {
-				return fmt.Errorf("provider %q has an invalid base_url: %w", p.Name, err)
+				// The same refusal class as the bounds above: the envelope
+				// carries what the admin API would reject, so a 400, not a 500.
+				return fmt.Errorf("%w: provider %q has an invalid base_url: %w", errInvalidSyncedProvider, p.Name, err)
 			}
 		}
 		_, err := tx.Exec(ctx, `

--- a/internal/api/configsync_apply_upserts.go
+++ b/internal/api/configsync_apply_upserts.go
@@ -78,7 +78,13 @@ func providerTypeForImport(p ExportProvider) string {
 // it, and the member's own sweep fires it immediately, which is what the
 // operator asked for. The URL's length is not bounded here: the admin API's
 // bound is cosmetic, a row past it is harmless, and refusing whole envelopes
-// over one would be a one-way door for a fleet.
+// over one would be a one-way door for a fleet. The name bound carries the
+// same door for a legacy row written before this check, and earns it: an
+// unprintable or ten-thousand-character name reaches logs, the dashboard
+// and hotel/ model strings, which a long URL never does. The name is
+// validated as sent and stored as sent (the admin API stores it trimmed):
+// storing a trimmed copy would diverge from the primary's hash and re-sync
+// forever, and trimming changes nothing the check cares about.
 func validateSyncedProvider(p ExportProvider) error {
 	if err := provider.ValidateMaxInFlight(p.MaxInFlight); err != nil {
 		return fmt.Errorf("%w: provider %q: %w", errInvalidSyncedProvider, p.Name, err)

--- a/internal/api/configsync_apply_upserts.go
+++ b/internal/api/configsync_apply_upserts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -66,18 +67,29 @@ func providerTypeForImport(p ExportProvider) string {
 	return provider.LegacyTypeFromURL(p.BaseURL)
 }
 
-// validateSyncedProvider applies to an imported provider the bounds the
+// validateSyncedProvider applies to an imported provider the checks the
 // interactive admin API applies on create and update, so a compromised
 // primary cannot write through this path what the dashboard would reject.
 // The URL's shape is checked separately (validateURL below); this is the
-// rest: the in-flight ceiling, through the same rule the admin API uses, and
-// the URL's length.
+// rest: the in-flight ceiling, through the same rule the admin API uses
+// (the load-bearing one: a value below one is read as no ceiling at all),
+// the name's length and printability, and the disable date's format. A
+// disable date in the past is accepted: it was valid when the primary set
+// it, and the member's own sweep fires it immediately, which is what the
+// operator asked for. The URL's length is not bounded here: the admin API's
+// bound is cosmetic, a row past it is harmless, and refusing whole envelopes
+// over one would be a one-way door for a fleet.
 func validateSyncedProvider(p ExportProvider) error {
 	if err := provider.ValidateMaxInFlight(p.MaxInFlight); err != nil {
 		return fmt.Errorf("%w: provider %q: %w", errInvalidSyncedProvider, p.Name, err)
 	}
-	if len(p.BaseURL) > maxProviderURLLen {
-		return fmt.Errorf("%w: provider %q: base_url must be at most %d characters", errInvalidSyncedProvider, p.Name, maxProviderURLLen)
+	if _, err := validateNameString("name", p.Name, 1, 100); err != nil {
+		return fmt.Errorf("%w: provider %q: %w", errInvalidSyncedProvider, p.Name, err)
+	}
+	if p.ScheduledDisableOn != nil {
+		if _, err := time.Parse("2006-01-02", *p.ScheduledDisableOn); err != nil {
+			return fmt.Errorf("%w: provider %q: scheduled_disable_on must be a YYYY-MM-DD date", errInvalidSyncedProvider, p.Name)
+		}
 	}
 	return nil
 }

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -110,6 +110,14 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 		debuglog.Warn("configsync: refused import with a malformed password hash", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	case errors.Is(err, errInvalidSyncedProvider):
+		// A provider in the envelope carries a value the interactive API
+		// rejects (a max_in_flight the runtime would read as "no ceiling"). A
+		// legitimate primary never exports one, so refuse the whole envelope
+		// with a 400 rather than store it and ship it on to every member.
+		debuglog.Warn("configsync: refused import with an invalid provider", "error", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	case errors.Is(err, errInvalidSyncedRateLimit):
 		// A virtual key or user in the envelope carries a rate limit the
 		// interactive API rejects: a negative TPM would import as "no cap" and a

--- a/internal/api/configsync_provider_bounds_test.go
+++ b/internal/api/configsync_provider_bounds_test.go
@@ -66,23 +66,38 @@ func TestConfigSync_RefusesOutOfRangeMaxInFlight(t *testing.T) {
 	}
 }
 
-// The import's provider validation is the admin API's rule, not a copy of
-// it: the same function decides both, so the two cannot drift apart.
-func TestValidateSyncedProvider_IsTheInteractiveRule(t *testing.T) {
+// The import's provider validation uses the shared rule rather than a copy:
+// it refuses exactly what provider.ValidateMaxInFlight refuses, adds no
+// condition of its own on the ceiling, and wraps every refusal in the
+// sentinel the handler maps to a 400. The admin API's use of the same rule is
+// pinned by TestUpdateProvider_ScheduledDisable.
+func TestValidateSyncedProvider_UsesTheSharedRule(t *testing.T) {
 	for _, v := range []*int{nil, new(1), new(10000), new(0), new(-1), new(10001)} {
 		p := ExportProvider{Name: "p", BaseURL: "https://p.example.test/v1", MaxInFlight: v}
 		synced := validateSyncedProvider(p)
-		interactive := provider.ValidateMaxInFlight(v)
-		if (synced != nil) != (interactive != nil) {
-			t.Fatalf("value %v: import path (%v) and admin API (%v) disagree", v, synced, interactive)
+		shared := provider.ValidateMaxInFlight(v)
+		if (synced != nil) != (shared != nil) {
+			t.Fatalf("value %v: import path (%v) and the shared rule (%v) disagree", v, synced, shared)
 		}
 		if synced != nil && !errors.Is(synced, errInvalidSyncedProvider) {
 			t.Fatalf("error %v does not wrap errInvalidSyncedProvider", synced)
 		}
 	}
-	long := ExportProvider{Name: "p", BaseURL: "https://" + strings.Repeat("a", maxProviderURLLen) + ".example.test/v1"}
-	if err := validateSyncedProvider(long); err == nil || !errors.Is(err, errInvalidSyncedProvider) {
-		t.Fatalf("an over-long base_url was not refused: %v", err)
+	for _, tc := range []struct {
+		name string
+		p    ExportProvider
+	}{
+		{"over-long name", ExportProvider{Name: strings.Repeat("n", 101), BaseURL: "https://p.example.test/v1"}},
+		{"unprintable name", ExportProvider{Name: "bad\x00name", BaseURL: "https://p.example.test/v1"}},
+		{"malformed disable date", ExportProvider{Name: "p", BaseURL: "https://p.example.test/v1", ScheduledDisableOn: new("next tuesday")}},
+	} {
+		if err := validateSyncedProvider(tc.p); err == nil || !errors.Is(err, errInvalidSyncedProvider) {
+			t.Fatalf("%s: not refused with the sentinel: %v", tc.name, err)
+		}
+	}
+	past := ExportProvider{Name: "p", BaseURL: "https://p.example.test/v1", ScheduledDisableOn: new("2020-01-01")}
+	if err := validateSyncedProvider(past); err != nil {
+		t.Fatalf("a past disable date must be accepted on import: %v", err)
 	}
 }
 

--- a/internal/api/configsync_provider_bounds_test.go
+++ b/internal/api/configsync_provider_bounds_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/hugalafutro/model-hotel/internal/config"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/settings"
+)
+
+// The import path applies the in-flight ceiling bound the admin API applies
+// (Strix 2026-09-01 vuln-0004): a value the runtime would read as "no
+// ceiling" (zero or less), or a typo past the ceiling, is refused with a 400
+// and nothing is written, instead of being stored, exported and shipped to
+// every member on the next sync. In-range values and null still apply.
+func TestConfigSync_RefusesOutOfRangeMaxInFlight(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value *int
+		want  int
+	}{
+		{"null is no ceiling", nil, http.StatusOK},
+		{"floor", new(1), http.StatusOK},
+		{"ceiling", new(provider.MaxInFlightCeiling), http.StatusOK},
+		{"zero reads as no ceiling at runtime", new(0), http.StatusBadRequest},
+		{"negative", new(-5), http.StatusBadRequest},
+		{"past the ceiling", new(provider.MaxInFlightCeiling + 1), http.StatusBadRequest},
+		{"absurd", new(999999999), http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanConfigTables(t)
+			r := newConfigSyncRouter(t, configSyncMasterKey)
+			seedProvider(t, "prov-a", "sk-secret", configSyncMasterKey)
+			env := doExport(t, r)
+			if len(env.Config.Providers) != 1 {
+				t.Fatalf("export carries %d providers, want 1", len(env.Config.Providers))
+			}
+			env.Config.Providers[0].MaxInFlight = tc.value
+
+			rec := doImport(t, r, env, "")
+			if rec.Code != tc.want {
+				t.Fatalf("import status = %d, want %d; body %s", rec.Code, tc.want, rec.Body.String())
+			}
+			var stored *int
+			if err := apiTestDB.Pool().QueryRow(t.Context(), `SELECT max_in_flight FROM providers WHERE name = 'prov-a'`).Scan(&stored); err != nil {
+				t.Fatalf("read row: %v", err)
+			}
+			if tc.want == http.StatusOK {
+				if (stored == nil) != (tc.value == nil) || (stored != nil && *stored != *tc.value) {
+					t.Fatalf("stored max_in_flight = %v, want %v", stored, tc.value)
+				}
+				return
+			}
+			if stored != nil {
+				t.Fatalf("a refused envelope wrote max_in_flight = %d", *stored)
+			}
+			if body := rec.Body.String(); !strings.Contains(body, errInvalidSyncedProvider.Error()) || !strings.Contains(body, "prov-a") {
+				t.Fatalf("refusal body = %q, want it to carry %q and the provider's name", body, errInvalidSyncedProvider.Error())
+			}
+		})
+	}
+}
+
+// The import's provider validation is the admin API's rule, not a copy of
+// it: the same function decides both, so the two cannot drift apart.
+func TestValidateSyncedProvider_IsTheInteractiveRule(t *testing.T) {
+	for _, v := range []*int{nil, new(1), new(10000), new(0), new(-1), new(10001)} {
+		p := ExportProvider{Name: "p", BaseURL: "https://p.example.test/v1", MaxInFlight: v}
+		synced := validateSyncedProvider(p)
+		interactive := provider.ValidateMaxInFlight(v)
+		if (synced != nil) != (interactive != nil) {
+			t.Fatalf("value %v: import path (%v) and admin API (%v) disagree", v, synced, interactive)
+		}
+		if synced != nil && !errors.Is(synced, errInvalidSyncedProvider) {
+			t.Fatalf("error %v does not wrap errInvalidSyncedProvider", synced)
+		}
+	}
+	long := ExportProvider{Name: "p", BaseURL: "https://" + strings.Repeat("a", maxProviderURLLen) + ".example.test/v1"}
+	if err := validateSyncedProvider(long); err == nil || !errors.Is(err, errInvalidSyncedProvider) {
+		t.Fatalf("an over-long base_url was not refused: %v", err)
+	}
+}
+
+// A base_url the admin API refuses (a private address) is a 400 on import
+// too, not a 500: the envelope carries what the dashboard would reject.
+func TestConfigSync_RefusesPrivateBaseURLAsBadRequest(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouterWithURLCheck(t, configSyncMasterKey)
+	seedProvider(t, "prov-a", "sk-secret", configSyncMasterKey)
+	env := doExport(t, r)
+	env.Config.Providers[0].BaseURL = "http://192.168.1.141:5001/v1"
+	rec := doImport(t, r, env, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("import status = %d, want 400; body %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "invalid base_url") {
+		t.Fatalf("refusal body = %q, want the base_url reason", body)
+	}
+}
+
+// newConfigSyncRouterWithURLCheck is newConfigSyncRouter with the same
+// base_url guard the admin API applies (config.ValidateProviderURL), for a
+// test about what the import refuses on a URL's account.
+func newConfigSyncRouterWithURLCheck(t *testing.T, masterKey string) chi.Router {
+	t.Helper()
+	h := NewConfigSyncHandler(apiTestDB, settings.NewRepository(apiTestDB.Pool()), masterKey, "v-test", nil, (&config.Config{}).ValidateProviderURL)
+	r := chi.NewRouter()
+	h.Register(r)
+	return r
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -20,6 +20,10 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
+// maxProviderURLLen bounds a provider base_url on every write path (the admin
+// API here, the config import in configsync_apply_upserts.go).
+const maxProviderURLLen = 500
+
 // CreateProvider creates a new provider.
 func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	var req provider.CreateProviderRequest
@@ -58,7 +62,7 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 
 	// Measured after normalization, so the value that is actually stored is the
 	// one that has to fit.
-	if len(req.BaseURL) > 500 {
+	if len(req.BaseURL) > maxProviderURLLen {
 		http.Error(w, "base_url must be less than 500 characters", http.StatusBadRequest)
 		return
 	}
@@ -397,11 +401,12 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if req.MaxInFlight.Set && req.MaxInFlight.Value != nil {
-		// A ceiling of zero would admit nothing forever, which is what the
-		// enabled toggle is for; the upper bound only catches typos.
-		if v := *req.MaxInFlight.Value; v < 1 || v > 10000 {
-			http.Error(w, "max_in_flight must be between 1 and 10000, or null for no ceiling", http.StatusBadRequest)
+	// The one rule the config import and the column's CHECK constraint share
+	// (provider.ValidateMaxInFlight): a ceiling of zero would not admit
+	// nothing, it would read as no ceiling at all.
+	if req.MaxInFlight.Set {
+		if err := provider.ValidateMaxInFlight(req.MaxInFlight.Value); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -20,10 +20,6 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
 
-// maxProviderURLLen bounds a provider base_url on every write path (the admin
-// API here, the config import in configsync_apply_upserts.go).
-const maxProviderURLLen = 500
-
 // CreateProvider creates a new provider.
 func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	var req provider.CreateProviderRequest
@@ -62,8 +58,8 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 
 	// Measured after normalization, so the value that is actually stored is the
 	// one that has to fit.
-	if len(req.BaseURL) > maxProviderURLLen {
-		http.Error(w, "base_url must be less than 500 characters", http.StatusBadRequest)
+	if len(req.BaseURL) > 500 {
+		http.Error(w, "base_url must be at most 500 characters", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/db/migration_max_in_flight_bounds_test.go
+++ b/internal/db/migration_max_in_flight_bounds_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+)
+
+const maxInFlightBoundsMigration = "migrations/079_provider_max_in_flight_bounds.sql"
+
+// TestMaxInFlightBoundsMigrationNormalizesLegacyRows covers the reason the
+// migration exists: an install that took an envelope through the unvalidated
+// config-sync import can hold a provider with max_in_flight = -5 (which the
+// runtime read as "no ceiling"), and the import now refuses the whole envelope
+// over it, so one stale row on the primary would stop the fleet converging.
+// The migration must null exactly the out-of-range rows, leave the rest, and
+// be safe to replay against a database that already carries the constraint.
+func TestMaxInFlightBoundsMigrationNormalizesLegacyRows(t *testing.T) {
+	ctx := context.Background()
+	b, err := fs.ReadFile(embeddedMigrations, maxInFlightBoundsMigration)
+	if err != nil {
+		t.Fatalf("read %s: %v", maxInFlightBoundsMigration, err)
+	}
+	sql := string(b)
+	// Pre-079 shape, so the legacy rows can be seeded at all.
+	if _, err := testPool.Exec(ctx, `ALTER TABLE providers DROP CONSTRAINT IF EXISTS providers_max_in_flight_bounds`); err != nil {
+		t.Fatalf("drop constraint: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM providers WHERE name LIKE 'mif-bounds-%'`)
+		// Leave the shared database with the constraint the migration
+		// installs, and prove the replay is harmless while doing so.
+		if _, err := testPool.Exec(context.Background(), sql); err != nil {
+			t.Errorf("restore migration: %v", err)
+		}
+	})
+
+	rows := map[string]*int{
+		"mif-bounds-negative": new(-5),
+		"mif-bounds-zero":     new(0),
+		"mif-bounds-absurd":   new(999999999),
+		"mif-bounds-floor":    new(1),
+		"mif-bounds-ceiling":  new(10000),
+		"mif-bounds-null":     nil,
+	}
+	for name, v := range rows {
+		if _, err := testPool.Exec(ctx, `INSERT INTO providers (name, base_url, provider_type, max_in_flight) VALUES ($1, 'https://mif.example.test/v1', 'custom', $2)`, name, v); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	if _, err := testPool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration: %v", err)
+	}
+	want := map[string]*int{
+		"mif-bounds-negative": nil, "mif-bounds-zero": nil, "mif-bounds-absurd": nil,
+		"mif-bounds-floor": new(1), "mif-bounds-ceiling": new(10000), "mif-bounds-null": nil,
+	}
+	for name, w := range want {
+		var got *int
+		if err := testPool.QueryRow(ctx, `SELECT max_in_flight FROM providers WHERE name = $1`, name).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if (got == nil) != (w == nil) || (got != nil && *got != *w) {
+			t.Errorf("%s: max_in_flight = %v, want %v", name, got, w)
+		}
+	}
+	// The constraint is in place and replaying the migration is a no-op.
+	if _, err := testPool.Exec(ctx, `UPDATE providers SET max_in_flight = -1 WHERE name = 'mif-bounds-floor'`); err == nil {
+		t.Fatal("the constraint did not come back with the migration")
+	}
+	if _, err := testPool.Exec(ctx, sql); err != nil {
+		t.Fatalf("replaying the migration failed: %v", err)
+	}
+}

--- a/internal/db/migrations/079_provider_max_in_flight_bounds.sql
+++ b/internal/db/migrations/079_provider_max_in_flight_bounds.sql
@@ -1,9 +1,31 @@
--- The per-provider in-flight ceiling is bounded at the column, mirroring the
--- rule every write path applies (provider.ValidateMaxInFlight: NULL for no
--- ceiling, else 1..10000). The runtime reads a ceiling of zero or less as "no
--- ceiling", so a value below one stored by any path (the config import wrote
--- the envelope's value verbatim) silently deleted the operator's cap and then
--- exported to every member on the next sync. Rows already out of range are
--- returned to "no ceiling" first, which is what the runtime treated them as.
+-- Bound the per-provider in-flight ceiling at rest, mirroring the rule every
+-- write path applies (provider.ValidateMaxInFlight: NULL for no ceiling, else
+-- 1..10000). The interactive API enforced it from the day the column arrived
+-- (migration 077); the config-sync import path wrote the envelope's value
+-- verbatim until the commit this migration accompanies, so a member that took
+-- an envelope carrying -5 or 999999999 persisted it, exported it, and shipped
+-- it to every other member on the next sync.
+--
+-- The runtime reads a ceiling of zero or less as "no ceiling"
+-- (proxy.effectiveLimit), so a value below one never rejected traffic: it
+-- silently deleted the operator's cap. Returning such a row to NULL is
+-- therefore meaning-preserving in the only safe direction (NULL is the
+-- documented "no ceiling"), and it removes the landmine before the import
+-- path starts refusing whole envelopes over it, which is what would otherwise
+-- stop a fleet converging over one stale row.
 UPDATE providers SET max_in_flight = NULL WHERE max_in_flight IS NOT NULL AND (max_in_flight < 1 OR max_in_flight > 10000);
-ALTER TABLE providers ADD CONSTRAINT providers_max_in_flight_bounds CHECK (max_in_flight IS NULL OR (max_in_flight BETWEEN 1 AND 10000));
+
+-- NULL passes: a CHECK that evaluates to NULL is not a violation, and the IS
+-- NULL arm is spelled out so a reader does not have to know that.
+--
+-- Postgres has no ADD CONSTRAINT IF NOT EXISTS, hence the duplicate_object
+-- swallow: migrations are recorded in schema_migrations and normally run once,
+-- but a restore can replay one against a database that already has the
+-- constraint.
+DO $$
+BEGIN
+    ALTER TABLE providers ADD CONSTRAINT providers_max_in_flight_bounds CHECK (
+        max_in_flight IS NULL OR (max_in_flight BETWEEN 1 AND 10000)
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/internal/db/migrations/079_provider_max_in_flight_bounds.sql
+++ b/internal/db/migrations/079_provider_max_in_flight_bounds.sql
@@ -1,0 +1,9 @@
+-- The per-provider in-flight ceiling is bounded at the column, mirroring the
+-- rule every write path applies (provider.ValidateMaxInFlight: NULL for no
+-- ceiling, else 1..10000). The runtime reads a ceiling of zero or less as "no
+-- ceiling", so a value below one stored by any path (the config import wrote
+-- the envelope's value verbatim) silently deleted the operator's cap and then
+-- exported to every member on the next sync. Rows already out of range are
+-- returned to "no ceiling" first, which is what the runtime treated them as.
+UPDATE providers SET max_in_flight = NULL WHERE max_in_flight IS NOT NULL AND (max_in_flight < 1 OR max_in_flight > 10000);
+ALTER TABLE providers ADD CONSTRAINT providers_max_in_flight_bounds CHECK (max_in_flight IS NULL OR (max_in_flight BETWEEN 1 AND 10000));

--- a/internal/provider/max_in_flight_test.go
+++ b/internal/provider/max_in_flight_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// The rule every write path shares.
+func TestValidateMaxInFlight(t *testing.T) {
+	for _, tc := range []struct {
+		v    *int
+		want bool
+	}{
+		{nil, true}, {new(1), true}, {new(MaxInFlightCeiling), true},
+		{new(0), false}, {new(-5), false}, {new(MaxInFlightCeiling + 1), false},
+	} {
+		err := ValidateMaxInFlight(tc.v)
+		if (err == nil) != tc.want {
+			t.Fatalf("ValidateMaxInFlight(%v) = %v, want ok=%v", tc.v, err, tc.want)
+		}
+		if err != nil && !strings.Contains(err.Error(), "max_in_flight must be between 1 and 10000") {
+			t.Fatalf("error text = %q", err)
+		}
+	}
+}
+
+// The column's CHECK constraint is the backstop for any write path that
+// forgets the rule: an out-of-range value cannot be stored at all.
+func TestMaxInFlightColumnBounds(t *testing.T) {
+	pool := testDB.Pool()
+	name := "bounds-" + uuid.New().String()[:8]
+	if _, err := pool.Exec(context.Background(), `INSERT INTO providers (name, base_url, provider_type) VALUES ($1, 'https://b.example.test/v1', 'custom')`, name); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	for _, v := range []int{0, -5, MaxInFlightCeiling + 1} {
+		if _, err := pool.Exec(context.Background(), `UPDATE providers SET max_in_flight = $1 WHERE name = $2`, v, name); err == nil {
+			t.Fatalf("stored max_in_flight = %d past the constraint", v)
+		} else if !strings.Contains(err.Error(), "providers_max_in_flight_bounds") {
+			t.Fatalf("unexpected error for %d: %v", v, err)
+		}
+	}
+	for _, v := range []int{1, MaxInFlightCeiling} {
+		if _, err := pool.Exec(context.Background(), `UPDATE providers SET max_in_flight = $1 WHERE name = $2`, v, name); err != nil {
+			t.Fatalf("in-range %d refused: %v", v, err)
+		}
+	}
+	if _, err := pool.Exec(context.Background(), `UPDATE providers SET max_in_flight = NULL WHERE name = $1`, name); err != nil {
+		t.Fatalf("null refused: %v", err)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -577,5 +578,26 @@ func (r *Repository) TouchLastUsed(ctx context.Context, id uuid.UUID) error {
 	// entries: a full flush here would empty the routing cache on every
 	// attempt/probe, and hedged streaming touches every launched candidate.
 	EvictProviderCacheByID(id)
+	return nil
+}
+
+// MaxInFlightCeiling bounds the operator's per-provider in-flight ceiling.
+// The floor is the load-bearing one: the runtime reads a ceiling of zero or
+// less as "no ceiling" (proxy.effectiveLimit), so a value below one would
+// not reject traffic but silently delete the cap; the upper bound catches
+// typos. One rule for every write path (the admin API, the config import, the
+// column's own CHECK constraint mirrors it), so none can admit what another
+// rejects.
+const MaxInFlightCeiling = 10000
+
+// ValidateMaxInFlight is the rule above as an error: nil is "no ceiling" and
+// is fine; anything else must be within 1 and MaxInFlightCeiling.
+func ValidateMaxInFlight(v *int) error {
+	if v == nil {
+		return nil
+	}
+	if *v < 1 || *v > MaxInFlightCeiling {
+		return fmt.Errorf("max_in_flight must be between 1 and %d, or null for no ceiling, got %d", MaxInFlightCeiling, *v)
+	}
 	return nil
 }

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -354,13 +354,15 @@ What makes this safe to leave running:
   members already matching the primary are skipped without so much as a diff, and
   an unreachable or `MASTER_KEY`-blocked member is retried later rather than
   overwritten.
-- **Only what the dashboard would accept.** A member applies an envelope with the
-  same checks its own admin API applies on the way in, so a primary cannot write
-  through sync what an operator could not type: provider `base_url` shape and
-  length, the per-provider `max_in_flight` ceiling (1 to 10000, or null), settings
-  minimums and URL-typed settings, per-key and per-user rate limits, and password
-  hash format. An envelope that fails any of them is refused whole with a 400 that
-  names the field, and nothing is written.
+- **What the dashboard would refuse, sync refuses.** A member applies an envelope
+  with the load-bearing checks its own admin API applies on the way in: provider
+  `base_url` shape (the same address rules), provider name length and
+  printability, the disable date's format, the per-provider `max_in_flight`
+  ceiling (1 to 10000, or null: a value below one would read as no ceiling at
+  all), settings minimums and URL-typed settings, per-key and per-user rate
+  limits, and password hash format. An envelope that fails any of them is
+  refused whole with a 400 and nothing is written; the member's own log names
+  the field, Front Desk reports the refusal by status.
 - **Newer config always wins.** Each push carries a monotonic source generation,
   and a member refuses any import older than the one it has already applied, so
   repointing the primary while an earlier push is still in flight can never strand a

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -354,6 +354,13 @@ What makes this safe to leave running:
   members already matching the primary are skipped without so much as a diff, and
   an unreachable or `MASTER_KEY`-blocked member is retried later rather than
   overwritten.
+- **Only what the dashboard would accept.** A member applies an envelope with the
+  same checks its own admin API applies on the way in, so a primary cannot write
+  through sync what an operator could not type: provider `base_url` shape and
+  length, the per-provider `max_in_flight` ceiling (1 to 10000, or null), settings
+  minimums and URL-typed settings, per-key and per-user rate limits, and password
+  hash format. An envelope that fails any of them is refused whole with a 400 that
+  names the field, and nothing is written.
 - **Newer config always wins.** Each push carries a monotonic source generation,
   and a member refuses any import older than the one it has already applied, so
   repointing the primary while an earlier push is still in flight can never strand a


### PR DESCRIPTION
## Summary

Strix 2026-09-01 vuln-0004 (LOW, CWE-20). `POST /api/config/import` wrote a provider's `max_in_flight` verbatim, so an envelope carrying `-5` or `999999999` landed in the row the interactive API would have refused with a 400, exported verbatim, and shipped to every member on the next fleet sync. The runtime reads a ceiling of zero or less as "no ceiling", so an imported value below one did not reject traffic; it silently deleted the operator's cap.

**The fix is one rule on every write path.** `provider.ValidateMaxInFlight` (null, or 1 to 10000) is what the admin API's update handler now calls, what the import applies to every provider in the envelope before writing (refused whole with a 400 that names the provider and the value, like the rate-limit and password-hash refusals), and what migration 079 mirrors as a CHECK constraint on the column, after returning any row already out of range to null, which is what the runtime treated it as. The import also applies the admin API's name rule and the disable date's format, and a `base_url` its SSRF check refuses is now a 400 rather than the 500 it surfaced as.

## Review rounds (adversarial, opus)

Round 1 confirmed the core fix (one rule, both write paths, column CHECK) and found the edges: the migration's backfill line had no test although its failure mode is a fatal startup on exactly the installs carrying the data, the constraint was not replay-safe unlike its precedent 064, and the `base_url` length bound this PR first added to the import was a one-way door (the admin API's update path measures before normalising, so its own row could wedge a fleet). Second commit: the migration has the 064-style replay test and the duplicate-object wrapper, the URL bound is dropped as cosmetic, and the import applies the name rule and the date format instead, which it had been missing. Round 2 confirmed every fix by mutation (dropping the migration's backfill line now fails with the exact production symptom, a constraint violation aborting the migration) and returned MERGE.

## Live test (dev stack, A/B)

Export, set one provider's `max_in_flight` to `-5` in the envelope, import, read the row back:

| | master | this branch |
|---|---|---|
| interactive `PUT` with `-5` | 400 | 400 |
| import of the same value | 200, row stores `-5` | 400 naming `bounds-probe` and the value, row unchanged |
| column constraint `providers_max_in_flight_bounds` | absent | present |

## Tests

The shared rule, the column constraint (out-of-range refused, in-range and null accepted), the migration replayed over every legacy row shape, the import refusing zero, negative and over-ceiling values while applying null, the floor and the ceiling, the shared-rule test with the name and date cases, and the private-address `base_url` refusal as a 400.

## Follow-up worth doing

Front Desk reports a member's refusal by status only (`this member rejected the request (HTTP 400)`), so the field named in the member's 400 body reaches the operator only through the member's own log. Surfacing the body in the Front Desk push report is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
