### PR TITLE
fix(gemini): carry the thought signature through a tool round trip

### DIFF
--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -53,6 +53,35 @@ type oaiMessage struct {
 	ToolCallID string          `json:"tool_call_id"`
 }
 
+// oaiExtraContent is the extra_content member of a tool call, Google's own
+// carrier for the thought signature on the OpenAI wire shape.
+type oaiExtraContent struct {
+	Google *struct {
+		ThoughtSignature string `json:"thought_signature,omitempty"`
+	} `json:"google,omitempty"`
+}
+
+// thoughtSignature reads the signature out of a possibly absent carrier.
+func (e *oaiExtraContent) thoughtSignature() string {
+	if e == nil || e.Google == nil {
+		return ""
+	}
+	return e.Google.ThoughtSignature
+}
+
+// extraContentFor wraps a signature for the OpenAI wire shape; nothing for an
+// unsigned call, so the member is absent rather than empty.
+func extraContentFor(signature string) *oaiExtraContent {
+	if signature == "" {
+		return nil
+	}
+	e := &oaiExtraContent{}
+	e.Google = &struct {
+		ThoughtSignature string `json:"thought_signature,omitempty"`
+	}{ThoughtSignature: signature}
+	return e
+}
+
 type oaiContentPart struct {
 	Type     string `json:"type"` // "text" | "image_url"
 	Text     string `json:"text"`
@@ -62,8 +91,12 @@ type oaiContentPart struct {
 }
 
 type oaiToolCall struct {
-	ID       string `json:"id"`
-	Function struct {
+	ID string `json:"id"`
+	// ExtraContent is where the signature travels on the OpenAI side, the
+	// shape Google's own compatibility layer uses and the chat path keeps
+	// verbatim (see proxy jsonextras): extra_content.google.thought_signature.
+	ExtraContent *oaiExtraContent `json:"extra_content,omitempty"`
+	Function     struct {
 		Name string `json:"name"`
 		// util.ToolArguments, not a plain string: the spec says a JSON string and
 		// several providers send the object, so #808 taught the RESPONSE side to
@@ -112,6 +145,11 @@ type genPart struct {
 	FileData         *genFileData     `json:"fileData,omitempty"`
 	FunctionCall     *genFunctionCall `json:"functionCall,omitempty"`
 	FunctionResponse *genFunctionResp `json:"functionResponse,omitempty"`
+	// ThoughtSignature rides beside a functionCall part on the way back in:
+	// Gemini 3 signs each call it makes and refuses the follow-up turn
+	// without the signature ("Function call is missing a thought_signature
+	// in functionCall parts").
+	ThoughtSignature string `json:"thoughtSignature,omitempty"`
 }
 
 type genBlob struct {
@@ -244,7 +282,10 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 				// non-object was a 400 from the provider where the other two
 				// egress paths quietly substituted something. One decision now.
 				args := util.ToolArgumentsObject(tc.Function.Arguments)
-				parts = append(parts, genPart{FunctionCall: &genFunctionCall{Name: tc.Function.Name, Args: args}})
+				parts = append(parts, genPart{
+					FunctionCall:     &genFunctionCall{Name: tc.Function.Name, Args: args},
+					ThoughtSignature: tc.ExtraContent.thoughtSignature(),
+				})
 			}
 			if len(parts) > 0 {
 				out.Contents = append(out.Contents, genContent{Role: "model", Parts: parts})

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -61,9 +61,14 @@ type oaiExtraContent struct {
 	} `json:"google,omitempty"`
 }
 
-// thoughtSignature reads the signature out of a possibly absent carrier.
-func (e *oaiExtraContent) thoughtSignature() string {
-	if e == nil || e.Google == nil {
+// thoughtSignatureIn reads the signature out of a raw extra_content member:
+// nothing for an absent, null, foreign or malformed one, never an error.
+func thoughtSignatureIn(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var e oaiExtraContent
+	if json.Unmarshal(raw, &e) != nil || e.Google == nil {
 		return ""
 	}
 	return e.Google.ThoughtSignature
@@ -95,7 +100,10 @@ type oaiToolCall struct {
 	// ExtraContent is where the signature travels on the OpenAI side, the
 	// shape Google's own compatibility layer uses and the chat path keeps
 	// verbatim (see proxy jsonextras): extra_content.google.thought_signature.
-	ExtraContent *oaiExtraContent `json:"extra_content,omitempty"`
+	// Raw, read leniently: an ingress decoder must not fail a conversation
+	// on every retry over a member of a shape it did not expect, the rule
+	// util.ToolArguments below states for the arguments.
+	ExtraContent json.RawMessage `json:"extra_content"`
 	Function     struct {
 		Name string `json:"name"`
 		// util.ToolArguments, not a plain string: the spec says a JSON string and
@@ -284,7 +292,7 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 				args := util.ToolArgumentsObject(tc.Function.Arguments)
 				parts = append(parts, genPart{
 					FunctionCall:     &genFunctionCall{Name: tc.Function.Name, Args: args},
-					ThoughtSignature: tc.ExtraContent.thoughtSignature(),
+					ThoughtSignature: thoughtSignatureIn(tc.ExtraContent),
 				})
 			}
 			if len(parts) > 0 {

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -42,8 +42,13 @@ type genRespPart struct {
 	Thought      bool             `json:"thought"`
 	FunctionCall *genRespFuncCall `json:"functionCall"`
 	// ThoughtSignature signs a functionCall part; the follow-up turn must
-	// carry it back, so it goes out on the tool call as extra_content.
-	ThoughtSignature string `json:"thoughtSignature"`
+	// carry it back, so it goes out on the tool call as extra_content. Only
+	// a function call's signature is carried: Gemini 3 may sign a text or
+	// thought part too, but omitting those is not validated, and the OpenAI
+	// wire shape has no carrier on a message. Google spells the field both
+	// ways across its own documents, so both are read.
+	ThoughtSignature      string `json:"thoughtSignature"`
+	ThoughtSignatureSnake string `json:"thought_signature"`
 	// InlineData carries a generated image (an image model answering a
 	// request whose response modalities named IMAGE): base64 bytes and
 	// their mime type.
@@ -110,6 +115,14 @@ func imageOut(blob *genRespBlob) (oaiImageOut, bool) {
 		return oaiImageOut{}, false
 	}
 	return oaiImageOut{Type: "image_url", ImageURL: oaiImageURLOut{URL: "data:" + blob.MimeType + ";base64," + blob.Data}}, true
+}
+
+// signature is the part's thought signature under either spelling.
+func (p genRespPart) signature() string {
+	if p.ThoughtSignature != "" {
+		return p.ThoughtSignature
+	}
+	return p.ThoughtSignatureSnake
 }
 
 type oaiToolCallOut struct {
@@ -214,7 +227,7 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 			tc := oaiToolCallOut{
 				ID:           fmt.Sprintf("call_%s_%d", id, len(toolCalls)),
 				Type:         "function",
-				ExtraContent: extraContentFor(p.ThoughtSignature),
+				ExtraContent: extraContentFor(p.signature()),
 			}
 			tc.Function.Name = p.FunctionCall.Name
 			tc.Function.Arguments = args

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -41,6 +41,9 @@ type genRespPart struct {
 	Text         string           `json:"text"`
 	Thought      bool             `json:"thought"`
 	FunctionCall *genRespFuncCall `json:"functionCall"`
+	// ThoughtSignature signs a functionCall part; the follow-up turn must
+	// carry it back, so it goes out on the tool call as extra_content.
+	ThoughtSignature string `json:"thoughtSignature"`
 	// InlineData carries a generated image (an image model answering a
 	// request whose response modalities named IMAGE): base64 bytes and
 	// their mime type.
@@ -116,6 +119,7 @@ type oaiToolCallOut struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 	} `json:"function"`
+	ExtraContent *oaiExtraContent `json:"extra_content,omitempty"`
 }
 
 type oaiUsage struct {
@@ -208,8 +212,9 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 				args = "{}"
 			}
 			tc := oaiToolCallOut{
-				ID:   fmt.Sprintf("call_%s_%d", id, len(toolCalls)),
-				Type: "function",
+				ID:           fmt.Sprintf("call_%s_%d", id, len(toolCalls)),
+				Type:         "function",
+				ExtraContent: extraContentFor(p.ThoughtSignature),
 			}
 			tc.Function.Name = p.FunctionCall.Name
 			tc.Function.Arguments = args

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -74,6 +74,7 @@ type oaiChunkToolCallOut struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 	} `json:"function"`
+	ExtraContent *oaiExtraContent `json:"extra_content,omitempty"`
 }
 
 // writeChunk appends one framed SSE chunk ("data: <json>\n\n").
@@ -144,9 +145,10 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 				args = "{}"
 			}
 			tc := oaiChunkToolCallOut{
-				Index: t.toolCalls,
-				ID:    fmt.Sprintf("call_%s_%d", t.id, t.toolCalls),
-				Type:  "function",
+				Index:        t.toolCalls,
+				ID:           fmt.Sprintf("call_%s_%d", t.id, t.toolCalls),
+				Type:         "function",
+				ExtraContent: extraContentFor(p.ThoughtSignature),
 			}
 			tc.Function.Name = p.FunctionCall.Name
 			tc.Function.Arguments = args

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -148,7 +148,7 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 				Index:        t.toolCalls,
 				ID:           fmt.Sprintf("call_%s_%d", t.id, t.toolCalls),
 				Type:         "function",
-				ExtraContent: extraContentFor(p.ThoughtSignature),
+				ExtraContent: extraContentFor(p.signature()),
 			}
 			tc.Function.Name = p.FunctionCall.Name
 			tc.Function.Arguments = args

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -140,6 +140,10 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 			continue
 		}
 		if p.FunctionCall != nil {
+			// The signature rides in the same part as the call: observed on
+			// Google AI Studio and Zen streams (one chunk carries both), and
+			// the tool_call delta is emitted here, so a signature arriving in
+			// a later part would not reach it.
 			args := compactJSON(p.FunctionCall.Args)
 			if args == "" {
 				args = "{}"

--- a/internal/gemini/thought_signature_test.go
+++ b/internal/gemini/thought_signature_test.go
@@ -82,4 +82,28 @@ func TestTranslateRequest_ThoughtSignatureBackOnTheCall(t *testing.T) {
 	if strings.Contains(string(out), "thoughtSignature") {
 		t.Fatalf("an unsigned call sent a thoughtSignature: %s", out)
 	}
+	// A carrier of an unexpected shape is ignored, never a failed request:
+	// each retry replays the same transcript.
+	for _, odd := range []string{`"sig"`, `["a"]`, `{"google":"sig"}`, `{"google":{"thought_signature":123}}`, `null`, `{}`} {
+		body := strings.Replace(plain, `"type":"function",`, `"type":"function","extra_content":`+odd+`,`, 1)
+		out, _, _, err := TranslateRequest([]byte(body))
+		if err != nil {
+			t.Fatalf("extra_content %s failed the request: %v", odd, err)
+		}
+		if strings.Contains(string(out), "thoughtSignature") {
+			t.Fatalf("extra_content %s produced a signature: %s", odd, out)
+		}
+	}
+}
+
+// Google spells the native field both ways across its documents; both read.
+func TestToolCall_SnakeCaseSignatureIsRead(t *testing.T) {
+	snake := strings.Replace(signedCall, `"thoughtSignature"`, `"thought_signature"`, 1)
+	out, err := BuildChatCompletion([]byte(snake), "chatcmpl-4", "gemini-3.1-pro", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !strings.Contains(string(out), `"thought_signature":"sig-abc"`) {
+		t.Fatalf("snake_case signature dropped: %s", out)
+	}
 }

--- a/internal/gemini/thought_signature_test.go
+++ b/internal/gemini/thought_signature_test.go
@@ -1,0 +1,85 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const signedCall = `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_temperature","args":{"city":"Prague"}},"thoughtSignature":"sig-abc"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
+
+// Gemini 3 signs each function call and refuses the follow-up turn without
+// the signature, so it travels out on the tool call as
+// extra_content.google.thought_signature, in the completion and in the
+// stream alike, and an unsigned call carries no extra_content at all.
+func TestToolCall_CarriesThoughtSignatureOut(t *testing.T) {
+	out, err := BuildChatCompletion([]byte(signedCall), "chatcmpl-1", "gemini-3.1-pro", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !strings.Contains(string(out), `"extra_content":{"google":{"thought_signature":"sig-abc"}}`) {
+		t.Fatalf("completion lost the signature: %s", out)
+	}
+	tr := NewStreamTranslator("chatcmpl-2", "gemini-3.1-pro", 1)
+	chunk, err := tr.Translate([]byte(signedCall))
+	if err != nil {
+		t.Fatalf("stream translate: %v", err)
+	}
+	if !strings.Contains(string(chunk), `"extra_content":{"google":{"thought_signature":"sig-abc"}}`) {
+		t.Fatalf("chunk lost the signature: %s", chunk)
+	}
+	unsigned := strings.Replace(signedCall, `,"thoughtSignature":"sig-abc"`, "", 1)
+	out, err = BuildChatCompletion([]byte(unsigned), "chatcmpl-3", "gemini-3.1-pro", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if strings.Contains(string(out), "extra_content") {
+		t.Fatalf("an unsigned call grew an extra_content member: %s", out)
+	}
+}
+
+// The follow-up turn puts the signature back beside the functionCall part.
+func TestTranslateRequest_ThoughtSignatureBackOnTheCall(t *testing.T) {
+	body := `{"model":"gemini-3.1-pro","messages":[
+		{"role":"user","content":"weather?"},
+		{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_temperature","arguments":"{\"city\":\"Prague\"}"},"extra_content":{"google":{"thought_signature":"sig-abc"}}}]},
+		{"role":"tool","tool_call_id":"call_1","content":"-7"}]}`
+	out, _, _, err := TranslateRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var req struct {
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				FunctionCall     *json.RawMessage `json:"functionCall"`
+				ThoughtSignature string           `json:"thoughtSignature"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found bool
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			if p.FunctionCall != nil {
+				found = true
+				if p.ThoughtSignature != "sig-abc" {
+					t.Fatalf("functionCall part signature = %q, want sig-abc", p.ThoughtSignature)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no functionCall part in %s", out)
+	}
+	plain := strings.Replace(body, `,"extra_content":{"google":{"thought_signature":"sig-abc"}}`, "", 1)
+	out, _, _, err = TranslateRequest([]byte(plain))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if strings.Contains(string(out), "thoughtSignature") {
+		t.Fatalf("an unsigned call sent a thoughtSignature: %s", out)
+	}
+}


### PR DESCRIPTION
## Why

The re-sweep after #873 failed the `tools` check on every Gemini 3 model served through the native-dialect translator: OpenCode Zen's `gemini-3.1-pro`, `gemini-3.5-flash`, `gemini-3.5-flash-lite` (pre-existing) and Google AI Studio's `gemini-3-pro-image`, `gemini-3.1-flash-lite-image` (reachable since #873). Gemini 3 signs each function call with a `thoughtSignature` on the part and refuses the follow-up turn without it:

```
Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly
```

The translator dropped the signature on the way out and had nowhere to read it from on the way back in, so no tool round trip through it could complete.

## What

- `internal/gemini/response.go` and `stream.go` read `thoughtSignature` from a function-call part and emit it on the tool call as `extra_content.google.thought_signature`, in completions and stream chunks alike. That is the shape Google's own OpenAI-compatibility layer uses, and the one the proxy's chat path already keeps verbatim (`jsonextras.go`, `ToolCall.Extra`), so a client that round-trips tool calls unchanged sends it back without knowing.
- `internal/gemini/request.go` reads it from an assistant tool call and sets `thoughtSignature` beside the `functionCall` part.
- An unsigned call carries no `extra_content` member and sends no `thoughtSignature`.

## Verified

- Dev, real keys, two-turn tool round trip (call, then tool result): Google AI Studio `gemini-3-pro-image` and OpenCode Zen `gemini-3.1-pro` both answered turn two with 200 and the temperature from the tool, non-streaming and streaming alike; on streams the signature arrives in the same chunk as the call.
- Tests: signature out on completion and chunk, absent when unsigned, read under both spellings; signature back on the function-call part, absent when unsigned; a carrier of any unexpected shape is ignored rather than failing the request.

## Not in this PR

The Anthropic ingress (`/v1/messages`) has no carrier for the signature on a `tool_use` block, so an Anthropic-dialect client still loses it on a Gemini 3 candidate. Tracked in #877, since it needs a wire-shape decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
