### PR TITLE
fix(gemini,proxy): serve Google AI Studio image models and return generated images

### DIFF
--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -55,17 +55,25 @@ type StreamAdapter struct {
 	readBuf  []byte
 	srcErr   error
 	transErr error // first translation failure; poisons the stream
+	eventCap int   // largest SSE event this adapter buffers; MaxSSEEventBytes unless the dialect says otherwise
 }
 
 // NewStreamAdapter builds an adapter for one streaming response. component is
 // the log prefix ("gemini", "anthropicegress"); tr is that dialect's stream
 // translator, already primed with the chunk id and model to echo.
 func NewStreamAdapter(component string, upstream io.ReadCloser, tr Translator) *StreamAdapter {
+	return NewStreamAdapterWithCap(component, upstream, tr, MaxSSEEventBytes)
+}
+
+// NewStreamAdapterWithCap is NewStreamAdapter with the dialect's own event
+// cap, for one whose single event legitimately outgrows MaxSSEEventBytes.
+func NewStreamAdapterWithCap(component string, upstream io.ReadCloser, tr Translator, eventCap int) *StreamAdapter {
 	return &StreamAdapter{
 		component: component,
 		upstream:  upstream,
 		tr:        tr,
 		readBuf:   make([]byte, 32*1024),
+		eventCap:  eventCap,
 	}
 }
 
