### PR TITLE
feat(frontdesk): show the member's own reason when a push is refused

### DIFF
--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -541,18 +542,25 @@ func (e *memberRefusal) Error() string {
 	return fmt.Sprintf("member config-import returned %d: %s", e.status, e.reason)
 }
 
-// maxRefusalReasonRunes bounds the member's reason as shown to the operator:
-// a refusal names one field and one value, and a body past this is not a
-// reason but a page.
+// maxRefusalReasonRunes bounds the member's reason as shown to the operator,
+// in runes: a refusal names one field and one value, and a body past this is
+// not a reason but a page. The member's own log carries the full text.
 const maxRefusalReasonRunes = 240
 
 // refusalReason extracts the operator-readable reason from a member's
 // refusal body: the "error" member of a JSON body (the member's coded
 // errors), else the first line of a plain-text one (http.Error). An HTML
-// page (a reverse proxy's or the SPA's 404) carries no reason. The text is
-// member-authored, so it is credential-masked with the shared exact-and-shape
-// rule, stripped of control characters, and bounded, before it reaches the
-// dashboard and the event log.
+// page (a reverse proxy's or the SPA's 404) carries no reason.
+//
+// The text is member-authored and reaches the dashboard, the event log, a
+// paired monitor device and the alert push, so it is reduced to one line
+// (Unicode line separators included), stripped of control and format
+// characters (bidi overrides, zero-width joiners), stripped of any userinfo
+// in a URL it quotes (a refused setting or base_url is echoed raw by
+// url.Parse, password included), key-shape masked, and bounded in runes.
+// The exact credential layer runs too but has nothing to match here: Front
+// Desk decrypts no provider key, so its held set is empty; the shape layer
+// is what does the work in this process.
 func refusalReason(body []byte) string {
 	text := strings.TrimSpace(string(body))
 	if text == "" || strings.HasPrefix(text, "<") {
@@ -567,15 +575,27 @@ func refusalReason(body []byte) string {
 		}
 		text = coded.Error
 	}
-	if i := strings.IndexAny(text, "\r\n"); i >= 0 {
+	if i := strings.IndexFunc(text, isLineBreak); i >= 0 {
 		text = text[:i]
 	}
 	text = strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
 			return -1
 		}
 		return r
 	}, text)
-	text = util.MaskCredentialsBounded(nil, text, maxRefusalReasonRunes)
-	return strings.TrimSpace(text)
+	text = urlUserinfoRE.ReplaceAllString(text, "$1")
+	// The byte bound here is generous on purpose (four bytes per rune is the
+	// UTF-8 maximum): the rune bound below is the one the operator sees.
+	text = strings.TrimSpace(util.MaskCredentialsBounded(nil, text, 4*maxRefusalReasonRunes))
+	if runes := []rune(text); len(runes) > maxRefusalReasonRunes {
+		text = strings.TrimSpace(string(runes[:maxRefusalReasonRunes])) + "…"
+	}
+	return text
+}
+
+// isLineBreak is every rune a terminal or a browser treats as a line break:
+// CR, LF, NEL and the Unicode line and paragraph separators.
+func isLineBreak(r rune) bool {
+	return r == '\r' || r == '\n' || r == 0x85 || r == 0x2028 || r == 0x2029
 }

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // This file implements the Front Desk side of HA fleet config sync. It
@@ -235,8 +236,14 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		res.Error = "could not reach this member"
 	case err != nil:
 		// The member answered, just with a status we cannot apply: surface it so a
-		// wrong stored token or a member-side error is not mislabeled "offline".
+		// wrong stored token or a member-side error is not mislabeled "offline",
+		// and with the member's own reason when it gave one, so a refused
+		// envelope names the field here rather than only in the member's log.
 		res.Error = fmt.Sprintf("this member rejected the request (HTTP %d)", status)
