### PR TITLE
test(settings): make the cache TTL test deterministic

### DIFF
--- a/internal/settings/settings_negative_test.go
+++ b/internal/settings/settings_negative_test.go
@@ -187,9 +187,12 @@ func TestSetTxThenInvalidateSeesThroughACachedAbsence(t *testing.T) {
 	}
 }
 
+// The one time-driven TTL test left in the package (TestCacheTTL forces its
+// expiry), so the budget for the queries before the "still cached" read is
+// generous: 250ms lost that race under the race detector's slowdown.
 func TestACachedAbsenceExpiresWithTheTTL(t *testing.T) {
 	r := NewRepository(testPool)
-	r.cacheTTL = 250 * time.Millisecond
+	r.cacheTTL = 2 * time.Second
 	ctx := context.Background()
 	clearSettings(t)
 	key := "absent_ttl_key"

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -502,6 +502,8 @@ func TestCacheTTL(t *testing.T) {
 	}
 
 	// Expire the entry in place: the same state the TTL elapsing leaves.
+	// cacheGen is left alone on purpose: expiry is not eviction, and only
+	// evictLocked bumps the generation.
 	r.mu.Lock()
 	entry, ok := r.cache[key]
 	if !ok {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -468,9 +468,13 @@ func TestGetFloat(t *testing.T) {
 	}
 }
 
+// A cached value is served until its entry expires, then re-read. The
+// "still cached" read used to race a 100ms TTL against the two queries
+// before it, which the race detector's slowdown lost on CI, so the TTL is
+// generous and expiry is forced on the entry rather than waited for.
 func TestCacheTTL(t *testing.T) {
 	r := NewRepository(testPool)
-	r.cacheTTL = 100 * time.Millisecond
+	r.cacheTTL = time.Minute
 	ctx := context.Background()
 	clearSettings(t)
 
@@ -497,7 +501,16 @@ func TestCacheTTL(t *testing.T) {
 		t.Errorf("got %q, want initial (cached)", val)
 	}
 
-	time.Sleep(r.cacheTTL + 50*time.Millisecond)
+	// Expire the entry in place: the same state the TTL elapsing leaves.
+	r.mu.Lock()
+	entry, ok := r.cache[key]
+	if !ok {
+		r.mu.Unlock()
+		t.Fatal("the read did not populate the cache")
+	}
+	entry.expiresAt = time.Now().Add(-time.Second)
+	r.cache[key] = entry
+	r.mu.Unlock()
 
 	val = r.GetWithDefault(ctx, key, "default")
 	if val != "updated" {


### PR DESCRIPTION
## Why

Master's Go Race job went red after #878 on `internal/settings` `TestCacheTTL`: `got "updated", want initial (cached)`. #878 touched only the Gemini translator. The test set a 100 ms cache TTL and did a Set, a Get, a DB update and a second Get, expecting the second Get to still serve the cached value. Under the race detector those queries exceeded 100 ms, the entry had expired, and the read returned the updated value.

## What

The TTL is a minute, so the "still cached" read is never a race, and expiry is forced on the cached entry in place (its `expiresAt` moved into the past under the repository's mutex, the same state the TTL elapsing leaves) instead of sleeping past it. The test proves the same two things it did, cached before expiry and re-read after, deterministically and without the sleep.

## Verified

`go test -race ./internal/settings/ -count=3 -run TestCacheTTL` and the whole package pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