@@ -165,12 +173,12 @@ func (a *StreamAdapter) consume(p []byte) {
 // of the line still being read, counted with the fields already joined so that
 // a folded event cannot carry more than a single line could.
 func (a *StreamAdapter) withinEventCap(partialLine int) bool {
-	if len(a.eventBuf)+partialLine <= MaxSSEEventBytes {
+	if len(a.eventBuf)+partialLine <= a.eventCap {
 		return true
 	}
 	a.lineBuf, a.eventBuf = nil, nil
-	a.transErr = fmt.Errorf("%s: upstream SSE event exceeds %d bytes", a.component, MaxSSEEventBytes)
-	debuglog.Warn(a.component+": stream event exceeds buffer cap", "limit", MaxSSEEventBytes)
+	a.transErr = fmt.Errorf("%s: upstream SSE event exceeds %d bytes", a.component, a.eventCap)
+	debuglog.Warn(a.component+": stream event exceeds buffer cap", "limit", a.eventCap)
 	return false
 }
 

--- a/internal/gemini/adapter.go
+++ b/internal/gemini/adapter.go
@@ -25,9 +25,15 @@ import (
 // tell them apart.
 type StreamAdapter = egress.StreamAdapter
 
+// MaxEventBytes caps one Gemini SSE event. An image model streams its whole
+// picture as a single inlineData part in one event, and a 2K or 4K PNG is
+// several MiB of base64, well past the 4 MiB the text dialects need; 32 MiB
+// matches the cap on a non-streaming body.
+const MaxEventBytes = 32 << 20
+
 // NewStreamAdapter builds an adapter for one streaming response. model is
 // echoed in every emitted chunk (the model string the client requested).
 func NewStreamAdapter(upstream io.ReadCloser, model string) *StreamAdapter {
 	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
-	return egress.NewStreamAdapter("gemini", upstream, NewStreamTranslator(id, model, time.Now().Unix()))
+	return egress.NewStreamAdapterWithCap("gemini", upstream, NewStreamTranslator(id, model, time.Now().Unix()), MaxEventBytes)
 }

--- a/internal/gemini/image_out_test.go
+++ b/internal/gemini/image_out_test.go
@@ -1,0 +1,77 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A chat request asking for image output names IMAGE among Gemini's response
+// modalities; one that does not leaves the config without them.
+func TestTranslateRequest_ImageModalities(t *testing.T) {
+	body := []byte(`{"model":"gemini-3-pro-image","messages":[{"role":"user","content":"a blue circle"}],"modalities":["image","text"]}`)
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var req struct {
+		GenerationConfig struct {
+			ResponseModalities []string `json:"responseModalities"`
+		} `json:"generationConfig"`
+	}
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := strings.Join(req.GenerationConfig.ResponseModalities, ","); got != "TEXT,IMAGE" {
+		t.Fatalf("responseModalities = %q, want TEXT,IMAGE", got)
+	}
+	plain, _, _, err := TranslateRequest([]byte(`{"model":"gemini-3-pro-image","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if strings.Contains(string(plain), "responseModalities") {
+		t.Fatalf("a request without modalities set responseModalities: %s", plain)
+	}
+}
+
+// A generated image part becomes an image_url data URL beside the text, in
+// the non-streaming message and in a streamed delta alike.
+func TestImageParts_BecomeImages(t *testing.T) {
+	upstream := `{"candidates":[{"content":{"parts":[{"text":"Here it is."},{"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2,"totalTokenCount":5}}`
+	out, err := BuildChatCompletion([]byte(upstream), "chatcmpl-1", "gemini-3-pro-image", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+				Images  []struct {
+					Type     string `json:"type"`
+					ImageURL struct {
+						URL string `json:"url"`
+					} `json:"image_url"`
+				} `json:"images"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	msg := resp.Choices[0].Message
+	if msg.Content != "Here it is." {
+		t.Fatalf("content = %q", msg.Content)
+	}
+	if len(msg.Images) != 1 || msg.Images[0].Type != "image_url" || msg.Images[0].ImageURL.URL != "data:image/png;base64,iVBORw0KGgo=" {
+		t.Fatalf("images = %+v", msg.Images)
+	}
+
+	tr := NewStreamTranslator("chatcmpl-2", "gemini-3-pro-image", 1)
+	chunk, err := tr.Translate([]byte(upstream))
+	if err != nil {
+		t.Fatalf("stream translate: %v", err)
+	}
+	if !strings.Contains(string(chunk), `"images":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]`) {
+		t.Fatalf("streamed delta carries no image: %s", chunk)
+	}
+}

--- a/internal/gemini/image_out_test.go
+++ b/internal/gemini/image_out_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 )
@@ -73,5 +74,57 @@ func TestImageParts_BecomeImages(t *testing.T) {
 	}
 	if !strings.Contains(string(chunk), `"images":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]`) {
 		t.Fatalf("streamed delta carries no image: %s", chunk)
+	}
+}
+
+// An image model drafts interim pictures as thought parts; only the final
+// image is the answer. A blob with no bytes or a non-image type is nothing.
+func TestImageParts_ThoughtAndEmptyBlobsAreSkipped(t *testing.T) {
+	upstream := `{"candidates":[{"content":{"parts":[{"thought":true,"inlineData":{"mimeType":"image/png","data":"ZHJhZnQ="}},{"inlineData":{"mimeType":"image/png","data":""}},{"inlineData":{"mimeType":"audio/L16","data":"AAAA"}},{"inlineData":{"mimeType":"image/png","data":"ZmluYWw="}}]},"finishReason":"STOP"}]}`
+	out, err := BuildChatCompletion([]byte(upstream), "chatcmpl-3", "gemini-3-pro-image", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if n := strings.Count(string(out), `"image_url":{"url":"data:image/png;base64,`); n != 1 || !strings.Contains(string(out), "base64,ZmluYWw=") {
+		t.Fatalf("images in completion = %d, want the final image only: %s", n, out)
+	}
+	tr := NewStreamTranslator("chatcmpl-4", "gemini-3-pro-image", 1)
+	chunk, err := tr.Translate([]byte(upstream))
+	if err != nil {
+		t.Fatalf("stream translate: %v", err)
+	}
+	if n := strings.Count(string(chunk), `"image_url":{"url":"data:image/png;base64,`); n != 1 || strings.Contains(string(chunk), "ZHJhZnQ=") {
+		t.Fatalf("images in chunk = %d, want the final image only: %s", n, chunk)
+	}
+	thoughtOnly, err := tr.Translate([]byte(`{"candidates":[{"content":{"parts":[{"thought":true,"inlineData":{"mimeType":"image/png","data":"ZHJhZnQ="}}]}}]}`))
+	if err != nil || thoughtOnly != nil {
+		t.Fatalf("a thought-only chunk emitted %q, %v", thoughtOnly, err)
+	}
+}
+
+// An image-only modalities list asks Gemini for the picture alone.
+func TestTranslateRequest_ImageOnlyModalities(t *testing.T) {
+	out, _, _, err := TranslateRequest([]byte(`{"model":"gemini-2.5-flash-image","messages":[{"role":"user","content":"a circle"}],"modalities":["image"]}`))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !strings.Contains(string(out), `"responseModalities":["IMAGE"]`) {
+		t.Fatalf("image-only request sent %s", out)
+	}
+}
+
+// A streamed picture arrives as one SSE event of several MiB; the gemini
+// adapter's cap admits it where the text dialects' 4 MiB would fail the
+// stream.
+func TestStreamAdapter_LargeImageEventPasses(t *testing.T) {
+	big := strings.Repeat("A", 5<<20)
+	event := "data: " + `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"` + big + `"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":1290,"totalTokenCount":1293}}` + "\n\n"
+	ad := NewStreamAdapter(io.NopCloser(strings.NewReader(event)), "gemini-3-pro-image")
+	out, err := io.ReadAll(ad)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(out), "base64,"+big[:64]) || !strings.Contains(string(out), "[DONE]") {
+		t.Fatalf("large image event did not pass: %d bytes, done=%v", len(out), strings.Contains(string(out), "[DONE]"))
 	}
 }

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -341,6 +341,19 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 	return &gc
 }
 
+// RequestWantsImage reports whether a chat request names image among its
+// output modalities; the proxy uses it to pick the native route for a
+// provider whose OpenAI-compatibility layer cannot return one.
+func RequestWantsImage(body []byte) bool {
+	var req struct {
+		Modalities []string `json:"modalities"`
+	}
+	if json.Unmarshal(body, &req) != nil {
+		return false
+	}
+	return wantsImageOutput(req.Modalities)
+}
+
 // wantsImageOutput reports a modalities list that names image output.
 func wantsImageOutput(modalities []string) bool {
 	for _, m := range modalities {

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -327,9 +327,11 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 		gc.ThinkingConfig = &genThinkingConfig{ThinkingBudget: budget}
 	}
 	if wantsImageOutput(req.Modalities) {
-		// TEXT alongside IMAGE: the image models answer with both, and
-		// asking for IMAGE alone is refused by the ones that always caption.
-		gc.ResponseModalities = []string{"TEXT", "IMAGE"}
+		// The request's list, translated: image plus text asks for both,
+		// image alone asks for the picture only. A request without the field
+		// sends nothing; an image model returns its image by default, which
+		// is what the text-only model probes rely on.
+		gc.ResponseModalities = responseModalities(req.Modalities)
 	}
 
 	if gc.MaxOutputTokens == 0 && gc.Temperature == nil && gc.TopP == nil &&
@@ -352,6 +354,19 @@ func RequestWantsImage(body []byte) bool {
 		return false
 	}
 	return wantsImageOutput(req.Modalities)
+}
+
+// responseModalities maps an OpenAI modalities list that names image onto
+// Gemini's response modalities, keeping text only when the client asked for
+// it.
+func responseModalities(modalities []string) []string {
+	out := []string{"IMAGE"}
+	for _, m := range modalities {
+		if strings.EqualFold(m, "text") {
+			return []string{"TEXT", "IMAGE"}
+		}
+	}
+	return out
 }
 
 // wantsImageOutput reports a modalities list that names image output.

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -38,6 +38,12 @@ type oaiRequest struct {
 	ToolChoice          json.RawMessage `json:"tool_choice"`
 	ReasoningEffort     string          `json:"reasoning_effort"`
 	ResponseFormat      *oaiRespFormat  `json:"response_format"`
+	// Modalities is the OpenAI-compatible request for image output from a
+	// chat model ("modalities": ["image", "text"]). Gemini's image models
+	// generate an image only when the request names IMAGE among its response
+	// modalities; without it the model still produces the image and the API
+	// then fails the response ("Unhandled generated data mime type").
+	Modalities []string `json:"modalities"`
 }
 
 type oaiMessage struct {
@@ -162,6 +168,7 @@ type genConfig struct {
 	ResponseMimeType   string             `json:"responseMimeType,omitempty"`
 	ResponseJSONSchema json.RawMessage    `json:"responseJsonSchema,omitempty"`
 	ThinkingConfig     *genThinkingConfig `json:"thinkingConfig,omitempty"`
+	ResponseModalities []string           `json:"responseModalities,omitempty"`
 }
 
 type genThinkingConfig struct {
@@ -319,13 +326,29 @@ func buildGenerationConfig(req *oaiRequest) *genConfig {
 	if budget, ok := reasoningBudgets[strings.ToLower(req.ReasoningEffort)]; ok && req.ReasoningEffort != "" {
 		gc.ThinkingConfig = &genThinkingConfig{ThinkingBudget: budget}
 	}
+	if wantsImageOutput(req.Modalities) {
+		// TEXT alongside IMAGE: the image models answer with both, and
+		// asking for IMAGE alone is refused by the ones that always caption.
+		gc.ResponseModalities = []string{"TEXT", "IMAGE"}
+	}
 
 	if gc.MaxOutputTokens == 0 && gc.Temperature == nil && gc.TopP == nil &&
 		gc.FrequencyPenalty == nil && gc.PresencePenalty == nil && gc.Seed == nil &&
-		len(gc.StopSequences) == 0 && gc.ResponseMimeType == "" && gc.ThinkingConfig == nil {
+		len(gc.StopSequences) == 0 && gc.ResponseMimeType == "" && gc.ThinkingConfig == nil &&
+		len(gc.ResponseModalities) == 0 {
 		return nil
 	}
 	return &gc
+}
+
+// wantsImageOutput reports a modalities list that names image output.
+func wantsImageOutput(modalities []string) bool {
+	for _, m := range modalities {
+		if strings.EqualFold(m, "image") {
+			return true
+		}
+	}
+	return false
 }
 
 // translateParts converts an OpenAI message content field (string, part array,

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -100,9 +100,13 @@ type oaiImageURLOut struct {
 	URL string `json:"url"`
 }
 
-// imageOut renders a generated image part as an image_url data URL.
-func imageOut(blob *genRespBlob) oaiImageOut {
-	return oaiImageOut{Type: "image_url", ImageURL: oaiImageURLOut{URL: "data:" + blob.MimeType + ";base64," + blob.Data}}
+// imageOut renders a generated image part as an image_url data URL. A part
+// that is not an image, or an image with no bytes or type, yields nothing.
+func imageOut(blob *genRespBlob) (oaiImageOut, bool) {
+	if blob == nil || blob.Data == "" || !strings.HasPrefix(blob.MimeType, "image/") {
+		return oaiImageOut{}, false
+	}
+	return oaiImageOut{Type: "image_url", ImageURL: oaiImageURLOut{URL: "data:" + blob.MimeType + ";base64," + blob.Data}}, true
 }
 
 type oaiToolCallOut struct {
@@ -189,8 +193,13 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 	var toolCalls []oaiToolCallOut
 	var images []oaiImageOut
 	for _, p := range parts {
-		if p.InlineData != nil && strings.HasPrefix(p.InlineData.MimeType, "image/") {
-			images = append(images, imageOut(p.InlineData))
+		// Thought parts first: an image model drafts interim images to test
+		// its composition, and those arrive as thought parts too.
+		if p.Thought {
+			continue
+		}
+		if img, ok := imageOut(p.InlineData); ok {
+			images = append(images, img)
 			continue
 		}
 		if p.FunctionCall != nil {
@@ -205,9 +214,6 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 			tc.Function.Name = p.FunctionCall.Name
 			tc.Function.Arguments = args
 			toolCalls = append(toolCalls, tc)
-			continue
-		}
-		if p.Thought {
 			continue
 		}
 		sb.WriteString(p.Text)

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -41,6 +41,15 @@ type genRespPart struct {
 	Text         string           `json:"text"`
 	Thought      bool             `json:"thought"`
 	FunctionCall *genRespFuncCall `json:"functionCall"`
+	// InlineData carries a generated image (an image model answering a
+	// request whose response modalities named IMAGE): base64 bytes and
+	// their mime type.
+	InlineData *genRespBlob `json:"inlineData"`
+}
+
+type genRespBlob struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
 }
 
 type genRespFuncCall struct {
@@ -76,6 +85,24 @@ type oaiMessageOut struct {
 	Role      string           `json:"role"`
 	Content   *string          `json:"content"`
 	ToolCalls []oaiToolCallOut `json:"tool_calls,omitempty"`
+	// Images is the OpenAI-compatible shape for image output from a chat
+	// model (the one OpenRouter and the image-capable chat models use): a
+	// list of image_url parts carrying data URLs, beside the text content.
+	Images []oaiImageOut `json:"images,omitempty"`
+}
+
+type oaiImageOut struct {
+	Type     string         `json:"type"`
+	ImageURL oaiImageURLOut `json:"image_url"`
+}
+
+type oaiImageURLOut struct {
+	URL string `json:"url"`
+}
+
+// imageOut renders a generated image part as an image_url data URL.
+func imageOut(blob *genRespBlob) oaiImageOut {
+	return oaiImageOut{Type: "image_url", ImageURL: oaiImageURLOut{URL: "data:" + blob.MimeType + ";base64," + blob.Data}}
 }
 
 type oaiToolCallOut struct {
@@ -128,9 +155,9 @@ func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, 
 	}
 
 	cand := resp.Candidates[0]
-	text, toolCalls := translateCandidateParts(id, cand.Content.Parts)
+	text, toolCalls, images := translateCandidateParts(id, cand.Content.Parts)
 
-	msg := oaiMessageOut{Role: "assistant", Content: &text, ToolCalls: toolCalls}
+	msg := oaiMessageOut{Role: "assistant", Content: &text, ToolCalls: toolCalls, Images: images}
 
 	out := oaiCompletion{
 		ID:      id,
@@ -153,14 +180,19 @@ func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, 
 }
 
 // translateCandidateParts joins visible text parts (thought parts are model
-// internals and must not surface as content) and converts functionCall parts
-// into OpenAI tool_calls. Gemini has no call IDs, so IDs are synthesized from
-// the response id + index; TranslateRequest resolves them back by mapping,
-// falling back to the function name.
-func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolCallOut) {
+// internals and must not surface as content), converts functionCall parts
+// into OpenAI tool_calls, and collects generated images. Gemini has no call
+// IDs, so IDs are synthesized from the response id + index; TranslateRequest
+// resolves them back by mapping, falling back to the function name.
+func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolCallOut, []oaiImageOut) {
 	var sb strings.Builder
 	var toolCalls []oaiToolCallOut
+	var images []oaiImageOut
 	for _, p := range parts {
+		if p.InlineData != nil && strings.HasPrefix(p.InlineData.MimeType, "image/") {
+			images = append(images, imageOut(p.InlineData))
+			continue
+		}
 		if p.FunctionCall != nil {
 			args := compactJSON(p.FunctionCall.Args)
 			if args == "" {
@@ -180,7 +212,7 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 		}
 		sb.WriteString(p.Text)
 	}
-	return sb.String(), toolCalls
+	return sb.String(), toolCalls, images
 }
 
 // compactJSON strips the pretty-print whitespace Vertex puts inside nested

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -58,6 +59,9 @@ type oaiChunkDelta struct {
 	Role      string                `json:"role,omitempty"`
 	Content   string                `json:"content,omitempty"`
 	ToolCalls []oaiChunkToolCallOut `json:"tool_calls,omitempty"`
+	// Images carries a generated image part, as the non-streaming message's
+	// images does: an image model streams its image as one inlineData part.
+	Images []oaiImageOut `json:"images,omitempty"`
 }
 
 // oaiChunkToolCallOut is a streamed tool call. Gemini delivers each
@@ -128,6 +132,10 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	delta := oaiChunkDelta{}
 	for _, p := range cand.Content.Parts {
+		if p.InlineData != nil && strings.HasPrefix(p.InlineData.MimeType, "image/") {
+			delta.Images = append(delta.Images, imageOut(p.InlineData))
+			continue
+		}
 		if p.FunctionCall != nil {
 			args := compactJSON(p.FunctionCall.Args)
 			if args == "" {
@@ -150,7 +158,7 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 		delta.Content += p.Text
 	}
 
-	if delta.Content == "" && len(delta.ToolCalls) == 0 {
+	if delta.Content == "" && len(delta.ToolCalls) == 0 && len(delta.Images) == 0 {
 		return nil, nil
 	}
 	if err := t.writeChunk(&buf, delta, nil, nil); err != nil {

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
 	"github.com/hugalafutro/model-hotel/internal/util"
@@ -132,8 +131,11 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	delta := oaiChunkDelta{}
 	for _, p := range cand.Content.Parts {
-		if p.InlineData != nil && strings.HasPrefix(p.InlineData.MimeType, "image/") {
-			delta.Images = append(delta.Images, imageOut(p.InlineData))
+		if p.Thought {
+			continue
+		}
+		if img, ok := imageOut(p.InlineData); ok {
+			delta.Images = append(delta.Images, img)
 			continue
 		}
 		if p.FunctionCall != nil {
@@ -150,9 +152,6 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 			tc.Function.Arguments = args
 			delta.ToolCalls = append(delta.ToolCalls, tc)
 			t.toolCalls++
-			continue
-		}
-		if p.Thought {
 			continue
 		}
 		delta.Content += p.Text

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -22,7 +22,7 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 
 	// Determine the native API base URL from the proxy base URL.
 	// The proxy uses /v1beta/openai/ but discovery uses /v1beta/models?key=KEY
-	nativeBaseURL := toNativeBaseURL(baseURL)
+	nativeBaseURL := GoogleNativeBaseURL(baseURL)
 
 	// Use ?key= auth for native API.
 	//
@@ -159,10 +159,11 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	return models, nil
 }
 
-// toNativeBaseURL converts a proxy base URL to the native API base URL.
+// GoogleNativeBaseURL converts a proxy base URL to the native API base URL;
+// the proxy's gemini egress adapter uses it too.
 // Proxy:  https://generativelanguage.googleapis.com/v1beta/openai
 // Native: https://generativelanguage.googleapis.com/v1beta
-func toNativeBaseURL(proxyURL string) string {
+func GoogleNativeBaseURL(proxyURL string) string {
 	u := strings.TrimSuffix(proxyURL, "/")
 	if before, ok := strings.CutSuffix(u, "/openai"); ok {
 		return before

--- a/internal/provider/discovery_google_test.go
+++ b/internal/provider/discovery_google_test.go
@@ -69,8 +69,8 @@ func TestToNativeBaseURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := toNativeBaseURL(tt.proxyURL); got != tt.want {
-				t.Errorf("toNativeBaseURL(%q) = %v, want %v", tt.proxyURL, got, tt.want)
+			if got := GoogleNativeBaseURL(tt.proxyURL); got != tt.want {
+				t.Errorf("GoogleNativeBaseURL(%q) = %v, want %v", tt.proxyURL, got, tt.want)
 			}
 		})
 	}

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -463,6 +463,9 @@ func TestChatAnswerCarriesContent_StaysNarrowForRetirement(t *testing.T) {
 		// clear the streak that is meant to retire the model.
 		{"a refusal envelope", `{"choices":[{"message":{"role":"assistant","content":null,"refusal":"this model is no longer available"}}]}`, false},
 		{"an audio answer", `{"choices":[{"message":{"role":"assistant","content":null,"audio":{"data":"AA"}}}]}`, false},
+		// An image-only answer is admitted by the completion-token fallback
+		// (an image model's usage counts its picture), never by a member of
+		// its own: the aggregator this bar exists to catch emits no images.
 		{"generated images", `{"choices":[{"message":{"role":"assistant","content":"","images":[{"image_url":{"url":"data:x"}}]}}]}`, false},
 		// The one addition, and why.
 		{"reasoning_details only", `{"choices":[{"message":{"role":"assistant","content":"","reasoning_details":[{"type":"reasoning.text","text":"t"}]}}]}`, true},

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -285,10 +285,10 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, stat
 // logData has not been stamped with it at this point.
 func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, status int, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
-	// Both translators read the body with an unbounded ReadAll under the
-	// attempt's context, so an interrupted request arrives here as a translation
-	// failure — a caller hanging up or this gateway's own request_timeout, and
-	// neither is the provider's doing.
+	// The translators read the body under the attempt's context, so an
+	// interrupted request arrives here as a translation failure — a caller
+	// hanging up or this gateway's own request_timeout, and neither is the
+	// provider's doing.
 	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
 		h.chargeBreaker(st, candidate, status, "upstream body could not be translated")
 	}
@@ -307,7 +307,7 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 // Charging for it took a healthy provider out of rotation for every tenant after
 // five blocked prompts, which is exactly what a client retries.
 func translationIsProviderFault(err error) bool {
-	return !errors.Is(err, gemini.ErrPromptBlocked)
+	return !errors.Is(err, gemini.ErrPromptBlocked) && !errors.Is(err, errEgressBodyOversized)
 }
 
 // answerCarriesSomething reports whether a completion carries anything at all

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -15,6 +16,10 @@ import (
 // anthropicegress.BuildChatCompletion both have this shape.
 type chatCompletionBuilder func(body []byte, id, model string, created int64) ([]byte, error)
 
+// errEgressBodyOversized is the refusal of a native-dialect body past
+// nonStreamingBodyCap: the gateway's own limit, never a provider fault.
+var errEgressBodyOversized = errors.New("upstream response body exceeds the non-streaming cap")
+
 // translateEgressResponseBody swaps a non-streaming native 200 body for its
 // chat.completion translation so handleNonStreamingResponse can meter and
 // forward it unchanged. The dialect differs only in the builder, so every
@@ -24,14 +29,21 @@ type chatCompletionBuilder func(body []byte, id, model string, created int64) ([
 // that surfaces the error still hands the pipeline a closed-once, drainable
 // response.
 func translateEgressResponseBody(resp *http.Response, model string, build chatCompletionBuilder) error {
-	// Bounded like the plain non-streaming read: a body past the cap is cut
-	// and fails the translation, so one upstream cannot hold more than the
-	// cap (twice, original and translated) per concurrent request.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap))
+	// Bounded like the plain non-streaming read: cap+1 is read, and a body
+	// that reaches it is refused with errEgressBodyOversized rather than
+	// translated, so one upstream cannot hold more than the cap (twice,
+	// original and translated) per concurrent request. The refusal is this
+	// gateway's policy and not the provider failing, which
+	// translationIsProviderFault knows.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
 	_ = resp.Body.Close()
 	if err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(nil))
 		return err
+	}
+	if len(body) > nonStreamingBodyCap {
+		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		return errEgressBodyOversized
 	}
 	id := "chatcmpl-" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	translated, err := build(body, id, model, time.Now().Unix())

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -24,7 +24,10 @@ type chatCompletionBuilder func(body []byte, id, model string, created int64) ([
 // that surfaces the error still hands the pipeline a closed-once, drainable
 // response.
 func translateEgressResponseBody(resp *http.Response, model string, build chatCompletionBuilder) error {
-	body, err := io.ReadAll(resp.Body)
+	// Bounded like the plain non-streaming read: a body past the cap is cut
+	// and fails the translation, so one upstream cannot hold more than the
+	// cap (twice, original and translated) per concurrent request.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap))
 	_ = resp.Body.Close()
 	if err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(nil))

--- a/internal/proxy/gemini_egress.go
+++ b/internal/proxy/gemini_egress.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/paramrewrite"
+	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -25,17 +27,34 @@ import (
 // override, no multipart body) bound for a provider that only speaks Gemini's
 // native dialect for this model.
 //
-// Two providers qualify. vertex-express speaks it for every model. OpenCode Zen
-// speaks it for its Gemini models only: Zen routes each model family to a
+// Three providers qualify. vertex-express speaks it for every model. OpenCode
+// Zen speaks it for its Gemini models only: Zen routes each model family to a
 // different upstream shape, and its Gemini models are a thin passthrough to
 // Google, so an OpenAI-shaped body sent to Zen's /chat/completions comes back
 // with Google's own `Invalid JSON request body: Missing key at ["contents"]`.
-// Every other Zen family stays on chat-completions.
-func isGeminiEgressAttempt(st *requestState, providerType, modelID string) bool {
+// Every other Zen family stays on chat-completions. Google AI Studio speaks it
+// for image output only (see isGoogleImageEgress).
+func isGeminiEgressAttempt(st *requestState, providerType, modelID, outputModalities string) bool {
 	if st.endpointPath != "" || st.makeUpstreamBody != nil {
 		return false
 	}
-	return providerType == "vertex-express" || isZenGeminiModel(providerType, modelID)
+	return providerType == "vertex-express" || isZenGeminiModel(providerType, modelID) ||
+		isGoogleImageEgress(providerType, outputModalities, st.bodyBytes)
+}
+
+// isGoogleImageEgress reports a Google AI Studio candidate that has to speak
+// the native dialect. Google's OpenAI-compatibility layer produces images
+// only on its own /images/generations route: a chat request to an image
+// model there is answered with a 400 whether or not it names an image
+// modality, while the native generateContent route serves it and returns the
+// image as an inlineData part. The model's discovered output modalities
+// decide, and a request naming an image modality is a second trigger for a
+// model discovery has not marked.
+func isGoogleImageEgress(providerType, outputModalities string, body []byte) bool {
+	if providerType != "google" {
+		return false
+	}
+	return slices.Contains(declaredModalities(outputModalities), "image") || gemini.RequestWantsImage(body)
 }
 
 // isZenGeminiModel reports whether this is an OpenCode Zen candidate for a
@@ -51,7 +70,7 @@ func isZenGeminiModel(providerType, modelID string) bool {
 // generateContent verbs directly under its own /models/{id}.
 func geminiEgressEndpoint(providerType, model string, stream bool) string {
 	prefix := "/publishers/google/models/"
-	if providerType == "opencode-zen" {
+	if providerType == "opencode-zen" || providerType == "google" {
 		prefix = "/models/"
 	}
 	if stream {
@@ -61,13 +80,14 @@ func geminiEgressEndpoint(providerType, model string, stream bool) string {
 }
 
 // setGeminiEgressAuth applies the auth scheme the native Google routes require.
-// Both providers reject Bearer here: Vertex reads it as an OAuth2 expectation,
-// and Zen's Gemini passthrough answers a Bearer token with
+// All three reject Bearer here: Vertex reads it as an OAuth2 expectation, and
+// Zen's Gemini passthrough answers a Bearer token with
 // {"type":"AuthError","message":"Missing API key."}. Only x-goog-api-key works,
-// which is why this cannot go through SetProviderAuthHeaders for Zen — that
-// switches on provider type alone, and Zen's other families do need Bearer.
+// which is why this cannot go through SetProviderAuthHeaders for Zen or
+// Google AI Studio — that switches on provider type alone, and Zen's other
+// families and Google's compat layer do need Bearer.
 func setGeminiEgressAuth(req *http.Request, providerType, apiKey string) {
-	if providerType == "opencode-zen" {
+	if providerType == "opencode-zen" || providerType == "google" {
 		if apiKey != "" {
 			req.Header.Set("x-goog-api-key", apiKey)
 		}
@@ -90,7 +110,13 @@ func (h *Handler) buildGeminiRequest(ctx context.Context, st *requestState, cand
 	}
 
 	endpoint := geminiEgressEndpoint(providerType, model, stream)
-	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, endpoint)
+	baseURL := candidate.provider.BaseURL
+	if providerType == "google" {
+		// The provider is configured with the /v1beta/openai compat base;
+		// the native routes live one segment up, as discovery already knows.
+		baseURL = provider.GoogleNativeBaseURL(baseURL)
+	}
+	targetURL := util.BuildProviderTargetURL(baseURL, providerType, endpoint)
 	debuglog.Info("proxy: routing via gemini egress adapter", "target_url", targetURL, "model", candidate.model.ModelID, "provider", candidate.provider.Name, "stream", stream)
 
 	proxyReq, err := newRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))

--- a/internal/proxy/gemini_egress.go
+++ b/internal/proxy/gemini_egress.go
@@ -48,13 +48,19 @@ func isGeminiEgressAttempt(st *requestState, providerType, modelID, outputModali
 // model there is answered with a 400 whether or not it names an image
 // modality, while the native generateContent route serves it and returns the
 // image as an inlineData part. The model's discovered output modalities
-// decide, and a request naming an image modality is a second trigger for a
-// model discovery has not marked.
+// decide. A request naming an image modality is a second trigger only for a
+// model whose modalities discovery left empty: a model declared text-only
+// stays on the compat route, since a client could otherwise steer it onto
+// the native one and have Google's refusal read as the model's retirement.
 func isGoogleImageEgress(providerType, outputModalities string, body []byte) bool {
 	if providerType != "google" {
 		return false
 	}
-	return slices.Contains(declaredModalities(outputModalities), "image") || gemini.RequestWantsImage(body)
+	declared := declaredModalities(outputModalities)
+	if slices.Contains(declared, "image") {
+		return true
+	}
+	return len(declared) == 0 && gemini.RequestWantsImage(body)
 }
 
 // isZenGeminiModel reports whether this is an OpenCode Zen candidate for a

--- a/internal/proxy/gemini_egress_google_test.go
+++ b/internal/proxy/gemini_egress_google_test.go
@@ -3,7 +3,9 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
@@ -34,9 +37,14 @@ func TestIsGeminiEgressAttempt_GoogleImage(t *testing.T) {
 		{"request names image", wantsImage, "google", "", true},
 		{"chat model, plain request", plain, "google", `["text"]`, false},
 		{"chat model, empty modalities", plain, "google", "", false},
+		{"text-only model, request names image", wantsImage, "google", `["text"]`, false},
 		{"image model on another compat provider", plain, "openai", `["text","image"]`, false},
 		{"explicit endpoint override", &requestState{bodyBytes: plain.bodyBytes, endpointPath: "/v1/embeddings"}, "google", `["text","image"]`, false},
 	}
+	// A client naming an image modality must not be able to steer a model
+	// discovery declared text-only onto the native route: Google's refusal
+	// there reads as a capability refusal, not a retirement, but the compat
+	// route is the one the model is known to serve.
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isGeminiEgressAttempt(tc.st, tc.providerType, "gemini-2.5-flash-image", tc.outputMods); got != tc.want {
@@ -136,5 +144,22 @@ func TestChatCompletions_GoogleImageEgress(t *testing.T) {
 	msg := resp.Choices[0].Message
 	if msg.Content != "A blue circle." || len(msg.Images) != 1 || msg.Images[0].ImageURL.URL != "data:image/png;base64,iVBORw0KGgo=" {
 		t.Fatalf("message = %+v", msg)
+	}
+}
+
+// A native-dialect body past the non-streaming cap is refused as the
+// gateway's own policy, never charged to the provider as a translation fault.
+func TestTranslateEgressResponseBody_OversizedIsNotTheProvidersFault(t *testing.T) {
+	big := `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"` + strings.Repeat("A", nonStreamingBodyCap) + `"}}]}}]}`
+	resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(big))}
+	err := translateEgressResponseBody(resp, "gemini-3-pro-image", gemini.BuildChatCompletion)
+	if !errors.Is(err, errEgressBodyOversized) {
+		t.Fatalf("err = %v, want errEgressBodyOversized", err)
+	}
+	if translationIsProviderFault(err) {
+		t.Fatal("the gateway's own cap was read as a provider fault")
+	}
+	if rest, _ := io.ReadAll(resp.Body); len(rest) != 0 {
+		t.Fatalf("body left readable with %d bytes", len(rest))
 	}
 }

--- a/internal/proxy/gemini_egress_google_test.go
+++ b/internal/proxy/gemini_egress_google_test.go
@@ -1,0 +1,140 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// A Google AI Studio candidate takes the native route only for image output:
+// an image model by its discovered output modalities, or a request naming an
+// image modality for a model discovery has not marked. Plain chat stays on
+// the compat layer, and the override paths never qualify.
+func TestIsGeminiEgressAttempt_GoogleImage(t *testing.T) {
+	plain := &requestState{bodyBytes: []byte(`{"messages":[{"role":"user","content":"hi"}]}`)}
+	wantsImage := &requestState{bodyBytes: []byte(`{"messages":[{"role":"user","content":"draw"}],"modalities":["image","text"]}`)}
+	cases := []struct {
+		name         string
+		st           *requestState
+		providerType string
+		outputMods   string
+		want         bool
+	}{
+		{"image model by modalities", plain, "google", `["text","image"]`, true},
+		{"request names image", wantsImage, "google", "", true},
+		{"chat model, plain request", plain, "google", `["text"]`, false},
+		{"chat model, empty modalities", plain, "google", "", false},
+		{"image model on another compat provider", plain, "openai", `["text","image"]`, false},
+		{"explicit endpoint override", &requestState{bodyBytes: plain.bodyBytes, endpointPath: "/v1/embeddings"}, "google", `["text","image"]`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGeminiEgressAttempt(tc.st, tc.providerType, "gemini-2.5-flash-image", tc.outputMods); got != tc.want {
+				t.Errorf("isGeminiEgressAttempt = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if got := geminiEgressEndpoint("google", "gemini-2.5-flash-image", false); got != "/models/gemini-2.5-flash-image:generateContent" {
+		t.Errorf("endpoint = %q", got)
+	}
+	req := httptest.NewRequest("POST", "http://x", nil)
+	setGeminiEgressAuth(req, "google", "studio-key")
+	if req.Header.Get("x-goog-api-key") != "studio-key" || req.Header.Get("Authorization") != "" {
+		t.Errorf("google egress auth headers = %v", req.Header)
+	}
+	if got := provider.GoogleNativeBaseURL("https://generativelanguage.googleapis.com/v1beta/openai"); got != "https://generativelanguage.googleapis.com/v1beta" {
+		t.Errorf("native base = %q", got)
+	}
+}
+
+// A chat request to a Google AI Studio image model lands on the native
+// generateContent route under the /v1beta base with the x-goog-api-key
+// header, and the generated image comes back as a data URL in
+// message.images beside the text.
+func TestChatCompletions_GoogleImageEgress(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-goog-api-key") != "test-api-key" || r.Header.Get("Authorization") != "" {
+			t.Errorf("auth headers = %v", r.Header)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1beta/models/gemini-2.5-flash-image:generateContent") || strings.Contains(r.URL.Path, "/openai/") {
+			t.Errorf("unexpected upstream path %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		var reqBody map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&reqBody)
+		if _, ok := reqBody["contents"]; !ok {
+			t.Errorf("upstream got untranslated body: %v", reqBody)
+		}
+		gc, _ := reqBody["generationConfig"].(map[string]any)
+		if mods, _ := gc["responseModalities"].([]any); len(mods) != 2 {
+			t.Errorf("responseModalities = %v", gc["responseModalities"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"A blue circle."},{"inlineData":{"mimeType":"image/png","data":"iVBORw0KGgo="}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}`))
+	}))
+	defer upstream.Close()
+
+	env := newTestProxyEnvWithUpstream(t, upstream)
+	pool := testDB.Pool()
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE providers SET base_url = 'http://generativelanguage.googleapis.com/v1beta/openai' WHERE id = $1`, env.ProviderID); err != nil {
+		t.Fatalf("failed to update provider base URL: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE models SET model_id = 'gemini-2.5-flash-image', output_modalities = '["text","image"]' WHERE id = $1`, env.ModelID); err != nil {
+		t.Fatalf("failed to update model: %v", err)
+	}
+	provider.InvalidateProviderCache()
+	model.InvalidateModelCache()
+	target := upstream.Listener.Addr().String()
+	env.Handler.upstreamTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
+		},
+	}
+
+	body := fmt.Sprintf(`{"model":"%s/gemini-2.5-flash-image","messages":[{"role":"user","content":"draw a blue circle"}],"modalities":["image","text"]}`, env.ProviderName)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req.WithContext(ctx))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d\n%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+				Images  []struct {
+					Type     string `json:"type"`
+					ImageURL struct {
+						URL string `json:"url"`
+					} `json:"image_url"`
+				} `json:"images"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v\n%s", err, w.Body.String())
+	}
+	msg := resp.Choices[0].Message
+	if msg.Content != "A blue circle." || len(msg.Images) != 1 || msg.Images[0].ImageURL.URL != "data:image/png;base64,iVBORw0KGgo=" {
+		t.Fatalf("message = %+v", msg)
+	}
+}

--- a/internal/proxy/gemini_egress_google_test.go
+++ b/internal/proxy/gemini_egress_google_test.go
@@ -48,7 +48,7 @@ func TestIsGeminiEgressAttempt_GoogleImage(t *testing.T) {
 	if got := geminiEgressEndpoint("google", "gemini-2.5-flash-image", false); got != "/models/gemini-2.5-flash-image:generateContent" {
 		t.Errorf("endpoint = %q", got)
 	}
-	req := httptest.NewRequest("POST", "http://x", nil)
+	req := httptest.NewRequest("POST", "http://x", http.NoBody)
 	setGeminiEgressAuth(req, "google", "studio-key")
 	if req.Header.Get("x-goog-api-key") != "studio-key" || req.Header.Get("Authorization") != "" {
 		t.Errorf("google egress auth headers = %v", req.Header)

--- a/internal/proxy/gemini_egress_zen_test.go
+++ b/internal/proxy/gemini_egress_zen_test.go
@@ -48,7 +48,7 @@ func TestIsGeminiEgressAttempt_ZenGeminiOnly(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isGeminiEgressAttempt(tc.st, tc.providerType, tc.modelID); got != tc.want {
+			if got := isGeminiEgressAttempt(tc.st, tc.providerType, tc.modelID, ""); got != tc.want {
 				t.Errorf("isGeminiEgressAttempt(%q, %q) = %v, want %v", tc.providerType, tc.modelID, got, tc.want)
 			}
 		})

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -416,7 +416,8 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		resp.Body = openairesponses.NewStreamAdapter(resp.Body, st.reqModel)
 	}
 	if st.geminiAttempt {
-		// Vertex-express candidate in a hedged race: same upstream-side
+		// Gemini egress candidate in a hedged race (vertex-express, a Zen
+		// Gemini model or a Google AI Studio image model): same upstream-side
 		// translation so the hedged pipeline sees chat-completions SSE.
 		resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 	}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -557,10 +557,11 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 		return h.buildResponsesRequest(ctx, st, candidate, providerType)
 	}
 
-	// Vertex express egress adapter: chat requests to a vertex-express
-	// provider are translated to Gemini generateContent on the way out and
-	// back on the response side (see gemini_egress.go).
-	if isGeminiEgressAttempt(st, providerType, candidate.model.ModelID) {
+	// Gemini egress adapter: chat requests to a vertex-express provider, a
+	// Zen Gemini model or a Google AI Studio image model are translated to
+	// generateContent on the way out and back on the response side (see
+	// gemini_egress.go).
+	if isGeminiEgressAttempt(st, providerType, candidate.model.ModelID, candidate.model.OutputModalities) {
 		st.geminiAttempt = true
 		return h.buildGeminiRequest(ctx, st, candidate, providerType)
 	}

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -60,6 +60,11 @@ type streamState struct {
 	// which does not depend on optional behaviour: usage chunks are omitted by
 	// some providers, and the TTFT probe can be turned off.
 	sawContent bool
+	// sawImage records a generated image delta: the whole answer of an image
+	// model, and the streaming twin of the non-streaming breaker bar's
+	// `images` member (choiceCarriesSomething). The retirement verdict does
+	// not read it, as it does not read that member either.
+	sawImage bool
 	// deliveredBytes counts the bytes of content, reasoning and tool-call
 	// arguments the model produced as it streamed (before any strip_reasoning
 	// transform, which drops text the provider still billed). It backs the
@@ -129,11 +134,12 @@ func providerAtFault(kind ErrorKind) bool {
 // ended having produced nothing. Reading it as delivery is what let a completely
 // empty /v1/messages response escape the charge entirely.
 //
-// A tool call is output. So is reasoning. The cost of missing one of these is a
-// charge against a provider that answered correctly, which after five requests
-// takes it out of rotation for every tenant — so this errs toward "delivered".
+// A tool call is output. So is reasoning, and so is a generated image. The
+// cost of missing one of these is a charge against a provider that answered
+// correctly, which after five requests takes it out of rotation for every
+// tenant — so this errs toward "delivered".
 func streamDeliveredOutput(st *streamState) bool {
-	return st.sawContent || st.deliveredBytes > 0 || st.completionTokens > 0
+	return st.sawContent || st.sawImage || st.deliveredBytes > 0 || st.completionTokens > 0
 }
 
 // judgeStreamForBreaker decides what a finished stream tells the circuit

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -154,6 +154,10 @@ type streamChunk struct {
 					Arguments util.ToolArguments `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
+			// Images is a generated picture (OpenRouter's shape, which the
+			// gemini egress adapter emits too): the whole answer of an image
+			// model, read for the breaker's bar alone.
+			Images json.RawMessage `json:"images"`
 		} `json:"delta"`
 		FinishReason       *string `json:"finish_reason"`
 		NativeFinishReason *string `json:"native_finish_reason"` // P2-7: OpenRouter passthrough
@@ -253,6 +257,12 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 			if tc.Function != nil {
 				st.deliveredBytes += len(tc.Function.Name) + len(tc.Function.Arguments)
 			}
+		}
+		// A generated image is output the model answered with, but no
+		// estimate is ever sized from its bytes (see estimateMissingUsage),
+		// so it is delivery for the breaker and not delivered bytes.
+		if util.ValueCarries(choice.Delta.Images) {
+			st.sawImage = true
 		}
 	}
 	if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {

--- a/internal/proxy/stream_observers_test.go
+++ b/internal/proxy/stream_observers_test.go
@@ -225,3 +225,24 @@ func TestObserveDataChunk_RecordsThatContentFlowed(t *testing.T) {
 		}
 	})
 }
+
+// An image-only delta is the whole answer of an image model: it satisfies the
+// breaker's delivery bar without counting as content or delivered bytes,
+// which the retirement verdict and the usage estimate read.
+func TestObserveDataChunk_ImageDeltaIsDeliveryForTheBreakerOnly(t *testing.T) {
+	t.Parallel()
+	st := &streamState{}
+	ld := &requestLogData{modelID: "m", providerName: "p"}
+	st.observeDataChunk(parseStreamChunk(t, `{"choices":[{"delta":{"role":"assistant","content":"","images":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}}]}`), false, 1, ld)
+	if !st.sawImage || st.sawContent || st.deliveredBytes != 0 {
+		t.Fatalf("sawImage=%v sawContent=%v deliveredBytes=%d, want true/false/0", st.sawImage, st.sawContent, st.deliveredBytes)
+	}
+	if !streamDeliveredOutput(st) {
+		t.Fatal("an image-only stream read as undelivered")
+	}
+	empty := &streamState{}
+	empty.observeDataChunk(parseStreamChunk(t, `{"choices":[{"delta":{"role":"assistant","content":"","images":[]}}]}`), false, 1, ld)
+	if empty.sawImage || streamDeliveredOutput(empty) {
+		t.Fatal("an empty images list counted as delivery")
+	}
+}

--- a/internal/proxy/upstream_classify_phrase.go
+++ b/internal/proxy/upstream_classify_phrase.go
@@ -61,7 +61,7 @@ const modelPhraseWindow = 80
 var modelCapabilityRefusal = regexp.MustCompile(
 	`^(is not supported|is no longer available|is not available) (for|with|on|in) ` +
 		`((this|that|the|your|our|any) )?([a-z]+ ){0,3}` +
-		`(operation|endpoint|method|route|api|api version|request|request type|mode|task|region|plan|tier|account|subscription)s?\b`)
+		`(operation|endpoint|method|route|api|api version|request|request type|mode|modality|modalitie|task|region|plan|tier|account|subscription)s?\b`)
 
 // refusesCapabilityAt reports whether the phrase starting at pos is a capability
 // refusal rather than a retirement. The pattern is anchored, so this tests that

--- a/internal/proxy/upstream_classify_test.go
+++ b/internal/proxy/upstream_classify_test.go
@@ -295,6 +295,7 @@ func TestClassifyUpstreamError_OperationRefusalsAreNotDeadModels(t *testing.T) {
 		body string
 	}{
 		{"operation", `{"error":{"message":"Model gpt-5.6-sol is not supported for this operation"}}`},
+		{"response modalities", `{"error":{"message":"Model gemini-3.6-flash is not supported for the requested response modalities."}}`},
 		{"endpoint", `{"error":{"message":"Model claude-opus-5 is not supported for this endpoint"}}`},
 		{"method", `{"error":{"message":"Model gemini-3.6-flash is not supported for this method"}}`},
 		{"api route", `{"error":{"message":"Model glm-5.2 is not supported on this route"}}`},


### PR DESCRIPTION
## Why

The fleet sweep failed `image_out` on every hotel for the Google AI Studio image models (`gemini-2.5-flash-image`, `gemini-3-pro-image`, `gemini-3.1-flash-lite-image`): upstream HTTP 400 on every request. Two causes, both fixed here.

1. Google AI Studio providers (type `google`) go through Google's OpenAI-compatibility layer, which produces images only on its own `/images/generations` route and answers a chat request to an image model with a 400 whether or not the request names an image modality.
2. The Gemini translator (`internal/gemini`, used for Vertex Express and Zen's Gemini models) never sent `responseModalities` and dropped `inlineData` image parts on the way back.

## What

- A Google AI Studio candidate whose discovered output modalities include `image` takes the Gemini egress adapter: the compat base is folded back to `/v1beta`, the request goes to `models/{id}:generateContent` (or `:streamGenerateContent?alt=sse`) with the `x-goog-api-key` header. A request naming an image modality is a second trigger only for a model whose modalities discovery left empty; a model declared text-only can never be steered onto the native route by a client.
- The translator sends `generationConfig.responseModalities` from the request's `modalities` (`["image","text"]` → `TEXT,IMAGE`; `["image"]` → `IMAGE`), and returns an `inlineData` image as `message.images[{type:"image_url", image_url:{url:"data:<mime>;base64,..."}}]` (OpenRouter's shape) on completions and `delta.images` on streams. Interim "thought" images an image model drafts are filtered like thought text; empty or non-image blobs yield nothing.
- A streamed picture is one SSE event of several MiB, past the 4 MiB cap the text dialects need, so the shared egress adapter takes a per-dialect cap and the Gemini adapter uses 32 MiB (matching `nonStreamingBodyCap`). The non-streaming egress read is bounded by the same cap and refuses an oversized body as the gateway's own policy, never charged to the provider's breaker.
- An image delta counts as delivery for the breaker on streams (the twin of the non-streaming bar's `images` member); the retirement verdict and the byte estimate do not read it, matching the existing narrow-bar decision.
- A refusal naming response modalities is a capability refusal to the error classifier, never a retirement.
- `provider.GoogleNativeBaseURL` is the exported name of discovery's proxy-base to native-base helper.

## Live on dev (real Google AI Studio key)

| request | result |
|---|---|
| plain chat to `gemini-2.5-flash-image` | 200, one PNG in `message.images`, content `""` |
| `modalities:["image","text"]` | 200, caption plus one PNG |
| `modalities:["image"]` | 200, one PNG, no caption |
| streamed `gemini-3-pro-image` 2K render | 200, 1.2 MB, exactly one image (interim drafts filtered), `[DONE]` |

Before the branch all four were upstream HTTP 400.

## Known limits, stated

- The dashboard chat renders `delta.content` only and never sends `modalities`, so an image request from the dashboard still shows an empty assistant bubble; this PR serves API clients. The renderer is `web/src/pages/Chat/chatStreaming.ts`.
- On the native route an `image_url` input that is a plain https URL becomes a `fileData` URI, which Gemini accepts only for Files API or GCS URIs; data URIs (what the dashboard sends) work. Pre-existing on Vertex Express and Zen, now reachable for Google AI Studio image models.

## Review

Three adversarial rounds by a separate agent on exported copies; every blocking finding fixed and covered by a test that fails on mutation (thought filter, event cap, image-only modalities, breaker delivery, oversize sentinel, trigger restriction, veto noun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