+		var refusal *memberRefusal
+		if errors.As(err, &refusal) && refusal.reason != "" {
+			res.Error = fmt.Sprintf("this member rejected the request (HTTP %d): %s", status, refusal.reason)
+		}
 		if lostAnswer5xx(status, time.Since(pushStart)) {
 			// This 5xx is not proof the import failed: a reverse proxy between Front
 			// Desk and the member answers 502/504 when the import outlives its own
@@ -512,6 +519,63 @@ func (s *Server) pushMemberImport(ctx context.Context, m *Member, token string, 
 		}
 		return res, status, nil
 	default:
-		return memberImportResult{}, status, fmt.Errorf("member config-import returned %d", status)
+		return memberImportResult{}, status, &memberRefusal{status: status, reason: refusalReason(body)}
 	}
+}
+
+// memberRefusal is a member answering the import with a status Front Desk
+// cannot apply, carrying whatever reason the member gave. A member refuses
+// an envelope it will not write (a provider field its own admin API would
+// reject, a wrong token) with a 400 whose body names the field; without the
+// body the operator driving the fleet saw only the status, and the reason
+// lived in the member's own log.
+type memberRefusal struct {
+	status int
+	reason string
+}
+
+func (e *memberRefusal) Error() string {
+	if e.reason == "" {
+		return fmt.Sprintf("member config-import returned %d", e.status)
+	}
+	return fmt.Sprintf("member config-import returned %d: %s", e.status, e.reason)
+}
+
+// maxRefusalReasonRunes bounds the member's reason as shown to the operator:
+// a refusal names one field and one value, and a body past this is not a
+// reason but a page.
+const maxRefusalReasonRunes = 240
+
+// refusalReason extracts the operator-readable reason from a member's
+// refusal body: the "error" member of a JSON body (the member's coded
+// errors), else the first line of a plain-text one (http.Error). An HTML
+// page (a reverse proxy's or the SPA's 404) carries no reason. The text is
+// member-authored, so it is credential-masked with the shared exact-and-shape
+// rule, stripped of control characters, and bounded, before it reaches the
+// dashboard and the event log.
+func refusalReason(body []byte) string {
+	text := strings.TrimSpace(string(body))
+	if text == "" || strings.HasPrefix(text, "<") {
+		return ""
+	}
+	if text[0] == '{' {
+		var coded struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &coded) != nil || coded.Error == "" {
+			return ""
+		}
+		text = coded.Error
+	}
+	if i := strings.IndexAny(text, "\r\n"); i >= 0 {
+		text = text[:i]
+	}
+	text = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, text)
+	text = util.MaskCredentialsBounded(nil, text, maxRefusalReasonRunes)
+	return strings.TrimSpace(text)
 }

--- a/internal/frontdesk/configsync_refusal_test.go
+++ b/internal/frontdesk/configsync_refusal_test.go
@@ -22,6 +22,8 @@ func TestConfigSyncCarriesTheMembersRefusalReason(t *testing.T) {
 		{"HTML page carries no reason", "<!doctype html><html><body>404</body></html>", "this member rejected the request (HTTP 404)", http.StatusNotFound},
 		{"credential in the body is masked", "invalid base_url for key sk-proj-0123456789abcdef0123456789abcdef\n", "this member rejected the request (HTTP 400): invalid base_url for key [redacted]", http.StatusBadRequest},
 		{"control characters stripped, first line only", "bad\x1b[31m field\nsecond line", "this member rejected the request (HTTP 400): bad[31m field", http.StatusBadRequest},
+		{"unicode line separator and format characters", "ok\u202eevil\u200bmore\u2028second line", "this member rejected the request (HTTP 400): okevilmore", http.StatusBadRequest},
+		{"userinfo in a quoted URL is redacted", `configsync: refusing to apply a setting with an invalid URL "oidc_issuer_url": invalid URL: parse "https://admin:sup3rs3cr3t@example.com/%zz": invalid URL escape "%zz"`, `this member rejected the request (HTTP 400): configsync: refusing to apply a setting with an invalid URL "oidc_issuer_url": invalid URL: parse "https://example.com/%zz": invalid URL escape "%zz"`, http.StatusBadRequest},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			srv, store := newTestServer(t)
@@ -65,13 +67,18 @@ func TestConfigSyncCarriesTheMembersRefusalReason(t *testing.T) {
 	}
 }
 
