### PR TITLE
fix(discovery): keep structured output off Google image models

### DIFF
--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -175,8 +175,14 @@ func isGoogleToolCallingModel(modelID string) bool {
 	return !isGoogleTTSModel(modelID)
 }
 
+// isGoogleStructuredOutputModel reports a model that honours JSON mode. An
+// image-output model does not, whatever Google's docs list for it: the API
+// answers responseMimeType application/json on gemini-2.5-flash-image with
+// "JSON mode is not enabled for this model" and on the gemini-3 image models
+// with a bare INVALID_ARGUMENT (google-gemini/cookbook#1028), for a schema
+// and for plain json_object alike.
 func isGoogleStructuredOutputModel(modelID string) bool {
-	return isGoogleToolCallingModel(modelID)
+	return isGoogleToolCallingModel(modelID) && !isGoogleImageGenModel(modelID)
 }
 
 func isGoogleVisionModel(modelID string) bool {

--- a/internal/provider/discovery_google_test.go
+++ b/internal/provider/discovery_google_test.go
@@ -138,6 +138,11 @@ func TestIsGoogleStructuredOutputModel(t *testing.T) {
 		{"live excluded", "gemini-live", false},
 		{"case insensitive", "Text-Embedding-004", false},
 		{"regular model", "gemma-2b", true},
+		// Image-output models answer JSON mode with a 400 whatever the docs say
+		// (google-gemini/cookbook#1028).
+		{"2.5 image model excluded", "gemini-2.5-flash-image", false},
+		{"3.x image model excluded", "gemini-3.1-flash-lite-image", false},
+		{"nano banana excluded", "nano-banana-pro-preview", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/provider/discovery_google_test.go
+++ b/internal/provider/discovery_google_test.go
@@ -142,6 +142,7 @@ func TestIsGoogleStructuredOutputModel(t *testing.T) {
 		// (google-gemini/cookbook#1028).
 		{"2.5 image model excluded", "gemini-2.5-flash-image", false},
 		{"3.x image model excluded", "gemini-3.1-flash-lite-image", false},
+		{"3 pro image model excluded", "gemini-3-pro-image", false},
 		{"nano banana excluded", "nano-banana-pro-preview", false},
 	}
 	for _, tt := range tests {

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -481,26 +481,32 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 // lists structured output for Google's image-output models, following
 // Google's own docs, and the API answers JSON mode on every one of them with
 // a 400 (google-gemini/cookbook#1028); discovery leaves the flag off for
-// them, so the merge must not switch it back on. The gate is the provider
-// types that reach Google's generateContent route: Google AI Studio, Vertex
-// AI express and OpenCode Zen's Gemini passthrough. An aggregator serving
-// the same model id over its own dialect answers for itself, and the flag
-// it advertises is its own claim. Reports whether it cleared anything, which
-// is what re-marshals the capabilities below.
+// them, so the merge must not switch it back on. Reports whether it cleared
+// anything, which is what re-marshals the capabilities below.
 func clearRefusedCapabilities(providerType, modelID string, caps *model.Capability) bool {
-	if !caps.StructuredOutput || !googleNativeRoute(providerType) || !isGoogleImageGenModel(modelID) {
+	if !caps.StructuredOutput || !googleServedImageModel(providerType, modelID) {
 		return false
 	}
 	caps.StructuredOutput = false
 	return true
 }
 
-// googleNativeRoute reports a provider type whose Gemini models are served
-// by Google's own generateContent route, where Google's refusals apply.
-func googleNativeRoute(providerType string) bool {
+// googleServedImageModel reports an image-output model that Google's own
+// generateContent route serves, where Google's refusals apply: on Google AI
+// Studio and Vertex AI express by name, and on OpenCode Zen for the Gemini
+// family it passes through to Google (Zen's own codenames share the naming
+// space, so the image-name match alone would claim a model Google never
+// served). An aggregator serving the same model id over its own dialect
+// answers for itself, and the flag it advertises is its own claim.
+func googleServedImageModel(providerType, modelID string) bool {
+	if !isGoogleImageGenModel(modelID) {
+		return false
+	}
 	switch providerType {
-	case "google", "vertex-express", "opencode-zen":
+	case "google", "vertex-express":
 		return true
+	case "opencode-zen":
+		return strings.HasPrefix(strings.ToLower(modelID), "gemini-")
 	}
 	return false
 }

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -476,6 +476,23 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 	return merged
 }
 
+// refuseSpecCapabilities clears a flag the catalog claims and the provider's
+// API refuses, after the OR-merge above has put it in. models.dev lists
+// structured output for Google's image-output models, following Google's own
+// docs, and the API answers JSON mode on every one of them with a 400
+// (google-gemini/cookbook#1028); discovery leaves the flag off for them, so
+// the merge must not switch it back on. Reports whether it cleared anything.
+func refuseSpecCapabilities(providerType, modelID string, caps *model.Capability) bool {
+	if !caps.StructuredOutput {
+		return false
+	}
+	if (providerType == "google" || providerType == "vertex-express") && isGoogleImageGenModel(modelID) {
+		caps.StructuredOutput = false
+		return true
+	}
+	return false
+}
+
 // attachmentImpliesVision reports whether an attachment claim is corroborated
 // by the declared input modalities.
 //
@@ -556,6 +573,7 @@ func (c *ModelsDevCache) EnrichModel(m *model.Model, providerType string) bool {
 
 	// Capabilities: only set individual fields if they're currently false.
 	enriched = mergeSpecCapabilities(spec, &caps) || enriched
+	enriched = refuseSpecCapabilities(providerType, m.ModelID, &caps) || enriched
 
 	// Modality arrays: only set if currently empty. The modality *class* is
 	// not set here — NormalizeModelClassification derives it from the arrays

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -476,18 +476,30 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 	return merged
 }
 
-// refuseSpecCapabilities clears a flag the catalog claims and the provider's
-// API refuses, after the OR-merge above has put it in. models.dev lists
-// structured output for Google's image-output models, following Google's own
-// docs, and the API answers JSON mode on every one of them with a 400
-// (google-gemini/cookbook#1028); discovery leaves the flag off for them, so
-// the merge must not switch it back on. Reports whether it cleared anything.
-func refuseSpecCapabilities(providerType, modelID string, caps *model.Capability) bool {
-	if !caps.StructuredOutput {
+// clearRefusedCapabilities clears a flag the catalog claims and the
+// provider's API refuses, after the OR-merge above has put it in. models.dev
+// lists structured output for Google's image-output models, following
+// Google's own docs, and the API answers JSON mode on every one of them with
+// a 400 (google-gemini/cookbook#1028); discovery leaves the flag off for
+// them, so the merge must not switch it back on. The gate is the provider
+// types that reach Google's generateContent route: Google AI Studio, Vertex
+// AI express and OpenCode Zen's Gemini passthrough. An aggregator serving
+// the same model id over its own dialect answers for itself, and the flag
+// it advertises is its own claim. Reports whether it cleared anything, which
+// is what re-marshals the capabilities below.
+func clearRefusedCapabilities(providerType, modelID string, caps *model.Capability) bool {
+	if !caps.StructuredOutput || !googleNativeRoute(providerType) || !isGoogleImageGenModel(modelID) {
 		return false
 	}
-	if (providerType == "google" || providerType == "vertex-express") && isGoogleImageGenModel(modelID) {
-		caps.StructuredOutput = false
+	caps.StructuredOutput = false
+	return true
+}
+
+// googleNativeRoute reports a provider type whose Gemini models are served
+// by Google's own generateContent route, where Google's refusals apply.
+func googleNativeRoute(providerType string) bool {
+	switch providerType {
+	case "google", "vertex-express", "opencode-zen":
 		return true
 	}
 	return false
@@ -573,7 +585,7 @@ func (c *ModelsDevCache) EnrichModel(m *model.Model, providerType string) bool {
 
 	// Capabilities: only set individual fields if they're currently false.
 	enriched = mergeSpecCapabilities(spec, &caps) || enriched
-	enriched = refuseSpecCapabilities(providerType, m.ModelID, &caps) || enriched
+	enriched = clearRefusedCapabilities(providerType, m.ModelID, &caps) || enriched
 
 	// Modality arrays: only set if currently empty. The modality *class* is
 	// not set here — NormalizeModelClassification derives it from the arrays

--- a/internal/provider/modelsdev_test.go
+++ b/internal/provider/modelsdev_test.go
@@ -352,7 +352,8 @@ func TestEnrichModel_GoogleImageModelsKeepJSONModeOff(t *testing.T) {
 	}
 	setupCacheWithModels(t, specs)
 	// Both Google types look the catalog up under their own provider index
-	// only (Exclusive), so the flat index alone finds nothing for them.
+	// only (Exclusive), so the flat index alone finds nothing for them; the
+	// non-exclusive types (Zen, OpenRouter) fall through to the flat index.
 	modelsDevCache.mu.Lock()
 	modelsDevCache.byProvider = map[string]map[string]*ModelsDevModelSpec{"google": specs, "google-vertex": specs}
 	modelsDevCache.mu.Unlock()
@@ -379,6 +380,9 @@ func TestEnrichModel_GoogleImageModelsKeepJSONModeOff(t *testing.T) {
 		{"nano-banana-pro-preview", "google", false},
 		{"gemini-2.5-flash", "google", true},
 		{"gemini-2.5-flash-image", "openrouter", true},
+		// Zen's own codenames share the naming space: only its Gemini
+		// family is Google's.
+		{"nano-banana-pro-preview", "opencode-zen", true},
 	} {
 		m := &model.Model{ModelID: tc.modelID, Capabilities: `{"vision":true}`}
 		cache.EnrichModel(m, tc.providerType)

--- a/internal/provider/modelsdev_test.go
+++ b/internal/provider/modelsdev_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -333,6 +334,63 @@ func TestEnrichModel_FallsBackToNameForAliasedDeployments(t *testing.T) {
 	// The alias stays the invokable ID.
 	if m.ModelID != "my-fast-gpt" {
 		t.Errorf("ModelID = %q, want my-fast-gpt", m.ModelID)
+	}
+}
+
+// models.dev lists structured output for Google's image-output models, as
+// Google's own docs do, and the API refuses JSON mode on every one of them
+// (google-gemini/cookbook#1028). Discovery leaves the flag off; the OR-merge
+// must not put it back, on either native Google provider type. A text model
+// keeps taking the flag from the catalog.
+func TestEnrichModel_GoogleImageModelsKeepJSONModeOff(t *testing.T) {
+	yes := true
+	specs := map[string]*ModelsDevModelSpec{
+		"gemini-2.5-flash-image":  {ID: "gemini-2.5-flash-image", StructuredOutput: &yes, ToolCall: true},
+		"nano-banana-pro-preview": {ID: "nano-banana-pro-preview", StructuredOutput: &yes},
+		"gemini-2.5-flash":        {ID: "gemini-2.5-flash", StructuredOutput: &yes},
+	}
+	setupCacheWithModels(t, specs)
+	// Both Google types look the catalog up under their own provider index
+	// only (Exclusive), so the flat index alone finds nothing for them.
+	modelsDevCache.mu.Lock()
+	modelsDevCache.byProvider = map[string]map[string]*ModelsDevModelSpec{"google": specs, "google-vertex": specs}
+	modelsDevCache.mu.Unlock()
+	cache := GetModelsDevCache()
+	if cache == nil {
+		t.Fatal("expected cache to be loaded")
+		return
+	}
+	capsOf := func(t *testing.T, m *model.Model) model.Capability {
+		t.Helper()
+		var caps model.Capability
+		if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+			t.Fatalf("capabilities %q: %v", m.Capabilities, err)
+		}
+		return caps
+	}
+	for _, tc := range []struct {
+		modelID, providerType string
+		wantStructured        bool
+	}{
+		{"gemini-2.5-flash-image", "google", false},
+		{"gemini-2.5-flash-image", "vertex-express", false},
+		{"nano-banana-pro-preview", "google", false},
+		{"gemini-2.5-flash", "google", true},
+	} {
+		m := &model.Model{ModelID: tc.modelID, Capabilities: `{"vision":true}`}
+		cache.EnrichModel(m, tc.providerType)
+		caps := capsOf(t, m)
+		if caps.StructuredOutput != tc.wantStructured {
+			t.Errorf("%s via %s: structured_output = %v, want %v (caps %s)", tc.modelID, tc.providerType, caps.StructuredOutput, tc.wantStructured, m.Capabilities)
+		}
+		if !caps.Vision {
+			t.Errorf("%s via %s: the discovered vision flag was lost", tc.modelID, tc.providerType)
+		}
+	}
+	m := &model.Model{ModelID: "gemini-2.5-flash-image"}
+	cache.EnrichModel(m, "google")
+	if caps := capsOf(t, m); !caps.ToolCalling || caps.StructuredOutput {
+		t.Errorf("only structured output is refused; caps = %s", m.Capabilities)
 	}
 }
 

--- a/internal/provider/modelsdev_test.go
+++ b/internal/provider/modelsdev_test.go
@@ -340,8 +340,9 @@ func TestEnrichModel_FallsBackToNameForAliasedDeployments(t *testing.T) {
 // models.dev lists structured output for Google's image-output models, as
 // Google's own docs do, and the API refuses JSON mode on every one of them
 // (google-gemini/cookbook#1028). Discovery leaves the flag off; the OR-merge
-// must not put it back, on either native Google provider type. A text model
-// keeps taking the flag from the catalog.
+// must not put it back on any provider type that reaches Google's own route.
+// A text model keeps taking the flag from the catalog, and so does the same
+// image model behind an aggregator, whose claim is its own.
 func TestEnrichModel_GoogleImageModelsKeepJSONModeOff(t *testing.T) {
 	yes := true
 	specs := map[string]*ModelsDevModelSpec{
@@ -374,8 +375,10 @@ func TestEnrichModel_GoogleImageModelsKeepJSONModeOff(t *testing.T) {
 	}{
 		{"gemini-2.5-flash-image", "google", false},
 		{"gemini-2.5-flash-image", "vertex-express", false},
+		{"gemini-2.5-flash-image", "opencode-zen", false},
 		{"nano-banana-pro-preview", "google", false},
 		{"gemini-2.5-flash", "google", true},
+		{"gemini-2.5-flash-image", "openrouter", true},
 	} {
 		m := &model.Model{ModelID: tc.modelID, Capabilities: `{"vision":true}`}
 		cache.EnrichModel(m, tc.providerType)

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -701,7 +701,7 @@ Model IDs from the native API have a `models/` prefix (e.g., `models/gemini-2.5-
 |-------|-------|
 | Vision | Name contains `gemini-2`, `gemini-3`, or `gemma` (excluding embedding/live and a `tts` name segment) |
 | Tool calling | Not embedding/imagen/veo/lyria/aqa/live, nor a `tts` name segment |
-| Structured output | Same as tool calling |
+| Structured output | Same as tool calling, minus the image-output models: Google answers JSON mode on those with a 400 whatever its docs list (google-gemini/cookbook#1028), and models.dev enrichment does not put the flag back for them |
 | Modality | Derived from the input/output lists by the shared classifier: `chat` whenever text is an output (Gemini image models included, since they emit text beside the image), `tts` for text in and audio out, `embedding` for an embedding output |
 | Input modalities | Vision → `["text","image"]`; live/native-audio → `["text","image","audio","video"]`; TTS (`tts` name segment) and embedding → `["text"]` |
 | Output modalities | Default `["text"]`; image gen → `["text","image"]`; live/native-audio → `["text","audio"]`; TTS → `["audio"]`; embedding → `["embedding"]` |
@@ -828,7 +828,7 @@ The `lookupFuzzyIn` helper implements this logic (the canonical-provider and cro
 | Input price per million (cache hit) | Only if nil/zero |
 | Reasoning capability | Only if false |
 | Tool calling capability | Only if false |
-| Structured output capability | Only if false |
+| Structured output capability | Only if false, and never for a Google or Vertex AI express image-output model, whose JSON mode the API refuses (google-gemini/cookbook#1028) |
 | Vision capability | Only if false (mapped from `attachment` field) |
 | Modality | Only if empty or default `"text"` |
 | Input modalities | Only if empty or default `"[]"` |

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -828,7 +828,7 @@ The `lookupFuzzyIn` helper implements this logic (the canonical-provider and cro
 | Input price per million (cache hit) | Only if nil/zero |
 | Reasoning capability | Only if false |
 | Tool calling capability | Only if false |
-| Structured output capability | Only if false, and never for a Google or Vertex AI express image-output model, whose JSON mode the API refuses (google-gemini/cookbook#1028) |
+| Structured output capability | Only if false, and never for an image-output model on a provider that reaches Google's own route (Google AI Studio, Vertex AI express, OpenCode Zen), whose JSON mode the API refuses (google-gemini/cookbook#1028) |
 | Vision capability | Only if false (mapped from `attachment` field) |
 | Modality | Only if empty or default `"text"` |
 | Input modalities | Only if empty or default `"[]"` |

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -828,7 +828,7 @@ The `lookupFuzzyIn` helper implements this logic (the canonical-provider and cro
 | Input price per million (cache hit) | Only if nil/zero |
 | Reasoning capability | Only if false |
 | Tool calling capability | Only if false |
-| Structured output capability | Only if false, and never for an image-output model on a provider that reaches Google's own route (Google AI Studio, Vertex AI express, OpenCode Zen), whose JSON mode the API refuses (google-gemini/cookbook#1028) |
+| Structured output capability | Only if false, and never for an image-output model on a provider that reaches Google's own route (Google AI Studio, Vertex AI express, and OpenCode Zen for its `gemini-*` ids), whose JSON mode the API refuses (google-gemini/cookbook#1028) |
 | Vision capability | Only if false (mapped from `attachment` field) |
 | Modality | Only if empty or default `"text"` |
 | Input modalities | Only if empty or default `"[]"` |


### PR DESCRIPTION
## Why

The fleet sweep's `structured` check fails on `Google AI Studio (Gemini)/gemini-3.1-flash-lite-image` with a bare `400 INVALID_ARGUMENT`. The model advertises `structured_output`, so the sweep and any client reading `/v1/models` expect JSON mode to work.

It does not, on any Google image-output model. Google's own docs list structured output for `gemini-2.5-flash-image` and the Gemini 3 image models, models.dev copies the claim, and the API refuses it: `JSON mode is not enabled for this model` on 2.5, a bare `INVALID_ARGUMENT` on 3.x, for a `json_schema` and for plain `json_object` alike ([google-gemini/cookbook#1028](https://github.com/google-gemini/cookbook/issues/1028), [Google AI forum thread](https://discuss.ai.google.dev/t/does-gemini-2-5-flash-image-support-structured-output-or-not/108828); reproduced on dev for both shapes, and with `modalities: ["text"]`). LiteLLM has no special case either way, so this is not a request-shape problem to translate around: the capability is absent.

## What

- `isGoogleStructuredOutputModel` no longer derives the flag for an image-output model (discovery derived it from tool calling, which these models have).
- models.dev enrichment ORs capability flags in and would have put it straight back, so `clearRefusedCapabilities` runs after the merge and clears `structured_output` for an image-output model on a provider that reaches Google's own route: Google AI Studio, Vertex AI express, and OpenCode Zen for its `gemini-*` ids (Zen's own codenames share the image-name space, so the family prefix is required there). An aggregator serving the same id over its own dialect keeps the flag it advertises.
- The upsert overwrites capabilities, so existing rows heal on the next Google scan; verified on dev, where every Google image model now reports `structured_output: false` and the text models keep it.

A client naming an image model with `response_format` still gets Google's 400, on purpose: stripping the field would hand prose to a client that asked for JSON.

## Verified

- `TestIsGoogleStructuredOutputModel` rows for the 2.5, 3.x and nano-banana ids; `TestEnrichModel_GoogleImageModelsKeepJSONModeOff` pins the merge on `google`, `vertex-express` and `opencode-zen`, the flag kept on `openrouter` and on a non-Gemini Zen id, and that only structured output is cleared. Two adversarial review rounds; each gate half fails its test when dropped.
- Dev: Google rediscovery after the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPcqgeUDN2Y7e9D4FKuDy6