-// The reason is bounded: a page-sized body yields a bounded reason, never
-// the whole page.
+// The reason is bounded in runes, not bytes: a page-sized body yields 240
+// runes and an ellipsis whatever script it is written in.
 func TestRefusalReasonIsBounded(t *testing.T) {
-	long := strings.Repeat("x", 5000)
-	got := refusalReason([]byte(long))
-	if len([]rune(got)) > maxRefusalReasonRunes+1 {
-		t.Fatalf("reason is %d runes, want at most %d plus the ellipsis", len([]rune(got)), maxRefusalReasonRunes)
+	for _, long := range []string{strings.Repeat("x", 5000), strings.Repeat("é", 400), strings.Repeat("配置", 300)} {
+		got := refusalReason([]byte(long))
+		runes := []rune(got)
+		if len(runes) != 241 || runes[240] != '…' {
+			t.Fatalf("reason is %d runes ending %q, want 240 plus the ellipsis", len(runes), string(runes[len(runes)-1]))
+		}
+	}
+	if got := refusalReason([]byte(strings.Repeat("y", 240))); len([]rune(got)) != 240 || strings.HasSuffix(got, "…") {
+		t.Fatalf("a reason exactly at the bound was cut: %q", got)
 	}
 	if refusalReason(nil) != "" || refusalReason([]byte("   ")) != "" || refusalReason([]byte(`{"code":"x"}`)) != "" {
 		t.Fatal("an empty or reason-less body must yield no reason")

--- a/internal/frontdesk/configsync_refusal_test.go
+++ b/internal/frontdesk/configsync_refusal_test.go
@@ -1,0 +1,79 @@
+package frontdesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// A member's refusal reason reaches the operator: the 400 body naming the
+// field is carried into the result and the failure event, bounded and
+// scrubbed, while a body with no reason in it (an HTML page) leaves the
+// status-only message.
+func TestConfigSyncCarriesTheMembersRefusalReason(t *testing.T) {
+	const reason = `configsync: refusing to apply an invalid provider: provider "mock-a": max_in_flight must be between 1 and 10000, or null for no ceiling, got -5`
+	for _, tc := range []struct {
+		name, body, want string
+		code             int
+	}{
+		{"plain-text refusal", reason + "\n", "this member rejected the request (HTTP 400): " + reason, http.StatusBadRequest},
+		{"coded JSON refusal", `{"code":"primary_required","error":"a primary must be designated first"}`, "this member rejected the request (HTTP 400): a primary must be designated first", http.StatusBadRequest},
+		{"HTML page carries no reason", "<!doctype html><html><body>404</body></html>", "this member rejected the request (HTTP 404)", http.StatusNotFound},
+		{"credential in the body is masked", "invalid base_url for key sk-proj-0123456789abcdef0123456789abcdef\n", "this member rejected the request (HTTP 400): invalid base_url for key [redacted]", http.StatusBadRequest},
+		{"control characters stripped, first line only", "bad\x1b[31m field\nsecond line", "this member rejected the request (HTTP 400): bad[31m field", http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, store := newTestServer(t)
+			primary := newStubConfigMember(t, "ptoken")
+			replica := newStubConfigMember(t, "rtoken")
+			replica.importCode = tc.code
+			replica.importBody = tc.body
+			pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+			enableAutoSync(t, store, pm.ID)
+			rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+			alignFleetVersions(t, srv, store, "dev")
+
+			rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("sync = %d", rec.Code)
+			}
+			var resp struct {
+				Results []syncResultItem `json:"results"`
+			}
+			_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+			if len(resp.Results) != 1 || resp.Results[0].OK {
+				t.Fatalf("expected a failure result, got %+v", resp.Results)
+			}
+			if got := resp.Results[0].Error; got != tc.want {
+				t.Fatalf("error = %q\nwant  %q", got, tc.want)
+			}
+			evs, _, _ := store.ListEvents(t.Context(), EventFilter{})
+			saw := false
+			for _, e := range evs {
+				if e.Type == "config.sync_failed" && e.MemberID == rm.ID {
+					saw = true
+					if !strings.Contains(e.Message, tc.want) {
+						t.Fatalf("event message %q does not carry the reason %q", e.Message, tc.want)
+					}
+				}
+			}
+			if !saw {
+				t.Fatal("no sync_failed event for the replica")
+			}
+		})
+	}
+}
+
+// The reason is bounded: a page-sized body yields a bounded reason, never
+// the whole page.
+func TestRefusalReasonIsBounded(t *testing.T) {
+	long := strings.Repeat("x", 5000)
+	got := refusalReason([]byte(long))
+	if len([]rune(got)) > maxRefusalReasonRunes+1 {
+		t.Fatalf("reason is %d runes, want at most %d plus the ellipsis", len([]rune(got)), maxRefusalReasonRunes)
+	}
+	if refusalReason(nil) != "" || refusalReason([]byte("   ")) != "" || refusalReason([]byte(`{"code":"x"}`)) != "" {
+		t.Fatal("an empty or reason-less body must yield no reason")
+	}
+}

--- a/internal/frontdesk/fleetstatus.go
+++ b/internal/frontdesk/fleetstatus.go
@@ -203,6 +203,12 @@ func (s *Server) fleetStatusForMember(ctx context.Context, m *Member, primaryID 
 			item.Note = fmt.Sprintf("this member rejected the stored admin token (HTTP %d); update it on the Members tab", status)
 		default:
 			item.Note = fmt.Sprintf("this member rejected the config request (HTTP %d)", status)
+			// With the member's own reason when it gave one ("refusing to
+			// import an empty config"), as the real push reports it.
+			var refusal *memberRefusal
+			if errors.As(err, &refusal) && refusal.reason != "" {
+				item.Note = fmt.Sprintf("this member rejected the config request (HTTP %d): %s", status, refusal.reason)
+			}
 		}
 		return item
 	}

--- a/internal/frontdesk/fleetstatus_test.go
+++ b/internal/frontdesk/fleetstatus_test.go
@@ -244,6 +244,34 @@ func TestFleetStatusMemberRejectsToken(t *testing.T) {
 	}
 }
 
+// A member refusing the dry run with a reason carries that reason into the
+// readiness note, as the real push does.
+func TestFleetStatusMemberRefusalCarriesTheReason(t *testing.T) {
+	srv, store := newTestServer(t)
+	primary := newStubConfigMember(t, "ptoken")
+	rejecting := newStubConfigMember(t, "rtoken")
+	rejecting.importCode = http.StatusBadRequest
+	rejecting.importBody = "configsync: refusing to import an empty config\n"
+
+	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
+	rm, _ := store.CreateMember(t.Context(), "rejecting", rejecting.srv.URL, "rtoken")
+
+	resp := fleetStatusByID(t, srv, pm.ID)
+	for _, it := range resp.Members {
+		if it.MemberID != rm.ID {
+			continue
+		}
+		if it.Reachable {
+			t.Errorf("refusing member reported reachable: %+v", it)
+		}
+		if want := "this member rejected the config request (HTTP 400): configsync: refusing to import an empty config"; it.Note != want {
+			t.Errorf("note = %q, want %q", it.Note, want)
+		}
+		return
+	}
+	t.Fatal("rejecting member missing from the status")
+}
+
 // TestFleetStatusKeylessFleet: when the primary has no provider keys there is
 // nothing to verify, so MASTER_KEY is reported as nil (not a false alarm).
 func TestFleetStatusKeylessFleet(t *testing.T) {

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -361,8 +361,10 @@ What makes this safe to leave running:
   ceiling (1 to 10000, or null: a value below one would read as no ceiling at
   all), settings minimums and URL-typed settings, per-key and per-user rate
   limits, and password hash format. An envelope that fails any of them is
-  refused whole with a 400 and nothing is written; the member's own log names
-  the field, Front Desk reports the refusal by status.
+  refused whole with a 400 and nothing is written. Front Desk shows the member's
+  own reason with the status (`this member rejected the request (HTTP 400):
+  provider "x": max_in_flight must be ...`), in the sync result and in the
+  failure event, so the field is named where the operator is looking.
 - **Newer config always wins.** Each push carries a monotonic source generation,
   and a member refuses any import older than the one it has already applied, so
   repointing the primary while an earlier push is still in flight can never strand a

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -363,8 +363,10 @@ What makes this safe to leave running:
   limits, and password hash format. An envelope that fails any of them is
   refused whole with a 400 and nothing is written. Front Desk shows the member's
   own reason with the status (`this member rejected the request (HTTP 400):
-  provider "x": max_in_flight must be ...`), in the sync result and in the
-  failure event, so the field is named where the operator is looking.
+  configsync: refusing to apply an invalid provider: provider "x": max_in_flight
+  must be ...`), in the sync result, in the failure event and in the readiness
+  check, cut to one line of 240 characters; the member's own log carries the
+  full text.
 - **Newer config always wins.** Each push carries a monotonic source generation,
   and a member refuses any import older than the one it has already applied, so
   repointing the primary while an earlier push is still in flight can never strand a


### PR DESCRIPTION
## Summary

Follow-up to #868. A member refuses a config envelope it will not write (a provider field its own admin API would reject, a wrong token) with a 400 whose body names the field, and Front Desk reported only `this member rejected the request (HTTP 400)`: the reason lived in the member's log, which the operator driving the fleet is not looking at.

The refusal now carries the member's own reason into the sync result and the `config.sync_failed` event: the `error` member of a coded JSON body, or the first line of a plain-text one, credential-masked with the shared rule, stripped of control characters, and bounded to 240 runes. An HTML page (a reverse proxy's or the SPA's 404) carries no reason and leaves the status-only message. The web UI already passes the result's `error` text through, so nothing changes there.

## Review rounds (adversarial, opus)

Round 1 found one real credential path: a refused URL-typed setting or `base_url` is echoed raw by `url.Parse`, password included, and the package's own userinfo redaction wasn't applied to the reason; it is now, along with Unicode line separators and format characters in the strip, a true rune bound (the constant said runes, the truncation was bytes), a bound test that pins the number rather than the constant, the same reason on the readiness note, an honest comment (the exact credential layer's held set is empty in this process) and the real message in the wiki. Round 2 confirmed all of it by mutation and returned MERGE.

## Live test (dev HA stack, A/B)

Front Desk with the dev gateway as primary (it holds a provider on a LAN address) and a fresh throwaway member with the default host allowlist, which refuses that provider's `base_url`:

| | before | after |
|---|---|---|
| sync result for the member | `this member rejected the request (HTTP 500)` | `this member rejected the request (HTTP 400): configsync: refusing to apply an invalid provider: provider "Kobold as custom" has an invalid base_url: host "192.168.1.141" resolves to private/reserved address …` |
| `config.sync_failed` event | status only | the same reason |

(The before column's 500 is the member's pre-#868 build; #868 made that refusal a 400.)

## Tests

Seven refusal shapes through the real handler and the stub member (plain text, coded JSON, an HTML page, a body quoting a key, control characters and a second line, Unicode separators and format characters, userinfo in a quoted URL), the rune bound across scripts, the readiness note, and the existing failure-reporting test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
