### PR TITLE
chore: strip history and narrative from code comments

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -50,10 +50,10 @@ func main() {
 	defer stop()
 
 	// OTLP log export: when the standard OTEL_EXPORTER_OTLP_* endpoint vars are
-	// set, fan the same structured records Front Desk already logs out to an
-	// OpenTelemetry collector, mirroring the main server. Logs only — no spans,
-	// no OTLP metrics (Prometheus stays the metrics path). Front Desk has no
-	// app-log ring buffer, so the fan-out base is the plain stdout handler.
+	// set, fan the structured records Front Desk logs out to an OpenTelemetry
+	// collector, as the main server does. Logs only: no spans, no OTLP metrics
+	// (Prometheus is the metrics path). Front Desk has no app-log ring buffer,
+	// so the fan-out base is the plain stdout handler.
 	var otelLogShutdown func(context.Context) error
 	if otelexport.LogsEnabled() {
 		otelHandler, shutdown, oerr := otelexport.NewSlogHandler(ctx, "front-desk", debuglog.Level())
@@ -121,8 +121,8 @@ func main() {
 	bus := events.NewBus()
 	poller := frontdesk.NewPoller(store, bus, traefikAPI)
 	// Resolve this Front Desk's persistent identity once and stamp it onto every
-	// announce. Members now reject announces without an id (it is how they know
-	// which control plane owns them), so a Front Desk that cannot establish its
+	// announce. Members reject announces without an id, it being how they know
+	// which control plane owns them, so a Front Desk that cannot establish its
 	// identity cannot manage any members: fail fast rather than run degraded.
 	fdID, err := store.EnsureFrontdeskID(ctx)
 	if err != nil {
@@ -207,8 +207,8 @@ func main() {
 	<-ctx.Done()
 	debuglog.Info("frontdesk: shutting down")
 	// End every open SSE stream first: each is an in-flight request that
-	// Shutdown would otherwise wait on until the deadline, so with a Front Desk
-	// tab open every restart burned the full 10s.
+	// Shutdown would otherwise wait on until the deadline, so one open Front
+	// Desk tab costs a restart the full 10s.
 	bus.Close()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -218,11 +218,11 @@ func main() {
 	// Nothing accepts requests any more, so no new background work can start:
 	// drain what is in flight and close the store. Its own budget, not
 	// shutdownCtx, which the HTTP drain may already have spent. Bounded, so a
-	// loop that ignores its cancellation delays exit rather than hanging it.
-	// 5s, not the HTTP drain's 10s: every loop returns on ctx within a tick, so the
-	// budget only has to absorb a straggler. It keeps the worst case (10s HTTP + 5s
-	// drain + 5s OTLP flush) at cmd/server's shape plus the drain, which the
-	// stop_grace_period on the front-desk service in deploy/ha covers.
+	// loop that ignores its cancellation delays exit rather than hanging it. 5s
+	// rather than the HTTP drain's 10s: every loop returns on ctx within a tick,
+	// so the budget only has to absorb a straggler, and the worst case (10s HTTP
+	// + 5s drain + 5s OTLP flush) stays inside the stop_grace_period on the
+	// front-desk service in deploy/ha.
 	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer drainCancel()
 	if err := srv.Shutdown(drainCtx); err != nil {
@@ -263,16 +263,11 @@ const (
 // the host to the operator's log store and retains it there under that store's
 // policy).
 //
-// To be precise about what this does and does not achieve: in a container,
-// stdout IS the log stream, so the token still reaches whatever collects
-// container output. What it stops is the token becoming a structured, indexed,
-// queryable attribute, and crossing the OTLP hop into a remote store. That is a
-// real reduction in reach and retention, not a guarantee the value never lands
-// in a log file.
-//
-// The gateway has always printed its own token straight to stdout for exactly
-// this reason (printAdminTokenBoxStdout); Front Desk logged it as a structured
-// attribute instead. Same credential, same requirement.
+// What this does and does not achieve: in a container, stdout IS the log
+// stream, so the token still reaches whatever collects container output. What
+// it stops is the token becoming a structured, indexed, queryable attribute,
+// and crossing the OTLP hop into a remote store. That is a reduction in reach
+// and retention, not a guarantee the value never lands in a log file.
 func announceGeneratedToken(w io.Writer, token string) {
 	// One Fprintf so the block cannot interleave with other Docker log output.
 	// This write is the ONLY copy the operator will ever get: the token is
@@ -287,9 +282,8 @@ func announceGeneratedToken(w io.Writer, token string) {
 }
 
 // sessionCleanupInterval is how often expired WebAuthn sessions are pruned,
-// matching the gateway's hourly sweep in cmd/server. A var, not a const, so a
-// test can prove the loop KEEPS sweeping after a failure rather than only that
-// it swept once and exited.
+// matching the gateway's hourly sweep in cmd/server. A var, not a const, so it
+// can be shortened under test.
 var sessionCleanupInterval = time.Hour
 
 // sessionCleaner is the slice of the WebAuthn store the cleanup loop needs.
@@ -301,16 +295,14 @@ type sessionCleaner interface {
 
 // webauthnSessionCleanupLoop prunes expired WebAuthn sessions until ctx is done.
 //
-// Front Desk had the store method and a SessionManager accessor documented as
-// existing for exactly this wiring, but nothing ever ran it, so the table only
-// grew. That matters here more than on the gateway: the OIDC login start is
-// unauthenticated and writes a session row per request, so anyone able to reach
-// Front Desk could grow its embedded SQLite database without limit.
+// It matters more here than on the gateway: the OIDC login start is
+// unauthenticated and writes a session row per request, so without the sweep
+// anyone able to reach Front Desk can grow its embedded SQLite database without
+// limit.
 //
-// The first sweep runs immediately rather than after a full interval: any
-// deployment upgrading into this fix already carries a backlog, and waiting an
-// hour to touch it serves nobody. A failed sweep is logged and the loop
-// continues, because a transient SQLite error must not disable cleanup for the
+// The first sweep runs immediately rather than after a full interval, since a
+// process starting up may inherit a backlog. A failed sweep is logged and the
+// loop continues, so a transient SQLite error does not disable cleanup for the
 // remaining life of the process.
 func webauthnSessionCleanupLoop(ctx context.Context, store sessionCleaner) {
 	sweep := func() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -68,8 +68,8 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Initialize admin manager before DB connection — it only needs the
-	// data directory and env token, no database dependency.
+	// Initialize the admin manager before the DB connection: it only needs the
+	// data directory and env token, no database.
 	adminMgr, isNew, err := admin.New(cfg.DataDir, cfg.AdminToken)
 	if err != nil {
 		debuglog.Fatal("startup: failed to initialize admin manager", "error", err)
@@ -103,8 +103,8 @@ func main() {
 
 	providerRepo := provider.NewRepository(database.Pool())
 	// Rows written before provider_type existed, or restored from an older
-	// dump, carry no type. Give them the one the URL rules used to imply
-	// before anything reads it.
+	// dump, carry no type. Give them the one the legacy URL rules imply before
+	// anything reads them.
 	if backfilled, err := providerRepo.BackfillTypes(ctx); err != nil {
 		debuglog.Error("startup: provider type backfill failed", "error", err)
 	} else if backfilled > 0 {
@@ -128,8 +128,8 @@ func main() {
 	// Global middleware
 	r.Use(middleware.RequestID)
 	// Resolve the client IP (trusted-proxy aware) once, before anything that
-	// logs an address — the access logger below, auth warnings, and the audit
-	// trail all read the resolved value via clientip.From.
+	// logs an address: the access logger, auth warnings, and the audit trail all
+	// read the resolved value via clientip.From.
 	r.Use(clientip.Middleware(cfg.TrustedProxies))
 	r.Use(silentLogger)
 	r.Use(middleware.Recoverer)
@@ -169,21 +169,22 @@ func main() {
 	proxyHandler.CircuitBreaker().SetOnOpen(apiHandler.NudgeQuotaPoll)
 
 	// Outbound alerting: a single consumer of the events bus that forwards
-	// operator-selected events to a stateless apprise-api container. Best-effort
-	// — a missing/failing apprise-api never affects request serving. Runs for the
-	// app lifetime (ctx), reading config live so toggles apply without a restart.
+	// operator-selected events to a stateless apprise-api container.
+	// Best-effort, so a missing or failing apprise-api never affects request
+	// serving. Runs for the app lifetime (ctx), reading config live so toggles
+	// apply without a restart.
 	alertDispatcher := alert.New(alert.NewSettingsConfigProvider(settingsRepo, cfg.MasterKey), nil)
 	go alertDispatcher.Run(ctx)
 
 	// Prometheus metrics at the conventional /metrics path (root, no IP rate
-	// limiter so scrapers aren't throttled). Authenticated via METRICS_TOKEN or
-	// the admin token — never unauthenticated.
+	// limiter so scrapers are not throttled). Authenticated via METRICS_TOKEN or
+	// the admin token, never unauthenticated.
 	r.Handle("/metrics", apiHandler.MetricsHandler())
 
 	// WebAuthn/FIDO2 passkey authentication (enabled when WEBAUTHN_RP_ID is set).
-	// The session manager is hoisted out of the WebAuthnRPID block so it is
-	// always available -- TOTP /totp/login reuses CreateAuthToken to mint session
-	// tokens once 2FA is enabled, even when passkeys (RP) are not configured.
+	// The session manager sits outside the WebAuthnRPID block so it is always
+	// available: TOTP /totp/login reuses CreateAuthToken to mint session tokens
+	// once 2FA is enabled, even when passkeys (RP) are not configured.
 	var webauthnHandler *adminauth.WebAuthnHandler
 	webauthnRepo := webauthn.NewRepository(database.Pool())
 	sessionMgr := webauthn.NewSessionManager(webauthnRepo)
@@ -198,7 +199,7 @@ func main() {
 	userRepo := user.NewRepository(database.Pool())
 	apiHandler.SetUserAuth(userRepo, webauthnRepo)
 	// Breached-password check: new dashboard passwords are screened against the
-	// Have I Been Pwned range API (k-anonymity — only a 5-char SHA-1 prefix ever
+	// Have I Been Pwned range API (k-anonymity: only a 5-char SHA-1 prefix
 	// leaves the process) unless disabled via the env kill-switch or DB toggle.
 	// It fails open, so an unreachable endpoint never blocks a password change;
 	// PWNED_PASSWORD_API_URL can point at a self-hosted mirror for offline or
@@ -265,7 +266,7 @@ func main() {
 		debuglog.Info("webauthn: passkey authentication enabled", "rp_id", cfg.WebAuthnRPID)
 	}
 
-	// API routes — IP rate limiting protects admin auth from brute-force.
+	// API routes. IP rate limiting protects admin auth from brute-force.
 	r.Route("/api", func(r chi.Router) {
 		r.Use(ipLimiter.Middleware)
 
@@ -303,18 +304,18 @@ func main() {
 			totpHandler.Register(r)
 		})
 
-		// OIDC SSO login endpoints (status/start/callback) — unauthenticated,
-		// same group as the other login routes; they ARE the login. The timeout
-		// matches the API group's posture so a slow or hostile IdP (discovery,
-		// token exchange, or UserInfo) can't pin a goroutine open indefinitely;
-		// the per-IP limiter and request-context cancellation already help.
+		// OIDC SSO login endpoints (status/start/callback): unauthenticated, in
+		// the same group as the other login routes, since they ARE the login. The
+		// timeout matches the API group's posture so a slow or hostile IdP
+		// (discovery, token exchange, or UserInfo) cannot pin a goroutine open
+		// indefinitely.
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(60 * time.Second))
 			oidcHandler.Register(r)
 			githubHandler.Register(r)
 		})
 
-		// Admin-token bootstrap exchange (POST /api/auth/admin-exchange) — a
+		// Admin-token bootstrap exchange (POST /api/auth/admin-exchange): a
 		// dashboard-only login front-end that trades a valid raw admin token for
 		// an HttpOnly session cookie so the browser never stores the raw token.
 		// Unauthenticated (the exchange IS the login), same posture as the other
@@ -332,16 +333,16 @@ func main() {
 
 	// The periodic backup scheduler must start AFTER apiHandler.Register, which
 	// is where the BackupHandler is constructed and wired as h.backupScheduler.
-	// Started any earlier it silently no-ops on a nil scheduler, so no automatic
-	// (GFS) backups ever run no matter what backup_enabled is set to.
+	// Started earlier it silently no-ops on a nil scheduler, so no automatic
+	// (GFS) backups run whatever backup_enabled is set to.
 	apiHandler.StartBackupScheduler(context.Background())
 
-	// Admin chat routes — admin-authenticated proxy for the Chat/Arena UI.
-	// Uses streaming-aware timeout (same as /v1) and rate limiting by IP.
+	// Admin chat routes: an admin-authenticated proxy for the Chat/Arena UI,
+	// with the streaming-aware timeout (as on /v1) and per-IP rate limiting.
 	// ChatUserContextMiddleware runs after the grant check because it reads the
 	// identity AuthMiddleware resolved, and before RegisterAdminChat because the
 	// consumers of what it publishes (the proxy's candidate filter and both rate
-	// limiters) are mounted in there. Without it the chat surface would carry
+	// limiters) are mounted in there. Without it the chat surface carries
 	// neither the caller's provider cap nor their per-user rate limits.
 	r.Route("/api/chat", func(r chi.Router) {
 		r.Use(ipLimiter.Middleware)
@@ -352,14 +353,12 @@ func main() {
 		proxyHandler.RegisterAdminChat(r)
 	})
 
-	// Proxy routes — streaming LLM requests can take many minutes.
-	// We must NOT apply a blanket timeout here; instead we use a
-	// streaming-aware middleware that:
+	// Proxy routes. Streaming LLM requests can take many minutes, so there is no
+	// blanket timeout here, only a streaming-aware middleware:
 	//   - streaming requests: no deadline (client-disconnect detection still works)
 	//   - non-streaming requests: 5-minute deadline
-	// It peeks at the body to decide, which buffers the body, so it is
-	// handed to Register to mount AFTER the virtual-key check (see
-	// mountProxyRoutes).
+	// It peeks at the body to decide, which buffers the body, so it is handed to
+	// Register to mount AFTER the virtual-key check (see mountProxyRoutes).
 	r.Route("/v1", func(r chi.Router) {
 		mountProxyRoutes(r, proxyHandler.Register)
 	})
@@ -448,8 +447,8 @@ func main() {
 	util.CloseDockerClient()
 
 	// End every open /api/events SSE stream. Each one is an in-flight request
-	// that server.Shutdown would otherwise wait on until the deadline, so with
-	// a dashboard tab open every restart burned the full 10s.
+	// that server.Shutdown would otherwise wait on until the deadline, so one
+	// open dashboard tab costs a restart the full 10s.
 	events.DefaultBus.Close()
 
 	// Flush pending app log DB writes before closing the database.

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -34,11 +34,10 @@ func securityHeadersMiddleware(cfg *config.Config) func(http.Handler) http.Handl
 			}
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 			// HSTS only over TLS. Plain HTTP (e.g. behind a reverse proxy that
-			// terminates TLS) must not set HSTS or browsers will cache a broken
-			// redirect to a non-existent HTTPS listener. Currently the server
-			// only serves plain HTTP (ListenAndServe), so this guard is a
-			// forward-compatible placeholder: it will activate automatically if
-			// TLS is added later via ListenAndServeTLS.
+			// terminates TLS) must not set HSTS, or browsers cache a broken
+			// redirect to a non-existent HTTPS listener. The server listens over
+			// plain HTTP (ListenAndServe), so this arm is reached only if TLS is
+			// added via ListenAndServeTLS.
 			if r.TLS != nil {
 				w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
 			}
@@ -182,17 +181,6 @@ func silentLogger(next http.Handler) http.Handler {
 	})
 }
 
-// streamingAwareTimeout returns middleware that sets a request deadline only
-// for non-streaming requests. Streaming LLM calls (e.g. code generation that
-// runs for 10+ minutes) must not be killed by a short server-side timeout.
-//
-// It works by peeking at the request body to check the "stream" field:
-//   - stream=true  → no context deadline (client disconnect detection still works)
-//   - stream=false/absent → context deadline of maxNonStreamingDur
-//
-// The request body is stored in the context so downstream handlers can
-// reuse it without a second allocation, and also restored as r.Body for
-// any handler that reads it directly.
 // isLongRunningPath reports whether the request targets a multimodal proxy
 // endpoint whose legitimate latency exceeds the non-streaming deadline:
 // image generation/edits and audio synthesis/transcription regularly take
@@ -202,6 +190,17 @@ func isLongRunningPath(path string) bool {
 	return strings.HasPrefix(path, "/v1/images/") || strings.HasPrefix(path, "/v1/audio/")
 }
 
+// streamingAwareTimeout returns middleware that sets a request deadline only
+// for non-streaming requests. Streaming LLM calls (code generation that runs
+// for 10+ minutes) must not be killed by a short server-side timeout.
+//
+// It peeks at the request body to read the "stream" field:
+//   - stream=true: no context deadline (client disconnect detection still works)
+//   - stream=false or absent: context deadline of maxNonStreamingDur
+//
+// The request body is stored in the context so downstream handlers can reuse it
+// without a second allocation, and also restored as r.Body for any handler that
+// reads it directly.
 func streamingAwareTimeout(maxNonStreamingDur time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -281,13 +280,12 @@ func streamingAwareTimeout(maxNonStreamingDur time.Duration) func(http.Handler) 
 }
 
 // mountProxyRoutes mounts the OpenAI-compatible surface with the body-peeking
-// timeout middleware placed by Register behind the virtual-key check, not
-// ahead of it as a plain r.Use would. The peek buffers the whole body (up to
-// MAX_REQUEST_SIZE) and used to run first, so an unauthenticated client made
-// the gateway hold that allocation for the length of its upload before being
-// told 401. Now the gateway never buffers an unauthenticated body; net/http
-// still discards up to 256 KiB of it after the refusal, bounded by the body
-// read deadline, so the connection itself is held no longer than that.
+// timeout middleware placed by Register behind the virtual-key check, not ahead
+// of it as a plain r.Use would. The peek buffers the whole body (up to
+// MAX_REQUEST_SIZE), so running it first would make the gateway hold that
+// allocation for an unauthenticated client's whole upload before answering 401.
+// Behind the check no unauthenticated body is buffered; net/http still discards
+// up to 256 KiB of it after the refusal, bounded by the body read deadline.
 func mountProxyRoutes(r chi.Router, register func(chi.Router, ...func(http.Handler) http.Handler)) {
 	register(r, streamingAwareTimeout(5*time.Minute))
 }

--- a/cmd/server/startup.go
+++ b/cmd/server/startup.go
@@ -46,10 +46,10 @@ func initAppLogging(ctx context.Context) func(context.Context) error {
 }
 
 // cleanupInterruptedRequests marks request logs left in "pending" or
-// "streaming" state from a previous server crash, restart, or unhandled error
-// as failed. Using serverStartTime (captured before DB was ready) means we
-// only reclaim rows that predate this process — a genuine streaming request
-// that happens to be long-running is never touched.
+// "streaming" state by a previous server crash, restart, or unhandled error as
+// failed. serverStartTime is captured before the DB is ready, so only rows that
+// predate this process are reclaimed and a long-running live streaming request
+// is never touched.
 func cleanupInterruptedRequests(pool *pgxpool.Pool, serverStartTime time.Time) {
 	tag, err := pool.Exec(context.Background(), `
 		UPDATE request_logs
@@ -69,12 +69,11 @@ func cleanupInterruptedRequests(pool *pgxpool.Pool, serverStartTime time.Time) {
 	}
 }
 
-// warmCaches pre-warms caches synchronously before accepting connections.
-// Provider, model, and failover lookups are fast (simple SELECT queries),
-// but key warming (Argon2id) can take ~150ms per provider. The total
-// warm-up cost is typically under 1s for a handful of providers —
-// far better than letting the first request pay the cold-cache penalty
-// of ~170ms+ in failover + model + provider + key decryption DB queries.
+// warmCaches pre-warms caches synchronously before connections are accepted.
+// Provider, model, and failover lookups are fast (simple SELECT queries), but
+// key warming (Argon2id) takes ~150ms per provider, for a total under 1s for a
+// handful of providers. It spares the first request the cold-cache penalty of
+// ~170ms+ across the failover, model, provider, and key-decryption queries.
 func warmCaches(deps discoveryDeps, settingsRepo *settings.Repository) {
 	ctx := context.Background()
 
@@ -94,12 +93,11 @@ func warmCaches(deps discoveryDeps, settingsRepo *settings.Repository) {
 		}
 		provider.WarmProviderCache(enabledProviders)
 	}
-	// Every provider key, enabled or not, joins the credential mask's held
-	// set; a disabled provider is the one a relay is most likely to quote.
-	// Synchronous like the warm above, and for the same reason: the set has
-	// to be complete before the listener opens, and the rows the warm just
-	// derived are cache hits here, so the extra cost is the disabled and
-	// non-autodiscovery rows at a few milliseconds each.
+	// Every provider key, enabled or not, joins the credential mask's held set;
+	// a disabled provider is the one a relay is most likely to quote. Synchronous
+	// like the warm above: the set has to be complete before the listener opens,
+	// and the rows that warm just derived are cache hits here, so the extra cost
+	// is the disabled and non-autodiscovery rows at a few milliseconds each.
 	held, failed := provider.HoldKeys(ctx, deps.providerRepo, deps.cfg.MasterKey)
 	debuglog.Info("cache: provider keys held for the credential mask", "held", held, "failed", failed)
 

--- a/frontdesk/web/src/api/client.ts
+++ b/frontdesk/web/src/api/client.ts
@@ -59,9 +59,9 @@ export function hasSession(): boolean {
 
 // clearSessionHint locally expires the readable cookie so the UI drops to the
 // login screen immediately; the server's Set-Cookie on logout/401 is the
-// authoritative clear. Stays on document.cookie rather than the async Cookie
-// Store API (unavailable in Safari/Firefox) since every caller here either
-// reloads the page or throws right after this returns.
+// authoritative clear. It uses document.cookie rather than the async Cookie
+// Store API (unavailable in Safari/Firefox) because every caller either reloads
+// the page or throws right after this returns.
 export function clearSessionHint(): void {
 	// biome-ignore lint/suspicious/noDocumentCookie: must be synchronous; see the doc comment above.
 	document.cookie = `${CSRF_COOKIE}=; path=/; max-age=0`;
@@ -69,8 +69,8 @@ export function clearSessionHint(): void {
 
 export class ApiError extends Error {
 	status: number;
-	// Stable machine-readable code from a JSON error body ({code, error}), when the
-	// endpoint provides one. Lets callers route on the code instead of matching
+	// Stable machine-readable code from a JSON error body ({code, error}) when
+	// the endpoint provides one, so callers route on the code instead of on
 	// translatable English text. Undefined for plain-text error responses.
 	code?: string;
 	constructor(status: number, message: string, code?: string) {
@@ -89,10 +89,9 @@ export function onUnauthorized(fn: UnauthorizedListener): () => void {
 	unauthorizedListeners.add(fn);
 	return () => unauthorizedListeners.delete(fn);
 }
-// Clear the session hint and notify listeners (the app falls back to login).
-// Exported so the SSE stream, which uses raw fetch and bypasses request(), can
-// trigger the same path on a 401, so the app drops to login instead of
-// reconnecting a dead session.
+// Clear the session hint and notify listeners, so the app falls back to login.
+// Exported for the SSE stream, which uses raw fetch and bypasses request() but
+// must take the same path on a 401 rather than reconnect a dead session.
 export function notifyUnauthorized() {
 	clearSessionHint();
 	for (const fn of unauthorizedListeners) fn();
@@ -123,9 +122,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 	}
 	if (!resp.ok) {
 		const text = (await resp.text().catch(() => "")).trim();
-		// Some endpoints return a JSON {code, error} body so the caller can route on
-		// a stable code; others return plain text. Parse the coded form when present,
-		// otherwise fall back to the raw text as the message.
+		// Some endpoints return a JSON {code, error} body so the caller can route
+		// on a stable code; others return plain text. Parse the coded form when
+		// present, otherwise use the raw text as the message.
 		let message = text || `HTTP ${resp.status}`;
 		let code: string | undefined;
 		if (text.startsWith("{")) {
@@ -288,16 +287,16 @@ export const api = {
 			jsonInit("POST", { primary_id: primaryId }),
 		),
 
-	// Reset circuit breakers on every member that has a stored token: the
-	// whole ledger, or one failover group's entries when a group id is given.
-	// Each member's breaker is local runtime state nothing syncs, so this is
-	// the only fleet-wide lever.
 	// The primary's failover groups, reduced to what the reset picker needs.
 	fleetFailoverGroups: (primaryId: string) =>
 		request<FleetFailoverGroup[]>(
 			`/api/fleet/failover-groups?primary_id=${encodeURIComponent(primaryId)}`,
 		),
 
+	// Reset circuit breakers on every member that has a stored token: the whole
+	// ledger, or one failover group's entries when a group id is given. Each
+	// member's breaker is local runtime state nothing syncs, so this is the only
+	// fleet-wide lever.
 	fleetCircuitReset: (groupId?: string) =>
 		request<FleetCircuitReset>(
 			"/api/fleet/circuit-breaker/reset",
@@ -339,7 +338,7 @@ export const api = {
 			jsonInit("POST", { session_id: sessionId, credential }),
 		),
 
-	// Passkey management (admin-gated; bearer attached automatically once logged in).
+	// Passkey management (admin-gated; the session cookie rides on every request).
 	webauthnRegisterStart: () =>
 		request<{
 			session_id: string;

--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -15,7 +15,7 @@ export interface Member {
 	// confirmed (member offline, or an older build). A refused token is a 400.
 	token_warning?: string;
 	// When Front Desk last applied config to this member (wizard or automatic),
-	// RFC3339; absent until the first sync. last_config_sync_reason explains why
+	// RFC3339; absent until the first sync. last_config_sync_reason says why
 	// (e.g. it did not hold the primary's config). Both drive the "Last Config
 	// Sync" column on the Members tab.
 	last_config_sync_at?: string;
@@ -347,7 +347,7 @@ export interface FleetVersionCheck {
 	skewed: FleetVersionSkewMember[];
 	// True when a real commit backed every alignment verdict. False means at
 	// least one rested on the version alone, which on a fleet of "dev" images
-	// means it rested on nothing - the case the acknowledgment covers.
+	// means it rested on nothing: the case the acknowledgment covers.
 	commit_vouched: boolean;
 }
 
@@ -478,9 +478,9 @@ export interface ZAICodingQuotaResponse {
 }
 
 // ── Kimi Code + MiniMax quota ───────────────────────────────────
-// Declared in web-shared/quota, which both Front Desk and the Model Hotel
-// dashboard parse these payloads with, and re-exported here so app code keeps
-// importing every API type from one place.
+// Declared in web-shared/quota, the parser both Front Desk and the Model Hotel
+// dashboard use for these payloads, and re-exported here so app code imports
+// every API type from one place.
 
 export type {
 	KimiCodeQuotaLimitEntry,
@@ -535,15 +535,14 @@ export interface NeuralWattQuotaUsagePeriod {
 /**
  * NeuralWatt's quota body, as relayed by the fleet primary.
  *
- * Only `balance` is declared required, and only because the badge visibility
- * gate (isNeuralWattQuotaVisible in web-shared/quota) refuses to render a
- * NeuralWatt badge at all unless balance.credits_remaining_usd is present, so
- * nothing downstream can be reached without it. Every other block is optional on purpose: this is an
- * upstream provider's JSON forwarded through another machine's export, not a
- * shape this build controls, and a fleet primary on a different version may
- * relay less than the current one does. Optional here is what makes the
- * compiler, rather than an operator's crashed dashboard, catch an unguarded
- * nested read.
+ * Only `balance` is required, because the badge visibility gate
+ * (isNeuralWattQuotaVisible in web-shared/quota) renders no NeuralWatt badge
+ * unless balance.credits_remaining_usd is present, so nothing downstream is
+ * reachable without it. Every other block is optional: this is an upstream
+ * provider's JSON forwarded through another machine's export, not a shape this
+ * build controls, and a fleet primary on a different version may relay less.
+ * Optional is what makes the compiler, rather than an operator's crashed
+ * dashboard, catch an unguarded nested read.
  */
 export interface NeuralWattQuotaResponse {
 	balance: {

--- a/frontdesk/web/src/pages/members/FleetCircuitReset.tsx
+++ b/frontdesk/web/src/pages/members/FleetCircuitReset.tsx
@@ -6,11 +6,10 @@ import { ConfirmModal } from "../../components/ConfirmModal";
 import { useToast } from "../../context/ToastContext";
 
 // The fleet-wide circuit-breaker reset: one failover group's circuits, cleared
-// on every member with a token. Group-scoped by design: clearing every circuit
-// on the fleet stays API-only, for the same reason the member-side reset-all
-// has no button (it discards the breaker's evidence about every other
-// provider). A mutation across the fleet, so it confirms first. Its own file
-// because MembersPage sits at the size ceiling.
+// on every member with a token. Group-scoped by design, since clearing every
+// circuit on the fleet discards the breaker's evidence about every other
+// provider and so stays API-only, as it does on a member. It mutates the whole
+// fleet, so it confirms first.
 export function FleetCircuitReset({ primaryId }: { primaryId: string }) {
 	const { t } = useTranslation();
 	const { toast } = useToast();

--- a/frontdesk/web/src/pages/members/MemberCircuitsCell.tsx
+++ b/frontdesk/web/src/pages/members/MemberCircuitsCell.tsx
@@ -2,11 +2,10 @@ import { useTranslation } from "react-i18next";
 import type { MemberStatus } from "../../api/types";
 import { formatAbsolute } from "../../utils/time";
 
-// The Members table's circuits column: how many circuits this member's
-// breaker holds open or owes a probe, with the ledger itself on hover
-// (provider, model, state, cause, next retry). Which member is dark for which
-// model, without a terminal per member. Read-only; the fleet reset button is
-// the write side.
+// The Members table's circuits column: how many circuits this member's breaker
+// holds open or owes a probe, with the ledger itself on hover (provider, model,
+// state, cause, next retry). Read-only; the fleet reset button is the write
+// side.
 export function MemberCircuitsCell({
 	status,
 	hasToken,

--- a/internal/anthropic/events.go
+++ b/internal/anthropic/events.go
@@ -1,16 +1,10 @@
 // Package anthropic translates between the Anthropic Messages API wire format
 // and the OpenAI chat-completions format the proxy pipeline speaks internally.
 //
-// Design note (2026-06-30): the plan's locked decision #5 said to emit the SSE
-// stream using anthropics/anthropic-sdk-go's struct definitions directly. In
-// SDK v1.53 those response/event types are decode-oriented: they carry no
-// `omitempty`, so marshaling them emits a wall of zero-value junk (a phantom
-// `stop_details.type:"refusal"` on every message_start, a full citation/document
-// union on every text content_block_start, etc.) that no Anthropic client should
-// be handed. We therefore emit via the small, omitempty-clean structs below and
-// VALIDATE that output by decoding it back through the real SDK's ssestream
-// decoder in the golden tests. The SDK still certifies our wire format; we just
-// don't let its decode structs author it.
+// The SSE events are emitted from the small omitempty structs below, not from
+// anthropic-sdk-go's response types: those are decode-oriented and marshal
+// zero-value members (a phantom stop_details, empty citation unions) that
+// Anthropic clients must not receive.
 package anthropic
 
 import "encoding/json"

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -8,13 +8,7 @@ import (
 
 // RewriteModel rewrites the top-level "model" field of an Anthropic Messages
 // request body to the resolved upstream model id, leaving every other field
-// (system, messages, tools, cache_control, thinking config, ...) semantically
-// intact. The round-trip through a map may reorder top-level keys, but JSON
-// object key order is not significant. This is the only mutation the native
-// passthrough path makes: the proxy routes on "provider/model" or "hotel/group",
-// but the upstream Anthropic API must receive the bare model id. On any parse
-// failure the original body is returned unchanged (the upstream surfaces a clear
-// model error).
+// intact. On any parse failure the original body is returned unchanged.
 func RewriteModel(body []byte, model string) []byte {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(body, &m); err != nil {
@@ -32,11 +26,10 @@ func RewriteModel(body []byte, model string) []byte {
 	return out
 }
 
-// ResponseUsage is the metering summary of one Anthropic Messages response,
-// produced from a single parse. PromptTokens is the whole prompt. CacheHit and
-// CacheMiss split it by how the tokens were billed and sum back to it, but only
-// when the response reports cache activity at all; an uncached response leaves
-// both zero rather than calling the whole prompt a miss (see summary).
+// ResponseUsage is the metering summary of one Anthropic Messages response.
+// PromptTokens is the whole prompt. CacheHit and CacheMiss split it by how the
+// tokens were billed and sum back to it, but only when the response reports a
+// cache read; an uncached response leaves both zero.
 type ResponseUsage struct {
 	PromptTokens     int
 	CompletionTokens int
@@ -53,8 +46,6 @@ type ResponseUsage struct {
 // not a breakdown, so a cache hit reports input_tokens: 4 alongside
 // cache_read_input_tokens: 20000 for a ~20004-token prompt. Metering the bare
 // input_tokens under-reports a warm-cache request by the whole cached figure.
-// The egress adapter does the same arithmetic (see
-// internal/anthropicegress.translateUsage), so both Anthropic paths agree.
 func ParseResponseUsage(body []byte) ResponseUsage {
 	var resp struct {
 		Usage json.RawMessage `json:"usage"`
@@ -78,22 +69,13 @@ type antUsage struct {
 // is the three disjoint input counts summed; of those, only
 // cache_read_input_tokens was served from cache and billed at the cache-hit
 // rate. Cache CREATION is a miss: those tokens are processed (and surcharged)
-// on this request and only pay off on the next one. Reporting the sum without
-// this split prices every cached token at full input rate, which is a different
-// skew from under-counting, not an absence of one.
+// on this request and only pay off on the next one.
 //
 // The split is reported only when a cache READ occurred. A response that
-// created a cache entry without reading one — and one with no cache activity at
-// all — reports NO cache counts rather than "miss = the whole prompt". The
-// translated egress path cannot express either reading: extractCacheTokens
-// keys off the cache-READ fields alone, so it yields (0, 0) for both, and one
-// Anthropic path claiming cache data the other cannot is exactly the
-// inconsistency this split exists to remove. It is also what every other
-// provider reports for a request that read nothing from cache, which is what
-// the dashboard's cache panel and the cache-miss stats series assume.
-//
-// Creation tokens are never lost either way: they count inside PromptTokens,
-// which is what the request is metered and priced on.
+// created a cache entry without reading one, or that used no cache at all,
+// reports NO cache counts rather than "miss = the whole prompt". Creation
+// tokens still count inside PromptTokens, which is what the request is metered
+// and priced on.
 func (u antUsage) summary() ResponseUsage {
 	out := ResponseUsage{
 		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
@@ -108,11 +90,10 @@ func (u antUsage) summary() ResponseUsage {
 
 // ResponseCarriesContent reports whether a non-streaming Messages response holds
 // any content block. A 200 with an empty content array is a status rather than
-// an answer, and the proxy's model-retirement path needs the difference: an
-// empty completion must not count as the model answering.
+// an answer, and must not count as the model answering.
 //
-// The blocks are left undecoded — a block of any type is the model producing
-// something, and their vocabulary is Anthropic's to extend.
+// The blocks are left undecoded: a block of any type is the model producing
+// something.
 func ResponseCarriesContent(body []byte) bool {
 	var resp struct {
 		Content []json.RawMessage `json:"content"`
@@ -124,8 +105,9 @@ func ResponseCarriesContent(body []byte) bool {
 }
 
 // ResponseTextBytes is the byte length of the text, thinking, tool name and
-// tool input of a non-streaming Messages response's content blocks, the delivered output a
-// usage estimate works from when the response carries no usage block.
+// tool input across a non-streaming Messages response's content blocks, the
+// delivered output a usage estimate works from when the response carries no
+// usage block.
 func ResponseTextBytes(body []byte) int {
 	var resp struct {
 		Content []struct {
@@ -145,12 +127,8 @@ func ResponseTextBytes(body []byte) int {
 	return n
 }
 
-// StreamEvent is the decoded summary of a single Anthropic stream event,
-// produced by InspectStreamEvent for the native passthrough path. It carries
-// everything that path needs from one parse: the event Type (so the terminal
-// message_stop can be detected and completion gated on it), any token usage, and
-// the error message on an "error" event (so a provider-sent error is recorded,
-// not just forwarded blind).
+// StreamEvent is the decoded summary of a single Anthropic stream event: the
+// event Type, any token usage, and the error message on an "error" event.
 type StreamEvent struct {
 	Type            string
 	InputTokens     int
@@ -162,9 +140,8 @@ type StreamEvent struct {
 	ErrorMessage    string // set only when Type == "error"
 	// CarriesError reports a populated error member on ANY event type: a
 	// relay wraps its rejection as {"type":"error","error":{...}}, sends it
-	// bare as {"error":{...}}, or stamps it on an ordinary event, and every
-	// one of those is error text for the credential mask, which must not
-	// depend on the wrapper's type to recognise it.
+	// bare as {"error":{...}}, or stamps it on an ordinary event, and all of
+	// those are error text for the credential mask.
 	CarriesError bool
 	// TextBytes is the byte length of the output a content block event carries:
 	// a content_block_delta's text, thinking or partial JSON, and a
@@ -182,7 +159,7 @@ type StreamEvent struct {
 //
 // InputTokens and its cache split come from the same arithmetic
 // ParseResponseUsage does, so a streamed warm-cache request meters its full
-// prompt — and prices it — exactly as the non-streaming path would.
+// prompt exactly as the non-streaming path does.
 func InspectStreamEvent(payload []byte) StreamEvent {
 	var ev struct {
 		Type    string `json:"type"`
@@ -190,17 +167,15 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			Usage json.RawMessage `json:"usage"`
 		} `json:"message"`
 		// json.RawMessage for the same reason the error member below is one: a
-		// count the provider spelled differently — quoted, or with a fraction on
-		// it — failed the WHOLE event unmarshal, so the event lost its TYPE with
-		// its counts and message_stop and the error events stopped being
-		// recognised for that frame.
+		// count the provider spells differently (quoted, or with a fraction on
+		// it) must not fail the WHOLE event unmarshal and cost the event its
+		// type along with its counts.
 		Usage json.RawMessage `json:"usage"`
 		// json.RawMessage, not a typed object: a relay is free to send a bare
-		// string here, and a typed field failed the WHOLE event unmarshal — so
-		// the event lost its type too, the error went uncounted, and the frame
-		// was forwarded to the caller with no key-shape masking at all,
-		// credential included. util.ErrorMemberCarries is the same rule the
-		// OpenAI-compatible path reads this member with.
+		// string here, and a typed field fails the WHOLE event unmarshal, which
+		// costs the event its type, leaves the error uncounted and forwards the
+		// frame with no key-shape masking. util.ErrorMemberCarries is the same
+		// rule the OpenAI-compatible path reads this member with.
 		Error json.RawMessage `json:"error"`
 		Delta *struct {
 			Text        string `json:"text"`
@@ -235,10 +210,9 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		}
 	case "message_delta":
 		if usage, ok := readEventUsage(ev.Usage); ok {
-			// The guard message_start has always had: an output figure that is
-			// not positive is not a reading. Assigned verbatim, a negative
-			// output_tokens here reached the completion metering after the
-			// whole answer had been forwarded and drew the key's usage down.
+			// An output figure that is not positive is not a reading: assigned
+			// verbatim, a negative output_tokens reaches the completion
+			// metering and draws the key's usage down.
 			if usage.OutputTokens > 0 {
 				info.OutputTokens, info.HasOutput = usage.OutputTokens, true
 			}
@@ -272,7 +246,7 @@ func readEventUsage(raw json.RawMessage) (antUsage, bool) {
 		return antUsage{}, false
 	}
 	// A member that could not be read costs the figures it FEEDS, not the whole
-	// block. See readUsage.
+	// block.
 	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
 		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
 	}
@@ -285,18 +259,11 @@ func readEventUsage(raw json.RawMessage) (antUsage, bool) {
 // promptAddends are the members Anthropic's prompt figure is SUMMED from.
 var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}
 
-// readUsage decodes an Anthropic usage block per FIGURE, not per block.
-//
-// Two rules were tried and both were wrong. Keeping whatever decoded corrupted
-// the prompt figure, which is input_tokens plus both cache counts: a cache-read
-// count of 20000 lost to an unreadable sibling billed 4, and 4 is non-zero, so
-// estimateMissingUsage never replaced it. Dropping the whole block instead threw
-// away output_tokens — read straight off one member, so never in doubt — and an
-// answer with a perfectly good completion count then read as empty, which since
-// #812 charges the provider's circuit breaker.
-//
-// So a member that could not be read costs the figures it FEEDS. output_tokens
-// stands or falls alone; the prompt figure needs all three of its addends.
+// readUsage decodes an Anthropic usage block per FIGURE, not per block: a
+// member that could not be read costs the figures it FEEDS. output_tokens
+// stands or falls alone; the prompt figure needs all three of its addends,
+// since a cache-read count of 20000 lost to an unreadable sibling would bill 4
+// and no estimate would replace a non-zero figure.
 func readUsage(raw json.RawMessage) ResponseUsage {
 	if !util.JSONMemberSet(raw) {
 		return ResponseUsage{}

--- a/internal/anthropic/openai_types.go
+++ b/internal/anthropic/openai_types.go
@@ -7,10 +7,8 @@ import (
 )
 
 // This file defines the minimal subset of the OpenAI chat-completions wire
-// format the translators consume. We deliberately do not import the proxy
-// package's own chunk types: the dependency runs proxy -> anthropic, never the
-// reverse, so the translator stays a leaf package the rest of the pipeline
-// composes. The proxy adapts its parsed chunks into these on the way in.
+// format the translators consume. The proxy adapts its parsed chunks into
+// these on the way in.
 
 // OAStreamChunk is one OpenAI `chat.completion.chunk` SSE payload.
 type OAStreamChunk struct {
@@ -38,9 +36,8 @@ type OAToolCallDelta struct {
 	ID       string          `json:"id"`
 	Type     string          `json:"type"`
 	Function OAFunctionDelta `json:"function"`
-	// ExtraContent is the Gemini 3 thought signature's carrier, on the
-	// fragment that opens the call (the Gemini translator and Google's own
-	// compatibility layer both put it there); raw, read leniently.
+	// ExtraContent carries the Gemini 3 thought signature, on the fragment
+	// that opens the call; raw, read leniently.
 	ExtraContent json.RawMessage `json:"extra_content"`
 }
 
@@ -48,10 +45,10 @@ type OAToolCallDelta struct {
 // JSON string.
 type OAFunctionDelta struct {
 	Name string `json:"name"`
-	// See util.ToolArguments. A plain string here dropped an object-form tool
-	// call from the translated stream, leaving the Anthropic client a
-	// message_delta with stop_reason "tool_use" and no tool_use content block
-	// at all — a shape the Anthropic SDKs reject.
+	// util.ToolArguments accepts both the string and the object form: a
+	// plain string drops an object-form tool call from the translated
+	// stream, leaving a stop_reason of "tool_use" with no tool_use block,
+	// a shape the Anthropic SDKs reject.
 	Arguments util.ToolArguments `json:"arguments"`
 }
 

--- a/internal/anthropic/request.go
+++ b/internal/anthropic/request.go
@@ -11,9 +11,8 @@ import (
 
 // --- Incoming Anthropic Messages request shape ---
 //
-// We decode only the fields the gateway needs to translate. Unknown fields are
-// ignored; provider-specific knobs the proxy already handles (and any params an
-// upstream rejects) are dropped here or stripped by the proxy's 400 auto-retry.
+// Only the fields the gateway needs to translate are decoded. Unknown fields
+// are ignored.
 
 // Request is a decoded Anthropic Messages API request.
 type Request struct {
@@ -108,8 +107,8 @@ type oaiToolCall struct {
 	Type     string          `json:"type"` // "function"
 	Function oaiToolCallFunc `json:"function"`
 	// ExtraContent carries a Gemini 3 thought signature recovered from the
-	// tool_use id (see thoughtSigMarker) in the shape the chat path and the
-	// Gemini translator read it.
+	// tool_use id (see thoughtSigMarker), in the shape the chat path and the
+	// Gemini translator read.
 	ExtraContent *egress.ExtraContent `json:"extra_content,omitempty"`
 }
 
@@ -131,10 +130,10 @@ type oaiToolFunc struct {
 
 // TranslateRequest converts an Anthropic Messages request body into an
 // OpenAI chat-completions request body. It returns the OpenAI JSON, the model
-// string (verbatim, for the proxy's existing provider/hotel routing), and the
-// stream flag. The translation is lossy by design for v1 (thinking blocks and
-// cache_control are dropped on this path; see plan), but preserves text, vision,
-// tool definitions, tool calls, and tool results.
+// string (verbatim, for the proxy's provider/hotel routing), and the stream
+// flag. The translation is lossy: thinking blocks and cache_control are dropped
+// on this path, while text, vision, tool definitions, tool calls and tool
+// results are preserved.
 func TranslateRequest(body []byte) (openaiBody []byte, model string, stream bool, err error) {
 	var req Request
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -200,7 +199,7 @@ func TranslateRequest(body []byte) (openaiBody []byte, model string, stream bool
 // message with tool_calls.
 func translateMessage(m ReqMessage) ([]oaiMessage, error) {
 	// Plain string content: straight passthrough. Only a genuine JSON string
-	// short-circuits here — an array of blocks must fall through to block
+	// short-circuits here; an array of blocks must fall through to block
 	// handling, or non-text blocks (images, tool_use, tool_result) are dropped.
 	if s, ok := egress.AsJSONString(m.Content); ok {
 		return []oaiMessage{{Role: m.Role, Content: s}}, nil
@@ -257,8 +256,8 @@ func translateMessage(m ReqMessage) ([]oaiMessage, error) {
 				Content:    content,
 			})
 		case "document", "thinking", "redacted_thinking":
-			// v1: best-effort drop. Documents have no clean OpenAI equivalent;
-			// thinking is preserved only on the native passthrough path.
+			// Dropped: documents have no clean OpenAI equivalent, and thinking
+			// is preserved only on the native passthrough path.
 		}
 	}
 
@@ -357,8 +356,8 @@ func translateToolChoice(raw json.RawMessage) (any, bool) {
 		return "auto", true
 	case "none":
 		// The caller explicitly prohibits tool use; OpenAI's equivalent is the
-		// literal "none". Dropping this would let the upstream default to "auto"
-		// and call a tool against the caller's intent.
+		// literal "none". Omitting it lets the upstream default to "auto" and
+		// call a tool against the caller's intent.
 		return "none", true
 	case "any":
 		return "required", true

--- a/internal/anthropic/response.go
+++ b/internal/anthropic/response.go
@@ -16,13 +16,10 @@ type oaiResponse struct {
 	ID      string      `json:"id"`
 	Model   string      `json:"model"`
 	Choices []oaiChoice `json:"choices"`
-	// Held raw and decoded on its own, so a usage block this package cannot read
-	// costs the usage and nothing else. Decoded inline it was part of the
-	// response object, and one count the provider spelled differently — quoted,
-	// or with a fraction on it — failed the whole decode, which the caller met
-	// as a 502 in place of the answer the model had already produced. The
-	// streaming twin of this path already reads counts that way; see
-	// proxy.anthropicResponseWriter.handleStreamLine.
+	// Held raw and decoded on its own, so a usage block this package cannot
+	// read costs the usage and nothing else. Decoded inline, one count the
+	// provider spells differently (quoted, or with a fraction on it) fails the
+	// whole decode and the caller gets a 502 in place of the answer.
 	Usage json.RawMessage `json:"usage"`
 }
 
@@ -38,8 +35,8 @@ type oaiRespMessage struct {
 	// structured-array response does not fail the whole translation.
 	Content   json.RawMessage   `json:"content"`
 	ToolCalls []oaiRespToolCall `json:"tool_calls"`
-	// reasoning_content is surfaced by some OpenAI-compatible providers; v1
-	// drops it on the translated path (thinking-block mapping is deferred).
+	// reasoning_content, surfaced by some OpenAI-compatible providers, has no
+	// field here: the translated path carries no thinking block.
 }
 
 // decodeRespContent extracts assistant text from an OpenAI chat-completion
@@ -76,25 +73,21 @@ type oaiRespToolCall struct {
 		Name      string             `json:"name"`
 		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
-	// ExtraContent is the Gemini 3 thought signature's carrier on the
-	// OpenAI side; raw, since a shape this package does not expect is an
-	// unsigned call and not a failed translation.
+	// ExtraContent carries the Gemini 3 thought signature on the OpenAI
+	// side; raw, since a shape this package does not expect is an unsigned
+	// call and not a failed translation.
 	ExtraContent json.RawMessage `json:"extra_content"`
 }
 
 // readOAUsage maps an OpenAI usage block to the Anthropic token accounting.
 //
-// util.DecodeCounts, so a count written as "12" or 12.0 is still a count; the
-// shape tolerance (util.ShapeError) so a member this translator has no field
-// for, or one figure that is not a count in any spelling, keeps the figure
-// beside it. Both counts are read straight off their own member — neither is a
-// sum — so an unreadable one costs only itself.
+// util.DecodeCounts reads a count written as "12" or 12.0; the shape tolerance
+// (util.ShapeError) keeps the figure beside a member this translator has no
+// field for, or one that is not a count in any spelling. Both counts are read
+// straight off their own member, so an unreadable one costs only itself.
 //
-// Absent, null and unreadable all land on the same zeros, and there is no
-// util.JSONMemberSet guard here because there is nothing for it to protect: the
-// Anthropic Message schema makes usage mandatory, this translation reports one
-// response rather than accumulating across chunks, and metering reads the
-// upstream body, not this output.
+// Absent, null and unreadable all land on the same zeros. No JSONMemberSet
+// guard: usage is mandatory here and nothing accumulates across chunks.
 func readOAUsage(raw json.RawMessage) usage {
 	var u OAUsage
 	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
@@ -140,9 +133,9 @@ func BuildMessageResponse(body []byte, messageID, model string) ([]byte, error) 
 			}
 			id := tc.ID
 			if id == "" {
-				// Anthropic requires a tool_use id; synthesize a stable one
-				// as the streaming twin does, since a signed empty id would
-				// otherwise pass the wire and come back as an empty call id.
+				// Anthropic requires a tool_use id; synthesize a stable one,
+				// or a signed empty id passes the wire and comes back as an
+				// empty call id.
 				id = fmt.Sprintf("toolu_%s_%d", messageID, i)
 			}
 			msg.Content = append(msg.Content, contentBlock{

--- a/internal/anthropic/stream.go
+++ b/internal/anthropic/stream.go
@@ -16,10 +16,9 @@ import (
 //	message_delta   // stop_reason + cumulative output usage
 //	message_stop
 //
-// It is a stateful state machine keyed on the active content block (blockKind),
-// not a text-vs-tool binary, so a thinking-block case is an additive change
-// later (plan Gap 5 design constraint). It is single-goroutine: the proxy drives
-// it from one streaming loop, exactly where the OpenAI chunks are parsed today.
+// It is a state machine keyed on the active content block (blockKind), not a
+// text-vs-tool binary. It is single-goroutine: the proxy drives it from one
+// streaming loop.
 type StreamTranslator struct {
 	messageID string
 	model     string
@@ -40,10 +39,10 @@ type StreamTranslator struct {
 	finishReason     string // last OpenAI finish_reason observed
 	finished         bool   // Finish() already emitted
 
-	// lateSignatures counts thought signatures that arrived on a fragment
+	// lateSignatures counts thought signatures that arrive on a fragment
 	// after the one that opened the call's block, where the id (their only
-	// carrier) was already fixed; the proxy logs the count at the end of the
-	// stream, since the loss surfaces a turn later as Gemini's refusal.
+	// carrier) is already fixed. The loss surfaces a turn later as Gemini's
+	// refusal, so the proxy logs the count at the end of the stream.
 	lateSignatures int
 }
 
@@ -81,7 +80,7 @@ func writeEvent(buf *bytes.Buffer, eventType string, payload any) error {
 // ensureStarted lazily emits message_start (and a ping, mirroring the real API)
 // the first time any content is processed. input_tokens is reported as 0:
 // OpenAI streaming does not reveal the prompt count until the terminal usage
-// chunk, and the locked decision is best-effort usage with no upstream mutation.
+// chunk.
 func (t *StreamTranslator) ensureStarted(buf *bytes.Buffer) error {
 	if t.started {
 		return nil
@@ -208,10 +207,9 @@ func (t *StreamTranslator) Translate(chunk OAStreamChunk) ([]byte, error) {
 	}
 
 	// Tool-call deltas. This assumes OpenAI streams each tool call's fragments
-	// contiguously (it does: the spec streams one call to completion before the
-	// next, keyed by Index). Truly interleaved fragments across two open tool
-	// blocks would emit input_json_delta against a closed Anthropic block; no
-	// known upstream does this, so we rely on the sequential guarantee.
+	// contiguously, as the spec does: one call runs to completion before the
+	// next, keyed by Index. Truly interleaved fragments across two open tool
+	// blocks would emit input_json_delta against a closed Anthropic block.
 	for _, tc := range choice.Delta.ToolCalls {
 		if err := t.ensureStarted(&buf); err != nil {
 			return nil, err

--- a/internal/anthropic/toolid.go
+++ b/internal/anthropic/toolid.go
@@ -49,8 +49,10 @@ func signedToolUseID(id, signature string) string {
 
 // splitToolUseID recovers the provider's id and the signature from a signed
 // id. The last marker is the one that counts, so an upstream id that happens
-// to contain the marker survives; the base64 payload cannot contain it. A payload that does not decode, or that
-// carries an unknown tag, falls back to the plain id.
+// to contain the marker survives. The base64 alphabet can spell the marker,
+// so a payload containing it is possible but vanishingly unlikely; the tag
+// and decode checks then fall back to the plain id, as does any payload that
+// does not decode or carries an unknown tag.
 func splitToolUseID(id string) (string, string) {
 	at := strings.LastIndex(id, thoughtSigMarker)
 	if at < 0 {

--- a/internal/anthropic/toolid.go
+++ b/internal/anthropic/toolid.go
@@ -11,26 +11,21 @@ import (
 //
 // Gemini 3 signs each function call and refuses the follow-up turn without
 // the signature. The chat-completions surface carries it on the tool call as
-// extra_content.google.thought_signature, Google's own shape, which the SDKs
-// keep because they round-trip the call object whole. The Messages surface
-// has no such member: a tool_use block is id, name and input, and a native
-// Anthropic provider, which the same conversation can fail over to, rejects a
-// member it does not know. The id is the one field every Messages SDK echoes
-// back untouched, on the tool_use block and again as the tool_result's
-// tool_use_id, so the signature travels inside it, the way UniClaudeProxy
-// carries it (an intermediary that rewrites ids loses it, and the next turn
-// gets Gemini's refusal, as it would with no carrier at all). The encoding
-// keeps to the id alphabet Anthropic accepts ([A-Za-z0-9_-]); an id without
-// the marker, or with a suffix that does not decode, is a plain id.
+// extra_content.google.thought_signature; the Messages surface has no such
+// member, and a native Anthropic provider rejects a member it does not know.
+// The id is the one field every Messages SDK echoes back untouched, on the
+// tool_use block and again as the tool_result's tool_use_id, so the signature
+// travels inside it. The encoding keeps to the id alphabet Anthropic accepts
+// ([A-Za-z0-9_-]); an id without the marker, or with a suffix that does not
+// decode, is a plain id.
 //
 // The signature is base64 text on Google's wire. Carrying it as the bytes it
 // encodes (tag "b", put back through the same encoding on the way in) rather
-// than as text (tag "t", for a signature that is not padded base64) keeps
-// the id a third shorter: an id is echoed twice per call per turn and every
-// byte of it is prompt for the rest of the conversation. The tag is also
-// the form's version: a payload under a tag this build does not know is a
-// plain id, so a changed form degrades to Gemini's refusal of the turn, as
-// with no carrier, never to a corrupted signature.
+// than as text (tag "t", for a signature that is not padded base64) keeps the
+// id a third shorter, and an id is echoed twice per call per turn. The tag is
+// also the form's version: a payload under a tag this build does not know is a
+// plain id, so a changed form degrades to Gemini's refusal of the turn, never
+// to a corrupted signature.
 const thoughtSigMarker = "_thoughtsig_"
 
 const (
@@ -54,12 +49,8 @@ func signedToolUseID(id, signature string) string {
 
 // splitToolUseID recovers the provider's id and the signature from a signed
 // id. The last marker is the one that counts, so an upstream id that happens
-// to contain the marker survives; the payload cannot contain it when the
-// signature is base64-alphabet text (no run of it encodes to the marker)
-// and does so for arbitrary bytes only by a collision of one part in 64^12
-// per position, whose outcome is the plain-id fallback below (the tag byte
-// after a marker inside the payload is not a tag) and Gemini's refusal of
-// the turn, as with no carrier.
+// to contain the marker survives; the base64 payload cannot contain it. A payload that does not decode, or that
+// carries an unknown tag, falls back to the plain id.
 func splitToolUseID(id string) (string, string) {
 	at := strings.LastIndex(id, thoughtSigMarker)
 	if at < 0 {
@@ -84,11 +75,9 @@ func splitToolUseID(id string) (string, string) {
 
 // StripSignedToolUseIDs returns a Messages body with the signature suffix
 // removed from every tool_use id and tool_result tool_use_id, for the native
-// passthrough: an Anthropic provider has no use for a Gemini signature, the
-// suffix is a kilobyte of prompt per call per turn, and the ids stay paired
-// since both ends are stripped alike. The client keeps its signed history
-// for the next Gemini attempt. A body that is not the expected shape, or
-// carries no signed id, is returned as it came.
+// passthrough: an Anthropic provider has no use for a Gemini signature, and
+// the ids stay paired since both ends are stripped alike. A body that is not
+// the expected shape, or that carries no signed id, is returned as it came.
 func StripSignedToolUseIDs(body []byte) []byte {
 	var top map[string]json.RawMessage
 	if json.Unmarshal(body, &top) != nil {

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -105,9 +105,9 @@ type WebAuthnSessionManager interface {
 	RevokeAuthToken(ctx context.Context, token string) bool
 	// RevokeOtherSessions signs out every session belonging to identity except
 	// the one the request was made from. identity must come from the
-	// authentication layer, never from a token the caller supplied; the
-	// candidate tokens only decide which session is spared, and one that does
-	// not belong to identity spares nothing.
+	// authentication layer, never from a token the caller supplied; the candidate
+	// tokens only decide which session is spared; one belonging to another
+	// identity spares nothing.
 	RevokeOtherSessions(ctx context.Context, identity []byte, candidateTokens ...string) (int64, error)
 	// CreateAuthToken mints a new session token for the given user handle. The
 	// admin-token exchange trades a valid admin token for a session cookie via
@@ -135,8 +135,8 @@ type PwnedChecker interface {
 // Handler manages admin API operations for providers, models, and virtual keys.
 type Handler struct {
 	cfg *config.Config
-	// Shared outbound client for the alert endpoints; nil is valid and makes
-	// each dispatcher build its own, which is what handlers in tests get.
+	// Shared outbound client for the alert endpoints; nil is valid and makes each
+	// dispatcher build its own.
 	alertClient            *http.Client
 	providerRepo           ProviderStore
 	dbPool                 *db.DB
@@ -148,7 +148,7 @@ type Handler struct {
 	appVersion             string
 	ghReleasesURL          string                                             // injectable for testing; defaults to githubReleasesURL const
 	ghTagsURL              string                                             // injectable for testing; defaults to githubTagsURL const
-	eventBus               *events.Bus                                        // /api/events subscribes here (DefaultBus in production); publishers still use events.Publish, so a private bus only isolates the stream side
+	eventBus               *events.Bus                                        // /api/events subscribes here (DefaultBus in production); publishers use events.Publish, so a private bus isolates only the stream side
 	webauthnSessionMgr     WebAuthnSessionManager                             // nil when webAuthn is not configured
 	clientIPs              webauthn.ClientIPSource                            // trusted-proxy-aware client IP for session device metadata; nil falls back to the peer address
 	userRepo               UserStore                                          // nil until SetUserAuth (multi-user identities)
@@ -160,26 +160,23 @@ type Handler struct {
 	discoveryDialCtx       func(ctx context.Context, network, addr string) (net.Conn, error)
 	discoveryCheckRedirect func(req *http.Request, via []*http.Request) error
 	// newDiscovery builds this handler's DiscoveryService. Per-handler rather
-	// than package-level: NewHandler used to assign a global here, which made
-	// two handlers built concurrently a data race (parallel tests each build
-	// one) and silently coupled every handler in the process to whichever was
-	// constructed last. Nil falls back to the package default, for the handlers
-	// tests build as bare structs.
+	// than package-level, so two handlers built concurrently neither race nor
+	// couple to whichever was constructed last. Nil falls back to the package
+	// default.
 	newDiscovery   func() *provider.DiscoveryService
 	circuitBreaker CircuitBreakerControl
 	capLedger      *provider.CapLedger
 	audit          *audit.Recorder   // nil until SetAudit (audit trail of admin actions)
-	totpStatus     TotpStatus        // nil when TOTP feature not wired -> TotpEnabled() returns false (today's behavior)
+	totpStatus     TotpStatus        // nil when the TOTP feature is not wired -> TotpEnabled() returns false
 	totpEnabled    atomic.Bool       // cached IsEnabled result; refreshed by enroll-verify/disable handlers after DB mutations
 	quotaRepo      *quota.Repository // read-through store for polled provider quota snapshots
 	quotaAdvisor   *QuotaAdvisor     // nil until SetQuotaAdvisor; populated by RefreshQuotaAdvice
 	pwnedChecker   PwnedChecker      // nil until SetPwnedChecker (breached-password check on create/reset/change)
 
-	// Debounce state for the quota schema-drift watch: a per-provider shape
-	// that has been seen but not yet confirmed by a second consecutive poll.
-	// Deliberately in-memory (a restart re-arms the debounce, costing one extra
-	// poll before a real change is reported) and guarded because it is
-	// process-wide state, even though only the poll goroutine touches it today.
+	// Debounce state for the quota schema-drift watch: a per-provider shape that
+	// has been seen but not yet confirmed by a second consecutive poll. In-memory
+	// (a restart re-arms the debounce, costing one extra poll before a real change
+	// is reported) and guarded because it is process-wide state.
 	quotaSchemaMu   sync.Mutex
 	quotaSchemaSeen map[uuid.UUID]quotaSchemaCandidate
 
@@ -207,12 +204,12 @@ func NewHandler(cfg *config.Config, providerRepo ProviderStore, database *db.DB,
 		testModelCheckRedirect: testModelCheckRedirect,
 		discoveryDialCtx:       discoveryDialCtx,
 		discoveryCheckRedirect: discoveryCheckRedirect,
-		// Same profile as the login throttles: an authenticated session must
-		// not be a free brute-force oracle for the account's current password.
+		// Same profile as the login throttles: an authenticated session must not be
+		// a free brute-force oracle for the account's current password.
 		pwThrottle: totp.NewThrottle(5, time.Second, 5*time.Minute),
 		quotaRepo:  quota.NewRepository(database.Pool()),
-		// One client for every alert probe/test this handler serves, rather than
-		// one per request: see alert.NewHTTPClient.
+		// One client for every alert probe/test this handler serves, rather than one
+		// per request: see alert.NewHTTPClient.
 		alertClient: alert.NewHTTPClient(),
 	}
 	// Wire the discovery service factory to use the SSRF-protected dial/redirect
@@ -348,9 +345,9 @@ func (h *Handler) StopBackupScheduler() {
 func (h *Handler) Register(r chi.Router) {
 	r.Use(h.AuthMiddleware)
 
-	// Audit trail: records every mutating request on this surface, including
-	// ones the demo read-only guard below refuses (mounted before it on
-	// purpose, so refused attempts appear with their 403).
+	// Audit trail: records every mutating request on this surface, including ones
+	// the demo read-only guard refuses. Mounted before that guard, so refused
+	// attempts appear with their 403.
 	if h.audit != nil {
 		r.Use(h.audit.Middleware)
 	}
@@ -372,10 +369,9 @@ func (h *Handler) Register(r chi.Router) {
 	r.Post("/auth/password", h.ChangeOwnPassword)
 
 	// Self-service session hygiene: sign this identity's other sessions out.
-	// Ungated like /auth/password because the handler takes the identity from
-	// this middleware rather than from the request, so a caller can only ever
-	// reach their own sessions. That property is what makes it safe to leave
-	// open, and auth_sessions_route_test.go pins it.
+	// Ungated like /auth/password, because the handler takes the identity from
+	// this middleware rather than from the request, so a caller can only reach
+	// their own sessions.
 	r.Post("/auth/sessions/revoke-others", h.RevokeOtherSessions)
 
 	// The active-sessions list and its per-row revoke. Same open-but-scoped
@@ -401,8 +397,8 @@ func (h *Handler) Register(r chi.Router) {
 		})
 		// Provider CRUD is synced config: a managed fleet member must not edit it
 		// locally (the primary owns it and replaces it on the next sync). Discovery
-		// routes under /providers (mounted via RegisterProviderDiscovery) are
-		// deliberately outside this group: models regenerate and are not synced.
+		// routes under /providers (mounted via RegisterProviderDiscovery) sit
+		// outside this group: models regenerate and are not synced.
 		r.Group(func(r chi.Router) {
 			r.Use(requireAdmin)
 			r.Use(managedWriteGuard(h.settingsRepo))
@@ -451,11 +447,10 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 	bh.Register(r)
 	h.backupScheduler = bh
 
-	// HA fleet config-sync endpoints (Phase 5). Always mounted: any member can be
-	// a primary (export) or a replica (import). Inherits this group's admin auth.
-	// The discovery callback lets an import populate this member's models so synced
-	// custom failover groups resolve without a manual discover (a freshly-synced
-	// member has providers but no models until discovery runs).
+	// HA fleet config-sync endpoints. Always mounted: any member can be a primary
+	// (export) or a replica (import). Inherits this group's admin auth. The
+	// discovery callback lets an import populate this member's models so synced
+	// custom failover groups resolve without a manual discover.
 	NewConfigSyncHandler(h.dbPool, h.settingsRepo, h.cfg.MasterKey, h.appVersion,
 		func(ctx context.Context) error {
 			// Request-bound (runs inside the config-sync import HTTP handler):
@@ -466,15 +461,15 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 			return err
 		}, h.cfg.ValidateProviderURL).Register(r)
 
-	// Fleet quota snapshot export/receive (quota poller Phase 2). Same
-	// fleet-authed router as config-sync; snapshots carry no key material, so
-	// unlike config import there is no MASTER_KEY canary.
+	// Fleet quota snapshot export/receive. Same fleet-authed router as
+	// config-sync; snapshots carry no key material, so unlike config import there
+	// is no MASTER_KEY canary.
 	NewQuotaFleetHandler(h.quotaRepo, h.providerRepo).Register(r)
 
-	// HA fleet membership heartbeat (Phase 6). Front Desk POSTs /fleet/announce
-	// on its poll; the member records the contact as instance-local _fleet_*
-	// settings and surfaces fleet state on its system payload. Inherits this
-	// group's admin auth so the badge cannot be forged.
+	// HA fleet membership heartbeat. Front Desk POSTs /fleet/announce on its poll;
+	// the member records the contact as instance-local _fleet_* settings and
+	// surfaces fleet state on its system payload. Inherits this group's admin auth
+	// so the badge cannot be forged.
 	NewFleetHandler(h.settingsRepo).Register(r)
 }
 
@@ -491,11 +486,11 @@ func (h *Handler) registerAdminOnly(r chi.Router) {
 //
 // use says whether this request counts as the person using the session: the
 // middleware passes true (stamp last-seen, slide the expiry); the SSE re-check
-// passes false and gets a pure lookup, because a heartbeat the server drives
-// is not use, must not keep an untouched tab's session alive by itself, and
-// could not carry a re-issued cookie anyway (its headers are long gone).
+// passes false and gets a pure lookup, because a server-driven heartbeat must
+// not keep an untouched tab's session alive and cannot carry a re-issued
+// cookie anyway.
 func (h *Handler) resolveCredentials(r *http.Request, use bool) (id *user.Identity, cookieAuth, ok bool, refresh *cookieRefresh) {
-	// Resolved lazily: both call sites below sit behind the nil guard on
+	// Resolved lazily: both call sites sit behind the nil guard on
 	// webauthnSessionMgr, and a method value taken from a nil interface would
 	// not.
 	authenticate := func(ctx context.Context, tok string) (webauthn.AuthResult, bool) {
@@ -524,19 +519,18 @@ func (h *Handler) resolveCredentials(r *http.Request, use bool) (id *user.Identi
 		return nil, false, false, nil
 	}
 
-	// Fast path: admin token (in-memory hash comparison) -- only when TOTP
-	// 2FA is disabled. With TOTP enabled, the raw admin token is a first
-	// factor only and must be exchanged for a session token via POST
-	// /api/totp/login; a bare admin token bearer is rejected so the second
-	// factor cannot be bypassed.
+	// Admin token (in-memory hash comparison), only when TOTP 2FA is disabled.
+	// With TOTP enabled the raw admin token is a first factor only and must be
+	// exchanged for a session token via POST /api/totp/login; a bare admin token
+	// bearer is rejected so the second factor cannot be bypassed.
 	if !h.TotpEnabled() && h.adminMgr.Validate(token) {
 		return user.AdminIdentity(), false, true, nil
 	}
 
-	// Fallback: session token (DB-backed SHA-256 hash lookup). The session's
-	// user handle resolves to an identity: legacy admin sessions stay admin,
-	// UUID handles must match an enabled users row (disabled/deleted users
-	// are rejected here even if their token has not been revoked yet).
+	// Fallback: session token (DB-backed SHA-256 hash lookup). The session's user
+	// handle resolves to an identity: legacy admin sessions stay admin, UUID
+	// handles must match an enabled users row (disabled or deleted users are
+	// rejected here even if their token is not revoked yet).
 	if h.webauthnSessionMgr != nil {
 		if res, valid := authenticate(r.Context(), token); valid {
 			if id, resolved := h.resolveIdentity(r.Context(), res.UserID); resolved {
@@ -563,9 +557,9 @@ func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id, cookieAuth, ok, refresh := h.resolveCredentials(r, true)
 		if !ok {
-			// Warn (not Error) with the remote address — never the token — so
-			// repeated admin-auth failures are visible for abuse detection
-			// without polluting the operator-actionable Error stream.
+			// Warn (not Error) with the remote address, never the token, so repeated
+			// admin-auth failures are visible for abuse detection without polluting
+			// the operator-actionable Error stream.
 			if _, hasBearer := util.ParseBearerToken(r); !hasBearer {
 				debuglog.Warn("auth: admin request missing bearer token", "remote_addr", clientip.From(r), "path", r.URL.Path)
 				http.Error(w, "Authorization header required (Bearer token)", http.StatusUnauthorized)
@@ -600,10 +594,10 @@ func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// RegisterEvents registers the SSE endpoint on a route group that is
-// exempt from the chi Timeout middleware.  SSE connections are long-lived
-// and must not be killed by a 60-second request deadline; the handler
-// detects client disconnect via r.Context().Done() instead.
+// RegisterEvents registers the SSE endpoint on a route group exempt from the
+// chi Timeout middleware. SSE connections are long-lived and must not be killed
+// by a 60-second request deadline; the handler detects client disconnect via
+// r.Context().Done() instead.
 func (h *Handler) RegisterEvents(r chi.Router) {
 	r.Use(h.AuthMiddleware)
 	r.Get("/events", h.StreamEvents)

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/settings"
 )
 
-// This file implements the HA "Phase 5" fleet config-sync member endpoints:
+// This file implements the HA fleet config-sync member endpoints:
 // GET /api/config/export and POST /api/config/import. Front Desk pulls the
 // export from a chosen primary and pushes the import to each replica so the
 // fleet converges to one configuration. Only config is moved: never request
@@ -29,9 +29,9 @@ import (
 // Synced: providers, virtual keys, the syncable settings subset, users, CUSTOM
 // (user-created) failover groups, and the operator's per-model disables. Model
 // rows themselves and AUTO-CREATED failover groups regenerate on each member from
-// the synced providers (discovery + automatic group formation), so they are
-// intentionally not copied. A custom group's priority_order / entry_enabled
-// reference instance-local model UUIDs, so it is carried as stable (provider name,
+// the synced providers (discovery + automatic group formation), so they are not
+// copied. A custom group's priority_order / entry_enabled reference
+// instance-local model UUIDs, so it is carried as stable (provider name,
 // model_id) entry refs and resolved back to this member's model UUIDs on import
 // (an entry whose model is absent here is dropped; a group left with fewer than
 // two routable entries is skipped).
@@ -40,55 +40,48 @@ import (
 // (models.disabled_manually) is carried: discovery's disable and the proxy's
 // traffic retirement are per-member evidence about what a provider served that
 // member, so replicating them would turn one member's provider trouble into a
-// fleet-wide outage. Migration 063 is what keeps the three kinds apart.
+// fleet-wide outage.
 //
-// The operator's manual-enable PINS (models.manually_enabled_at, migration 070)
-// travel the same way and for the same reason: a pin says the operator tested a
-// model the provider stopped listing and it serves, which is a statement about
-// the provider, not about one member, so every member should honour it instead
-// of disabling the model two scans after its own listing drops it.
+// The operator's manual-enable PINS (models.manually_enabled_at) travel the same
+// way and for the same reason: a pin says a model the provider stopped listing
+// still serves, which is a statement about the provider, not about one member.
 
 const (
 	// configSchemaVersion is the envelope version a member understands. An import
 	// carrying a different version is refused rather than half-applied.
 	//
-	// v2 changed what an EXISTING field MEANS, which is why it moved even though
-	// no field was added or removed. In v1 a virtual key's allowed_provider_names
-	// was a plain list and an empty one was indistinguishable from an absent one;
-	// in v2 it is a pointer, and present-but-empty means "restricted, but none of
-	// its providers resolve on this member".
+	// v2 changes what an EXISTING field MEANS rather than adding or removing one.
+	// In v1 a virtual key's allowed_provider_names is a plain list whose empty
+	// value is indistinguishable from an absent one; in v2 it is a pointer, and
+	// present-but-empty means "restricted, but none of its providers resolve on
+	// this member".
 	//
-	// The bump exists to protect the IMPORTING side, which this repo's fix could
-	// not reach. A v1 member decodes the v2 [] into a zero-length slice and
-	// applies its own guard, `len(v.AllowedProviderNames) > 0 && len(allowed) == 0`
-	// (upsertVirtualKeys before this change): the first conjunct is false, so it
-	// skips nothing and writes a nil allowed_providers, which is SQL NULL, which
-	// the proxy reads as every provider. A stale-only restricted key would land on
-	// that member wide open. Refusing the envelope outright is the only defence,
-	// and configsync_import.go already does it with 422 + SchemaVersionOK: false.
+	// The bump protects the IMPORTING side: a v1 member decodes the v2 [] into a
+	// zero-length slice, skips nothing, and writes a nil allowed_providers, which
+	// is SQL NULL and reads as every provider, landing a restricted key wide open.
+	// Refusing the envelope outright is the only defence, and
+	// configsync_import.go does it with 422 + SchemaVersionOK: false.
 	configSchemaVersion = 2
 
 	// maxConfigImportBody bounds an import payload. Fleet config is small (a
 	// handful of providers + keys); 8 MiB is generous and caps a hostile body.
 	maxConfigImportBody = 8 << 20
 
-	// fleetSourceGenHeader carries Front Desk's monotonic source generation
-	// (its auto_sync_gen) on a real import. It is the member-side commit fence:
-	// an import whose generation is older than the highest this member has
-	// applied is refused, so a stale push that was already in flight when the
-	// primary was repointed cannot land after the fresh one. The header is
-	// optional: an older Front Desk omits it and the import applies unfenced
-	// (the pre-fence behaviour), and an older member ignores it, so the fence
-	// engages only when both ends understand it. Never set on a dry run.
+	// fleetSourceGenHeader carries Front Desk's monotonic source generation (its
+	// auto_sync_gen) on a real import. It is the member-side commit fence: an
+	// import whose generation is older than the highest this member applied is
+	// refused, so a stale push in flight when the primary was repointed cannot
+	// land after the fresh one. The header is optional: an older Front Desk omits
+	// it and the import applies unfenced, and an older member ignores it, so the
+	// fence engages only when both ends understand it. Never set on a dry run.
 	fleetSourceGenHeader = "X-Fleet-Source-Gen"
 
-	// fleetSourceGenLock is the Postgres advisory-lock key that serializes
-	// fenced imports on this member, so the read-current-generation / reject-or-
-	// advance step is atomic against a concurrent import (two pushes whose bytes
-	// both arrived before either committed). It is transaction-scoped, released
-	// when the import's transaction ends. The value is an arbitrary fixed
-	// constant; it only has to be unique within this app's advisory-lock use,
-	// and config sync is the only advisory lock taken.
+	// fleetSourceGenLock is the Postgres advisory-lock key that serializes fenced
+	// imports on this member, so the read-current-generation / reject-or-advance
+	// step is atomic against a concurrent import. It is transaction-scoped,
+	// released when the import's transaction ends. The value is an arbitrary
+	// constant that only has to be unique within this app's advisory-lock use, and
+	// config sync is the only advisory lock taken.
 	fleetSourceGenLock int64 = 0x4D48_5F46_454E_4331 // "MH_FENC1"
 )
 
@@ -98,90 +91,71 @@ const (
 var errStaleSourceGen = errors.New("configsync: import source generation is older than last applied")
 
 // errWouldWipeProviders is returned by apply when the envelope carries zero
-// providers but this member currently has providers: applying the declarative
-// replace would delete every provider (and, via the users replace, is the
-// reported backdoor-wipe vector). Import maps it to a 400 refusal.
+// providers but this member has providers: applying the declarative replace
+// would delete every provider. Import maps it to a 400 refusal.
 var errWouldWipeProviders = errors.New("configsync: refusing to wipe every provider off a populated member")
 
 // errInvalidSyncedURL is returned by apply when a syncable url-typed setting in
 // the envelope fails the same netguard validation the interactive PUT
-// /api/settings handler enforces (the reported CWE-918 SSRF bypass). Import
-// maps it to a 400 refusal. Currently a standing guard with no live path: every
-// url-typed setting (apprise + SSO) is instance-local and skipped before
-// validation, so this fires only if a future url-typed setting joins the
-// syncable set.
+// /api/settings handler enforces. Import maps it to a 400 refusal. A standing
+// guard with no live path: every url-typed setting (apprise + SSO) is
+// instance-local and skipped before validation, so this fires only if a
+// url-typed setting joins the syncable set.
 var errInvalidSyncedURL = errors.New("configsync: refusing to apply a setting with an invalid URL")
 
 // errInvalidSyncedSettingBound is returned by apply when a syncable numeric
 // setting in the envelope falls below the minimum the interactive PUT
-// /api/settings handler enforces. Same class of hole as the per-key limits
-// below, one level up and with a wider blast radius: rate_limit_ip_burst is
-// min 1 interactively, and IPLimiter.getLimiter hands a negative one straight to
-// rate.NewLimiter with no clamp, so every client IP is denied. Import maps it to
-// a 400 refusal.
+// /api/settings handler enforces. rate_limit_ip_burst is min 1 interactively,
+// and IPLimiter.getLimiter hands a negative one straight to rate.NewLimiter with
+// no clamp, denying every client IP. Import maps it to a 400 refusal.
 var errInvalidSyncedSettingBound = errors.New("configsync: refusing to apply a setting below its minimum")
 
 // errInvalidSyncedRateLimit is returned by apply when a virtual key or user in
-// the envelope carries a rate limit the interactive API would reject. The values
-// are not merely cosmetic: rate_limit_tpm <= 0 is the TPMLimiter's "no cap"
-// sentinel, so a negative one bought this member unmetered token spend past the
-// global default, and a negative rate_limit_burst alongside a positive RPS makes
-// rate.NewLimiter refuse every request (a per-key denial of service). Import
-// maps it to a 400 refusal.
+// the envelope carries a rate limit the interactive API would reject.
+// rate_limit_tpm <= 0 is the TPMLimiter's "no cap" sentinel, so a negative one
+// buys unmetered token spend past the global default, and a negative
+// rate_limit_burst alongside a positive RPS makes rate.NewLimiter refuse every
+// request. Import maps it to a 400 refusal.
 var errInvalidSyncedRateLimit = errors.New("configsync: refusing to apply an invalid rate limit")
 
 // errInvalidSyncedProvider is returned by apply when a provider in the envelope
 // carries a field the interactive API would reject: a max_in_flight outside
-// 1..10000, which the runtime would read as "no ceiling" (zero or less) rather
-// than reject, silently deleting the operator's cap and then exporting the
-// value to every member on the next sync; a base_url its SSRF check refuses;
-// an unprintable or over-long name; or a disable date that is not a date.
-// Import maps it to a 400 refusal.
+// 1..10000, which the runtime reads as "no ceiling" (zero or less) rather than
+// rejecting, silently deleting the operator's cap and exporting the value to
+// every member on the next sync; a base_url its SSRF check refuses; an
+// unprintable or over-long name; or a disable date that is not a date. Import
+// maps it to a 400 refusal.
 var errInvalidSyncedProvider = errors.New("configsync: refusing to apply an invalid provider")
 
 // errInvalidSyncedPasswordHash is returned by apply when a user in the envelope
-// carries a password_hash that is not a well-formed argon2id hash. A password
-// hash is the one credential field this member does not compute itself, and
-// login already fails closed on a malformed one, so this is not an
-// authentication fix: it keeps an unusable hash out of the database instead of
-// letting it surface later as an account that silently cannot log in. Import
-// maps it to a 400 refusal.
+// carries a password_hash that is not a well-formed argon2id hash. Login already
+// fails closed on a malformed one, so this is not an authentication fix: it
+// keeps an unusable hash out of the database instead of letting it surface as an
+// account that silently cannot log in. Import maps it to a 400 refusal.
 //
-// This refusal is deliberately harsher than the harm it prevents, and that is
-// worth being explicit about. The neighbouring sentinels refuse envelopes that
-// would be actively damaging to apply (an SSRF-capable URL, a rate limit that
-// denies every request, a cap that silently widens). A malformed hash is inert
-// by comparison, yet refusing the envelope stops providers, keys, settings and
-// failover groups from converging too, fleet-wide, for as long as it persists.
-// It is accepted because a legitimate primary only ever exports hashes it
+// The refusal is harsher than the harm: it freezes providers, keys, settings and
+// failover groups from converging fleet-wide for as long as the bad hash
+// persists. It is accepted because a legitimate primary only exports hashes it
 // computed itself, so one that fails to parse means a corrupt or tampered
-// envelope, and applying credentials from an envelope that has demonstrably
-// been altered is the worse trade. Be clear about which half carries the
-// argument: for the TAMPERED reading refusing is the point, but for plain
-// CORRUPTION (a direct database write, a bad hash imported before this check
-// existed on a member later promoted to primary) the refusal is pure cost with
-// no security benefit. That case is why exportUsers checks the same encoding
-// and raises configsync.malformed_password_hash at the source, so the fleet
-// freeze is at least explained and fixable rather than silent.
+// envelope. exportUsers checks the same encoding and raises
+// configsync.malformed_password_hash at the source, so the freeze is explained
+// and fixable rather than silent.
 var errInvalidSyncedPasswordHash = errors.New("configsync: refusing to apply a malformed password hash")
 
 // errUnresolvableUserProviders is returned by apply when a user in the envelope
 // carries a NON-EMPTY provider cap none of whose names resolve on this member.
-// That is anomalous rather than merely inconvenient: providers are replaced
-// declaratively earlier in the same transaction, so every name a legitimate
-// primary exported resolves. Writing the user with a NULL cap would silently
-// promote them from restricted to unrestricted, so the whole import is refused.
-// Import maps it to a 400.
+// That is anomalous: providers are replaced declaratively earlier in the same
+// transaction, so every name a legitimate primary exported resolves. Writing the
+// user with a NULL cap would promote them from restricted to unrestricted, so
+// the whole import is refused with a 400.
 //
-// Skipping the row is not the escape it looks like. For a user who does not yet
-// exist on this member, skipping means usernameToID cannot find her afterwards,
-// so upsertVirtualKeys imports every key she owns with owner_user_id NULL. The
-// proxy then loads no Owner at all, never populates UserAllowedProvidersKey, and
-// effectiveAllowedProviders takes its owner == nil arm, which drops the owner
-// side of the intersection entirely: a key with no cap of its own ends up
-// completely unrestricted. That is a wider escalation than the one being
-// guarded. For a user who does exist, skipping is merely stale, leaving a
-// pre-existing cap that may be broader than the primary now intends.
+// Skipping the row is not an escape. For a user who does not exist on this
+// member, skipping means usernameToID cannot find her, so upsertVirtualKeys
+// imports every key she owns with owner_user_id NULL; the proxy then loads no
+// Owner, never populates UserAllowedProvidersKey, and effectiveAllowedProviders
+// drops the owner side of the intersection, leaving a key with no cap of its own
+// completely unrestricted. For a user who does exist, skipping leaves a stale
+// cap that may be broader than the primary intends.
 //
 // A present-but-EMPTY cap is deliberately NOT this error: there the primary
 // itself resolves nothing, and applyUsers writes the empty array through so the
@@ -190,25 +164,23 @@ var errInvalidSyncedPasswordHash = errors.New("configsync: refusing to apply a m
 var errUnresolvableUserProviders = errors.New("configsync: refusing to apply a user whose provider cap does not resolve")
 
 // ConfigSyncHandler serves the member-side config export/import endpoints. It is
-// mounted inside the admin-authenticated /api group, so every call already
-// requires the admin token (or a session when TOTP is on): a caller able to
-// import config controls the data plane, so no weaker gate is acceptable.
+// mounted inside the admin-authenticated /api group, so every call requires the
+// admin token (or a session when TOTP is on): a caller able to import config
+// controls the data plane.
 type ConfigSyncHandler struct {
 	db         *db.DB
 	settings   SettingsStore
 	masterKey  string
 	appVersion string
 	// discoverAll runs model discovery on this member after an import commits its
-	// providers, so custom failover groups can resolve. Nil disables it (tests
-	// that seed models directly pass nil).
+	// providers, so custom failover groups can resolve. Nil disables it.
 	discoverAll func(context.Context) error
 	// validateProviderURL guards imported provider base_urls with the same SSRF
 	// check the interactive admin API applies on CreateProvider/UpdateProvider
-	// (config.ValidateProviderURL): resolve DNS and reject loopback, RFC
-	// 1918/ULA, link-local, CGNAT and cloud-metadata addresses (hosts in
+	// (config.ValidateProviderURL): resolve DNS and reject loopback, RFC 1918/ULA,
+	// link-local, CGNAT and cloud-metadata addresses (hosts in
 	// ALLOWED_PROVIDER_HOSTS are exempted). Keeps a compromised primary from
-	// persisting a base_url the admin API would refuse. Nil disables the check
-	// (tests that do not exercise it pass nil).
+	// persisting a base_url the admin API would refuse. Nil disables the check.
 	validateProviderURL func(string) error
 }
 
@@ -251,26 +223,24 @@ type ConfigPayload struct {
 	Providers   []ExportProvider  `json:"providers"`
 	VirtualKeys []ExportVK        `json:"virtual_keys"`
 	Settings    map[string]string `json:"settings"`
-	// Not omitempty: a member running this code always emits the key, as [] when it
-	// has no custom groups. That lets import tell "primary genuinely has zero custom
-	// groups" (present empty array, reconcile to zero) apart from "envelope predates
-	// this field" (key absent, decodes to nil, leave the member's groups alone).
+	// Not omitempty: a member running this code always emits the key, as [] when
+	// it has no custom groups. That lets import tell "primary has zero custom
+	// groups" (present empty array, reconcile to zero) from "envelope omits the
+	// field" (absent, decodes to nil, leave the member's groups alone).
 	FailoverGroups []ExportFailoverGroup `json:"failover_groups"`
 	// Same nil-vs-empty contract as FailoverGroups: always emitted by a member
-	// running this code ([] when there are no accounts), absent in an envelope
-	// from an older primary (decodes to nil, import leaves users alone).
+	// running this code ([] when there are no accounts), absent in an envelope from
+	// an older primary (decodes to nil, import leaves users alone).
 	Users []ExportUser `json:"users"`
 	// DisabledModels are the models the operator switched off by hand, by stable
-	// ref. Same nil-vs-empty contract again: [] means "the primary has none, clear
-	// yours", absent means an older primary whose per-model state must be left
-	// alone.
+	// ref. Same nil-vs-empty contract: [] means "the primary has none, clear
+	// yours", absent means an older primary whose per-model state is left alone.
 	DisabledModels []ExportModelRef `json:"disabled_models"`
 	// EnabledModels are the models the operator pinned enabled by hand while the
 	// provider's listing omits them (models.manually_enabled_at), by stable ref.
-	// Same nil-vs-empty contract as DisabledModels: [] means "the primary has no
-	// pins, clear yours", absent means an older primary whose pins must be left
-	// alone. Import force-enables and pins; reconcile only clears pins, never
-	// disables, so a member's own listing-based disable machinery resumes.
+	// Same nil-vs-empty contract as DisabledModels. Import force-enables and pins;
+	// reconcile only clears pins, never disables, so a member's own listing-based
+	// disable machinery resumes.
 	EnabledModels []ExportModelRef `json:"enabled_models"`
 }
 
@@ -284,11 +254,9 @@ type ExportModelRef struct {
 
 // String renders a ref the way the gateway names that model everywhere else: the
 // provider, a slash, then the provider-scoped id. Model ids routinely contain
-// slashes themselves (meta-llama/Llama-3-70b), which makes this look ambiguous and
-// is not: the proxy resolves an incoming name with SplitN(name, "/", 2)
-// (proxy_request.go), so the first slash separates and the rest is the id. An
-// operator reading openai/meta-llama/Llama-3-70b in an alert sees exactly the
-// string they would send to /v1/chat/completions.
+// slashes (meta-llama/Llama-3-70b), which is unambiguous: the proxy resolves an
+// incoming name with SplitN(name, "/", 2) (proxy_request.go), so the first slash
+// separates and the rest is the id.
 func (r ExportModelRef) String() string { return r.ProviderName + "/" + r.ModelID }
 
 // ExportProvider is a provider with its encrypted key material verbatim.
@@ -316,27 +284,25 @@ type ExportVK struct {
 	RateLimitRPS   *float64 `json:"rate_limit_rps,omitempty"`
 	RateLimitBurst *int     `json:"rate_limit_burst,omitempty"`
 	RateLimitTPM   *int     `json:"rate_limit_tpm,omitempty"`
-	// AllowedProviderNames carries the key's provider restriction by NAME
-	// (UUIDs are instance-local). Three distinct states, and the distinction is
-	// load-bearing:
+	// AllowedProviderNames carries the key's provider restriction by NAME (UUIDs
+	// are instance-local). Three distinct states:
 	//   nil            - no restriction, every provider
 	//   ["openai"]     - restricted, and the names resolve here
 	//   [] (non-nil)   - restricted, but NOTHING resolves on this member
 	// Collapsing the last two is a privilege escalation: a key whose providers
 	// were all deleted would import as unrestricted.
 	//
-	// Two separate JSON mechanisms keep those states distinct on the wire.
-	// Marshalling: omitempty tests the POINTER, not the slice length, so a
-	// present-but-empty restriction is emitted as [] rather than dropped.
-	// Unmarshalling: an absent field leaves the zero value untouched, so an
-	// older primary that never emits the field yields nil and reads as
-	// unrestricted, exactly as it did before this became a pointer.
+	// Two JSON mechanisms keep those states distinct on the wire. Marshalling:
+	// omitempty tests the POINTER, not the slice length, so a present-but-empty
+	// restriction is emitted as [] rather than dropped. Unmarshalling: an absent
+	// field leaves the zero value untouched, so an older primary that never emits
+	// the field yields nil and reads as unrestricted.
 	AllowedProviderNames *[]string `json:"allowed_provider_names,omitempty"`
 	StripReasoning       bool      `json:"strip_reasoning"`
 	// OwnerUsername carries key ownership by username (user ids are
-	// instance-local; usernames are the users sync key). Nil = unowned. An
-	// owner that does not resolve on the member imports as unowned rather
-	// than failing the sync.
+	// instance-local; usernames are the users sync key). Nil = unowned. An owner
+	// that does not resolve on the member imports as unowned rather than failing
+	// the sync.
 	OwnerUsername *string `json:"owner_username,omitempty"`
 }
 
@@ -361,15 +327,13 @@ type ExportFailoverEntry struct {
 	Enabled      bool   `json:"enabled"`
 }
 
-// ExportUser is a dashboard user account, keyed by username. The password
-// hash travels verbatim: it is argon2id-encoded (never plaintext) and the
-// whole envelope only moves between admin-authenticated fleet members.
-// Deliberately NOT wrapped in MASTER_KEY encryption for transit: the envelope
-// uniformly carries what the DB stores (provider keys travel as ciphertext
-// only because they are encrypted at rest), the identical bytes ride the
-// pg_dump backup at the same trust boundary, and argon2id is the one field
-// here actually designed to survive exfiltration (VK sha256 hashes are the
-// weaker neighbours).
+// ExportUser is a dashboard user account, keyed by username. The password hash
+// travels verbatim: it is argon2id-encoded (never plaintext) and the whole
+// envelope only moves between admin-authenticated fleet members. NOT wrapped in
+// MASTER_KEY encryption for transit: the envelope carries what the DB stores
+// (provider keys travel as ciphertext only because they are encrypted at rest),
+// the identical bytes ride the pg_dump backup at the same trust boundary, and
+// argon2id is designed to survive exfiltration.
 type ExportUser struct {
 	Username     string   `json:"username"`
 	DisplayName  string   `json:"display_name,omitempty"`
@@ -378,23 +342,21 @@ type ExportUser struct {
 	Role         string   `json:"role"`
 	Grants       []string `json:"grants"`
 	Enabled      bool     `json:"enabled"`
-	// Aggregate per-user proxy limits (phase 2 of multi-user).
+	// Aggregate per-user proxy limits.
 	RateLimitRPS   *float64 `json:"rate_limit_rps,omitempty"`
 	RateLimitBurst *int     `json:"rate_limit_burst,omitempty"`
 	RateLimitTPM   *int     `json:"rate_limit_tpm,omitempty"`
-	// AllowedProviderNames carries the account provider cap by NAME, with the
-	// same three-state contract as ExportVK.AllowedProviderNames (nil = no cap,
+	// AllowedProviderNames carries the account provider cap by NAME, with the same
+	// three-state contract as ExportVK.AllowedProviderNames (nil = no cap,
 	// non-empty = capped and resolves, present-but-empty = capped with nothing
-	// resolving on the exporting member). Where a key with an unresolvable cap
-	// is skipped, a user cannot be: skipping a user this member does not have
-	// yet makes her keys import unowned, which removes the owner side of the
-	// proxy's cap intersection outright (see errUnresolvableUserProviders). So
-	// applyUsers splits the third state by which side failed to resolve - a
-	// present-but-empty list is written through as an empty array (the primary
-	// itself resolves nothing, and an empty cap denies everything), while names
-	// that arrive non-empty and resolve to nothing are anomalous and refuse the
-	// import. Writing NULL is never an option: it would promote a capped account
-	// to unrestricted.
+	// resolving on the exporting member). Where a key with an unresolvable cap is
+	// skipped, a user cannot be: skipping a user this member does not have makes
+	// her keys import unowned, removing the owner side of the proxy's cap
+	// intersection (see errUnresolvableUserProviders). So applyUsers splits the
+	// third state by which side failed to resolve: a present-but-empty list is
+	// written through as an empty array (an empty cap denies everything), while
+	// names that arrive non-empty and resolve to nothing refuse the import.
+	// Writing NULL would promote a capped account to unrestricted.
 	AllowedProviderNames *[]string `json:"allowed_provider_names,omitempty"`
 }
 
@@ -420,9 +382,9 @@ type importResponse struct {
 	MasterKeyOK     bool `json:"master_key_ok"`
 	Applied         bool `json:"applied"`
 	// Stale is true when the import was refused by the commit fence because its
-	// source generation was older than the one already applied. It is a benign,
-	// expected outcome (a newer config won), not a failure: SchemaVersionOK and
-	// MasterKeyOK are still true, Applied is false, and nothing was written.
+	// source generation was older than the one already applied. It is an expected
+	// outcome (a newer config won), not a failure: SchemaVersionOK and MasterKeyOK
+	// are still true, Applied is false, and nothing was written.
 	Stale bool       `json:"stale,omitempty"`
 	Diff  configDiff `json:"diff"`
 	// Incomplete is true when the import committed but this member could not
@@ -434,20 +396,19 @@ type importResponse struct {
 	// Partial names custom failover groups this member built with fewer entries
 	// than the primary sent, so it fails over across fewer providers for those
 	// models. Reported alongside Incomplete, never as part of it: the member
-	// applied everything it was asked to.
+	// applied everything it was asked for.
 	Partial []string `json:"partial,omitempty"`
 	// UnappliedModels names the per-model intent this member could not apply, as
 	// provider/model_id, because it holds no such model: the primary's disables and
 	// its manual-enable pins alike. Reported alongside Incomplete for the same
-	// reason as Partial, and it is what explains a config hash that will keep
-	// differing until this member discovers those models.
+	// reason as Partial, and it explains a config hash that keeps differing until
+	// this member discovers those models.
 	UnappliedModels []string `json:"unapplied_models,omitempty"`
 	// ModelStateFailed is true when a per-model reconcile (disables or pins) failed
 	// outright, so this member is still routing to models the primary switched off,
 	// or still auto-disabling ones it pinned. It is one of the two things Incomplete
-	// can mean, and without it the reader cannot tell which: an unbuilt failover
-	// group names itself in Unapplied, but a failed reconcile has no names to give,
-	// and was reported as a group failure.
+	// can mean, and the only one with no names to give: an unbuilt failover group
+	// names itself in Unapplied.
 	ModelStateFailed bool `json:"model_state_failed,omitempty"`
 }
 
@@ -502,27 +463,26 @@ func names[T any](items []T, key func(T) string) []string {
 	return out
 }
 
-// appriseSettingKeys are the alerting destination settings v1 leaves
+// appriseSettingKeys are the alerting destination settings config sync leaves
 // instance-local (the apprise endpoint + encrypted targets), so a member keeps
-// its own alert routing even after a config sync.
+// its own alert routing across a sync.
 var appriseSettingKeys = map[string]bool{
 	"alert_apprise_api_url": true,
 	"alert_apprise_targets": true,
 }
 
 // sessionIdleTimeoutKey is the dashboard auto-logout window. It is a per-instance
-// admin-session preference (each deployment's operators choose their own idle
-// timeout), so config sync leaves it instance-local like the apprise routing
-// secrets above: a managed member keeps and can edit its own value.
+// admin-session preference, so config sync leaves it instance-local like the
+// apprise routing secrets: a managed member keeps and can edit its own value.
 const sessionIdleTimeoutKey = "session_idle_timeout_minutes"
 
-// ssoInstanceLocalKeys are the SSO provider settings each member keeps to
-// itself: which IdPs this member offers and how it reaches them. Per-member so
-// a fleet can enable an IdP on some members and not others, and because the
-// public base URL (the IdP callback) is inherently this member's own address.
-// The email allowlists are deliberately NOT here: who may log in is an ACL,
-// and ACL drift across members is how a revoked account keeps access - the
-// allowlists stay fleet-synced alongside the user accounts they bind to.
+// ssoInstanceLocalKeys are the SSO provider settings each member keeps to itself:
+// which IdPs this member offers and how it reaches them. Per-member so a fleet
+// can enable an IdP on some members and not others, and because the public base
+// URL (the IdP callback) is this member's own address. The email allowlists are
+// NOT here: who may log in is an ACL, and ACL drift across members is how a
+// revoked account keeps access, so the allowlists stay fleet-synced alongside the
+// user accounts they bind to.
 var ssoInstanceLocalKeys = map[string]bool{
 	"oidc_enabled":           true,
 	"oidc_issuer_url":        true,

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -29,39 +29,38 @@ type applyOutcome struct {
 	SkippedGroups []string
 	// PartialGroups names custom failover groups this member built with fewer
 	// entries than the primary sent, because it holds fewer of the models they
-	// reference. Reported so the operator alert can name them; see incomplete.
+	// reference. Reported so the operator alert can name them.
 	PartialGroups []string
 	// GroupApplyErr is set when the whole group build failed, in which case no
 	// group was evaluated.
 	GroupApplyErr error
 	// DiscoveryErr is set when post-import discovery failed. Recorded for operators
-	// but does not on its own mark the import incomplete: a provider outage is
-	// routine, and a discovery failure that matters shows up as skipped groups.
+	// but does not itself mark the import incomplete: a provider outage is routine,
+	// and a discovery failure that matters shows up as skipped groups.
 	DiscoveryErr error
 	// UnappliedModels names the per-model intent this member could not apply because
 	// it holds no such model: the primary's disables and its manual-enable pins
 	// alike. Like PartialGroups it is reported, not counted as a failure to apply:
-	// the member did everything the envelope asked and simply has fewer models. It
-	// routes to none of them either, so nothing is mis-served; what it explains is
-	// the config hash difference that keeps the member flagged.
+	// the member did everything the envelope asked and holds fewer models. It routes
+	// to none of them either, so nothing is mis-served; it explains the config hash
+	// difference that keeps the member flagged.
 	UnappliedModels []string
 	// ModelStateErr is set when a per-model reconcile (disables or pins) failed
-	// outright. Both are joined into it, because either one leaves the member
-	// diverging from the primary and the operator needs to see whichever failed.
+	// outright. Both are joined into it, because either leaves the member diverging
+	// from the primary.
 	ModelStateErr error
 }
 
 // incomplete reports whether the member failed to materialise part of the
 // config: a failover group it could not build, or a per-model reconcile that
-// failed outright, both of which leave it routing differently from the
-// primary. A discovery error alone is not one: a provider outage is routine, and
-// one that matters surfaces as skipped groups.
+// failed outright, both of which leave it routing differently from the primary.
+// A discovery error alone is not one: a provider outage is routine, and one that
+// matters surfaces as skipped groups.
 //
-// PartialGroups and UnappliedModels are deliberately NOT part of this. Both mean
-// the member did everything the envelope asked and simply holds fewer models: it
-// built the group with what it has, and it cannot disable a model it does not
-// have. It is still configured differently from the primary, but that divergence
-// is established by the config hash. These two only let the operator alert say
+// PartialGroups and UnappliedModels are NOT part of this. Both mean the member
+// did everything the envelope asked and holds fewer models: it built the group
+// with what it has, and it cannot disable a model it does not have. The config
+// hash establishes that divergence; these two only let the operator alert say
 // which group is short and which models are missing.
 func (o applyOutcome) incomplete() bool {
 	return o.GroupApplyErr != nil || len(o.SkippedGroups) > 0 || o.ModelStateErr != nil
@@ -75,11 +74,11 @@ func (o applyOutcome) incomplete() bool {
 //   - sourceGen present (a fenced push): refuses with errStaleSourceGen if it is
 //     older than the marker, otherwise applies and advances the marker in the same
 //     transaction as the config write;
-//   - sourceGen absent (a pre-fence Front Desk, which sends no header): applies
-//     only while the marker is unset (a member no fenced push has touched), and is
-//     refused once any fenced generation has been recorded. An un-versioned write
-//     must never overwrite versioned config, or it could leave the member on old
-//     config while the marker claims a newer generation already applied.
+//   - sourceGen absent (a Front Desk that sends no header): applies only while the
+//     marker is unset (a member no fenced push has touched), and is refused once any
+//     fenced generation has been recorded. An un-versioned write must never
+//     overwrite versioned config, or it could leave the member on old config while
+//     the marker claims a newer generation applied.
 //
 // The lock is taken for every import, headed or not, so a headerless push cannot
 // slip past a generation that already committed. That, plus the same-transaction
@@ -101,17 +100,17 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := upsertProviders(ctx, tx, env.Config.Providers, h.validateProviderURL); err != nil {
 		return applyOutcome{}, err
 	}
-	// Declarative replace: drop providers absent from the primary. This cascades
-	// to their discovered models (FK ON DELETE CASCADE) but request_logs are
-	// preserved: their provider_id FK is ON DELETE SET NULL (migration 010), so
-	// history stays and only the provider link is nulled.
+	// Declarative replace: drop providers absent from the primary. This cascades to
+	// their discovered models (FK ON DELETE CASCADE) but preserves request_logs:
+	// their provider_id FK is ON DELETE SET NULL, so history stays and only the
+	// provider link is nulled.
 	//
 	// RETURNING the deleted ids so their references can be pruned out of the two
-	// allow-list columns, which no foreign key covers. Already inside the import
-	// transaction, so the delete and the prune commit together. Ordering matters
-	// as well: this runs BEFORE upsertVirtualKeys and applyUsers, so a row the
-	// envelope also rewrites ends up with the envelope's value rather than a
-	// pruned one, and a row the envelope skips still gets cleaned.
+	// allow-list columns, which no foreign key covers. Inside the import
+	// transaction, so the delete and the prune commit together. Ordering matters:
+	// this runs BEFORE upsertVirtualKeys and applyUsers, so a row the envelope also
+	// rewrites ends up with the envelope's value rather than a pruned one, and a row
+	// the envelope skips still gets cleaned.
 	providerNames := names(env.Config.Providers, func(p ExportProvider) string { return p.Name })
 	deletedRows, err := tx.Query(ctx, `DELETE FROM providers WHERE name <> ALL($1) RETURNING id::text`, providerNames)
 	if err != nil {
@@ -130,8 +129,8 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err != nil {
 		return applyOutcome{}, err
 	}
-	// Users converge before virtual keys so key ownership (carried by
-	// username) resolves against the freshly synced roster.
+	// Users converge before virtual keys so key ownership (carried by username)
+	// resolves against the freshly synced roster.
 	if err := applyUsers(ctx, tx, env.Config.Users, nameToID); err != nil {
 		return applyOutcome{}, err
 	}
@@ -154,10 +153,10 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 
 	if sourceGen != nil {
 		// Advance the fence marker in the same transaction as the config write, so
-		// the commit that applies this generation's config and the record that it
-		// was applied are atomic. A raw upsert (not settings.SetTx) because the
-		// _fleet_* keys are deliberately outside the SetTx allowlist; the value is
-		// monotonic because an older generation was already rejected above.
+		// the commit that applies this generation's config and the record that it was
+		// applied are atomic. A raw upsert (not settings.SetTx) because the _fleet_*
+		// keys sit outside the SetTx allowlist; the value is monotonic because an
+		// older generation was already rejected above.
 		if err := writeAppliedSourceGen(ctx, tx, *sourceGen); err != nil {
 			return applyOutcome{}, err
 		}
@@ -191,26 +190,23 @@ func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) err
 			return errStaleSourceGen // a newer generation already applied; refuse
 		}
 	case fenced:
-		// Headerless (pre-fence) import onto a member any fenced generation already
-		// converged (including generation 0): applying an un-versioned write now
-		// could clobber that config and leave the marker lying. Refuse; the fenced
-		// source reconverges.
+		// Headerless import onto a member a fenced generation already converged
+		// (including generation 0): an un-versioned write could clobber that config
+		// and leave the marker lying. Refuse; the fenced source reconverges.
 		return errStaleSourceGen
 	}
 	return nil
 }
 
-// guardAgainstProviderWipe is the destructive-wipe rail. The declarative
-// delete in apply removes every provider absent from the envelope, so an
-// envelope with zero providers would delete the member's entire provider set
-// (cascading to discovered models) and, paired with the users replace, is the
-// reported backdoor-wipe vector. buildEnvelope always ships the full config,
-// so a functioning primary never legitimately pushes zero providers onto a
-// member that has some. Refuse here, inside the transaction and before any
-// delete, so the check and the delete it guards are atomic and no throwaway
-// setting or virtual key can dress the envelope past it. An empty-provider
-// envelope onto a member that also has no providers is a harmless no-op and is
-// allowed (fleet bootstrap / keys-only sync onto an empty member).
+// guardAgainstProviderWipe is the destructive-wipe rail. The declarative delete
+// in apply removes every provider absent from the envelope, so an envelope with
+// zero providers would delete the member's entire provider set, cascading to
+// discovered models. buildEnvelope always ships the full config, so a
+// functioning primary never pushes zero providers onto a member that has some.
+// The check sits inside the transaction and before any delete, so it and the
+// delete it guards are atomic. An empty-provider envelope onto a member that
+// also has no providers is a harmless no-op and is allowed (fleet bootstrap or
+// keys-only sync onto an empty member).
 func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
 	if len(providers) == 0 {
 		var existing int
@@ -236,9 +232,9 @@ func (h *ConfigSyncHandler) applySettingsTx(ctx context.Context, tx pgx.Tx, want
 			continue // skip non-syncable / unknown keys silently
 		}
 		// Mirror the interactive PUT /api/settings validation: the config-sync path
-		// writes the same url-typed settings the server later fetches (CWE-918) and
-		// the same numeric limiter settings the data plane enforces on. A legitimate
-		// primary already validated both on the way in.
+		// writes the same url-typed settings the server later fetches and the same
+		// numeric limiter settings the data plane enforces on. A legitimate primary
+		// already validated both on the way in.
 		if err := validateSyncedSetting(k, v); err != nil {
 			return nil, err
 		}
@@ -262,24 +258,20 @@ func (h *ConfigSyncHandler) applySettingsTx(ctx context.Context, tx pgx.Tx, want
 // Unknown keys pass through untouched; the caller has already gated syncability.
 //
 // url / url_public get the full netguard treatment: these are values the server
-// itself later fetches or reflects into a redirect URI (reported SSRF bypass,
-// CWE-918). Standing guard with no live path today: every current url-typed
-// setting (apprise + SSO) is instance-local and skipped before validation, so
-// these branches fire only if a future url-typed setting joins the syncable
-// set.
+// itself later fetches or reflects into a redirect URI (SSRF). Standing guard
+// with no live path: every url-typed setting (apprise + SSO) is instance-local
+// and skipped before validation, so these branches fire only if a url-typed
+// setting joins the syncable set.
 //
-// int / float get their MINIMUM enforced, and deliberately not their maximum or
-// their parseability. The floors are the ones that change runtime enforcement:
-// rate_limit_ip_burst is min 1 because IPLimiter.getLimiter passes it to
-// rate.NewLimiter unclamped, so a negative one denies every request from every
-// IP, and rate_limit_burst is the same bug for every virtual key without a
-// per-key override. A value above the ceiling is a capacity/sanity bound that
-// relaxes no enforcement, and an unparseable one is inert because GetInt/GetFloat
-// fall back to the built-in default. Skipping both keeps rolling upgrades
-// working: a newer primary that raises a ceiling (or sends a value shape an older
-// member cannot parse) must not make that member reject the ENTIRE envelope, the
-// same trap validateSyncedRateLimits documents for grants. Floors are the
-// structural end of the range and are not widened downward in practice.
+// int / float get their MINIMUM enforced, and not their maximum or their
+// parseability. The floors are what change runtime enforcement: rate_limit_ip_burst
+// is min 1 because IPLimiter.getLimiter passes it to rate.NewLimiter unclamped, so
+// a negative one denies every request from every IP, and rate_limit_burst is the
+// same bug for every virtual key without a per-key override. A value above the
+// ceiling relaxes no enforcement, and an unparseable one is inert because
+// GetInt/GetFloat fall back to the built-in default. Skipping both keeps rolling
+// upgrades working: a newer primary that raises a ceiling must not make an older
+// member reject the ENTIRE envelope.
 func validateSyncedSetting(key, value string) error {
 	rule, ok := allowedSettings[key]
 	if !ok {
@@ -315,19 +307,18 @@ func validateSyncedSetting(key, value string) error {
 // names the row for the error message. Nil values mean "fall back to the global
 // setting" and are always fine.
 //
-// This is the same defense-in-depth shape as validateSyncedSetting: a
-// legitimate primary already validated these on the way in, so anything out of
-// bounds here means a compromised or corrupt envelope, and the limits it would
-// relax are the ones metering the data plane.
+// Same defense-in-depth shape as validateSyncedSetting: a legitimate primary
+// already validated these on the way in, so anything out of bounds means a
+// compromised or corrupt envelope, and the limits it would relax meter the data
+// plane.
 //
-// Deliberately NOT mirrored on the import path: the interactive API's username
+// NOT mirrored on the import path: the interactive API's username
 // length/whitespace rules, display-name length, role allowlist, virtual-key
 // reserved names, and user.ValidateGrants. Those are cosmetic or structural
-// rather than security bounds (a compromised primary that could exploit them can
-// already push an admin user outright), and porting the allowlists specifically
-// would break rolling upgrades: a newer primary pushing a grant or role an older
-// member does not know yet would fail the ENTIRE import rather than degrade one
-// field. Only bounds that change runtime enforcement belong here.
+// rather than security bounds, and porting the allowlists would break rolling
+// upgrades: a newer primary pushing a grant or role an older member does not know
+// would fail the ENTIRE import rather than degrade one field. Only bounds that
+// change runtime enforcement belong here.
 func validateSyncedRateLimits(subject string, rps *float64, burst, tpm *int) error {
 	if rps != nil && *rps < 0 {
 		return fmt.Errorf("%w: %s rate_limit_rps must be >= 0, got %f", errInvalidSyncedRateLimit, subject, *rps)
@@ -348,34 +339,30 @@ func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnv
 	var out applyOutcome
 	// The core config is committed, so the remaining work is not bound to the
 	// caller's request. Front Desk's import client gives up after 240s
-	// (frontdesk.memberSyncTimeout) while discovery on a fresh member routinely
-	// runs longer, and inheriting that deadline starves the group build, which
-	// depends on discovery's output.
+	// (frontdesk.memberSyncTimeout) while discovery on a fresh member runs longer,
+	// and inheriting that deadline starves the group build, which depends on
+	// discovery's output.
 	//
-	// Detached rather than given an aggregate deadline. A ceiling here would not
+	// Detached rather than given an aggregate deadline: a ceiling here would not
 	// bound discovery, which detaches each provider under its own 180s timeout and
-	// never consults this context (discovery.go), so the only thing it could expire
-	// is the group build below: exactly the step that must run. The real bound is
-	// per provider, times a finite provider list, and the group build carries its
-	// own budget.
+	// never consults this context (discovery.go), so it could only expire the group
+	// build. The real bound is per provider times a finite provider list, and the
+	// group build carries its own budget.
 	ctx = context.WithoutCancel(ctx)
 
 	// Stamp the HA synced marker AFTER the commit, via Set (not SetTx): this
-	// instance-local, non-syncable key drives the member dashboard's "synced
-	// from primary" readout. It must be written post-commit and through Set
-	// because SetTx enforces the settings allowlist, which _fleet_* keys are
-	// deliberately absent from (so the declarative replace above never touches
-	// them). A failure here is non-fatal: the config is already durable.
+	// instance-local, non-syncable key drives the member dashboard's "synced from
+	// primary" readout. Set because SetTx enforces the settings allowlist, which
+	// _fleet_* keys are absent from, so the declarative replace never touches them.
+	// A failure here is non-fatal: the config is already durable.
 	if err := h.settings.Set(ctx, keyFleetConfigSyncedAt, time.Now().UTC().Format(time.RFC3339)); err != nil {
 		debuglog.Warn("configsync: failed to stamp fleet synced marker", "error", err)
 	}
 
-	// Every imported key joins the credential mask's held set, whatever its
-	// row's enabled state; the sample decrypt above proved the master key,
-	// this proves each row and registers it. Inline, and BEFORE the cache
-	// invalidation below makes the new rows routable: the seed must be in
-	// place before the proxy can send the first request to them. An import
-	// is an admin action and the table is small.
+	// Every imported key joins the credential mask's held set, whatever its row's
+	// enabled state: this proves each row and registers it. Inline, and BEFORE the
+	// cache invalidation makes the new rows routable, so the seed is in place
+	// before the proxy sends the first request to them.
 	held, failed := provider.HoldKeys(ctx, provider.NewRepository(h.db.Pool()), h.masterKey)
 	debuglog.Info("configsync: provider keys held for the credential mask", "held", held, "failed", failed)
 
@@ -384,13 +371,12 @@ func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnv
 	// providers/keys and discovery must re-read providers.
 	provider.InvalidateProviderCache()
 	model.InvalidateModelCache()
-	// Settings too, and here rather than after the discovery pass below: that
-	// pass can run for minutes, and the settings cache holds absences as well as
-	// values, so a key the primary set for the first time would otherwise stay
-	// "unset" on this member until the pass ended or the cache TTL ran out,
-	// whichever came first. A removed key gets NotifyDeleted alone: it evicts
-	// and notifies subscribers with the empty value, where InvalidateCache would
-	// first re-read a row that no longer exists.
+	// Settings too, and here rather than after the discovery pass: that pass can
+	// run for minutes, and the settings cache holds absences as well as values, so
+	// a key the primary set for the first time would stay "unset" on this member
+	// until the pass ended or the cache TTL ran out. A removed key gets
+	// NotifyDeleted alone: it evicts and notifies subscribers with the empty value,
+	// where InvalidateCache would first re-read a row that no longer exists.
 	for k := range env.Config.Settings {
 		if isSyncableSetting(k) {
 			h.settings.InvalidateCache(k)
@@ -401,11 +387,11 @@ func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnv
 	}
 
 	// Populate this member's models so custom failover groups can resolve. The
-	// "discover on provider creation" default is a dashboard action this raw
-	// import bypasses, and scheduled discovery may be off, so without this a
-	// freshly-synced member would have providers but no models, and hotel/<group>
-	// would route to nothing until a restart or a manual discover. Best-effort:
-	// the core config already committed, and groups reconcile on the next sync.
+	// "discover on provider creation" default is a dashboard action this raw import
+	// bypasses, and scheduled discovery may be off, so without this a freshly-synced
+	// member has providers but no models and hotel/<group> routes to nothing until a
+	// restart or a manual discover. Best-effort: the core config already committed,
+	// and groups reconcile on the next sync.
 	if h.discoverAll != nil {
 		if err := h.discoverAll(ctx); err != nil {
 			debuglog.Warn("configsync: post-import discovery failed; custom failover groups may not resolve until models exist", "error", err)
@@ -415,9 +401,9 @@ func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnv
 
 	// Per-model disables, after discovery for the same reason the group build is:
 	// the rows these refs resolve against are the ones discovery just created. It
-	// runs before the group build only so the model state is settled by the time
-	// anything downstream reads it; upsertFailoverGroups resolves entries by model
-	// presence alone and is indifferent to the order.
+	// runs before the group build so the model state is settled by the time anything
+	// downstream reads it; upsertFailoverGroups resolves entries by model presence
+	// alone and is indifferent to the order.
 	unapplied, err := h.applyDisabledModels(ctx, env.Config.DisabledModels)
 	out.UnappliedModels = unapplied
 	if err != nil {
@@ -427,8 +413,7 @@ func (h *ConfigSyncHandler) postImportRefresh(ctx context.Context, env ConfigEnv
 
 	// Manual-enable pins, immediately after the disables so a member ends up in the
 	// same state whichever order a malformed envelope names a model in. Joined
-	// rather than assigned, so a pin failure cannot erase a disable failure the
-	// operator alert still has to report.
+	// rather than assigned, so a pin failure cannot erase a disable failure.
 	pinned, err := h.applyEnabledModels(ctx, env.Config.EnabledModels)
 	out.UnappliedModels = append(out.UnappliedModels, pinned...)
 	if err != nil {
@@ -472,13 +457,13 @@ func (h *ConfigSyncHandler) syncableSettingsToDelete(ctx context.Context, q quer
 }
 
 // readAppliedSourceGen returns the highest Front Desk source generation this
-// member has applied and whether a marker row exists at all, read inside the
-// import transaction. present is the signal the fence keys on: a generation of 0
-// is a real applied generation (the wizard can sync at auto_sync_gen 0), so it
-// must be distinguished from "never fenced" rather than collapsed to the same
-// zero. A missing row reports present=false; an unparseable value reports
-// present=true at a floor of 0, so the corrupt marker still fences out a
-// header-less write yet a fresh fenced import can rewrite a clean value.
+// member has applied and whether a marker row exists, read inside the import
+// transaction. present is the signal the fence keys on: a generation of 0 is a
+// real applied generation (the wizard can sync at auto_sync_gen 0), so it is
+// distinct from "never fenced". A missing row reports present=false; an
+// unparseable value reports present=true at a floor of 0, so the corrupt marker
+// still fences out a header-less write yet a fresh fenced import can rewrite a
+// clean value.
 func readAppliedSourceGen(ctx context.Context, tx pgx.Tx) (gen int64, present bool, err error) {
 	var raw string
 	switch scanErr := tx.QueryRow(ctx, `SELECT value FROM settings WHERE key = $1`, keyFleetLastSourceGen).Scan(&raw); {
@@ -489,9 +474,9 @@ func readAppliedSourceGen(ctx context.Context, tx pgx.Tx) (gen int64, present bo
 	}
 	n, parseErr := strconv.ParseInt(raw, 10, 64)
 	if parseErr != nil {
-		// Deliberate: a corrupt marker floors to 0 but stays present, so a header-
-		// less write is still refused and a fenced import rewrites a clean value,
-		// rather than wedging the fence on a 500 forever.
+		// A corrupt marker floors to 0 but stays present, so a header-less write is
+		// still refused and a fenced import rewrites a clean value, rather than
+		// wedging the fence on a 500.
 		debuglog.Warn("configsync: unparseable stored source generation, flooring to 0", "value", raw)
 		return 0, true, nil //nolint:nilerr // intentional: corrupt marker floors but stays present
 	}
@@ -499,13 +484,13 @@ func readAppliedSourceGen(ctx context.Context, tx pgx.Tx) (gen int64, present bo
 }
 
 // writeAppliedSourceGen records gen as the highest applied source generation,
-// upserting the _fleet_last_source_gen row directly (the key is outside the
-// SetTx allowlist). Called inside the import transaction so the marker advances
-// atomically with the config it certifies. Because it bypasses the settings
-// repository, nothing evicts the repository's cache for this key: that is fine
-// only while the key is read the way readAppliedSourceGen reads it, with raw SQL
-// inside the transaction. A repository read of it would serve a cached value,
-// or a cached absence, for up to the cache TTL against this write.
+// upserting the _fleet_last_source_gen row directly (the key is outside the SetTx
+// allowlist). Called inside the import transaction so the marker advances
+// atomically with the config it certifies. It bypasses the settings repository,
+// so nothing evicts that cache for this key: safe only while the key is read the
+// way readAppliedSourceGen reads it, with raw SQL inside the transaction. A
+// repository read would serve a cached value or absence for up to the cache TTL
+// against this write.
 func writeAppliedSourceGen(ctx context.Context, tx pgx.Tx, gen int64) error {
 	_, err := tx.Exec(ctx, `
 		INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, now())

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -286,8 +286,6 @@ func validateSyncedSetting(key, value string) error {
 		if err := netguard.ValidatePublicURL(value); err != nil {
 			return fmt.Errorf("%w %q: %w", errInvalidSyncedURL, key, err)
 		}
-	// An unparseable value is left alone rather than rejected: GetInt/GetFloat
-	// answer with the built-in default, so it relaxes nothing.
 	case "int":
 		if v, err := strconv.Atoi(value); err == nil && float64(v) < rule.min {
 			return fmt.Errorf("%w: %s must be >= %d, got %d", errInvalidSyncedSettingBound, key, int(rule.min), v)

--- a/internal/api/configsync_apply_upserts.go
+++ b/internal/api/configsync_apply_upserts.go
@@ -23,11 +23,11 @@ import (
 // operator's group. It returns what the build could not fully do.
 func (h *ConfigSyncHandler) applyFailoverGroups(ctx context.Context, groups []ExportFailoverGroup) (groupApplyResult, error) {
 	// Distinguish "field absent" from "explicitly empty". A nil slice means the
-	// envelope carried no failover_groups key at all (a pre-PR primary), so leave
-	// the member's own custom groups untouched rather than wiping them on the first
-	// sync of a rolling upgrade. A non-nil empty slice means a current primary that
-	// genuinely has zero custom groups, which must reconcile: the declarative delete
-	// below then removes every stale custom group the member still has.
+	// envelope carried no failover_groups key, so leave the member's own custom
+	// groups untouched rather than wiping them on the first sync of a rolling
+	// upgrade. A non-nil empty slice means a primary with zero custom groups, which
+	// must reconcile: the declarative delete below removes every stale custom group
+	// the member still has.
 	if groups == nil {
 		return groupApplyResult{}, nil
 	}
@@ -54,13 +54,11 @@ func (h *ConfigSyncHandler) applyFailoverGroups(ctx context.Context, groups []Ex
 }
 
 // providerTypeForImport keeps an imported provider's type non-empty. A payload
-// from a member that predates the stored type carries none, and a row without a
-// type would fall back to the URL rules on every read; deriving it once here
-// pins the same answer to the row instead.
+// that carries none would leave a row falling back to the URL rules on every
+// read; deriving the type once here pins the answer to the row instead.
 func providerTypeForImport(p ExportProvider) string {
-	// An unknown type would be stored verbatim and then fall through to the
-	// generic path on every read, so a payload from a newer build (or a
-	// tampered one) is derived rather than trusted.
+	// An unknown type would be stored verbatim and fall through to the generic
+	// path on every read, so it is derived rather than trusted.
 	if provider.IsKnownType(p.ProviderType) {
 		return p.ProviderType
 	}
@@ -68,23 +66,17 @@ func providerTypeForImport(p ExportProvider) string {
 }
 
 // validateSyncedProvider applies to an imported provider the checks the
-// interactive admin API applies on create and update, so a compromised
-// primary cannot write through this path what the dashboard would reject.
-// The URL's shape is checked separately (validateURL below); this is the
-// rest: the in-flight ceiling, through the same rule the admin API uses
-// (the load-bearing one: a value below one is read as no ceiling at all),
-// the name's length and printability, and the disable date's format. A
-// disable date in the past is accepted: it was valid when the primary set
-// it, and the member's own sweep fires it immediately, which is what the
-// operator asked for. The URL's length is not bounded here: the admin API's
-// bound is cosmetic, a row past it is harmless, and refusing whole envelopes
-// over one would be a one-way door for a fleet. The name bound carries the
-// same door for a legacy row written before this check, and earns it: an
-// unprintable or ten-thousand-character name reaches logs, the dashboard
-// and hotel/ model strings, which a long URL never does. The name is
-// validated as sent and stored as sent (the admin API stores it trimmed):
-// storing a trimmed copy would diverge from the primary's hash and re-sync
-// forever, and trimming changes nothing the check cares about.
+// interactive admin API applies on create and update, so a compromised primary
+// cannot write through this path what the dashboard would reject. The URL's
+// shape is checked separately (validateURL); this covers the in-flight ceiling
+// (a value below one is read as no ceiling at all), the name's length and
+// printability, and the disable date's format. A disable date in the past is
+// accepted: the member's own sweep fires it immediately, which is what the
+// operator asked for. The URL's length is not bounded here, because a long URL
+// is harmless where an unprintable or ten-thousand-character name reaches logs,
+// the dashboard and hotel/ model strings. The name is validated as sent and
+// stored as sent (the admin API stores it trimmed): storing a trimmed copy would
+// diverge from the primary's hash and re-sync forever.
 func validateSyncedProvider(p ExportProvider) error {
 	if err := provider.ValidateMaxInFlight(p.MaxInFlight); err != nil {
 		return fmt.Errorf("%w: provider %q: %w", errInvalidSyncedProvider, p.Name, err)
@@ -105,18 +97,18 @@ func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider,
 		if err := validateSyncedProvider(p); err != nil {
 			return err
 		}
-		// Defense in depth on the import path: a compromised primary must not be
-		// able to write a provider base_url that the interactive admin API would
-		// reject. validateURL is the same guard CreateProvider/UpdateProvider use
+		// Defense in depth on the import path: a compromised primary must not write
+		// a provider base_url the interactive admin API would reject. validateURL is
+		// the same guard CreateProvider/UpdateProvider use
 		// (config.ValidateProviderURL): it resolves DNS and blocks loopback, RFC
 		// 1918/ULA, link-local, CGNAT and cloud-metadata addresses (hosts in
-		// ALLOWED_PROVIDER_HOSTS are exempted). The runtime proxy SafeDialer also
-		// blocks these at dial time, but rejecting here keeps the poisoned value
-		// out of the database entirely. Nil validateURL disables the check (tests).
+		// ALLOWED_PROVIDER_HOSTS are exempted). The runtime proxy SafeDialer blocks
+		// these at dial time too, but rejecting here keeps the poisoned value out of
+		// the database. Nil validateURL disables the check.
 		if validateURL != nil {
 			if err := validateURL(p.BaseURL); err != nil {
-				// The same refusal class as the bounds above: the envelope
-				// carries what the admin API would reject, so a 400, not a 500.
+				// Same refusal class as the bounds above: the envelope carries what
+				// the admin API would reject, so a 400, not a 500.
 				return fmt.Errorf("%w: provider %q has an invalid base_url: %w", errInvalidSyncedProvider, p.Name, err)
 			}
 		}
@@ -143,17 +135,16 @@ func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider,
 	return nil
 }
 
-// applyUsers converges the users table to the envelope, keyed by username. A
-// nil slice means the envelope predates the field: leave this member's users
-// alone (same contract as failover groups). Sequence matters: delete absent
-// users first, then blank all remaining emails, then upsert. The blanking step
-// lets an email move between two surviving accounts without tripping the
-// unique index mid-upsert (row-by-row upserts would otherwise 23505 on a
-// swap). Sessions of removed or disabled users die at the auth middleware,
-// which re-checks the users row on every request. nameToID resolves each
-// account's provider cap back to this member's provider UUIDs; it is built
-// after the provider upsert so every name a legitimate primary exported
-// resolves.
+// applyUsers converges the users table to the envelope, keyed by username. A nil
+// slice means the envelope omits the field: leave this member's users alone
+// (same contract as failover groups). Sequence matters: delete absent users
+// first, then blank all remaining emails, then upsert. The blanking step lets an
+// email move between two surviving accounts without tripping the unique index
+// mid-upsert (row-by-row upserts would otherwise 23505 on a swap). Sessions of
+// removed or disabled users die at the auth middleware, which re-checks the
+// users row on every request. nameToID resolves each account's provider cap back
+// to this member's provider UUIDs; it is built after the provider upsert so
+// every name a legitimate primary exported resolves.
 func applyUsers(ctx context.Context, tx pgx.Tx, users []ExportUser, nameToID map[string]string) error {
 	if users == nil {
 		return nil
@@ -169,12 +160,11 @@ func applyUsers(ctx context.Context, tx pgx.Tx, users []ExportUser, nameToID map
 		if err := validateSyncedRateLimits("user "+strconv.Quote(u.Username), u.RateLimitRPS, u.RateLimitBurst, u.RateLimitTPM); err != nil {
 			return err
 		}
-		// The interactive API only ever stores hashes it computed itself; this
-		// path takes them off the wire, so it checks the encoding here. Login
-		// already fails closed on a malformed hash, so this is not an
-		// authentication fix: it stops an unusable hash from being written at
-		// all, where it would otherwise surface much later as an account that
-		// silently cannot log in.
+		// The interactive API only stores hashes it computed itself; this path takes
+		// them off the wire, so it checks the encoding. Login already fails closed
+		// on a malformed hash, so this is not an authentication fix: it stops an
+		// unusable hash from being written at all, where it would surface later as
+		// an account that silently cannot log in.
 		if err := user.ValidateHashFormat(u.PasswordHash); err != nil {
 			return fmt.Errorf("%w: user %s", errInvalidSyncedPasswordHash, strconv.Quote(u.Username))
 		}
@@ -186,7 +176,7 @@ func applyUsers(ctx context.Context, tx pgx.Tx, users []ExportUser, nameToID map
 		// test is the POINTER, not the length, for the same reason as
 		// upsertVirtualKeys: an account whose capped providers were all deleted
 		// exports a present-but-empty list, and reading that as "uncapped" is the
-		// escalation being guarded.
+		// escalation this guards.
 		var allowedProviders *[]string
 		if u.AllowedProviderNames != nil {
 			resolved := []string{}
@@ -195,32 +185,28 @@ func applyUsers(ctx context.Context, tx pgx.Tx, users []ExportUser, nameToID map
 					resolved = append(resolved, id)
 				}
 			}
-			// Two ways a cap can resolve to nothing here, and they are NOT the
-			// same thing.
+			// Two ways a cap resolves to nothing here, and they are NOT the same.
 			//
-			// The wire list is EMPTY: the primary itself resolved nothing, i.e.
-			// every provider in this account's cap has been deleted there. Fall
-			// through and write the empty array. proxy.effectiveAllowedProviders
-			// treats a non-nil cap as "exactly these providers" INCLUDING when
-			// empty, so `{}` reproduces the primary's own effective behaviour
-			// (deny everything) rather than NULL's "every provider". Refusing
-			// instead would wedge fleet sync on an ordinary provider deletion,
-			// and because a refusal fails the ENTIRE import the member would stay
-			// frozen on its previous cap for this account, which may be WIDER
-			// than what the primary now effectively enforces.
+			// The wire list is EMPTY: the primary itself resolved nothing, i.e. every
+			// provider in this account's cap has been deleted there. Fall through and
+			// write the empty array. proxy.effectiveAllowedProviders treats a non-nil
+			// cap as "exactly these providers" INCLUDING when empty, so `{}`
+			// reproduces the primary's own deny-everything behaviour rather than
+			// NULL's "every provider". Refusing would wedge fleet sync on an ordinary
+			// provider deletion and freeze the member on its previous cap, which may
+			// be WIDER than what the primary now enforces.
 			//
 			// The wire list is NON-EMPTY but none of it resolves: anomalous. The
-			// declarative provider replace runs earlier in this same transaction
-			// and nameToID is built from its result, so every name a legitimate
-			// primary exported resolves here. Refuse the envelope; the rollback
-			// undoes the users delete above with it.
+			// declarative provider replace runs earlier in this transaction and
+			// nameToID is built from its result, so every name a legitimate primary
+			// exported resolves here. Refuse the envelope; the rollback undoes the
+			// users delete with it.
 			if len(resolved) == 0 && len(*u.AllowedProviderNames) > 0 {
 				return fmt.Errorf("%w: user %s", errUnresolvableUserProviders, strconv.Quote(u.Username))
 			}
-			// A partially resolving list is just as anomalous as a fully
-			// unresolvable one for the same reason, and it narrows the account
-			// silently, so say so. Matches the warn upsertVirtualKeys emits on its
-			// analogous branch. Username only: no request content is ever logged.
+			// A partially resolving list is as anomalous as a fully unresolvable one
+			// and narrows the account silently, so it is logged. Username only: no
+			// request content is ever logged.
 			if len(resolved) < len(*u.AllowedProviderNames) {
 				debuglog.Warn("configsync: some of a user's allowed_providers do not resolve on this member; importing the subset",
 					"user", u.Username, "wanted", len(*u.AllowedProviderNames), "resolved", len(resolved))
@@ -283,40 +269,34 @@ func upsertVirtualKeys(ctx context.Context, tx pgx.Tx, vks []ExportVK, nameToID,
 				}
 			}
 		}
-		// Privilege-safety: if this key was restricted to providers but none of
-		// them resolve on this member, do NOT import it. A nil allowed_providers
-		// means "all providers allowed" (pgx writes the nil slice as NULL, and
-		// the proxy treats only NULL as unrestricted), so writing it would
-		// silently turn a restricted key into an unrestricted one. Skipping is
-		// the lesser evil rather than a clean no-op: a key this member does not
-		// have yet simply stays absent, but a key it already has keeps its
-		// existing row, whose allowed_providers may be broader than the primary
-		// now intends. Stale-but-bounded still beats writing NULL.
+		// Privilege-safety: a key restricted to providers none of which resolve on
+		// this member is NOT imported. A nil allowed_providers means "all providers
+		// allowed" (pgx writes the nil slice as NULL, and the proxy treats only NULL
+		// as unrestricted), so writing it would turn a restricted key into an
+		// unrestricted one. Skipping is not a clean no-op: a key this member does
+		// not have stays absent, but one it already has keeps its existing row,
+		// whose allowed_providers may be broader than the primary intends.
 		//
 		// The presence test is the POINTER, not the length. A key whose providers
 		// were all deleted upstream exports a present-but-empty list, and reading
-		// that as "unrestricted" is exactly the escalation this guards.
+		// that as "unrestricted" is the escalation this guards.
 		//
-		// Which is also how this branch is reached in practice. Deleting a provider
-		// on the primary runs provider.PruneAllowLists, so any key scoped solely to
-		// it is left with `{}` and exports an empty list: an ordinary admin action
-		// trips this skip, with its warn, on every sync until the key is repaired or
-		// removed. The other way in, a NON-empty list none of whose names resolve,
-		// stays the rare one: providers are upserted in the same transaction before
-		// this runs, so every name a legitimate primary exported does resolve.
+		// That is also how the branch is reached in practice: deleting a provider on
+		// the primary runs provider.PruneAllowLists, so a key scoped solely to it is
+		// left with `{}` and exports an empty list, tripping this skip on every sync
+		// until the key is repaired or removed. A NON-empty list none of whose names
+		// resolve is rare: providers are upserted in the same transaction first.
 		//
-		// Note the deliberate difference from applyUsers, which writes an empty wire
-		// cap through as `{}` instead of skipping. A user cannot be skipped: the
-		// declarative replace would delete the row. A key can, and skipping keeps the
-		// member's own row rather than converging it, which is the accepted gap
-		// recorded in the design doc.
+		// applyUsers instead writes an empty wire cap through as `{}`: a user cannot
+		// be skipped, because the declarative replace would delete the row. A key
+		// can, and skipping keeps the member's own row rather than converging it.
 		if v.AllowedProviderNames != nil && len(allowed) == 0 {
 			debuglog.Warn("configsync: skipping virtual key whose allowed_providers do not resolve on this member", "key", v.Name)
 			continue
 		}
-		// Owner rides by username; an owner that does not resolve here (should
-		// not happen: users are applied first in the same transaction) imports
-		// as unowned rather than failing the sync.
+		// Owner rides by username; an owner that does not resolve here (users are
+		// applied first in the same transaction) imports as unowned rather than
+		// failing the sync.
 		var ownerID *string
 		if v.OwnerUsername != nil {
 			if id, ok := userNameToID[*v.OwnerUsername]; ok {
@@ -368,8 +348,8 @@ func upsertFailoverGroups(ctx context.Context, tx pgx.Tx, groups []ExportFailove
 	if len(groups) == 0 {
 		return res, nil
 	}
-	// (provider, model_id) -> local model UUID. Built inside the transaction so
-	// it reflects the just-synced provider set (deleted providers cascade-removed
+	// (provider, model_id) -> local model UUID. Built inside the transaction so it
+	// reflects the just-synced provider set (deleted providers cascade-removed
 	// their models). Models themselves come from each member's discovery.
 	localUUID := map[string]string{}
 	rows, err := tx.Query(ctx,
@@ -410,7 +390,7 @@ func upsertFailoverGroups(ctx context.Context, tx pgx.Tx, groups []ExportFailove
 		if len(priority) < len(g.Entries) {
 			// Routable, but across fewer providers than the primary routes it: this
 			// member holds fewer of the group's models. The group is written with what
-			// resolved, and named so the operator alert can say which one is short.
+			// resolved, and named so the operator alert can say which is short.
 			debuglog.Warn("configsync: building custom failover group with fewer entries than the primary sent",
 				"group", g.DisplayModel, "resolved", len(priority), "wanted", len(g.Entries))
 			res.Partial = append(res.Partial, g.DisplayModel)

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -30,14 +30,12 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 	if len(env.Config.Providers) == 0 && len(env.Config.VirtualKeys) == 0 &&
 		len(env.Config.Settings) == 0 {
 		// Structural guard: an envelope with no providers, no virtual keys, and no
-		// syncable settings has nothing meaningful to sync (a bare users or
-		// failover-groups list cannot stand on its own, since those reference a
-		// data plane that isn't here). Applying it would only run the declarative
-		// deletes and wipe the member, so refuse rather than write. This is the
-		// "obvious mistake" rail; the destructive-wipe rail that can't be dressed
-		// around lives in apply() (errWouldWipeProviders), which refuses any
-		// envelope whose empty provider list would delete providers this member
-		// actually has, whatever settings/keys/users decorate it.
+		// syncable settings has nothing to sync (a bare users or failover-groups list
+		// references a data plane that is not here). Applying it would only run the
+		// declarative deletes and wipe the member. This is the "obvious mistake"
+		// rail; the rail that cannot be dressed around is errWouldWipeProviders in
+		// apply(), which refuses any envelope whose empty provider list would delete
+		// providers this member has.
 		http.Error(w, "refusing to import an empty config", http.StatusBadRequest)
 		return
 	}
@@ -58,39 +56,39 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.URL.Query().Get("dryRun") != "" {
-		// A dry run is read-only and is never fenced: Front Desk relies on it to
-		// preview the diff before deciding to snapshot and import.
+		// A dry run is read-only and never fenced: Front Desk uses it to preview the
+		// diff before deciding to snapshot and import.
 		writeJSON(w, importResponse{SchemaVersionOK: true, MasterKeyOK: true, Applied: false, Diff: diff})
 		return
 	}
 
 	// Commit fence: a real import may carry Front Desk's monotonic source
-	// generation. apply rejects one older than this member last applied, and
-	// advances the marker atomically with the write, so an out-of-order push
-	// cannot clobber a newer config. The header is absent for an older Front
-	// Desk, in which case sourceGen is nil and the import applies unfenced.
+	// generation. apply rejects one older than this member last applied and
+	// advances the marker atomically with the write, so an out-of-order push cannot
+	// clobber a newer config. An absent header leaves sourceGen nil and the import
+	// applies unfenced.
 	sourceGen := parseSourceGen(r.Header.Get(fleetSourceGenHeader))
 	out, err := h.apply(ctx, env, sourceGen)
 	switch {
 	case errors.Is(err, errStaleSourceGen):
-		// Benign: a newer generation already won on this member (or an un-versioned
-		// push arrived after one had). Report it as a non-applied, non-error outcome
-		// so Front Desk does not surface a failure.
+		// A newer generation already won on this member (or an un-versioned push
+		// arrived after one had). Reported as a non-applied, non-error outcome so
+		// Front Desk does not surface a failure.
 		debuglog.Debug("configsync: refused stale import", "source_gen", sourceGenLabel(sourceGen))
 		writeJSON(w, importResponse{SchemaVersionOK: true, MasterKeyOK: true, Applied: false, Stale: true, Diff: diff})
 		return
 	case errors.Is(err, errWouldWipeProviders):
 		// The envelope carries no providers but this member has some: applying it
-		// would delete every provider (the reported backdoor-wipe vector). Refuse
-		// with a 400 so the caller sees a deliberate rejection, not a server error.
+		// would delete every provider. A 400 so the caller sees a deliberate
+		// rejection, not a server error.
 		debuglog.Warn("configsync: refused provider-wiping import")
 		http.Error(w, "refusing to import a config that would delete every provider on this member", http.StatusBadRequest)
 		return
 	case errors.Is(err, errInvalidSyncedURL):
 		// A syncable url-typed setting failed the same netguard validation the
-		// interactive settings endpoint enforces (reported SSRF bypass, CWE-918).
-		// A legitimate primary never exports such a value, so a 400 surfaces the
-		// poisoned/corrupt envelope to Front Desk rather than silently applying it.
+		// interactive settings endpoint enforces. A legitimate primary never exports
+		// such a value, so a 400 surfaces the poisoned or corrupt envelope to Front
+		// Desk rather than applying it.
 		debuglog.Warn("configsync: refused import with invalid URL setting", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -98,43 +96,39 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 		// A syncable numeric setting arrived below the minimum the interactive
 		// settings endpoint enforces. The limiter floors are the dangerous ones: a
 		// negative rate_limit_ip_burst denies every request from every client IP.
-		// Same reasoning as the URL case.
 		debuglog.Warn("configsync: refused import with out-of-range setting", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	case errors.Is(err, errInvalidSyncedPasswordHash):
-		// A user in the envelope carries a password_hash login could never
-		// verify. A legitimate primary only ever exports hashes it computed, so
-		// refuse the envelope rather than write an account that cannot log in
-		// and would look like a password problem months later.
+		// A user in the envelope carries a password_hash login could never verify. A
+		// legitimate primary only exports hashes it computed, so the envelope is
+		// refused rather than writing an account that cannot log in.
 		debuglog.Warn("configsync: refused import with a malformed password hash", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	case errors.Is(err, errInvalidSyncedProvider):
-		// A provider in the envelope carries a value the interactive API
-		// rejects (a max_in_flight the runtime would read as "no ceiling"). A
-		// legitimate primary never exports one, so refuse the whole envelope
-		// with a 400 rather than store it and ship it on to every member.
+		// A provider in the envelope carries a value the interactive API rejects (a
+		// max_in_flight the runtime would read as "no ceiling"). A legitimate primary
+		// never exports one, so the whole envelope is refused rather than stored and
+		// shipped on to every member.
 		debuglog.Warn("configsync: refused import with an invalid provider", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	case errors.Is(err, errInvalidSyncedRateLimit):
-		// A virtual key or user in the envelope carries a rate limit the
-		// interactive API rejects: a negative TPM would import as "no cap" and a
-		// negative burst would reject every request on that key. Same reasoning as
-		// the URL case: a legitimate primary never exports one, so refuse the whole
-		// envelope with a 400 rather than write it.
+		// A virtual key or user in the envelope carries a rate limit the interactive
+		// API rejects: a negative TPM imports as "no cap" and a negative burst
+		// rejects every request on that key. A legitimate primary never exports one,
+		// so the whole envelope is refused.
 		debuglog.Warn("configsync: refused import with invalid rate limit", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	case errors.Is(err, errUnresolvableUserProviders):
-		// A capped account naming providers absent here would import as
-		// unrestricted. Refuse the envelope rather than widen the account. Only
-		// the non-empty-but-unresolvable case reaches this: after the declarative
-		// provider replace every name a legitimate primary exported resolves, so
-		// it means a corrupt or tampered envelope. A cap the primary itself
-		// resolves to nothing rides through as an empty array instead, so an
-		// ordinary provider deletion never wedges fleet sync here.
+		// A capped account naming providers absent here would import as unrestricted,
+		// so the envelope is refused rather than the account widened. Only the
+		// non-empty-but-unresolvable case reaches this: after the declarative
+		// provider replace every name a legitimate primary exported resolves, so it
+		// means a corrupt or tampered envelope. A cap the primary itself resolves to
+		// nothing rides through as an empty array instead.
 		debuglog.Warn("configsync: refused import with an unresolvable user provider cap", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -190,12 +184,12 @@ func (h *ConfigSyncHandler) canDecryptSample(providers []ExportProvider) bool {
 	return true // keyless fleet: nothing to verify
 }
 
-// diffKeyed classifies items against the member's current rows: a key present
-// on both sides is updated, a new key added, and a current row whose key no
-// item carries removed. keyLabel returns an item's identity key and the label
-// the diff reports (virtual keys are keyed by hash but reported by name).
-// includeRemovals=false suppresses the removed bucket, for envelope fields
-// whose nil form the apply side leaves untouched.
+// diffKeyed classifies items against the member's current rows: a key present on
+// both sides is updated, a new key added, and a current row whose key no item
+// carries removed. keyLabel returns an item's identity key and the label the diff
+// reports (virtual keys are keyed by hash but reported by name).
+// includeRemovals=false suppresses the removed bucket, for envelope fields whose
+// nil form the apply side leaves untouched.
 func diffKeyed[T any](cur map[string]string, items []T, keyLabel func(T) (key, label string), includeRemovals bool) entityDiff {
 	var d entityDiff
 	want := make(map[string]struct{}, len(items))
@@ -276,11 +270,9 @@ func (h *ConfigSyncHandler) computeDiff(ctx context.Context, env ConfigEnvelope)
 	// reflect intent: a group the importer later skips for too few resolvable
 	// entries on this member still shows as added/updated here.
 	//
-	// Removals mirror applyFailoverGroups exactly: a nil slice means the field
-	// was absent (a pre-PR primary), which apply leaves untouched, so report no
-	// removals. An explicit empty array reconciles to zero, so its removals are
-	// real. Reporting removals for a nil slice would scare an operator
-	// mid-rolling-upgrade with deletions the apply never performs.
+	// Removals mirror applyFailoverGroups: a nil slice means the field was absent,
+	// which apply leaves untouched, so report no removals. An explicit empty array
+	// reconciles to zero, so its removals are real.
 	curGroups, err := nameSet(ctx, pool, `SELECT display_model FROM model_failover_groups WHERE auto_created = false`)
 	if err != nil {
 		return d, err
@@ -289,9 +281,9 @@ func (h *ConfigSyncHandler) computeDiff(ctx context.Context, env ConfigEnvelope)
 		func(g ExportFailoverGroup) (string, string) { return g.DisplayModel, g.DisplayModel },
 		env.Config.FailoverGroups != nil)
 
-	// Users, keyed by username, with the same nil-guard as failover groups: a
-	// nil slice means the envelope predates the field and apply leaves users
-	// alone, so report no removals either.
+	// Users, keyed by username, with the same nil-guard as failover groups: a nil
+	// slice means the envelope omits the field and apply leaves users alone, so
+	// report no removals either.
 	curUsers, err := nameSet(ctx, pool, `SELECT username FROM users`)
 	if err != nil {
 		return d, err

--- a/internal/api/failover_circuitbreaker.go
+++ b/internal/api/failover_circuitbreaker.go
@@ -37,11 +37,11 @@ type CircuitBreakerResetter interface {
 }
 
 // CircuitBreakerQuotaPinner lets a successful quota refresh lift the cooldown
-// pins of providers that are no longer exhausted. Separate from the reset
-// contract because it is a different power: it shortens a wait, it never clears
-// a circuit. Keeping it its own interface is also what keeps internal/failover
-// free of any dependency on internal/quota — the set of recovered providers
-// crosses the boundary as plain UUIDs.
+// pins of providers that are no longer exhausted. Separate from the reset contract
+// because it is a different power: it shortens a wait, it never clears a
+// circuit. Its own interface also keeps internal/failover free of any dependency
+// on internal/quota: the set of recovered providers crosses the boundary as
+// plain UUIDs.
 type CircuitBreakerQuotaPinner interface {
 	// ReleaseQuotaPins clears the quota cooldown override on every tracked
 	// circuit whose provider appears in recovered, returning how many pins it
@@ -50,9 +50,9 @@ type CircuitBreakerQuotaPinner interface {
 	// anything absent (stale, unassessable, or never snapshotted) keeps its pin.
 	ReleaseQuotaPins(recovered map[uuid.UUID]struct{}) int
 	// ReleaseAllQuotaPins clears the override on every pinned circuit, for the
-	// one case where absence of evidence is decisive: quota polling has been
-	// switched off, so no refresh will ever report a recovery again. It must
-	// not change any circuit's state either.
+	// one case where absence of evidence is decisive: quota polling is switched
+	// off, so no refresh will report a recovery again. It must not change any
+	// circuit's state either.
 	ReleaseAllQuotaPins() int
 	// ApplyQuotaPins retargets the cooldown of every already-open circuit whose
 	// provider appears in advice, returning how many it retargeted. It only
@@ -64,8 +64,8 @@ type CircuitBreakerQuotaPinner interface {
 }
 
 // CircuitBreakerControl is the whole breaker surface the failover API needs.
-// Composed from the narrow interfaces above so internal/api still depends
-// on behaviour it names rather than on *failover.CircuitBreaker.
+// Composed from the narrow interfaces above so internal/api depends on behaviour
+// it names rather than on *failover.CircuitBreaker.
 type CircuitBreakerControl interface {
 	CircuitBreakerReader
 	CircuitBreakerResetter
@@ -80,9 +80,9 @@ type CircuitBreakerStatusResponse struct {
 	Providers []failover.ProviderStatus `json:"providers,omitempty"`
 }
 
-// cbStatusCacheTTL is how long the aggregate circuit-breaker status cache
-// is valid before re-computing. This avoids scanning all failover groups
-// on every 15s poll from each connected client.
+// cbStatusCacheTTL is how long the aggregate circuit-breaker status cache stays
+// valid, so a 15s poll from every connected client does not rescan all failover
+// groups.
 const cbStatusCacheTTL = 5 * time.Second
 
 // CircuitBreakerStatus returns the current circuit breaker state for all tracked providers.
@@ -127,16 +127,14 @@ func (h *FailoverHandler) CircuitBreakerStatus(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	// Count failover group members not yet tracked by the circuit breaker as closed.
-	// Providers only appear in the CB map after being routed; until then they're
-	// implicitly healthy (closed).
+	// Count failover group members not yet tracked by the circuit breaker as
+	// closed: providers appear in the CB map only after being routed, and until
+	// then they are implicitly healthy.
 	//
-	// Note: there is an inherent race between reading cbReader.Status() above and
-	// failoverRepo.List() below. A provider that transitions from untracked to
-	// tracked (e.g., after a route that triggers its first CB circuit creation)
-	// could be counted in both passes, slightly inflating totals. This is acceptable
-	// for an aggregate dashboard endpoint with a 5s cache TTL — the next poll
-	// will correct any transient overcount.
+	// Reading cbReader.Status() and failoverRepo.List() races: a provider that goes
+	// from untracked to tracked in between is counted in both passes, slightly
+	// inflating the totals. Acceptable for an aggregate dashboard endpoint with a
+	// 5s cache TTL, since the next poll corrects the overcount.
 	var providerNameMap map[string]string // provider UUID -> name (for detail responses)
 	if h.failoverRepo != nil {
 		groups, err := h.failoverRepo.List(r.Context())
@@ -146,9 +144,9 @@ func (h *FailoverHandler) CircuitBreakerStatus(w http.ResponseWriter, r *http.Re
 				tracked[p.ProviderID] = struct{}{}
 			}
 
-			// Collect all model UUIDs across all groups, then resolve to
-			// provider UUIDs so we can compare against the tracked map
-			// (which is keyed by provider UUID, not model UUID).
+			// Collect all model UUIDs across all groups, then resolve them to
+			// provider UUIDs to compare against the tracked map, which is keyed by
+			// provider UUID.
 			var allModelIDs []uuid.UUID
 			seenModel := make(map[string]struct{})
 			for _, g := range groups {
@@ -210,7 +208,7 @@ func (h *FailoverHandler) CircuitBreakerStatus(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	// Cache the response (after providers are appended for detail requests).
+	// Cache the response, after providers are appended for detail requests.
 	h.cbStatusMu.Lock()
 	if wantDetail {
 		h.cbDetailCache = resp
@@ -225,10 +223,10 @@ func (h *FailoverHandler) CircuitBreakerStatus(w http.ResponseWriter, r *http.Re
 }
 
 // CircuitBreakerResetResponse reports the outcome of resetting one provider's
-// circuit. PreviousState is what the breaker reported for that provider a
-// moment before it was cleared; Reset is false when there was nothing to clear
-// (an already-closed or never-tracked provider), so the UI can say "no change"
-// instead of claiming a recovery that did not happen.
+// circuit. PreviousState is what the breaker reported for that provider a moment
+// before it was cleared; Reset is false when there was nothing to clear (an
+// already-closed or never-tracked provider), so the UI can say "no change"
+// instead of claiming a recovery.
 type CircuitBreakerResetResponse struct {
 	ProviderID    string `json:"provider_id"`
 	PreviousState string `json:"previous_state"`
@@ -259,9 +257,9 @@ type CircuitBreakerResetAllResponse struct {
 }
 
 // invalidateCBStatusCache drops both cached circuit-breaker status slots. A
-// reset must be visible on the very next poll: without this the dashboard
-// refetches immediately after the mutation and is served the pre-reset snapshot
-// for up to cbStatusCacheTTL, which reads as "the reset did nothing".
+// reset must be visible on the next poll: without this the dashboard refetches
+// immediately after the mutation and is served the pre-reset snapshot for up to
+// cbStatusCacheTTL, which reads as "the reset did nothing".
 func (h *FailoverHandler) invalidateCBStatusCache() {
 	h.cbStatusMu.Lock()
 	defer h.cbStatusMu.Unlock()
@@ -285,10 +283,10 @@ func (h *FailoverHandler) ResetCircuitBreaker(w http.ResponseWriter, r *http.Req
 	}
 
 	// ?model=<resolved upstream id> scopes the reset to that one circuit; without
-	// it every circuit of the provider is cleared, as before. The breaker logs
-	// one "manual reset" line per circuit either way; the summary line below is
-	// the operator's action itself, written even when there was nothing to
-	// clear, so an audit of who reset what never depends on a circuit existing.
+	// it every circuit of the provider is cleared. The breaker logs one "manual
+	// reset" line per circuit either way; the summary line below is the operator's
+	// action itself, written even when there was nothing to clear, so an audit of
+	// who reset what never depends on a circuit existing.
 	model := r.URL.Query().Get("model")
 	var previous failover.State
 	if model != "" {
@@ -298,8 +296,8 @@ func (h *FailoverHandler) ResetCircuitBreaker(w http.ResponseWriter, r *http.Req
 	}
 	h.invalidateCBStatusCache()
 	// The action, not the circuits: those have their own lines. "reset" says
-	// whether anything was sidelined; the previous state per circuit is on
-	// the per-circuit line, and on the unscoped path there is no single one.
+	// whether anything was sidelined; the previous state per circuit is on the
+	// per-circuit line, and the unscoped path has no single one.
 	attrs := []any{"provider_id", providerID, "cause", "manual reset", "reset", previous != failover.StateClosed}
 	if model != "" {
 		attrs = append(attrs, "model", model)
@@ -315,11 +313,10 @@ func (h *FailoverHandler) ResetCircuitBreaker(w http.ResponseWriter, r *http.Req
 }
 
 // ResetGroupCircuitBreakers clears every circuit behind a failover group's
-// entries on this member, the operation the 2026-08-31 reset loop performed by
-// hand across four providers. Only the group's (provider, model) pairs are
-// touched: a provider's circuits for models outside the group keep their
-// state. Like the other resets it is deliberately outside the managed-write
-// guard: a circuit is local runtime health, not synced config.
+// entries on this member. Only the group's (provider, model) pairs are touched:
+// a provider's circuits for models outside the group keep their state. Like the
+// other resets it sits outside the managed-write guard, because a circuit is
+// local runtime health, not synced config.
 func (h *FailoverHandler) ResetGroupCircuitBreakers(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseUUIDParam(w, r, "id", "failover group ID")
 	if !ok {

--- a/internal/api/failover_circuitbreaker.go
+++ b/internal/api/failover_circuitbreaker.go
@@ -38,8 +38,8 @@ type CircuitBreakerResetter interface {
 
 // CircuitBreakerQuotaPinner lets a successful quota refresh lift the cooldown
 // pins of providers that are no longer exhausted. Separate from the reset contract
-// because it is a different power: it shortens a wait, it never clears a
-// circuit. Its own interface also keeps internal/failover free of any dependency
+// because it is a different power: it moves a cooldown, it never changes a
+// circuit's state. Its own interface also keeps internal/failover free of any dependency
 // on internal/quota: the set of recovered providers crosses the boundary as
 // plain UUIDs.
 type CircuitBreakerQuotaPinner interface {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -16,9 +16,8 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// CacheHits is an alias for the shared CacheHits type defined in util.
-// The API uses this alias for clarity in LogEntry — the underlying type
-// is the same one the proxy produces.
+// CacheHits aliases the shared CacheHits type in util, the same type the proxy
+// produces.
 type CacheHits = util.CacheHits
 
 // LogEntry represents a single request log entry.
@@ -52,18 +51,17 @@ type LogEntry struct {
 	VirtualKeyName            string     `json:"virtual_key_name"`
 	VirtualKeyDeleted         bool       `json:"virtual_key_deleted"`
 	VirtualKeyID              string     `json:"virtual_key_id"`
-	ClientIP                  string     `json:"client_ip"` // "" for rows predating migration 073 or address-less ingest paths
+	ClientIP                  string     `json:"client_ip"` // "" for legacy rows and address-less ingest paths
 	ErrorMessage              string     `json:"error_message"`
-	ErrorKind                 string     `json:"error_kind"` // "" when unclassified (legacy rows); frontend falls back to substring matching
+	ErrorKind                 string     `json:"error_kind"` // "" when unclassified; the frontend falls back to substring matching
 	FailoverAttempt           int        `json:"failover_attempt"`
 	State                     string     `json:"state"`
 	CreatedAt                 time.Time  `json:"created_at"`
 	ResolvedModelID           string     `json:"resolved_model_id"`
 	EndpointType              string     `json:"endpoint_type"`
-	// Attempts is the per-attempt trail (request_logs.attempts, migration
-	// 078): one element per failover attempt, hedged probes and skips
-	// included, forwarded verbatim. Omitted for rows without one (legacy rows,
-	// rows an older member wrote, requests that never reached a candidate).
+	// Attempts is the per-attempt trail (request_logs.attempts): one element per
+	// failover attempt, hedged probes and skips included, forwarded verbatim.
+	// Omitted for rows without one.
 	Attempts json.RawMessage `json:"attempts,omitempty"`
 }
 
@@ -99,9 +97,9 @@ func (h *Handler) GetLog(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
 
-	// Non-admins can only fetch their own rows; a non-owned id scans zero rows
-	// and answers 404 below, so ownership is not an existence oracle. Same
-	// two-shape disjunction as appendLogFilters — see the comment there.
+	// Non-admins can only fetch their own rows; a non-owned id scans zero rows and
+	// answers 404, so ownership is not an existence oracle. Same two-shape
+	// disjunction as appendLogFilters.
 	ownerPredicate := ""
 	ownerArgs := []any{id}
 	if scope := ownerScopeFromIdentity(r); scope != "" {
@@ -180,11 +178,10 @@ func (h *Handler) GetLog(w http.ResponseWriter, r *http.Request) {
 }
 
 // ownerScopeFromIdentity returns the forced virtual-key-owner scope for the
-// caller: non-admin identities only ever see traffic from keys they own, so
-// their own user id is returned. Admins are unscoped (""). A non-admin
-// without a users row cannot normally exist (resolveIdentity rejects it), but
-// if one ever appears it scopes to uuid.Nil, which owns no keys - fail closed,
-// not open.
+// caller: non-admin identities only see traffic from keys they own, so their own
+// user id is returned. Admins are unscoped (""). A non-admin without a users row
+// (which resolveIdentity rejects) scopes to uuid.Nil, which owns no keys, so it
+// fails closed.
 func ownerScopeFromIdentity(r *http.Request) string {
 	id := user.IdentityFrom(r.Context())
 	if id == nil || id.IsAdmin() {
@@ -223,16 +220,16 @@ type LogsCursorResponse struct {
 //
 // Query parameters:
 //   - cursor: encoded cursor from a previous response (base64 JSON of {created_at, id})
-//   - direction: "after" (default) or "before" — which way to scroll from cursor
+//   - direction: "after" (default) or "before", which way to scroll from cursor
 //   - limit: page size (default 20, max 200)
 //   - model_id, provider_id, virtual_key_id, client_ip, status_code, from, to: same
 //     filters as ListLogs
 //   - sort_by: only "time" is supported for cursor pagination (default "time")
 //   - sort_dir: "desc" (default, newest first) or "asc"
 //
-// The first request omits cursor to get the newest entries.
-// Subsequent requests pass the cursor from the response boundary and
-// direction to scroll older ("before") or newer ("after").
+// The first request omits cursor to get the newest entries. Subsequent requests
+// pass the cursor from the response boundary and a direction to scroll older
+// ("before") or newer ("after").
 func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	p, ok := parseLogListParams(w, r)
 	if !ok {
@@ -252,9 +249,9 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	// limit is clamped to [1, 200] above; prealloc with the hard upper bound
-	// to satisfy CodeQL's uncontrolled-allocation-size check (user input must
-	// not flow into make() capacity even after clamping).
+	// limit is clamped to [1, 200]; the prealloc uses the hard upper bound to
+	// satisfy CodeQL's uncontrolled-allocation-size check, which forbids user input
+	// flowing into make() capacity even after clamping.
 	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
 	for rows.Next() {
 		entry, err := scanLogEntry(rows)
@@ -286,10 +283,10 @@ type PurgeLogsRequest struct {
 // values, reused in the 400 message by every purge endpoint.
 const purgeOlderThanTokens = "1h, 1d, 1w, 1m, all"
 
-// olderThanCutoff maps a purge range token to a cutoff time. all=true signals
-// "delete everything" (cutoff is unused in that case); ok=false means the token
-// was not recognized. Shared by the request-log and app-log purge endpoints so
-// they accept exactly the same vocabulary.
+// olderThanCutoff maps a purge range token to a cutoff time. all=true means
+// "delete everything" (cutoff is unused then); ok=false means the token was not
+// recognized. Shared by the request-log and app-log purge endpoints so they
+// accept the same vocabulary.
 func olderThanCutoff(olderThan string) (cutoff time.Time, all, ok bool) {
 	switch olderThan {
 	case "1h":
@@ -347,9 +344,9 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 	page := max(util.GetIntQueryParam(r, "page", 1), 1)
 	perPage := min(max(util.GetIntQueryParam(r, "per_page", 20), 1), 200)
 	ownerUserID := logOwnerScope(r)
-	// The response cache is shared across callers, so the key must carry the
-	// owner scope: a non-admin page and the admin's unscoped page for the same
-	// RawQuery are different result sets.
+	// The response cache is shared across callers, so the key carries the owner
+	// scope: a non-admin page and the admin's unscoped page for the same RawQuery
+	// are different result sets.
 	cacheKey := ownerUserID + "|" + r.URL.RawQuery
 	modelID := r.URL.Query().Get("model_id")
 	providerID := r.URL.Query().Get("provider_id")

--- a/internal/api/logs_query.go
+++ b/internal/api/logs_query.go
@@ -56,9 +56,9 @@ const logEntrySelectColumns = `rl.id, COALESCE(rl.provider_id::text, ''),
     `
 
 // buildLogListQuery assembles the cursor data query: the column projection, the
-// shared filters, the keyset predicate (when a cursor is present), and the
-// ORDER BY + LIMIT — fetching limit+1 to detect has_more, with the sort
-// inverted for backward pagination so LIMIT picks from the correct end.
+// shared filters, the keyset predicate (when a cursor is present), and the ORDER
+// BY + LIMIT. It fetches limit+1 to detect has_more, with the sort inverted for
+// backward pagination so LIMIT picks from the correct end.
 func buildLogListQuery(p logListParams) (string, []any) {
 	query := "SELECT " + logEntrySelectColumns
 
@@ -95,11 +95,11 @@ func (h *Handler) countLogs(ctx context.Context, p logListParams) int {
 	return total
 }
 
-// paginateCursor applies has_after/has_before detection (using the fetched-one-
-// extra signal and cursor presence), trims to limit, and reverses the slice for
-// backward pagination (which fetched in inverted sort order). It is the single
-// keyset-pagination tail shared by the request-log, app-log, and model cursor
-// endpoints (T = LogEntry | AppLogEntry | ModelResponse).
+// paginateCursor applies has_after/has_before detection from the fetched-one-extra
+// signal and cursor presence, trims to limit, and reverses the slice for backward
+// pagination, which fetched in inverted sort order. It is the keyset-pagination
+// tail shared by the request-log, app-log, and model cursor endpoints
+// (T = LogEntry | AppLogEntry | ModelResponse).
 func paginateCursor[T any](entries []T, direction string, limit int, hasCursor bool) ([]T, bool, bool) {
 	var hasAfter, hasBefore bool
 	switch direction {
@@ -109,9 +109,9 @@ func paginateCursor[T any](entries []T, direction string, limit int, hasCursor b
 			hasAfter = true
 			entries = entries[:limit]
 		}
-		// For an initial request (no cursor) we're at the newest — nothing
-		// before. For cursor requests, assume newer entries exist until proven
-		// otherwise (a fetchBefore returning 0 corrects this client-side).
+		// An initial request (no cursor) is at the newest, so nothing is before it.
+		// A cursor request assumes newer entries exist until proven otherwise; a
+		// fetchBefore returning 0 corrects that client-side.
 		if hasCursor {
 			hasBefore = true
 		}
@@ -168,22 +168,18 @@ func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
 	return entry, err
 }
 
-// appendLogFilters appends the shared modelID/providerID/statusCode/from/to
-// WHERE fragments, returning the extended query, args, and next placeholder
-// index. The single source of truth used by both the data and count queries
-// in ListLogsCursor (previously two copy-pasted blocks that had drifted: the
-// count copy lacked the `statusCode >= 0` guard the data copy has; both now use
-// the guard, so an invalid negative status_code is uniformly ignored — a
-// behaviour-neutral fix since status codes are always >= 0).
+// appendLogFilters appends the shared modelID/providerID/statusCode/from/to WHERE
+// fragments, returning the extended query, args, and next placeholder index. It
+// is the single source of truth for both the data and count queries in
+// ListLogsCursor, so a negative status_code is ignored uniformly.
 func appendLogFilters(query string, args []any, argIndex int, modelID, providerID, virtualKeyID, clientIP, statusCodeStr, fromDate, toDate, endpointType, ownerUserID, attemptProviderID, attemptStatus string) (string, []any, int) {
-	// Owner scope first: for non-admins this is mandatory row-level security,
-	// for admins an optional dashboard filter. The two branches cover the two
-	// disjoint row shapes. A KEYED row resolves through the key's CURRENT owner,
-	// so reassigning a key moves its whole history with it. A KEYLESS row
-	// (dashboard chat/arena, which have no key to join through) carries the
-	// owner stamped at request time in request_logs.owner_user_id, written only
-	// for that shape; see migration 067. Rows predating that column stay NULL on
-	// both sides and remain admin-only.
+	// Owner scope first: mandatory row-level security for non-admins, an optional
+	// dashboard filter for admins. The two branches cover the two disjoint row
+	// shapes. A KEYED row resolves through the key's CURRENT owner, so reassigning
+	// a key moves its whole history with it. A KEYLESS row (dashboard chat/arena,
+	// which have no key to join through) carries the owner stamped at request time
+	// in request_logs.owner_user_id, written only for that shape. Rows with NULL on
+	// both sides stay admin-only.
 	if ownerUserID != "" {
 		ph := util.IntToStr(argIndex)
 		query += " AND (rl.virtual_key_id IN (SELECT vko.id FROM virtual_keys vko WHERE vko.owner_user_id = $" + ph + ")" +
@@ -254,12 +250,12 @@ func appendLogFilters(query string, args []any, argIndex int, modelID, providerI
 	return appendAttemptFilter(query, args, argIndex, attemptProviderID, attemptStatus)
 }
 
-// appendAttemptFilter adds the per-attempt trail filter: "every request in
-// which THIS provider answered THIS status, whoever served it in the end". One
-// containment predicate carrying both keys, so the two must hold on the same
-// element rather than on two different attempts; jsonb_path_ops on the
-// attempts index serves it. Either key alone is allowed. An unparseable
-// provider id or status is ignored, matching the other lenient filters.
+// appendAttemptFilter adds the per-attempt trail filter: "every request in which
+// THIS provider answered THIS status, whoever served it in the end". One
+// containment predicate carries both keys, so the two must hold on the same
+// element rather than on two different attempts; jsonb_path_ops on the attempts
+// index serves it. Either key alone is allowed. An unparseable provider id or
+// status is ignored, matching the other lenient filters.
 func appendAttemptFilter(query string, args []any, argIndex int, attemptProviderID, attemptStatus string) (string, []any, int) {
 	element := map[string]any{}
 	if attemptProviderID != "" {
@@ -286,8 +282,8 @@ func appendAttemptFilter(query string, args []any, argIndex int, attemptProvider
 }
 
 // isValidEndpointType reports whether s is a known endpoint family for the
-// endpoint_type log filter. Unknown values are ignored (no filter applied)
-// rather than rejected, matching the other filters' lenient behavior.
+// endpoint_type log filter. Unknown values are ignored (no filter applied) rather
+// than rejected, matching the other filters.
 func isValidEndpointType(s string) bool {
 	switch s {
 	case "chat", "embeddings", "image", "tts", "stt":
@@ -298,10 +294,9 @@ func isValidEndpointType(s string) bool {
 }
 
 // appendKeysetPredicate appends the (created_at, id) keyset comparison relative
-// to the cursor. The comparison operator is "<" when scrolling toward older
-// rows — (after, desc) or (before, asc) — and ">" otherwise, collapsing the
-// four direction/sort branches into one template. SQL is byte-identical to the
-// per-branch form.
+// to the cursor. The comparison operator is "<" when scrolling toward older rows
+// ((after, desc) or (before, asc)) and ">" otherwise, collapsing the four
+// direction/sort branches into one template.
 func appendKeysetPredicate(query string, args []any, argIndex int, cursor logCursor, direction, sortDir string) (string, []any, int) {
 	op := ">"
 	if (direction == "after") == (sortDir == "desc") {
@@ -381,9 +376,9 @@ func parseLogListParams(w http.ResponseWriter, r *http.Request) (logListParams, 
 	return p, true
 }
 
-// logCursor is the keyset cursor for cursor-based log pagination.
-// It encodes the created_at and id of a boundary row so the next page
-// can be fetched relative to it.
+// logCursor is the keyset cursor for cursor-based log pagination. It encodes the
+// created_at and id of a boundary row so the next page can be fetched relative
+// to it.
 type logCursor struct {
 	CreatedAt time.Time `json:"created_at"`
 	ID        string    `json:"id"`
@@ -404,8 +399,8 @@ func (c *logCursor) decode(s string) error {
 
 // logsSortDef resolves a user-supplied sort_by value to its ORDER BY
 // expressions, normalizing anything outside the whitelist to "time". Every
-// expression is a fixed compile-time constant; user input only ever selects a
-// map key, never reaches the SQL.
+// expression is a fixed compile-time constant; user input only selects a map
+// key and never reaches the SQL.
 func logsSortDef(sortBy string) (string, logSortDef) {
 	sortColumns := map[string]logSortDef{
 		"time":               {"", "rl.created_at"},
@@ -419,9 +414,9 @@ func logsSortDef(sortBy string) (string, logSortDef) {
 		"duration":           {"CASE WHEN rl.duration_ms = 0 THEN 1 ELSE 0 END", "rl.duration_ms"},
 		"overhead":           {"CASE WHEN rl.proxy_overhead_ms = 0 THEN 1 ELSE 0 END", "rl.proxy_overhead_ms"},
 		"key":                {"", "CASE WHEN rl.virtual_key_id IS NOT NULL AND rl.virtual_key_id::text != '' AND vk.id IS NULL THEN 'zzzzzzzz' ELSE COALESCE(rl.virtual_key_name, '') END"},
-		// client_ip is TEXT, so this orders lexicographically (10.* before 9.*);
-		// good enough for grouping same-address rows, which is what the column
-		// sort is for. Rows without an address always sort last.
+		// client_ip is TEXT, so this orders lexicographically (10.* before 9.*),
+		// which is enough for grouping same-address rows. Rows without an address
+		// sort last.
 		"ip": {"CASE WHEN COALESCE(rl.client_ip, '') = '' THEN 1 ELSE 0 END", "COALESCE(rl.client_ip, '')"},
 	}
 	if _, ok := sortColumns[sortBy]; !ok {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -41,9 +41,8 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The dashboard sends the type the operator picked. A client that omits it
-	// gets the vendor-hostname derivation: enough to keep scripted adds of
-	// cloud providers working, without resurrecting the port guessing for
-	// self-hosted servers (which must be named to be added).
+	// gets the vendor-hostname derivation, which covers scripted adds of cloud
+	// providers; self-hosted servers must name their type to be added.
 	derivedType := req.ProviderType == ""
 	if derivedType {
 		req.ProviderType = provider.TypeFromHostname(req.BaseURL)
@@ -57,24 +56,24 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	// operator should not have to get right.
 	req.BaseURL = provider.NormalizeLocalBaseURL(req.ProviderType, req.BaseURL)
 
-	// Measured after normalization, so the value that is actually stored is the
-	// one that has to fit.
+	// Measured after normalization, so the stored value is the one that has to
+	// fit.
 	if len(req.BaseURL) > 500 {
 		http.Error(w, "base_url must be at most 500 characters", http.StatusBadRequest)
 		return
 	}
 
-	// An address that matches no vendor host and was given no type is a
-	// generic OpenAI endpoint. That is right for a gateway and wrong for a
-	// self-hosted server the caller forgot to name, and the difference is
-	// invisible afterwards, so say so once.
+	// An address matching no vendor host and given no type is a generic OpenAI
+	// endpoint. That is right for a gateway and wrong for a self-hosted server the
+	// caller forgot to name, and the difference is invisible afterwards, so it is
+	// logged once.
 	if derivedType && req.ProviderType == "openai" {
 		debuglog.Info("provider: no provider_type given, treating as a generic OpenAI-compatible endpoint",
 			"name", req.Name, "hint", "self-hosted servers (ollama, lmstudio, koboldcpp) must name their type to get native discovery")
 	}
 
-	// Some providers (e.g. OpenCode Zen) support keyless access for free models.
-	// Allow empty API key only for providers that support it.
+	// Some providers (e.g. OpenCode Zen) support keyless access for free models, so
+	// an empty API key is allowed only for those types.
 	if req.APIKey == "" && !providerTypeAllowsEmptyKey(req.ProviderType) {
 		http.Error(w, "api_key is required for this provider type", http.StatusBadRequest)
 		return
@@ -89,12 +88,12 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Application-level duplicate name check
+	// Application-level duplicate name check.
 	existing, err := h.providerRepo.GetByName(r.Context(), req.Name)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		// A DB error here silently looks like "no duplicate", so the app-level
-		// guard is bypassed (the DB unique constraint is the backstop). Surface
-		// it so a flaky DB doesn't quietly admit dupes.
+		// A DB error here looks like "no duplicate" and bypasses the app-level
+		// guard, leaving the DB unique constraint as the backstop. Surfaced so a
+		// flaky DB does not quietly admit duplicates.
 		debuglog.Warn("provider create: duplicate-name check failed, relying on DB constraint", "name", req.Name, "error", err)
 	}
 	if existing != nil {
@@ -139,13 +138,13 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Skip key cache warming for keyless providers (nil encrypted key bytes)
+	// Skip key cache warming for keyless providers (nil encrypted key bytes).
 	if len(p.EncryptedKey) > 0 {
 		go auth.WarmKeyCache(p.EncryptedKey, p.KeyNonce, p.KeySalt, h.cfg.MasterKey)
 	}
-	// The plaintext is in hand: hold it for the credential mask now rather
-	// than after the warm above lands, so a relay quoting this key is masked
-	// from the first request.
+	// The plaintext is in hand: hold it for the credential mask now rather than
+	// after the warm lands, so a relay quoting this key is masked from the first
+	// request.
 	util.HoldSecret(req.APIKey)
 
 	response := provider.ToResponse(p)
@@ -178,9 +177,9 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 		modelCounts[providerID] = count
 	}
 
-	// Non-admins only ever see their own traffic in these totals: the same
-	// owner predicate the logs/stats surfaces apply, so a usage-granted user
-	// cannot read other tenants' aggregate volume off the provider list.
+	// Non-admins only see their own traffic in these totals: the same owner
+	// predicate the logs and stats surfaces apply, so a usage-granted user cannot
+	// read other tenants' aggregate volume off the provider list.
 	ownerFrag, ownerArgs := ownerFilterFragment(ownerScopeFromIdentity(r), 1)
 	tokenRows, err := h.dbPool.Pool().Query(r.Context(), "SELECT rl.provider_id, SUM(COALESCE(rl.tokens_prompt, 0) + COALESCE(rl.tokens_completion, 0)) FROM request_logs rl WHERE rl.provider_id IS NOT NULL"+ownerFrag+" GROUP BY rl.provider_id", ownerArgs...)
 	if err != nil {
@@ -252,8 +251,8 @@ func (h *Handler) acceptProviderIdentity(w http.ResponseWriter, r *http.Request,
 		http.Error(w, "unknown provider_type", http.StatusBadRequest)
 		return false
 	}
-	// Checked before the provider is even loaded, so a refused address fails
-	// fast and for the right reason.
+	// Checked before the provider is loaded, so a refused address fails fast and
+	// for the right reason.
 	if req.BaseURL != nil && !h.acceptProviderURLShape(w, *req.BaseURL) {
 		return false
 	}
@@ -268,9 +267,9 @@ func (h *Handler) acceptProviderIdentity(w http.ResponseWriter, r *http.Request,
 		return false
 	}
 
-	// The type the provider will have once this update lands drives everything
-	// below: a new address must answer as it, and a corrected type must match
-	// the address already stored.
+	// The type the provider has once this update lands drives everything below: a
+	// new address must answer as it, and a corrected type must match the address
+	// already stored.
 	effectiveType := provider.TypeOf(current)
 	typeChanged := false
 	if req.ProviderType != nil && *req.ProviderType != effectiveType {
@@ -287,18 +286,17 @@ func (h *Handler) acceptProviderIdentity(w http.ResponseWriter, r *http.Request,
 		req.BaseURL = &normalized
 	}
 
-	// A type-only change probes the address already stored, which was checked
-	// when it was set. Re-check it: ALLOWED_PROVIDER_HOSTS may have been
-	// narrowed since, and every address this handler probes must be one the
-	// SSRF rules accept right now.
+	// A type-only change probes the address already stored. It is re-checked
+	// because ALLOWED_PROVIDER_HOSTS may have narrowed since, and every address
+	// this handler probes must be one the SSRF rules accept now.
 	if req.BaseURL == nil && !h.acceptProviderURLShape(w, normalized) {
 		return false
 	}
 
-	// Nothing that decides where requests land is actually changing: an update
-	// that only renames the provider must not fail because the server happens
-	// to be down. Both sides are normalized first, so a client echoing back a
-	// stored URL written before the /v1 form was canonical does not trip it.
+	// Nothing that decides where requests land is changing: an update that only
+	// renames the provider must not fail because the server is down. Both sides
+	// are normalized first, so a client echoing back a stored URL in a
+	// non-canonical form does not trip it.
 	if !typeChanged && normalized == provider.NormalizeLocalBaseURL(effectiveType, current.BaseURL) {
 		return true
 	}
@@ -315,8 +313,8 @@ func (h *Handler) acceptProviderIdentity(w http.ResponseWriter, r *http.Request,
 	} else if len(current.EncryptedKey) > 0 {
 		plain, decErr := auth.Decrypt(current.EncryptedKey, current.KeyNonce, current.KeySalt, h.cfg.MasterKey)
 		if decErr != nil {
-			// Not fatal: the probe simply goes out unauthenticated, and an
-			// unreadable key is the update's problem to report, not this check's.
+			// Not fatal: the probe goes out unauthenticated, and an unreadable key
+			// is the update's problem to report, not this check's.
 			debuglog.Warn("provider: could not decrypt key for the type probe", "provider_id", id, "error", decErr)
 		} else {
 			apiKey = plain
@@ -336,10 +334,10 @@ func (h *Handler) acceptProviderURLShape(w http.ResponseWriter, baseURL string) 
 		}
 	}
 	if err := h.cfg.ValidateProviderURL(baseURL); err != nil {
-		// The reason matters to the operator: "not in ALLOWED_PROVIDER_HOSTS"
-		// and "resolves to a private address" call for different fixes, and a
-		// containerised Model Hotel cannot reach the operator's localhost at
-		// all. This endpoint is admin-only, so echoing the reason leaks nothing.
+		// The reason matters to the operator: "not in ALLOWED_PROVIDER_HOSTS" and
+		// "resolves to a private address" call for different fixes, and a
+		// containerised Model Hotel cannot reach the operator's localhost at all.
+		// This endpoint is admin-only, so echoing the reason leaks nothing.
 		debuglog.Info("provider: base URL rejected", "error", err)
 		writeCodedError(w, http.StatusBadRequest, codeProviderURLRejected, err.Error())
 		return false
@@ -359,7 +357,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate field lengths
+	// Validate field lengths.
 	if req.Name != nil {
 		trimmed, err := validateNamePtr("name", req.Name, 1, 100)
 		if err != nil {
@@ -391,20 +389,20 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 			respondBadRequest(w, "invalid scheduled_disable_on", err)
 			return
 		}
-		// ISO dates compare correctly as strings. The client's calendar floors
-		// at browser-tomorrow, but the server accepts its own today: a browser
-		// lagging the server clock would otherwise get a 400 on its earliest
-		// selectable day. A server-today schedule is due immediately, and the
-		// sweep fires it on its next tick.
+		// ISO dates compare correctly as strings. The client's calendar floors at
+		// browser-tomorrow, but the server accepts its own today, so a browser
+		// lagging the server clock does not get a 400 on its earliest selectable
+		// day. A server-today schedule is due immediately and the sweep fires it on
+		// its next tick.
 		if v < time.Now().Format("2006-01-02") {
 			http.Error(w, "scheduled_disable_on must not be in the past", http.StatusBadRequest)
 			return
 		}
 	}
 
-	// The one rule the config import and the column's CHECK constraint share
-	// (provider.ValidateMaxInFlight): a ceiling of zero would not admit
-	// nothing, it would read as no ceiling at all.
+	// The rule the config import and the column's CHECK constraint share
+	// (provider.ValidateMaxInFlight): a ceiling of zero does not admit nothing, it
+	// reads as no ceiling at all.
 	if req.MaxInFlight.Set {
 		if err := provider.ValidateMaxInFlight(req.MaxInFlight.Value); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -412,7 +410,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Application-level duplicate name check when renaming
+	// Application-level duplicate name check when renaming.
 	if req.Name != nil {
 		existing, _ := h.providerRepo.GetByName(r.Context(), *req.Name)
 		if existing != nil && existing.ID != id {
@@ -458,9 +456,9 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the provider was just disabled, sync failover groups to remove
-	// stale entries from auto-created groups (routing already skips them,
-	// but the UI and group membership should reflect the new state).
+	// A newly disabled provider syncs failover groups to remove stale entries from
+	// auto-created groups; routing already skips them, but the UI and group
+	// membership must reflect the new state.
 	if req.Enabled != nil && !*req.Enabled {
 		if h.dbPool != nil {
 			failoverRepo := failover.NewRepository(h.dbPool.Pool())
@@ -491,18 +489,17 @@ func (h *Handler) DeleteProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The quota drift watch keeps a per-provider schema baseline in the settings
-	// K/V; nothing else removes it, so it would outlive the provider forever.
-	// Detached from the request context like the sync below: the row is already
-	// deleted, and a client that hangs up now must not leave the orphan behind.
+	// K/V and nothing else removes it, so it would outlive the provider. Detached
+	// from the request context like the sync below: the row is already deleted, and
+	// a client that hangs up must not leave the orphan behind.
 	h.forgetQuotaSchema(context.WithoutCancel(r.Context()), id)
 
-	// Sync failover groups since the cascade-deleted models may leave
-	// groups with stale entries or zero candidates.
-	// Guarded because unit tests pass nil dbPool.
+	// Sync failover groups, since the cascade-deleted models may leave groups with
+	// stale entries or zero candidates. Guarded because dbPool can be nil.
 	if h.dbPool != nil {
 		failoverRepo := failover.NewRepository(h.dbPool.Pool())
 		if _, err := failoverRepo.SyncAllModels(context.WithoutCancel(r.Context())); err != nil {
-			// Log but don't fail the delete — the provider is already gone.
+			// Logged but not fatal: the provider is already gone.
 			debuglog.Info("admin: failed to sync failover groups after provider delete", "error", err)
 		}
 	}
@@ -522,7 +519,7 @@ func providerTypeAllowsEmptyKey(providerType string) bool {
 	}
 }
 
-// isForeignKeyViolation checks if the error is a PostgreSQL foreign key violation (error code 23503).
+// isForeignKeyViolation reports whether err is a PostgreSQL foreign key violation (error code 23503).
 func isForeignKeyViolation(err error) bool {
 	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23503"

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,9 +1,9 @@
 // Package audit records an audit trail of admin actions: one row per mutating
-// request (POST/PUT/PATCH/DELETE) on the authenticated dashboard API. Capture
-// is middleware-based so new endpoints are covered without per-handler code.
-// Request bodies are NEVER stored - they carry provider keys, passwords, and
-// TOTP codes - only actor, method, route, entity id, response status, and the
-// caller address. The table is instance-local operational telemetry (not
+// request (POST/PUT/PATCH/DELETE) on the authenticated dashboard API. Capture is
+// middleware-based so new endpoints are covered without per-handler code.
+// Request bodies are NEVER stored, since they carry provider keys, passwords and
+// TOTP codes; a row holds only actor, method, route, entity id, response status
+// and the caller address. The table is instance-local operational telemetry (not
 // fleet-synced, not in backups) and is pruned opportunistically after inserts
 // against a configurable retention.
 package audit
@@ -45,9 +45,9 @@ type Entry struct {
 	EntityID   string    `json:"entity_id,omitempty"`
 	StatusCode int       `json:"status_code"`
 	RemoteAddr string    `json:"remote_addr"`
-	// EntityName is filled at read time by ResolveEntityNames for entities
-	// that still exist - never stored, so a rename shows the current name and
-	// a deleted entity leaves only the UUID.
+	// EntityName is filled at read time by ResolveEntityNames for entities that
+	// still exist. Never stored, so a rename shows the current name and a deleted
+	// entity leaves only the UUID.
 	EntityName string `json:"entity_name,omitempty"`
 }
 
@@ -58,10 +58,9 @@ type ListParams struct {
 	CursorCreatedAt time.Time
 	CursorID        string
 	Limit           int
-	// Offset skips this many rows before the page (0 = from the top). Used by the
-	// dashboard's page-numbered view; the keyset cursor above is used by infinite
-	// scroll. They are mutually exclusive in practice - a caller sends one or the
-	// other - but both may be set and are simply ANDed.
+	// Offset skips this many rows before the page (0 = from the top), for the
+	// dashboard's page-numbered view; the keyset cursor above serves infinite
+	// scroll. A caller sends one or the other, but both may be set and are ANDed.
 	Offset int
 	Actor  string
 	Method string
@@ -89,7 +88,7 @@ func New(pool *pgxpool.Pool, retentionDays func() int) *Recorder {
 
 // actorOf renders the request identity for the audit row: the username for
 // users-row identities, "admin" for every legacy admin login (env token,
-// passkey, TOTP, SSO allowlist - they all share the fixed admin identity).
+// passkey, TOTP, SSO allowlist all share the fixed admin identity).
 func actorOf(id *user.Identity) (actor, role string) {
 	if id == nil {
 		return "unknown", ""
@@ -116,14 +115,14 @@ func (w *statusRecorder) WriteHeader(code int) {
 	w.ResponseWriter.WriteHeader(code)
 }
 
-// Write is deliberately NOT overridden: the embedded ResponseWriter's Write is
-// inherited unchanged so the wrapper never touches the response body (a body
-// passthrough would be a reflected-XSS sink). A body written without an
-// explicit WriteHeader leaves status at 0; the middleware defaults that to 200
-// when it builds the entry.
+// Write is NOT overridden: the embedded ResponseWriter's Write is inherited
+// unchanged so the wrapper never touches the response body (a body passthrough
+// would be a reflected-XSS sink). A body written without an explicit WriteHeader
+// leaves status at 0; the middleware defaults that to 200 when it builds the
+// entry.
 
-// Unwrap lets http.ResponseController reach the underlying writer (flushing
-// SSE etc. keeps working through the wrapper).
+// Unwrap lets http.ResponseController reach the underlying writer, so flushing
+// SSE keeps working through the wrapper.
 func (w *statusRecorder) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
@@ -156,9 +155,9 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			}
 		}
 		// Two kinds of non-GET call are not admin actions and are skipped:
-		// machine-to-machine fleet traffic (the liveness ping, the quota
-		// relay) and a read-only POST that answers a question without
-		// changing anything (see isAuditExempt for both).
+		// machine-to-machine fleet traffic (the liveness ping, the quota relay) and
+		// a read-only POST that answers a question without changing anything. See
+		// isAuditExempt.
 		if isAuditExempt(route) {
 			return
 		}
@@ -167,15 +166,15 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 		if status == 0 {
 			status = http.StatusOK
 		}
-		// Recorded on a background goroutine: the response is already written,
-		// so the insert (up to 5s under DB pressure) must not hold the handler
-		// goroutine or tie up server concurrency. Best-effort by design. The
-		// goroutine is tracked by rec.wg so Wait can drain it on shutdown.
+		// Recorded on a background goroutine: the response is already written, so
+		// the insert (up to 5s under DB pressure) must not hold the handler
+		// goroutine. Best-effort, and tracked by rec.wg so Wait can drain it on
+		// shutdown.
 		entry := Entry{
-			// Stamped here, at request completion, so the trail's order reflects
-			// when actions happened. The insert runs on a background goroutine, so
-			// leaving created_at to the DB default would let two rapid mutations
-			// race and land out of request order.
+			// Stamped at request completion so the trail's order reflects when
+			// actions happened. The insert runs on a background goroutine, so leaving
+			// created_at to the DB default would let two rapid mutations land out of
+			// request order.
 			CreatedAt:  time.Now(),
 			Actor:      actor,
 			ActorRole:  role,
@@ -184,8 +183,8 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			Path:       r.URL.Path,
 			EntityID:   entityID,
 			StatusCode: status,
-			// Trusted-proxy-aware client address (no ephemeral port): behind
-			// the reverse proxy this is the operator's real IP, not the proxy.
+			// Trusted-proxy-aware client address (no ephemeral port): behind a
+			// reverse proxy this is the operator's real IP, not the proxy's.
 			RemoteAddr: clientip.From(r),
 		}
 		//nolint:gosec // G118: record deliberately uses a background context so a
@@ -200,10 +199,9 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 // entityParam finds the entity a route acts on when the route does not name its
 // parameter "id". Routes that reach across resources spell the parameter out
 // (e.g. {provider_id} on the circuit-breaker reset), and without this the audit
-// row would record the action with an empty entity, leaving the trail unable to
-// answer "which provider was reset". Only "*_id"/"*_uuid" keys qualify, so
-// non-entity parameters (a backup {filename}, a wildcard) still record nothing
-// rather than something misleading.
+// row records an empty entity. Only "*_id"/"*_uuid" keys qualify, so non-entity
+// parameters (a backup {filename}, a wildcard) record nothing rather than
+// something misleading.
 //
 // Keys are scanned newest-first, matching chi's own URLParam lookup, so a nested
 // router's inner parameter wins over an outer one of the same shape.
@@ -222,20 +220,18 @@ func entityParam(rctx *chi.Context) string {
 // literal path check cannot be fooled by trailing slashes or query strings:
 //
 //   - machine-to-machine fleet traffic: the liveness ping Front Desk POSTs to
-//     every member every few seconds, and the quota snapshots it relays from
-//     the primary to every other member each minute (196 of the last 200 rows
-//     on every non-primary member of a live fleet). Neither carries an entity
-//     or an operator's choice;
-//   - read-only POSTs, endpoints that answer a question without changing
-//     anything and are POST only because their input is a body. The backup
-//     prune preview classifies the backups on disk and writes nothing; the
-//     dashboard re-read it on every backup change, and recording each read as
-//     an admin action buried the real mutations under bursts of identical
-//     rows seconds apart.
+//     every member every few seconds, and the quota snapshots it relays from the
+//     primary to every other member each minute. Neither carries an entity or an
+//     operator's choice;
+//   - read-only POSTs, endpoints that answer a question without changing anything
+//     and are POST only because their input is a body. The backup prune preview
+//     classifies the backups on disk and writes nothing, and the dashboard
+//     re-reads it on every backup change, which would bury real mutations under
+//     bursts of identical rows.
 //
-// The trail is a record of admin actions: a route belongs here when no
-// operator chose to call it (the heartbeat, which does write its liveness
-// stamps) or when a successful call leaves the system as it found it.
+// The trail is a record of admin actions: a route belongs here when no operator
+// chose to call it (the heartbeat, which does write its liveness stamps) or when
+// a successful call leaves the system as it found it.
 func isAuditExempt(route string) bool {
 	switch route {
 	case "/api/fleet/announce", "/api/config/quota-snapshots", "/api/backups/prune-preview":
@@ -250,8 +246,8 @@ func isAuditExempt(route string) bool {
 // sweep.
 func (rec *Recorder) record(e Entry) {
 	// The middleware stamps CreatedAt at request completion so the trail keeps
-	// request order despite the async insert. Fall back to now for any direct
-	// caller that left it zero, so no row lands with a year-0001 timestamp.
+	// request order despite the async insert. A direct caller that left it zero
+	// falls back to now, so no row lands with a year-0001 timestamp.
 	if e.CreatedAt.IsZero() {
 		e.CreatedAt = time.Now()
 	}
@@ -347,8 +343,8 @@ func (rec *Recorder) List(ctx context.Context, p ListParams) ([]Entry, error) {
 	}
 	query += fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", idx)
 	args = append(args, p.Limit+1)
-	// Offset-based paging for the page-numbered view. The +1 lookahead above still
-	// gives HasMore for the current page.
+	// Offset-based paging for the page-numbered view. The +1 lookahead above gives
+	// HasMore for the current page.
 	if p.Offset > 0 {
 		query += fmt.Sprintf(" OFFSET $%d", idx+1)
 		args = append(args, p.Offset)
@@ -415,7 +411,7 @@ func (rec *Recorder) Purge(ctx context.Context, cutoff time.Time, all bool) erro
 
 // isAuditedMethod reports whether m is one of the recorded HTTP methods, so
 // filter input cannot smuggle arbitrary values into the query (harmless with
-// binds, but a bogus method can only ever match nothing).
+// binds, but a bogus method matches nothing).
 func isAuditedMethod(m string) bool {
 	switch strings.ToUpper(m) {
 	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:

--- a/internal/ctxkeys/keys.go
+++ b/internal/ctxkeys/keys.go
@@ -1,12 +1,11 @@
 // Package ctxkeys defines shared context key constants used across multiple
 // packages (e.g. proxy and ratelimit). Centralising them here avoids import
-// cycles — packages that need to read or write the same context value can
-// both depend on ctxkeys without depending on each other.
+// cycles: packages that read or write the same context value both depend on
+// ctxkeys rather than on each other.
 //
-// Go's context.Value requires an exact type match on the key, so we use a
-// dedicated unexported type (contextKey) with exported constants of that
-// type. This prevents accidental collisions with context keys defined
-// elsewhere.
+// context.Value requires an exact type match on the key, so the keys are
+// exported constants of an unexported type (contextKey), which prevents
+// collisions with context keys defined elsewhere.
 package ctxkeys
 
 import (
@@ -17,70 +16,67 @@ import (
 type contextKey string
 
 // VirtualKeyHashKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the SHA-256 hash of the virtual key used
-// for the current request. The ratelimit middleware reads this same
-// key to enforce per-key throttling.
+// ProxyKeyMiddleware stores the SHA-256 hash of the virtual key used for the
+// current request. The ratelimit middleware reads it to enforce per-key
+// throttling.
 const VirtualKeyHashKey contextKey = "virtual_key_hash"
 
 // VirtualKeyStripReasoningKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the per-key strip_reasoning flag (bool).
-// When true, reasoning/reasoning_content fields are stripped from streaming output.
+// ProxyKeyMiddleware stores the per-key strip_reasoning flag (bool). When true,
+// reasoning and reasoning_content fields are stripped from streaming output.
 const VirtualKeyStripReasoningKey contextKey = "virtual_key_strip_reasoning"
 
-// RequestBodyKey is the context key under which the streaming-aware
-// timeout middleware stores the already-read request body bytes.
-// Downstream handlers (proxy.ChatCompletions) can read from this
-// instead of re-reading r.Body, avoiding a full second allocation.
+// RequestBodyKey is the context key under which the streaming-aware timeout
+// middleware stores the already-read request body bytes. Downstream handlers
+// (proxy.ChatCompletions) read it instead of re-reading r.Body, avoiding a
+// second allocation.
 const RequestBodyKey contextKey = "request_body"
 
-// SettingsReadMsKey is the context key under which the rate limiter
-// middleware stores a *float64 pointer for accumulating settings read
-// time across the entire request pipeline (in ms). The ratelimiter
-// creates the pointer; downstream code (resolve, proxy) adds to it.
-// Use AddSettingsReadMs to safely add to the accumulated total.
+// SettingsReadMsKey is the context key under which the rate limiter middleware
+// stores a *float64 accumulating settings read time across the request pipeline
+// (in ms). The ratelimiter creates the pointer; downstream code (resolve, proxy)
+// adds to it via AddSettingsReadMs.
 const SettingsReadMsKey contextKey = "settings_read_ms"
 
 // DialMsKey is the context key under which the proxy handler stores its
-// per-request dial-timing slot (an atomic; the proxy package owns the type)
-// for capturing upstream dial time (DNS resolution + TCP connect). The
-// SafeDialer's DialContext stores the total dial duration into it and the
-// handler swaps it out after the upstream request completes. Atomic because
-// the transport's dial goroutine can outlive the request that started it.
+// per-request dial-timing slot (an atomic; the proxy package owns the type) for
+// upstream dial time (DNS resolution plus TCP connect). The SafeDialer's
+// DialContext stores the total dial duration into it and the handler swaps it
+// out after the upstream request completes. Atomic because the transport's dial
+// goroutine can outlive the request that started it.
 const DialMsKey contextKey = "dial_ms"
 
 // VirtualKeyRateLimitRPSKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the per-key RPS override (float64 pointer,
-// nil when unset). The ratelimit middleware reads this to apply
-// per-key rate limits that take precedence over global settings.
+// ProxyKeyMiddleware stores the per-key RPS override (float64 pointer, nil when
+// unset). The ratelimit middleware reads it to apply per-key rate limits, which
+// take precedence over global settings.
 const VirtualKeyRateLimitRPSKey contextKey = "virtual_key_rate_limit_rps"
 
 // VirtualKeyRateLimitBurstKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the per-key burst override (int pointer,
-// nil when unset). The ratelimit middleware reads this alongside
-// VirtualKeyRateLimitRPSKey.
+// ProxyKeyMiddleware stores the per-key burst override (int pointer, nil when
+// unset). The ratelimit middleware reads it alongside VirtualKeyRateLimitRPSKey.
 const VirtualKeyRateLimitBurstKey contextKey = "virtual_key_rate_limit_burst"
 
 // VirtualKeyRateLimitTPMKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the per-key tokens-per-minute cap (int pointer,
-// nil when unset). The TPM admission middleware reads this to enforce the
-// per-key minute token budget; nil falls back to the global default.
+// ProxyKeyMiddleware stores the per-key tokens-per-minute cap (int pointer, nil
+// when unset). The TPM admission middleware reads it to enforce the per-key
+// minute token budget; nil falls back to the global default.
 const VirtualKeyRateLimitTPMKey contextKey = "virtual_key_rate_limit_tpm"
 
 // VirtualKeyAllowedProvidersKey is the context key under which the proxy's
-// ProxyKeyMiddleware stores the per-key allowed provider list (*[]string,
-// nil when all providers are allowed). The proxy handler reads this to
-// filter resolved candidates so restricted keys can only reach specific
-// providers.
+// ProxyKeyMiddleware stores the per-key allowed provider list (*[]string, nil
+// when all providers are allowed). The proxy handler reads it to filter resolved
+// candidates, so a restricted key only reaches its own providers.
 const VirtualKeyAllowedProvidersKey contextKey = "virtual_key_allowed_providers"
 
 // VirtualKeyOwnerIDKey is the context key under which the account behind the
 // request is published as a UUID string (absent when there is none). The
 // rate-limit middlewares derive the shared "user:<uuid>" bucket key from it so
 // one user's traffic aggregates across every surface and key they use, and the
-// proxy stamps it on request lifecycle SSE events so a non-admin's live log
-// feed can be scoped to their own activity. On surfaces with no virtual key it
-// is also persisted to request_logs.owner_user_id, the only owner a keyless row
-// can have (migration 067).
+// proxy stamps it on request lifecycle SSE events so a non-admin's live log feed
+// can be scoped to their own activity. On surfaces with no virtual key it is
+// also persisted to request_logs.owner_user_id, the only owner a keyless row can
+// have.
 //
 // Written by the same two middlewares as UserAllowedProvidersKey below: the
 // proxy's ProxyKeyMiddleware (from the virtual key's OWNER, absent when the key
@@ -116,11 +112,10 @@ const UserRateLimitTPMKey contextKey = "user_rate_limit_tpm"
 const UserAllowedProvidersKey contextKey = "user_allowed_providers"
 
 // CancelOriginKey is the context key under which the proxy handler stores a
-// string describing why a derived context (failover, retry) was created.
-// When a context cancellation error is caught, this value identifies whether
-// the cancellation came from the client disconnecting, the failover timeout
-// expiring, or the retry timeout expiring. This makes "context canceled" errors
-// actionable instead of opaque.
+// string describing why a derived context (failover, retry) was created. When a
+// context cancellation error is caught, this value says whether the cancellation
+// came from the client disconnecting, the failover timeout expiring, or the
+// retry timeout expiring, so "context canceled" errors are actionable.
 //
 // Values: "client_disconnect", "failover_timeout", "retry_timeout"
 const CancelOriginKey contextKey = "cancel_origin"
@@ -131,38 +126,35 @@ const CancelOriginKey contextKey = "cancel_origin"
 // the race.
 //
 // Cancelling an attempt produces context.Canceled, which is indistinguishable
-// from the client hanging up — so without this flag a hedge loser is reported
-// as a client disconnect even though the client is still connected and gets a
-// 200 from the winner. The origin is read only for context.Canceled; a
-// deadline on the same context still resolves via CancelOriginKey.
+// from the client hanging up, so without this flag a hedge loser is reported as
+// a client disconnect even though the client is still connected and gets a 200
+// from the winner. The origin is read only for context.Canceled; a deadline on
+// the same context resolves via CancelOriginKey.
 const HedgeSupersededKey contextKey = "hedge_superseded"
 
 // RequestBodyParseMsKey is the context key under which the
-// streamingAwareTimeout middleware stores the time spent reading and
-// parsing the request body (float64, in ms). This covers both the
-// io.ReadAll of the body and the json.Unmarshal to extract model and
-// stream fields. The proxy handler reads this for accurate overhead
-// timing instead of measuring only its own re-unmarshal of cached bytes.
+// streamingAwareTimeout middleware stores the time spent reading and parsing the
+// request body (float64, in ms). It covers both the io.ReadAll of the body and
+// the json.Unmarshal that extracts the model and stream fields, so the proxy
+// handler's overhead timing does not count only its own re-unmarshal.
 const RequestBodyParseMsKey contextKey = "request_body_parse_ms"
 
-// RequestModelKey is the context key under which the
-// streamingAwareTimeout middleware stores the model name extracted
-// from the request body (string). This avoids a redundant
-// json.Unmarshal in ChatCompletions when the body bytes are already
-// cached via RequestBodyKey.
+// RequestModelKey is the context key under which the streamingAwareTimeout
+// middleware stores the model name extracted from the request body (string). It
+// saves a redundant json.Unmarshal in ChatCompletions when the body bytes are
+// already cached via RequestBodyKey.
 const RequestModelKey contextKey = "request_model"
 
-// IsStreamingKey is the context key under which the
-// streamingAwareTimeout middleware stores the stream flag (bool)
-// extracted from the request body. This avoids a redundant
-// json.Unmarshal in ChatCompletions when the body bytes are already
-// cached via RequestBodyKey.
+// IsStreamingKey is the context key under which the streamingAwareTimeout
+// middleware stores the stream flag (bool) extracted from the request body. It
+// saves a redundant json.Unmarshal in ChatCompletions when the body bytes are
+// already cached via RequestBodyKey.
 const IsStreamingKey contextKey = "is_streaming"
 
-// AddSettingsReadMs adds duration (in ms) to the accumulated settings
-// read time stored under SettingsReadMsKey. Safe to call when the
-// pointer is nil (no-op). Each call site that reads settings should
-// call this to ensure all settings reads are captured in overhead.
+// AddSettingsReadMs adds the elapsed time since start (in ms) to the accumulated
+// settings read time stored under SettingsReadMsKey. A nil pointer is a no-op.
+// Every call site that reads settings calls this, so all reads land in the
+// overhead total.
 func AddSettingsReadMs(ctx context.Context, start time.Time) {
 	if v := ctx.Value(SettingsReadMsKey); v != nil {
 		if p, ok := v.(*float64); ok {

--- a/internal/egress/adapter.go
+++ b/internal/egress/adapter.go
@@ -11,19 +11,18 @@ import (
 
 // MaxSSEEventBytes caps the SSE event an adapter will buffer: the data fields
 // joined so far plus the line still being read. The Responses dialect sets the
-// floor — its response.completed event embeds the whole generated output, so a
-// 128k-token generation with JSON escaping approaches 1 MiB — and 4 MiB clears
-// that with headroom while still bounding a runaway upstream: one that never
-// closes an event fails the stream instead of growing the buffer until the
-// process suffers.
+// floor, since its response.completed event embeds the whole generated output
+// (a 128k-token generation with JSON escaping approaches 1 MiB); 4 MiB clears
+// that with headroom while still bounding an upstream that never closes an
+// event.
 const MaxSSEEventBytes = 4 << 20
 
 // Translator converts one upstream SSE data payload into the client-facing
 // bytes for that event, and produces the stream's terminal bytes on Finish.
 // Implemented by each dialect's StreamTranslator.
 type Translator interface {
-	// Translate maps one event's payload — every "data:" field of that event,
-	// joined with newlines — to zero or more output bytes. A non-nil error
+	// Translate maps one event's payload (every "data:" field of that event,
+	// joined with newlines) to zero or more output bytes. A non-nil error
 	// means the upstream stream is corrupt or carried an error event, and
 	// poisons the adapter.
 	Translate(payload []byte) ([]byte, error)
@@ -34,11 +33,9 @@ type Translator interface {
 
 // StreamAdapter wraps an upstream vendor SSE body as an io.ReadCloser that
 // yields chat.completion.chunk SSE bytes. Wrapping the UPSTREAM body (not the
-// client writer) lets the whole existing streaming pipeline — TTFT probe, stall
-// watchdog, transforms, metering — run unchanged on what it already
-// understands. All three dialect adapters — gemini, anthropicegress and
-// openairesponses — are this type; each supplies only its translator and its
-// log prefix.
+// client writer) lets the whole streaming pipeline (TTFT probe, stall watchdog,
+// transforms, metering) run unchanged on what it already understands. Each
+// dialect adapter is this type and supplies only its translator and log prefix.
 //
 // Vendor streams carry no [DONE] sentinel of their own, so the translator's
 // Finish() supplies the terminal chunk + [DONE] when upstream EOF arrives. Any
@@ -82,9 +79,9 @@ func NewStreamAdapterWithCap(component string, upstream io.ReadCloser, tr Transl
 // and the terminal Finish() bytes are appended before the EOF is
 // surfaced; other upstream errors surface only after all translated bytes have
 // been drained. A translation failure poisons the stream: already translated
-// bytes drain, then the error surfaces — Finish() is never fabricated over a
+// bytes drain, then the error surfaces. Finish() is never fabricated over a
 // corrupt upstream, so the proxy sees a failed stream instead of a clean
-// empty/partial success.
+// empty or partial success.
 func (a *StreamAdapter) Read(p []byte) (int, error) {
 	for len(a.pending) == 0 {
 		if a.transErr != nil {
@@ -126,7 +123,7 @@ func (a *StreamAdapter) Read(p []byte) (int, error) {
 // so a field is appended to the event under construction rather than
 // translated on its own, and the blank line that terminates the event hands
 // the joined payload to the translator exactly once. Comment lines (":") and
-// every other field — "event:", "id:", "retry:" — are ignored, because the
+// every other field ("event:", "id:", "retry:") are ignored, because the
 // dialect translators key off the payload's own JSON type rather than the SSE
 // event name. The adapter generates its own framing on the way out.
 func (a *StreamAdapter) consume(p []byte) {
@@ -150,8 +147,8 @@ func (a *StreamAdapter) consume(p []byte) {
 		}
 		// The spec strips one optional leading space; trimming both ends is
 		// safe on top of that because JSON ignores whitespace around a value,
-		// and a folded payload cannot split inside a string literal — the
-		// newline the join inserts would be illegal there — so no byte a
+		// and a folded payload cannot split inside a string literal (the
+		// newline the join inserts would be illegal there), so no byte a
 		// translator reads can be trimmed away. A field with no value adds
 		// nothing to the event.
 		value := bytes.TrimSpace(line[len("data:"):])
@@ -204,12 +201,11 @@ func (a *StreamAdapter) dispatchEvent() bool {
 }
 
 // flushAtEOF dispatches the stream's unterminated tail: the residual line the
-// upstream never terminated, and then the event no blank line ever closed. An
-// upstream that closes without that framing would otherwise lose its last event
-// entirely — including a final message_delta's stop_reason — while Finish()
-// still emitted a clean terminal chunk, which is exactly the quiet truncation
-// this adapter exists to prevent. A tail that does not translate poisons the
-// stream, so a connection cut mid-event surfaces as the failure it is.
+// upstream never terminated, and then the event no blank line ever closed.
+// Without this, an upstream that closes without that framing loses its last
+// event entirely (a final message_delta's stop_reason included) while Finish()
+// still emits a clean terminal chunk. A tail that does not translate poisons
+// the stream, so a connection cut mid-event surfaces as a failure.
 func (a *StreamAdapter) flushAtEOF() {
 	if a.transErr != nil {
 		return

--- a/internal/egress/thoughtsig.go
+++ b/internal/egress/thoughtsig.go
@@ -3,11 +3,11 @@ package egress
 import "encoding/json"
 
 // ExtraContent is the extra_content member of an OpenAI-shaped tool call,
-// Google's own carrier for a Gemini 3 thought signature on that wire: the
-// model signs each function call and refuses the follow-up turn without the
-// signature, so it has to travel out to the client and back. The chat path
-// keeps the member verbatim (see proxy jsonextras); the dialect translators
-// read and write it here so they agree on the shape.
+// Google's carrier for a Gemini 3 thought signature on that wire: the model
+// signs each function call and refuses the follow-up turn without the
+// signature, so it travels out to the client and back. The chat path keeps the
+// member verbatim; the dialect translators read and write it here so they
+// agree on the shape.
 type ExtraContent struct {
 	Google *GoogleExtraContent `json:"google,omitempty"`
 }
@@ -18,9 +18,8 @@ type GoogleExtraContent struct {
 }
 
 // ThoughtSignatureIn reads the signature out of a raw extra_content member.
-// Lenient on purpose: a member of a shape it did not expect is an unsigned
-// call, never a failed request, since an ingress decoder that rejected it
-// would fail the conversation on every retry.
+// Lenient on purpose: a member of an unexpected shape is an unsigned call,
+// never a failed request.
 func ThoughtSignatureIn(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""

--- a/internal/failover/circuit_events.go
+++ b/internal/failover/circuit_events.go
@@ -9,8 +9,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/events"
 )
 
-// The breaker's SSE event and the sentence an alert renders from it. Split out
-// of circuitbreaker.go when that file reached the size ceiling.
+// The breaker's SSE event and the sentence an alert renders from it.
 
 // publishEvent builds the SSE event for a circuit breaker state transition and
 // hands it to after, for the caller to publish once cb.mu is released. r is the
@@ -18,12 +17,10 @@ import (
 // reported. Must be called with cb.mu held: everything the event says is read
 // from the breaker here, and nothing is read once it leaves.
 func (cb *CircuitBreaker) publishEvent(after *afterUnlock, providerID uuid.UUID, providerName, state, model string, c *circuit, r *cooldownReads) {
-	// quota_pinned and backed_off report the overrides currently governing this
-	// circuit, not a claim about whether the circuit is blocking traffic right
-	// now — the same predicates ProviderStatus uses. With the default
-	// HalfOpenMaxProbes of 1 the distinction never surfaces, but a half-open
-	// circuit that has banked a probe still carries its override until
-	// RecordSuccess closes it.
+	// quota_pinned and backed_off report the overrides governing this circuit,
+	// not whether it is blocking traffic; these are the predicates
+	// ProviderStatus uses. A half-open circuit that has banked a probe still
+	// carries its override until RecordSuccess closes it.
 	pinned := cb.quotaPinnedForWith(c, r)
 	backedOff := cb.backedOffForWith(c, r)
 	cooldown := cb.effectiveCooldownForWith(c, r)
@@ -36,18 +33,15 @@ func (cb *CircuitBreaker) publishEvent(after *afterUnlock, providerID uuid.UUID,
 		// cause and status are the verdict that produced this transition: why
 		// the circuit opened ("upstream status 429 (saturated)") or what closed
 		// it ("success"), and the upstream status behind it, 0 when none was
-		// seen. They are what an alert has to say for an operator to act on it
-		// without opening a terminal.
+		// seen.
 		"cause":  c.lastCause,
 		"status": c.lastStatus,
 		// pin_source tells a measured pin ("advisor") from one inferred out of
 		// the exhausted response itself ("response"); empty when no pin governs.
 		"pin_source": cb.pinSourceForWith(c, r),
 		// provider_open is the derived verdict as it stands after this
-		// transition. The event names one model, and at the default span of 2 the
-		// first model to open leaves the provider serving everything else, so
-		// without this flag a consumer would have to re-derive the verdict from a
-		// span setting it cannot see and circuits it is not shown.
+		// transition. The event names one model, so without this flag a consumer
+		// would have to re-derive the verdict from a span setting it cannot see.
 		"provider_open":     providerOpen,
 		"consecutive_fails": c.consecutiveFails,
 		"quota_pinned":      pinned,
@@ -57,46 +51,35 @@ func (cb *CircuitBreaker) publishEvent(after *afterUnlock, providerID uuid.UUID,
 		"failed_probes": c.failedProbes,
 	}
 	// model_id is the identity the alert dispatcher debounces on. An open
-	// carries it only while the provider is still serving: then the event is
-	// about one model, and keying it on the provider would let the first model
-	// to fail suppress every sibling that fails beside it. Once the verdict says
-	// the provider itself is skipped, an open is about the provider: the verdict
-	// lapses every time a blocking circuit's cooldown elapses, which lets one
-	// more sibling through to fail and open, and a fifty-model provider outage
-	// keyed per model would notify fifty times inside one alert window for what
-	// is one fact. Without the key the dispatcher falls back to provider_id. A
-	// close always carries it: a recovery is about the model that recovered
-	// whatever the verdict still says about its siblings, and two models coming
-	// back inside one window are two recoveries, not one.
+	// carries it only while the provider is still serving, so the first model to
+	// fail does not suppress its siblings. Once the verdict says the provider
+	// itself is skipped, an open is about the provider, and the dispatcher falls
+	// back to provider_id rather than notifying once per model. A close always
+	// carries it: two models coming back inside one window are two recoveries.
 	if state != "open" || !providerOpen {
 		meta["model_id"] = model
 	}
 	if state == "open" {
-		// cooldown_ms is the wait actually enforced. next_retry_at accompanies
-		// it whenever something other than the configured cooldown governs, so
-		// a consumer never has to add the two itself, and it is deliberately not
-		// called "resets_at": under a pin it is openedAt plus the ceiling-clamped
-		// and jittered pin, exactly the instant the status API publishes under
-		// that name, not the provider's quota reset, which on a weekly plan lies
-		// days beyond a 24h-capped pin.
+		// cooldown_ms is the wait enforced. next_retry_at accompanies it whenever
+		// something other than the configured cooldown governs. It is not
+		// "resets_at": under a pin it is openedAt plus the ceiling-clamped and
+		// jittered pin, not the provider's quota reset, which can lie days beyond
+		// a 24h-capped pin.
 		meta["cooldown_ms"] = cooldown.Milliseconds()
 		if pinned || backedOff {
 			meta["next_retry_at"] = c.openedAt.Add(cooldown).Format(time.RFC3339)
 		}
 	}
 	msg := breakerEventMessage(providerName, state, model, providerOpen, c.lastCause)
-	// The suffix attributes the wait to the backoff, so it is added only when
-	// the backoff is the value in force. A circuit can be backed off and pinned
-	// at once, and when the pin reaches further it is quota, not failed retries,
-	// that holds the circuit; saying "backing off, next retry in 10h" there
-	// would blame the model for a provider's spent window.
+	// The suffix attributes the wait to the backoff, so it is added only when the
+	// backoff is the value in force. A circuit can be backed off and pinned at
+	// once, and when the pin reaches further it is quota that holds the circuit.
 	if state == "open" && backedOff && cooldown == c.cooldownBackoff {
 		msg += backoffSuffix(cooldown, c.failedProbes)
 	}
-	// Stamped here, under the lock, rather than by Publish: two goroutines
-	// transitioning the same circuit publish once each has unlocked, in
-	// whichever order they resume, and a consumer ordering by timestamp must
-	// still see the transitions in the order they happened.
+	// Stamped under the lock rather than by Publish: two goroutines transitioning
+	// the same circuit publish in whichever order they resume, and a consumer
+	// ordering by timestamp must see the transitions in the order they happened.
 	ev := events.Event{
 		Type:      "circuit_breaker." + state,
 		Severity:  cb.severityForState(state),
@@ -109,10 +92,8 @@ func (cb *CircuitBreaker) publishEvent(after *afterUnlock, providerID uuid.UUID,
 }
 
 // backoffSuffix extends the open message when the probe backoff governs. The
-// message is all an outbound alert renders, so without it the notification for
-// a circuit fifteen minutes from its next retry is byte-identical to one sixty
-// seconds from it, and the operator has no way to tell a blip from a model that
-// has been failing its retries all afternoon.
+// message is all an outbound alert renders, so without it a circuit fifteen
+// minutes from its next retry reads identically to one sixty seconds from it.
 func backoffSuffix(cooldown time.Duration, failedProbes int) string {
 	noun := "retries"
 	if failedProbes == 1 {
@@ -143,18 +124,15 @@ func shortDuration(d time.Duration) string {
 }
 
 // breakerEventMessage is the sentence an operator reads in a dashboard toast and
-// in an Apprise alert. It names the model because the breaker charges one model
-// circuit at a time: at the default span of 2 the first model to open leaves the
-// provider serving everything else, and "Provider X circuit breaker: open" alone
-// reports an outage that is not happening. The provider-wide verdict is spelled
-// out when it flips, because that is the transition that takes the remaining
-// models out of rotation, and it is the part worth acting on.
+// in an Apprise alert. It names the model, because the breaker charges one model
+// circuit at a time and the provider usually keeps serving the rest. The
+// provider-wide verdict is spelled out when it flips, since that is what takes
+// the remaining models out of rotation.
 //
 // An open names its cause after a colon ("open for model glm-5.3: upstream
-// status 429 (saturated)"), because the message is all an alert renders and
-// "open" alone sent the operator to a terminal on 2026-08-31. The model id goes
-// before it, and the closed form deliberately says nothing about the verdict or
-// the cause: a recovery says only what recovered.
+// status 429 (saturated)"), the message being all an alert renders. The closed
+// form says nothing about the verdict or the cause: a recovery says only what
+// recovered.
 func breakerEventMessage(providerName, state, model string, providerOpen bool, cause string) string {
 	msg := fmt.Sprintf("Provider %s circuit breaker: %s", providerName, state)
 	if model == "" {

--- a/internal/failover/circuit_quota.go
+++ b/internal/failover/circuit_quota.go
@@ -20,30 +20,23 @@ import (
 // applyQuotaPin sets c.cooldownOverride when the provider's quota window is
 // spent and resets further out than the cooldown already in force. Must be
 // called with cb.mu held, immediately after c transitions to Open and after
-// applyBackoff, because the floor is the backoff when one is stamped: pinning
-// must never make the breaker more aggressive, and a backed-off circuit is one
-// the breaker has already decided to leave alone for longer.
+// applyBackoff, because the floor is the backoff when one is stamped.
 //
 // Clamp order is ceiling, then floor, then jitter, the same order ApplyQuotaPins
-// uses and for the same reason: a pin has to be compared against the floor
-// AFTER the ceiling has been applied, or a ceiling below the cooldown in force
-// (a quota_pin_max of ten minutes against a backed-off half hour) would stamp a
-// pin that shortens the wait the floor exists to protect. Jitter is positive
-// only: a negative offset would probe before the window actually resets, which
-// is a guaranteed 429 and precisely the waste this exists to avoid. The ceiling
-// is applied before jitter, so quotaPinMax() is a pre-jitter cap, not a hard
-// one — e.g. the default 24h ceiling can yield up to ~25.2h once jitter is
-// added. Jittering before capping would let two providers pinned at the
-// ceiling collide on the same retry instant, which is exactly the fleet
-// stampede jitter exists to prevent.
+// uses: the pin is compared against the floor AFTER the ceiling, or a ceiling
+// below the cooldown in force (a quota_pin_max of ten minutes against a
+// backed-off half hour) would stamp a pin that shortens the wait. Jitter is
+// positive only, since a negative offset probes before the window resets and
+// draws a certain 429. Applying the ceiling before jitter makes quotaPinMax() a
+// pre-jitter cap (the default 24h can yield ~25.2h) and keeps two providers
+// pinned at the ceiling from colliding on one retry instant.
+//
 // exhaustHint is a second pin source: the exhausted 429's own claim (a dated
 // Retry-After, or the matched phrase's per-marker default), used only when the
-// advisor has nothing — the advisor measured the actual window, so when it has
-// a reading it wins. The hint goes through the SAME ceiling/floor/jitter, so
-// it can never make the breaker more aggressive and never outlast the
-// configured ceiling; it adds a pin source, not a new kind of pin, and
-// ReleaseQuotaPins and the manual reset lift it exactly as they lift an
-// advisor pin. pinSource records which source stamped the pin in force.
+// advisor has no reading; the advisor measured the actual window, so it wins. The hint
+// goes through the same ceiling, floor and jitter, and the release paths lift it
+// as they lift an advisor pin. pinSource records which source stamped the pin in
+// force.
 func (cb *CircuitBreaker) applyQuotaPin(providerID uuid.UUID, c *circuit, exhaustHint time.Duration) {
 	c.cooldownOverride = 0
 	c.pinSource = ""
@@ -83,46 +76,40 @@ const (
 // ReleaseQuotaPins lifts the quota cooldown override from every circuit whose
 // provider appears in recovered, and reports how many pins it lifted. It is how
 // a provider that has recovered (a topped-up plan, a reset window observed early
-// by the quota poller) stops serving out a pin that was stamped on when its
-// circuit opened and could otherwise run to the 24h ceiling.
+// by the quota poller) stops serving out a pin that could otherwise run to the
+// 24h ceiling.
 //
 // It only ever shortens a wait. The circuit keeps its state and its failure
-// count and simply reverts to the cooldown it would otherwise serve (its probe
-// backoff if one is in force, else the configured cooldown), so HTTP still
-// decides recovery through the ordinary half-open probe. That is the whole
-// quota contract: quota never opens a circuit, never closes one, never blocks a
-// request, and only chooses the cooldown of an already-open circuit.
+// count and reverts to the cooldown it would otherwise serve (its probe backoff
+// if one is in force, else the configured cooldown), so HTTP still decides
+// recovery through the ordinary half-open probe.
 //
 // recovered must carry *affirmative* evidence: providers a successful refresh
 // assessed from a fresh snapshot and found not exhausted. Absence is not
-// evidence. A provider is equally absent when its snapshot went stale, when its
-// payload could not be assessed, and when it has no snapshot at all — and those
-// are precisely the cases where quota fetching is broken and the window is most
-// likely still spent. Releasing on absence would therefore unpin exactly the
-// provider the pin exists to protect, so anything not affirmatively recovered
-// is left untouched.
+// evidence: a provider is equally absent when its snapshot went stale, when its
+// payload could not be assessed, and when it has none at all, which are the
+// cases where the window is most likely still spent. Anything not affirmatively
+// recovered is left untouched.
 func (cb *CircuitBreaker) ReleaseQuotaPins(recovered map[uuid.UUID]struct{}) int {
 	cb.mu.Lock()
 	var after afterUnlock
 	defer func() { cb.mu.Unlock(); after.run() }()
 
-	// One walk's reads for the loop: this runs on the quota poll goroutine every
-	// few minutes and the values are identical for every circuit.
+	// One walk's settings reads for the loop: the values are identical for every
+	// circuit.
 	r := cb.cooldowns()
 
-	// Walk the recovered set rather than every circuit: it is the smaller side
-	// (a fleet has few providers recovering per pass), and the circuits map is
-	// keyed by the provider's UUID string, so one conversion per candidate
-	// replaces parsing every key.
+	// Walk the recovered set rather than every circuit: it is the smaller side,
+	// and the circuits map is keyed by the provider's UUID string, so one
+	// conversion per candidate replaces parsing every key.
 	released := 0
 	for providerID := range recovered {
 		id := providerID.String()
 		for model, c := range cb.circuits[id] {
-			// An affirmative "not exhausted" reading also clears the
-			// 429-open escalation: the escalation infers exhaustion from
-			// behaviour, and the advisor just measured the opposite. Cleared
-			// on every circuit, pinned or not, because the escalated ones
-			// usually carry a backoff rather than a pin.
+			// An affirmative "not exhausted" reading also clears the 429-open
+			// escalation: it inferred exhaustion from behaviour, and the advisor
+			// measured the opposite. Cleared on every circuit, pinned or not, because
+			// escalated ones usually carry a backoff rather than a pin.
 			c.clear429Escalation()
 			if c.cooldownOverride == 0 {
 				continue
@@ -135,27 +122,23 @@ func (cb *CircuitBreaker) ReleaseQuotaPins(recovered map[uuid.UUID]struct{}) int
 }
 
 // ApplyQuotaPins retargets the cooldown of every already-open circuit whose
-// provider is now known to be exhausted, and reports how many it retargeted. It
-// is the counterpart to applyQuotaPin, which stamps a pin at the instant a
-// circuit opens and therefore only ever sees the advice that existed by then. A
-// reading that lands moments later (the poll a breaker open triggers) has to
-// reach the circuit that prompted it, or that circuit serves out an ordinary
-// cooldown and probes into a certain 429 before the pin finally applies on the
-// re-open.
+// provider is known to be exhausted, and reports how many it retargeted. It is
+// the counterpart to applyQuotaPin, which stamps a pin at the instant a circuit
+// opens and so only sees the advice existing by then. A reading that lands
+// moments later (the poll a breaker open triggers) has to reach the circuit that
+// prompted it, or that circuit probes into a certain 429 first.
 //
 // It only ever lengthens a wait, and only for circuits open right now:
 //
 //   - A closed circuit is serving traffic and has no cooldown to retarget.
 //   - A half-open circuit has a probe out or due, so HTTP is mid-verdict.
-//     logicalState decides that, which means an open circuit whose cooldown has
-//     already elapsed counts as half-open here too: it is owed a probe, and
-//     pushing it back into the dark would overturn a decision the breaker has
-//     already handed to the request path.
+//     logicalState decides that, so an open circuit whose cooldown has elapsed
+//     counts as half-open here too: it is owed a probe, and pushing it back into
+//     the dark would overturn a decision already handed to the request path.
 //   - A pin already reaching further than the advice stands. Releasing needs
-//     affirmative proof the provider recovered, which is ReleaseQuotaPins' job;
-//     a nearer deadline arriving here is not that proof.
-//   - A probe backoff already reaching further than the advice stands too, for
-//     the reason applyQuotaPin gives: the floor is the cooldown in force.
+//     affirmative proof the provider recovered, which is ReleaseQuotaPins' job.
+//   - A probe backoff already reaching further than the advice stands too: the
+//     floor is the cooldown in force.
 //
 // advice is read, never retained: the caller may hand the same map to the
 // advisor afterwards.
@@ -168,8 +151,8 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 		return 0
 	}
 	r := cb.cooldowns()
-	// Hoisted with the walk's reads: it is a settings read too, and a cold
-	// settings cache turns that into a DB round trip under cb.mu held for write.
+	// Hoisted with the walk's reads: it is a settings read too, and a cold cache
+	// turns that into a DB round trip under cb.mu held for write.
 	maxPin := cb.quotaPinMax()
 
 	// Walk the advice rather than every circuit, for the same reason
@@ -182,15 +165,12 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 				continue
 			}
 			// Measured from openedAt, because that is what the enforced cooldown is
-			// measured from. applyQuotaPin computes this from time.Until(resetsAt)
-			// instead, which is the same number at the one instant it runs; here
-			// openedAt is already in the past, and a pin derived from "time until
-			// reset" would expire that much too early and probe before the window
-			// rolls over.
+			// measured from. openedAt is in the past here, so a pin derived from
+			// time until reset would expire that much too early and probe before
+			// the window rolls over.
 			d := resetsAt.Sub(c.openedAt)
-			// Ceiling first, so a clamped value is compared against the floor
-			// rather than smuggled past it: capping after the check could shorten
-			// a wait that is already longer.
+			// Ceiling first, so a clamped value is compared against the floor:
+			// capping after the check could shorten a longer wait.
 			if d > maxPin {
 				d = maxPin
 			}
@@ -206,14 +186,14 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 			c.cooldownOverride = d
 			c.pinSource = pinSourceAdvisor
 			// A transition with no request behind it: the wait changed, and the
-			// status the open recorded stays, so the row still says what opened
-			// the circuit as well as what is now holding it.
+			// status the open recorded stays, so the row says both what opened the
+			// circuit and what holds it.
 			c.note(time.Now(), Cause{Status: c.lastStatus, Reason: causePinRetargeted})
 			retargeted++
-			// The open transition already logged a cooldown_ms that is now wrong,
-			// and the corrected one can mean hours of darkness, so an operator gets
-			// the same Info-level line a release gets. Routing metadata only, never
-			// payload or credentials.
+			// The open transition logged a cooldown_ms this supersedes, and the
+			// corrected one can mean hours of darkness, so it gets the same
+			// Info-level line a release gets. Routing metadata only, never payload
+			// or credentials.
 			ms := d.Milliseconds()
 			after.add(func() {
 				debuglog.Info("circuit-breaker: quota pin retargeted (fresh exhaustion reading)", "provider_id", providerID, "cooldown_ms", ms, "model", model)
@@ -226,19 +206,14 @@ func (cb *CircuitBreaker) ApplyQuotaPins(advice map[uuid.UUID]time.Time) int {
 // ReleaseAllQuotaPins lifts the quota cooldown override from every circuit that
 // carries one, and reports how many it lifted.
 //
-// This is the other half of the release rule, and the reason it can be this
-// blunt where ReleaseQuotaPins must not be: it is called when quota polling has
-// been switched off. No refresh will ever report a recovery again, so every pin
-// still in force would be served out to its ceiling — up to 24 hours — on
-// evidence the operator deliberately stopped collecting. Absence of evidence
-// keeps a pin only while the gateway is still looking; once it stops looking it
-// stops holding, because benching a healthy provider is the expensive mistake
-// and an unnecessary probe is the cheap one.
+// It can be this blunt where ReleaseQuotaPins must not be because it is called
+// when quota polling is switched off: no refresh will report a recovery again,
+// so every pin in force would be served out to its ceiling (up to 24 hours) on
+// evidence nobody is collecting.
 //
 // Like ReleaseQuotaPins it only shortens a wait: circuit state and failure
 // counts are untouched, and HTTP still decides recovery through the ordinary
-// half-open probe. It is idempotent, so a caller can run it once per disabled
-// span without bookkeeping.
+// half-open probe. It is idempotent.
 func (cb *CircuitBreaker) ReleaseAllQuotaPins() int {
 	cb.mu.Lock()
 	var after afterUnlock
@@ -260,18 +235,15 @@ func (cb *CircuitBreaker) ReleaseAllQuotaPins() int {
 }
 
 // releasePin drops one circuit's quota override, logs it and records it as the
-// circuit's last verdict. The reason is a named phrase rather than being
-// assembled from parts: an operator reading "pin released" needs to know
-// whether the provider recovered or whether the poller was switched off,
-// because only one of those means the window is actually back.
+// circuit's last verdict. The reason is a named phrase, so an operator can tell
+// a recovered provider from a switched-off poller.
 //
-// The open transition logged a cooldown_ms that may have promised hours of
-// darkness, so the line that says it ended early is logged at the same Info
-// level the half-open→closed recovery uses. cooldown_ms is the wait the circuit
-// falls back to, which is its backoff when one is in force: a recovered quota
-// does not undo the probes that failed. Routing metadata only — never payload
-// or credentials. Must be called with cb.mu held; the line goes to after, for
-// the caller to write once the lock is released.
+// The line is logged at the same Info level the half-open to closed recovery
+// uses. cooldown_ms is the wait the circuit falls back to, which is its backoff
+// when one is in force: a recovered quota does not undo the probes that failed.
+// Routing metadata only, never payload or credentials. Must be called with cb.mu
+// held; the line goes to after, for the caller to write once the lock is
+// released.
 func (cb *CircuitBreaker) releasePin(after *afterUnlock, reason, providerID, model string, c *circuit, r *cooldownReads) {
 	c.cooldownOverride = 0
 	c.pinSource = ""

--- a/internal/failover/circuit_reset.go
+++ b/internal/failover/circuit_reset.go
@@ -6,8 +6,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
-// The manual resets: one circuit, one provider, or everything. Split out of
-// circuitbreaker.go when that file reached the size ceiling. Every reset
+// The manual resets: one circuit, one provider, or everything. Every reset
 // collects what it cleared under the lock and logs it after; see afterUnlock.
 
 // Reset clears every model circuit of a specific provider and returns the
@@ -49,9 +48,8 @@ func (cb *CircuitBreaker) resetProvider(providerID uuid.UUID) (State, []manualRe
 // can report "recovered", "was already closed" and "nothing tracked" apart. An
 // untracked pair is a harmless no-op, like Reset on an untracked provider.
 //
-// This is the lever the 2026-08-31 reset loop lacked: Reset clears every model
-// of the provider, which also forgets the charges its healthy siblings have
-// legitimately accrued.
+// Unlike Reset it does not forget the charges the provider's healthy siblings
+// have legitimately accrued.
 func (cb *CircuitBreaker) ResetModel(providerID uuid.UUID, model string) (prev State, existed bool) {
 	prev, existed = cb.resetModel(providerID, model)
 	if existed {
@@ -85,10 +83,9 @@ type manualReset struct {
 	prev              State
 }
 
-// logManualResets writes the one line every manual reset produces per circuit,
-// with the same cause vocabulary the open line and the status API use, so a
-// fleet-wide reset reads in the app log as N circuits with N causes rather than
-// one summary a search for a model cannot find. Called with the lock released.
+// logManualResets writes one line per circuit a manual reset cleared, with the
+// same cause vocabulary the open line and the status API use, so a fleet-wide
+// reset is searchable per model. Called with the lock released.
 func logManualResets(resets []manualReset) {
 	for _, r := range resets {
 		debuglog.Info("circuit-breaker: manual reset", "provider_id", r.providerID, "cause", "manual reset", "previous_state", r.prev.String(), "model", r.model)
@@ -101,9 +98,8 @@ func logManualResets(resets []manualReset) {
 // instead of implying every tracked circuit was broken.
 //
 // Both counts are circuits, not providers: the map holds one entry per
-// (provider, resolved upstream model), and a provider serving five models that
-// have all been charged is five things the lever just threw away. The API hands
-// these numbers to the operator verbatim.
+// (provider, resolved upstream model). The API hands these numbers to the
+// operator verbatim.
 func (cb *CircuitBreaker) ResetAll() (cleared, recovered int) {
 	cleared, recovered, resets := cb.resetAll()
 	logManualResets(resets)
@@ -115,8 +111,8 @@ func (cb *CircuitBreaker) resetAll() (cleared, recovered int, resets []manualRes
 	defer cb.mu.Unlock()
 
 	// Hoisted for the same reason Status hoists it: this walks every circuit in
-	// the fleet under the write lock, and reading the cooldown per circuit would
-	// take a DB round trip per circuit on a deployment that never overrode it.
+	// the fleet under the write lock, and an unoverridden cooldown read per
+	// circuit is a DB round trip per circuit.
 	r := cb.cooldowns()
 
 	for id, models := range cb.circuits {

--- a/internal/failover/circuit_status.go
+++ b/internal/failover/circuit_status.go
@@ -15,10 +15,9 @@ import (
 // reason and the upstream HTTP status behind it, 0 when no response was seen (a
 // connection that never completed, a stream that died before its status meant
 // anything). The circuit remembers its most recent one as its last verdict, the
-// open transition publishes it, and the detail endpoint lists it per circuit,
-// so a status row, an SSE event and an outbound alert can all say what the
-// breaker SAW rather than only what it did. Diagnosing the 2026-08-31 incident
-// took an hour of polling because none of them could.
+// open transition publishes it, and the detail endpoint lists it per circuit, so
+// a status row, an SSE event and an outbound alert can say what the breaker SAW
+// rather than only what it did.
 //
 // Routing metadata only. The reason is always a fixed phrase chosen by the
 // caller, never text copied from a provider response, so it can never carry a
@@ -60,11 +59,10 @@ func (c *circuit) note(now time.Time, cause Cause) {
 }
 
 // CircuitStatus is one (provider, resolved upstream model) circuit as the
-// detail endpoint reports it: the same fields the provider row carries, at the
-// level the breaker actually keeps them, plus the last verdict that landed on
-// it. The provider row is built from the most degraded of these, so a row
-// saying "open" while the model an operator cares about reads "closed" here is
-// not a contradiction: it is the per-model keying made visible.
+// detail endpoint reports it: the fields the provider row carries, at the level
+// the breaker keeps them, plus the last verdict that landed on it. The provider
+// row is built from the most degraded of these, so a row saying "open" while a
+// circuit here reads "closed" is the per-model keying, not a contradiction.
 type CircuitStatus struct {
 	Model            string `json:"model"`
 	State            string `json:"state"`

--- a/internal/failover/circuitbreaker.go
+++ b/internal/failover/circuitbreaker.go
@@ -18,9 +18,9 @@ type State int
 
 // Circuit breaker states.
 const (
-	StateClosed   State = iota // Normal operation — requests pass through
-	StateOpen                  // Provider is failing — requests are skipped
-	StateHalfOpen              // Testing recovery — limited probe requests allowed
+	StateClosed   State = iota // requests pass through
+	StateOpen                  // requests are skipped
+	StateHalfOpen              // limited probe requests allowed
 )
 
 func (s State) String() string {
@@ -41,15 +41,13 @@ func (s State) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
 }
 
-// ProviderStatus represents the health status of a single provider for
-// API responses and SSE events.
+// ProviderStatus is the health status of a single provider for API responses
+// and SSE events.
 //
 // State and the fields beside it describe the provider's most degraded model
-// circuit. ProviderOpen and OpenModels describe the provider as a whole: the
-// derived verdict and the evidence it is derived from. The two answer different
-// questions and can disagree — one open model at the default span of 2 gives
-// State "open" and ProviderOpen false, which is exactly the case an operator
-// needs to see, because the provider is still serving every other model.
+// circuit. ProviderOpen and OpenModels describe the provider as a whole. The
+// two can disagree: one open model at the default span of 2 gives State "open"
+// and ProviderOpen false.
 type ProviderStatus struct {
 	ProviderID       string `json:"provider_id"`
 	ProviderName     string `json:"provider_name,omitempty"`
@@ -61,40 +59,33 @@ type ProviderStatus struct {
 	QuotaPinned      bool   `json:"quota_pinned,omitempty"`
 	// PinSource says where the dominant circuit's quota pin came from:
 	// "advisor" (a measured quota reading) or "response" (inferred from the
-	// exhausted 429 itself). Empty when that circuit carries no pin. It rides
-	// beside QuotaPinned so an operator can tell a measured pin from an
-	// inferred one; like BackedOff/FailedProbes it describes the dominant
-	// circuit, whose CooldownMs/NextRetryAt it explains.
+	// exhausted 429 itself). Empty when that circuit carries no pin.
 	PinSource string `json:"pin_source,omitempty"`
 	// BackedOff is true when the cooldown governing the circuit is the probe
 	// backoff rather than circuit_breaker_cooldown: CooldownMs and NextRetryAt
 	// are then the doubled value. FailedProbes is the count behind it, the
-	// half-open probes that failed since the circuit last closed. The count is
-	// reported even when backoff is switched off, because it is what happened;
-	// the flag says what governs.
+	// half-open probes that failed since the circuit last closed, and is
+	// reported even when backoff is switched off.
 	BackedOff    bool `json:"backed_off,omitempty"`
 	FailedProbes int  `json:"failed_probes,omitempty"`
 	// ProviderOpen is the derived provider-wide verdict: whether the breaker is
-	// skipping this provider for every model. Always emitted, including its
-	// false, so a consumer can tell "the provider is fine" from "the field is
-	// missing" without re-deriving it from OpenModels and the span setting.
+	// skipping this provider for every model. Always emitted, including when
+	// false, so a consumer never re-derives it from OpenModels and the span
+	// setting.
 	ProviderOpen bool `json:"provider_open"`
 	// OpenModels lists the resolved upstream model ids the breaker is currently
-	// blocking, sorted so a polling UI does not reshuffle the list. It is exactly
-	// the set ProviderOpen is counted from, so a provider detail can name the
-	// models a verdict rests on. Circuits owed a probe are not in it: they are no
-	// longer blocking anything.
+	// blocking, sorted so a polling UI does not reshuffle the list. It is the
+	// set ProviderOpen is counted from. Circuits owed a probe are excluded:
+	// they block nothing.
 	OpenModels []string `json:"open_models,omitempty"`
 	// Circuits lists every circuit the row above is built from, sorted by
 	// model, each with its own state, cooldown and last verdict. Filled only by
-	// StatusDetail. Additive: the row and OpenModels stay what the dashboard
-	// keys on, and an older member in a mixed-version fleet simply omits this.
+	// StatusDetail.
 	Circuits []CircuitStatus `json:"circuits,omitempty"`
 }
 
 // SettingsReader provides dynamic configuration for the circuit breaker.
-// This decouples the breaker from the settings package — callers inject
-// a thin shim that reads from their settings repository.
+// Callers inject a thin shim over their settings repository.
 type SettingsReader interface {
 	GetInt(ctx context.Context, key string, defaultValue int) int
 	GetDuration(ctx context.Context, key string, defaultValue time.Duration) time.Duration
@@ -103,9 +94,9 @@ type SettingsReader interface {
 
 // QuotaAdvisor supplies the reset deadline for a provider whose quota window is
 // spent. Implementations must be non-blocking: this is consulted while the
-// breaker holds its write lock on the request path. Implementations must not
-// call back into the CircuitBreaker (e.g. GetState, Status) — cb.mu is held
-// exclusively across the call and any such re-entry self-deadlocks.
+// breaker holds its write lock on the request path. They must not call back
+// into the CircuitBreaker (e.g. GetState, Status): cb.mu is held exclusively
+// across the call and any such re-entry self-deadlocks.
 type QuotaAdvisor interface {
 	ResetsAt(providerID uuid.UUID) (time.Time, bool)
 }
@@ -126,11 +117,9 @@ type CircuitBreaker struct {
 	// cooldown of an already-open circuit. Nil disables quota pinning.
 	quota QuotaAdvisor
 
-	// onOpen is notified whenever a circuit transitions to Open. It exists so a
-	// consumer can refresh what it knows about the provider at the one moment
-	// that knowledge decides how long the circuit stays dark. A plain callback
-	// rather than a package dependency: the breaker must not know what the
-	// consumer does with the notification. Nil when nothing is wired.
+	// onOpen is notified whenever a circuit transitions to Open, letting a
+	// consumer refresh what it knows about the provider. Nil when nothing is
+	// wired.
 	onOpen func(providerID uuid.UUID)
 
 	// Threshold is the number of consecutive failures before opening a model
@@ -191,9 +180,8 @@ func (cb *CircuitBreaker) SetOnOpen(fn func(providerID uuid.UUID)) {
 
 // notifyOpen fires the open-transition callback for a circuit that just went
 // open. The callback runs on its own goroutine, so it never executes under
-// cb.mu and never adds latency to the request that opened the circuit: this is
-// reached from RecordFailure on the proxy path, and a consumer is free to reach
-// the network. Must be called with cb.mu held.
+// cb.mu and never adds latency to the request that opened the circuit. Must be
+// called with cb.mu held.
 func (cb *CircuitBreaker) notifyOpen(providerID uuid.UUID) {
 	if cb.onOpen == nil {
 		return
@@ -208,8 +196,8 @@ func (cb *CircuitBreaker) notifyOpen(providerID uuid.UUID) {
 // takes, so nothing may write a line while holding it. Every value a line or
 // event carries is computed under the lock; only the write waits. Used as
 // `defer func() { cb.mu.Unlock(); after.run() }()`. Emission order across
-// goroutines is no longer transition order: two sections can unlock and then
-// resume in either order, so events carry the timestamp taken under the lock.
+// goroutines is not transition order, so events carry the timestamp taken
+// under the lock.
 type afterUnlock []func()
 
 func (a *afterUnlock) add(f func()) { *a = append(*a, f) }
@@ -229,8 +217,8 @@ func (a afterUnlock) run() {
 // Fast path: most calls hit the Closed state, which only needs a read lock.
 // Only the Open→HalfOpen transition requires a write lock.
 func (cb *CircuitBreaker) IsOpen(providerID uuid.UUID, providerName, model string) bool {
-	// Fast path: read lock for the common case (nothing tracked, or a closed
-	// model circuit against a provider that is not indicted).
+	// Read lock for the common case: nothing tracked, or a closed model circuit
+	// against a provider that is not indicted.
 	cb.mu.RLock()
 	models, ok := cb.circuits[providerID.String()]
 	if !ok {
@@ -249,11 +237,9 @@ func (cb *CircuitBreaker) IsOpen(providerID uuid.UUID, providerName, model strin
 	}
 	cb.mu.RUnlock()
 
-	// Slow path: write lock for the Open→HalfOpen transition. The circuit is
-	// re-read after acquiring the write lock, so we operate on the current
-	// state and not the snapshot from the RLock phase. If another goroutine
-	// transitioned it in between (e.g. RecordSuccess: HalfOpen→Closed), we see
-	// the up-to-date state and return the correct result.
+	// Write lock for the Open→HalfOpen transition. The circuit is re-read under
+	// the write lock, so a transition by another goroutine in between (e.g.
+	// RecordSuccess: HalfOpen→Closed) is seen rather than the RLock snapshot.
 	cb.mu.Lock()
 	var after afterUnlock
 	defer func() { cb.mu.Unlock(); after.run() }()
@@ -269,18 +255,15 @@ func (cb *CircuitBreaker) IsOpen(providerID uuid.UUID, providerName, model strin
 			debuglog.Info("circuit-breaker: model state=open→half-open (cooldown elapsed)", "provider", providerName, "provider_id", providerID, "model", model)
 		})
 	}
-	// This circuit is owed a probe and so counts for nothing in the provider
-	// verdict: only circuits still inside their cooldown do. That is what lets a
-	// provider recover, because a circuit that kept counting after its cooldown
-	// elapsed would keep the provider dark and block the very probes that close
-	// it. The provider can still be open on the others, which have not changed.
+	// A circuit owed a probe counts for nothing in the provider verdict: only
+	// circuits still inside their cooldown do, which is what lets a provider
+	// recover. The provider can still be open on the others.
 	return cb.providerOpen(models)
 }
 
 // RecordFailure records a failed request to one of a provider's models. It
-// charges that model's circuit and nothing else: a failure is evidence about
-// the model it was routed to, and only the derived provider verdict decides
-// whether enough models agree to call the provider itself down.
+// charges that model's circuit and nothing else; only the derived provider
+// verdict decides whether enough models agree to call the provider down.
 //   - Closed: increments the failure counter. Opens the circuit if the
 //     threshold is reached.
 //   - Half-open: immediately re-opens the circuit with a fresh cooldown, doubled
@@ -288,17 +271,16 @@ func (cb *CircuitBreaker) IsOpen(providerID uuid.UUID, providerName, model strin
 //   - Open: no-op.
 //
 // cause is remembered as the circuit's last verdict and published with the open
-// it may produce; see Cause for what it must and must not carry.
+// it may produce.
 func (cb *CircuitBreaker) RecordFailure(providerID uuid.UUID, providerName, model string, cause Cause) {
 	cb.recordFailure(providerID, providerName, model, false, cause)
 }
 
 // RecordRateLimited is RecordFailure for an UNCLASSIFIED 429: it charges
-// identically, and additionally feeds the rate-limit-open streak so a circuit
+// identically and additionally feeds the rate-limit-open streak, so a circuit
 // that only ever opens on 429s escalates to exhausted handling without any
-// provider phrase saying so (see circuit.note429Open). The classified cases
-// never come here: a saturated 429 is a breaker no-op at the call site
-// (RecordSaturated remembers it), and an exhausted one goes through
+// provider phrase saying so (see circuit.note429Open). Classified cases go
+// elsewhere: a saturated 429 to RecordSaturated, an exhausted one to
 // RecordExhausted. cause says which reading of the 429 the caller reached.
 func (cb *CircuitBreaker) RecordRateLimited(providerID uuid.UUID, providerName, model string, cause Cause) {
 	cb.recordFailure(providerID, providerName, model, true, cause)
@@ -311,8 +293,8 @@ func (cb *CircuitBreaker) recordFailure(providerID uuid.UUID, providerName, mode
 
 	c := cb.getOrCreate(providerID.String(), model)
 	c.lastCharged = time.Now()
-	// Stamped before the switch so the open transition below logs and
-	// publishes the verdict that produced it.
+	// Stamped before the switch so an open transition logs and publishes the
+	// verdict that produced it.
 	c.note(c.lastCharged, cause)
 
 	switch c.state {
@@ -323,33 +305,28 @@ func (cb *CircuitBreaker) recordFailure(providerID uuid.UUID, providerName, mode
 		}
 	case StateHalfOpen:
 		c.consecutiveFails = cb.effectiveThreshold()
-		// The probe was a live request that just failed against a model the
-		// breaker already had reason to doubt. Counted before the open so the
-		// cooldown stamped there is the one this failure has earned.
+		// Counted before the open so the cooldown stamped there reflects this
+		// failed probe.
 		c.failedProbes++
 		cb.openCircuit(&after, "circuit-breaker: model state=half-open→open (probe failed)", providerID, providerName, model, c, by429, 0)
 	case StateOpen:
-		// Already open — no-op.
+		// Already open, no-op.
 	}
 }
 
 // RecordExhausted records a 429 whose body says the window or balance behind
-// this model is SPENT. One such response opens the circuit outright — the
-// charge jumps to the threshold the way a failed half-open probe does —
-// because the second request an ordinary charge would wait for exists only to
-// confirm what the body already said, and on a saturated sibling it is also
-// the request that tips that one over.
+// this model is SPENT. One such response opens the circuit outright: the charge
+// jumps to the threshold the way a failed half-open probe does.
 //
-// pinHint is the cooldown the response itself suggests (a dated Retry-After,
-// or the matched phrase's per-marker default); zero means none. It reaches the
+// pinHint is the cooldown the response itself suggests (a dated Retry-After, or
+// the matched phrase's per-marker default); zero means none. It reaches the
 // cooldown through the same clamps an advisor pin gets, and a real advisor
-// reading always beats it — see applyQuotaPin.
-// status is the status the upstream actually answered. It is a parameter
-// rather than a constant 429 because exhaustion is a claim, not a number: a 429
-// whose body says the window is spent and a 402 payment_required make the same
-// claim and take the same pin, and stamping every one of them as 429 would put
-// a status the provider never sent into the circuit's cause, the breaker-open
-// log line, the Front Desk circuits ledger and the opens_total metric.
+// reading beats it (see applyQuotaPin).
+//
+// status is the status the upstream answered. It is a parameter rather than a
+// constant 429 because a 402 payment_required makes the same exhaustion claim
+// and takes the same pin, and the status is stamped into the circuit's cause,
+// the breaker-open log line and the opens_total metric.
 func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, model string, status int, pinHint time.Duration) {
 	cb.mu.Lock()
 	var after afterUnlock
@@ -360,12 +337,10 @@ func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, mo
 	c.note(c.lastCharged, UpstreamStatus(status, causeExhausted))
 
 	// by429 feeds the rate-limit-only open streak, so it follows the status the
-	// provider actually sent rather than the fact that this is the exhaustion
-	// path. A 402 is an exhaustion but not a rate limit: counting it would let
-	// repeated payment refusals escalate a streak documented as 429-only, and
-	// that escalation raises the probe-backoff ceiling into a backoff which no
-	// quota lever clears — not ReleaseQuotaPins, not quota_pin_enabled=false —
-	// because those only ever clear a pin.
+	// provider sent rather than the fact that this is the exhaustion path. A 402
+	// is an exhaustion but not a rate limit, and counting it would let repeated
+	// payment refusals escalate a streak defined as 429-only into a probe
+	// backoff that no quota lever clears.
 	by429 := status == 429
 
 	switch c.state {
@@ -377,26 +352,21 @@ func (cb *CircuitBreaker) RecordExhausted(providerID uuid.UUID, providerName, mo
 		c.failedProbes++
 		cb.openCircuit(&after, "circuit-breaker: model state=half-open→open (probe drew exhaustion)", providerID, providerName, model, c, by429, pinHint)
 	case StateOpen:
-		// Already open — no-op. The quota poller's ApplyQuotaPins retargets an
-		// open circuit when a fresh reading lands; a second exhausted body is
-		// not fresher evidence than the one that opened it.
+		// Already open, no-op. ApplyQuotaPins retargets an open circuit when a
+		// fresh quota reading lands; a second exhausted body is not fresher
+		// evidence than the one that opened it.
 	}
 }
 
 // RecordSaturated remembers a 429 the classifier read as load rather than a
-// spent window. It is deliberately NOT a charge and not a credit: a provider at
-// its concurrency ceiling is alive, and benching it benches the slots that are
-// all busy serving (see recordRateLimitOutcome in the proxy). What it does is
-// leave the verdict on the circuit, so a status row can say "busy" about a
-// provider whose circuit is closed but whose last three answers were 429s,
-// which on 2026-08-31 was the whole story and was visible nowhere.
+// spent window. It is deliberately neither a charge nor a credit: a provider at
+// its concurrency ceiling is alive. It only leaves the verdict on the circuit,
+// so a status row can say "busy" about a provider whose circuit is closed but
+// whose last answers were 429s.
 //
-// It does not touch lastCharged: nothing landed, so the circuit ranks for
-// eviction exactly as it did, and a circuit that exists only because of this
-// stamp ranks first, behind every circuit a charge or credit ever reached.
-// That is also what keeps the creation here harmless at the cap: a burst of
-// saturated 429s across many untracked models evicts its own zero-stamped
-// entries first, never a circuit a charge ever reached.
+// It does not touch lastCharged, so a circuit that exists only because of this
+// stamp ranks first for eviction, behind every circuit a charge or credit
+// reached.
 func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, model string) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
@@ -409,11 +379,11 @@ func (cb *CircuitBreaker) RecordSaturated(providerID uuid.UUID, model string) {
 // quota-pinned. It answers for the same rule IsOpen enforces: the model's own
 // blocking circuit when it has one, else the provider-wide verdict's blocking
 // set (whose earliest expiry is when the verdict can lapse). ok is false when
-// nothing is blocking the pair — the caller should not have skipped it.
+// nothing is blocking the pair: the caller should not have skipped it.
 //
-// It backs the honest all-skipped response: "no available provider" with a
-// Retry-After naming the earliest of these instants, and an exhausted kind
-// only when every blocking circuit is pinned (spent windows), else saturated.
+// It backs the all-skipped response: "no available provider" with a Retry-After
+// naming the earliest of these instants, and an exhausted kind only when every
+// blocking circuit is pinned (spent windows), else saturated.
 func (cb *CircuitBreaker) BlockedUntil(providerID uuid.UUID, model string) (retryAt time.Time, pinned, ok bool) {
 	cb.mu.RLock()
 	defer cb.mu.RUnlock()
@@ -446,10 +416,8 @@ func (cb *CircuitBreaker) BlockedUntil(providerID uuid.UUID, model string) (retr
 
 // LastSuccessWithin reports whether this (provider, model) circuit served a
 // success inside the window. It backs the 429 behavioural fallback: a rate
-// limit from a model that answered moments ago is load, not a spent window,
-// because a spent window does not come back in a minute. An untracked pair has
-// no recorded success and reports false, so an unfamiliar provider never gets
-// the gentler treatment on a guess.
+// limit from a model that answered moments ago is load, not a spent window. An
+// untracked pair reports false.
 func (cb *CircuitBreaker) LastSuccessWithin(providerID uuid.UUID, model string, window time.Duration) bool {
 	cb.mu.RLock()
 	defer cb.mu.RUnlock()
@@ -466,11 +434,9 @@ func (cb *CircuitBreaker) LastSuccessWithin(providerID uuid.UUID, model string, 
 // watches for it.
 //
 // cooldown_ms, quota_pinned, backed_off and failed_probes are the operator's
-// only log trail for how long this model will be dark and why: a quota pin can
-// hold a circuit open for a day, a backoff for an hour, and the failure count
-// alone says nothing about either. Routing metadata only — never payload or
-// credentials, and the model id goes last because it is the one attribute a
-// request can influence.
+// log trail for how long this model stays dark and why. Routing metadata only,
+// never payload or credentials, and the model id goes last because it is the
+// one attribute a request can influence.
 //
 // by429 feeds the rate-limit-open streak (note429Open) BEFORE the backoff is
 // stamped, so the escalation's lifted ceiling applies to the open that earned
@@ -489,8 +455,8 @@ func (cb *CircuitBreaker) openCircuit(after *afterUnlock, msg string, providerID
 	cb.applyBackoff(c)
 	cb.applyQuotaPin(providerID, c, exhaustHint)
 	// One walk for the log line and the event, so the two cannot disagree. The
-	// attributes are read now, under the lock, because the circuit keeps
-	// changing once it is released.
+	// attributes are read under the lock, because the circuit keeps changing
+	// once it is released.
 	r := cb.cooldowns()
 	attrs := []any{"provider", providerName, "provider_id", providerID, "cause", c.lastCause, "status", c.lastStatus, "consecutive_failures", c.consecutiveFails, "cooldown_ms", cb.effectiveCooldownForWith(c, r).Milliseconds(), "quota_pinned", cb.quotaPinnedForWith(c, r), "backed_off", cb.backedOffForWith(c, r), "failed_probes", c.failedProbes, "model", model}
 	cause := c.lastCause
@@ -503,26 +469,19 @@ func (cb *CircuitBreaker) openCircuit(after *afterUnlock, msg string, providerID
 		opens := c.opens
 		after.add(func() { cb.reportUnstable(providerID, providerName, model, opens) })
 	}
-	// After the line and the event, as before: the callback is the quota
-	// refresh, whose retarget line must not precede the open it retargets.
+	// After the line and the event: the callback is the quota refresh, whose
+	// retarget line must not precede the open it retargets.
 	after.add(func() { cb.notifyOpen(providerID) })
 }
 
 // reportUnstable says once that a model has opened its circuit repeatedly inside
 // one window, so a chronically broken model stops being invisible.
 //
-// It reports rather than retires, and that is the whole design. Retiring means
-// "the provider no longer serves this model", which only a request refused BY
-// NAME establishes, and a model failing that way is already nominated by the
-// gone-classified streak on the first refusal. What is left here is the model
-// that fails some OTHER way, repeatedly: timeouts, 5xx, a provider having a bad
-// week. Disabling that model would take a working one out of routing on
-// evidence that says only "upstream is unwell".
-//
-// It cannot hand the model to the retirement probe either, even to let the probe
-// decide. That path refuses to probe a model whose circuit is open (see
-// model_gone.go), which is by definition this model's state at the moment this
-// fires, so a nomination from here would be postponed and dropped every time.
+// It reports rather than retires: the failures counted here (timeouts, 5xx) say
+// only "upstream is unwell", not that the provider stopped serving the model.
+// It cannot nominate the model to the retirement probe either, because that
+// probe skips models whose circuit is open (see model_gone.go), which is this
+// model's state whenever this fires.
 //
 // Routing metadata only, and the model id goes last because it is the one
 // attribute a request can influence. Reads nothing from the breaker, so it
@@ -535,10 +494,9 @@ func (cb *CircuitBreaker) reportUnstable(providerID uuid.UUID, providerName, mod
 		Type:     "circuit_breaker.unstable",
 		Severity: "warning",
 		Source:   "failover",
-		// What the counter establishes is how many times the circuit opened, not
-		// what the model was doing in between: a success does not reset the
-		// count, so three recovered blips across a working day land here too.
-		// The sentence says only what was counted.
+		// The counter says how many times the circuit opened, not what the model
+		// did in between: a success does not reset it, so recovered blips land
+		// here too.
 		Message: fmt.Sprintf("%s on %s opened its circuit %d times in %s",
 			model, providerName, opens, reopenWindowLabel),
 		Metadata: map[string]any{
@@ -546,11 +504,9 @@ func (cb *CircuitBreaker) reportUnstable(providerID uuid.UUID, providerName, mod
 			"provider":    providerName,
 			"model":       model,
 			// model_id repeats model as the identity the alert dispatcher
-			// debounces on. Without it the most specific key present is
-			// provider_id, and two models crossing the threshold on one provider
-			// inside the dispatcher's cooldown collapse to one alert, silently
-			// dropping the second - which is the failure debouncing per entity
-			// exists to prevent.
+			// debounces on. Without it the most specific key is provider_id, and
+			// two models crossing the threshold on one provider inside the
+			// dispatcher's cooldown collapse to a single alert.
 			"model_id": model,
 			"opens":    opens,
 			"window":   reopenWindowLabel,
@@ -560,8 +516,7 @@ func (cb *CircuitBreaker) reportUnstable(providerID uuid.UUID, providerName, mod
 
 // RecordSuccess records a successful request to one of a provider's models. It
 // resets that model's circuit only: a model that works says nothing about a
-// sibling that does not, and erasing the sibling's streak is exactly how a
-// failing model stays in rotation forever.
+// sibling that does not.
 //   - Closed: resets the failure counter.
 //   - Half-open: increments the probe counter. Closes the circuit if
 //     enough probes succeed.
@@ -570,11 +525,10 @@ func (cb *CircuitBreaker) RecordSuccess(providerID uuid.UUID, providerName, mode
 }
 
 // RecordAlive is RecordSuccess for a response that proves the provider ALIVE
-// without having served anything: a non-failover-eligible non-2xx (a plain
-// 400, a 422). It credits the circuit identically but does not stamp
-// lastSuccess, because the 429 behavioural fallback reads that stamp as "this
-// model SERVED moments ago, so the window cannot be spent" — and a client's
-// own malformed payloads must not keep classifying a spent window as busy.
+// without having served anything: a non-failover-eligible non-2xx (a plain 400,
+// a 422). It credits the circuit identically but does not stamp lastSuccess,
+// which the 429 behavioural fallback reads as "this model SERVED moments ago";
+// a client's malformed payloads must not classify a spent window as busy.
 // status is that response's status, remembered as the verdict.
 func (cb *CircuitBreaker) RecordAlive(providerID uuid.UUID, providerName, model string, status int) {
 	cb.recordSuccess(providerID, providerName, model, false, UpstreamStatus(status, causeAlive))
@@ -603,9 +557,9 @@ func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, mode
 			c.halfOpenProbes = 0
 			c.cooldownOverride = 0
 			c.pinSource = ""
-			// A probe that succeeded is the evidence the backoff was waiting for:
-			// the next open is a fresh incident and starts from the base again.
-			// The 429-open streak clears with it — HTTP just proved recovery.
+			// A succeeded probe clears the backoff: the next open is a fresh
+			// incident and starts from the base cooldown. The 429-open streak
+			// clears with it.
 			c.failedProbes = 0
 			c.cooldownBackoff = 0
 			c.clear429Escalation()
@@ -619,16 +573,15 @@ func (cb *CircuitBreaker) recordSuccess(providerID uuid.UUID, providerName, mode
 
 // Status returns the current status of all tracked providers, one row per
 // provider built from its most degraded model circuit, without the per-circuit
-// list. This is what the Prometheus scrape and the aggregate status poll read,
-// and both look only at the row.
+// list. The Prometheus scrape and the aggregate status poll read it.
 func (cb *CircuitBreaker) Status() []ProviderStatus {
 	return cb.status(false)
 }
 
 // StatusDetail is Status with Circuits filled in on every row: one entry per
-// circuit, sorted by model, with its own state, wait and last verdict. Only
-// the detail endpoint asks for it, because building the list allocates per
-// circuit under the lock the request path takes.
+// circuit, sorted by model, with its own state, wait and last verdict. Only the
+// detail endpoint asks for it, because building the list allocates per circuit
+// under the lock the request path takes.
 func (cb *CircuitBreaker) StatusDetail() []ProviderStatus {
 	return cb.status(true)
 }
@@ -637,10 +590,9 @@ func (cb *CircuitBreaker) status(detail bool) []ProviderStatus {
 	cb.mu.RLock()
 	defer cb.mu.RUnlock()
 
-	// One walk's reads for the whole scan, not per circuit: this is the
-	// Prometheus scrape path, it holds the lock the request path takes, and a
-	// deployment that never overrode a key has no settings row to cache, so every
-	// read is a DB round trip. Everything below takes the hoisted reads.
+	// One walk's settings reads for the whole scan, not per circuit: this holds
+	// the lock the request path takes, and an unoverridden key has no settings
+	// row to cache, so every read is a DB round trip.
 	r := cb.cooldowns()
 
 	statuses := make([]ProviderStatus, 0, len(cb.circuits))
@@ -652,9 +604,8 @@ func (cb *CircuitBreaker) status(detail bool) []ProviderStatus {
 		cooldown := cb.effectiveCooldownForWith(c, r)
 		state := cb.logicalStateWith(c, r)
 		// quotaPinned comes from this walk rather than from the dominant circuit:
-		// the verdict's pin arm is "any blocking circuit is pinned", and a row that
-		// answered the flag from the dominant circuit alone would tell an operator
-		// a provider is skipped outright when it is in fact waiting out a quota
+		// the verdict's pin arm is "any blocking circuit is pinned", and the
+		// dominant circuit alone would misreport a provider waiting out a quota
 		// window on a sibling model.
 		providerOpen, openModels, quotaPinned := cb.providerReport(models, r)
 		s := ProviderStatus{
@@ -663,8 +614,8 @@ func (cb *CircuitBreaker) status(detail bool) []ProviderStatus {
 			ConsecutiveFails: c.consecutiveFails,
 			QuotaPinned:      quotaPinned,
 			PinSource:        cb.pinSourceForWith(c, r),
-			// Both from the dominant circuit, like CooldownMs and NextRetryAt: they
-			// explain those two numbers, so they must come from the same circuit.
+			// From the dominant circuit, like CooldownMs and NextRetryAt: these
+			// explain those two numbers, so they come from the same circuit.
 			BackedOff:    cb.backedOffForWith(c, r),
 			FailedProbes: c.failedProbes,
 			ProviderOpen: providerOpen,

--- a/internal/failover/model_circuits.go
+++ b/internal/failover/model_circuits.go
@@ -9,10 +9,9 @@ import (
 
 // maxModelCircuitsPerProvider bounds how many model circuits one provider may
 // track. Breaker state is in-memory and every distinct upstream model id a
-// request resolves to earns a circuit, so an unbounded map would grow with the
-// provider's catalog (and with anything that looks like a model id to the
-// upstream). The cap is far above any real catalog, so it only ever bites on
-// churn that carries no routing signal.
+// request resolves to earns a circuit, so an unbounded map grows with the
+// provider's catalog and with anything that looks like a model id upstream. The
+// cap sits far above any real catalog.
 const maxModelCircuitsPerProvider = 256
 
 // defaultSpanModels is how many distinct model circuits must be open before the
@@ -24,11 +23,9 @@ const defaultSpanModels = 2
 // defaultBackoffMax is the ceiling a probe backoff may reach. Fifteen minutes:
 // at the default cooldown the waits run 1, 2, 4, 8 minutes and then hold, so a
 // model broken all day costs a hundred or so wasted requests rather than 1440,
-// while a model fixed upstream is back within a quarter of an hour with nobody
-// resetting anything. It is deliberately not longer: a probe is the only way a
-// model with no healthy sibling ever gets tried again, and the verdict that
-// skips a whole provider holds for as long as enough of its circuits keep
-// blocking, which a backoff stretches.
+// while a model fixed upstream is back within a quarter of an hour. Not longer,
+// because a probe is the only way a model with no healthy sibling gets tried
+// again, and a backoff also stretches the provider-wide verdict.
 const defaultBackoffMax = 15 * time.Minute
 
 // circuit is the health state of one (provider, resolved upstream model) pair.
@@ -48,8 +45,7 @@ type circuit struct {
 	// earned: the configured cooldown doubled once per failed probe, capped by
 	// circuit_breaker_backoff_max, stamped at the open transition the way the
 	// quota pin is. Zero means "no backoff in force". A probe is a live user
-	// request, so a model that is broken all day fails one real request per
-	// cooldown unless each failure buys a longer wait before the next.
+	// request, so each failure buys a longer wait before the next one is spent.
 	failedProbes    int
 	cooldownBackoff time.Duration
 	// lastCharged is when a failure or success last landed on this circuit. It
@@ -67,11 +63,11 @@ type circuit struct {
 	// mechanics do not read it.
 	pinSource string
 	// lastCause, lastStatus and lastAt are the circuit's most recent verdict:
-	// why it was last charged, credited, pinned or released, the upstream
-	// status behind that (0 when none was seen) and when it landed. Like
-	// pinSource they are observability only; nothing in the breaker's mechanics
-	// reads them. They are what lets a status row, an event and an alert say
-	// WHY a circuit is open rather than only that it is (see Cause).
+	// why it was last charged, credited, pinned or released, the upstream status
+	// behind that (0 when none was seen) and when it landed. Like pinSource they
+	// are observability only; nothing in the breaker's mechanics reads them. They
+	// let a status row, an event and an alert say WHY a circuit is open (see
+	// Cause).
 	lastCause  string
 	lastStatus int
 	lastAt     time.Time
@@ -96,37 +92,32 @@ type circuit struct {
 
 const (
 	// reopenWindow is how long the open transitions that escalate together must
-	// fall within. A day is long enough to catch a model that breaks a few times
-	// across a working day and short enough that failures months apart never add
-	// up to a report about the present.
+	// fall within. A day catches a model that breaks a few times across a working
+	// day without letting failures months apart add up.
 	reopenWindow = 24 * time.Hour
 	// opensBeforeEscalation is how many times a circuit opens inside one window
-	// before the breaker says so. Three, because two is an ordinary bad
-	// afternoon for a provider and the second open is already the first repeat.
+	// before the breaker says so. Three, because two is an ordinary bad afternoon
+	// for a provider.
 	opensBeforeEscalation = 3
 )
 
 // reopenWindowLabel writes the window the way an operator reads it and the way
-// the event publishes it. Duration.String renders a day as "24h0m0s", which is
-// noise in a sentence and a surprise to a consumer comparing the metadata
-// against the documented value. Derived rather than written twice so the
-// sentence cannot drift from the constant it describes.
+// the event publishes it, since Duration.String renders a day as "24h0m0s".
+// Derived from the constant so the two cannot drift apart.
 var reopenWindowLabel = fmt.Sprintf("%dh", int(reopenWindow.Hours()))
 
 // noteOpen records a transition into Open and reports whether this circuit has
 // now opened often enough inside one window to be worth escalating.
 //
 // A transition arriving after the window has run out starts a new window rather
-// than extending the old one, so an escalation is always drawn from one run of
-// recent failures rather than from unrelated outages that share a model. This
-// mirrors goneStreak.strike, for the same reason.
+// than extending the old one, so an escalation is drawn from one run of recent
+// failures rather than from unrelated outages that share a model. This mirrors
+// goneStreak.strike.
 //
 // Crossing the threshold marks the window reported rather than clearing it, so
 // the window keeps running and a report costs a full reopenWindow before another
-// can follow. Clearing it instead would start a fresh window on the very next
-// open: a model failing every cooldown reaches three opens again within minutes,
-// and the operator would be told every few minutes that it "broke 3 times in
-// 24h" — a sentence the cadence itself contradicts.
+// can follow. Clearing it would start a fresh window on the next open, and a
+// model failing every cooldown would report every few minutes.
 func (c *circuit) noteOpen(now time.Time) bool {
 	if c.openWindowStart.IsZero() || now.Sub(c.openWindowStart) > reopenWindow {
 		c.openWindowStart = now
@@ -143,11 +134,10 @@ func (c *circuit) noteOpen(now time.Time) bool {
 }
 
 // note429Open updates the rate-limit-open streak for one transition into Open.
-// Same window semantics as noteOpen, tracked separately because the two answer
-// different questions: noteOpen reports chronic instability whatever the
-// cause, this one escalates only when EVERY open in the run was a rate limit —
-// a 5xx-caused open in between is evidence of a different failure and resets
-// the streak, exactly as the design requires.
+// Same window semantics as noteOpen, tracked separately: noteOpen reports
+// chronic instability whatever the cause, this one escalates only when EVERY
+// open in the run was a rate limit, so a 5xx-caused open in between resets the
+// streak.
 func (c *circuit) note429Open(now time.Time, by429 bool) {
 	if !by429 {
 		c.opens429Streak = 0
@@ -162,10 +152,9 @@ func (c *circuit) note429Open(now time.Time, by429 bool) {
 	c.opens429Streak++
 }
 
-// exhaustedEscalated reports whether the streak has reached the point where
-// the circuit is treated as exhausted without any provider phrase saying so.
-// Three, matching opensBeforeEscalation: the provider's own text can shorten
-// this to one open; its absence only makes it slower, never wrong.
+// exhaustedEscalated reports whether the streak has reached the point where the
+// circuit is treated as exhausted without any provider phrase saying so. Three,
+// matching opensBeforeEscalation; a provider phrase shortens this to one open.
 func (c *circuit) exhaustedEscalated() bool {
 	return c.opens429Streak >= opensBeforeEscalation
 }
@@ -202,12 +191,11 @@ func (cb *CircuitBreaker) getOrCreate(providerID, model string) *circuit {
 // evictIfFull drops the least recently charged closed circuit when a provider
 // is at the cap, making room for the one about to be created.
 //
-// Only closed circuits are candidates. Evicting an open or half-open circuit
-// would silently restore the provider for a model the breaker has decided is
-// broken, which is the one outcome the cap must never cause: a provider that
-// somehow holds more open circuits than the cap keeps every one of them and the
-// map is allowed to grow instead. Evicting a closed circuit costs at most a
-// partial failure streak on a model nothing has routed to in a long time.
+// Only closed circuits are candidates: evicting an open or half-open one would
+// silently restore the provider for a model the breaker has decided is broken.
+// A provider holding more open circuits than the cap keeps every one of them and
+// the map grows instead. Evicting a closed circuit costs at most a partial
+// failure streak on a model nothing has routed to in a long time.
 //
 // Must be called with cb.mu held.
 func (cb *CircuitBreaker) evictIfFull(models modelCircuits) {
@@ -218,7 +206,7 @@ func (cb *CircuitBreaker) evictIfFull(models modelCircuits) {
 	victim := ""
 	var oldest time.Time
 	// found, rather than an empty victim, marks "nothing chosen yet": the empty
-	// string is a legitimate model key and must be as evictable as any other.
+	// string is a legitimate model key and is as evictable as any other.
 	found := false
 	for model, c := range models {
 		if cb.logicalStateWith(c, r) != StateClosed {
@@ -236,20 +224,17 @@ func (cb *CircuitBreaker) evictIfFull(models modelCircuits) {
 }
 
 // cooldownReads is everything a walk over circuits needs from settings, read at
-// most once per walk. A deployment that never overrode a key has no settings row
-// to serve from cache, so each read is a DB round trip, and every walk here runs
-// under cb.mu: Status on every Prometheus scrape, the provider verdict on the
-// request path. The configured cooldown is read up front because every circuit
-// needs it. The two kill switches are read lazily, on the first circuit that
-// carries an override or a backoff, so the healthy case (nothing overridden,
-// nothing backed off) costs exactly the one read it always did, and a provider
-// with a hundred backed-off circuits costs one more, not a hundred.
+// most once per walk. An unoverridden key has no settings row to serve from
+// cache, so each read is a DB round trip, and every walk here runs under cb.mu:
+// Status on every Prometheus scrape, the provider verdict on the request path.
+// The configured cooldown is read up front because every circuit needs it. The
+// two kill switches are read lazily, on the first circuit carrying an override
+// or a backoff, so the healthy case costs one read and a provider with a hundred
+// backed-off circuits costs one more, not a hundred.
 //
-// The switches are read per walk rather than only when a circuit opens because
-// an operator who flips one to get a provider back expects every override
-// already in force to be released at once, not only the circuits that open
-// afterwards. Per walk is also what keeps the surfaces consistent: one Status
-// row cannot report a pin its neighbour's read said was disabled.
+// The switches are read per walk rather than only when a circuit opens, so an
+// operator who flips one releases every override already in force, and one
+// Status row cannot report a pin its neighbour's read said was disabled.
 type cooldownReads struct {
 	cb        *CircuitBreaker
 	base      time.Duration
@@ -284,21 +269,19 @@ func (r *cooldownReads) pinEnabled() bool {
 // a provider directly, it reads one off the circuits it does charge.
 //
 // A provider is down when the quota ADVISOR's pin says its window is spent, or
-// when the failures span at least `span` distinct models. One model refusing
-// is evidence about that model (a plan that excludes it, a retirement, a bad
-// routing id) and must not darken its healthy siblings; corroboration across
-// models is what makes "the provider is broken" the better explanation. A pin
-// inferred from a single response (pinSource "response") is one model's
-// evidence and deliberately does not count here — see providerReport.
+// when the failures span at least `span` distinct models. One model refusing is
+// evidence about that model (a plan that excludes it, a retirement, a bad
+// routing id) and must not darken its healthy siblings. A pin inferred from a
+// single response (pinSource "response") is one model's evidence and does not
+// count here; see providerReport.
 //
 // Must be called with cb.mu held (read lock suffices).
 func (cb *CircuitBreaker) providerOpen(models modelCircuits) bool {
-	// Cheap pre-pass: a provider with nothing stored open has no verdict to
-	// derive. That is the state nearly every request finds, and this way it
-	// reads no settings at all to establish it — a cold settings cache turns
-	// each of the settings reads below into a DB round trip taken under the
-	// lock, on the request path. It also keeps the healthy path allocation-free,
-	// because providerReport builds a list.
+	// Pre-pass: a provider with nothing stored open has no verdict to derive,
+	// which is the state nearly every request finds, and establishing it reads no
+	// settings (a cold cache would make each read below a DB round trip under the
+	// lock, on the request path). It also keeps the healthy path allocation-free,
+	// since providerReport builds a list.
 	anyOpen := false
 	for _, c := range models {
 		if c.state == StateOpen {
@@ -310,8 +293,8 @@ func (cb *CircuitBreaker) providerOpen(models modelCircuits) bool {
 		return false
 	}
 
-	// Settings are read only now, after the pre-pass has established there is
-	// a verdict to derive, and once for the whole walk.
+	// Settings are read only now, after the pre-pass establishes there is a
+	// verdict to derive, and once for the whole walk.
 	open, _, _ := cb.providerReport(models, cb.cooldowns())
 	return open
 }
@@ -319,18 +302,16 @@ func (cb *CircuitBreaker) providerOpen(models modelCircuits) bool {
 // providerReport derives the provider-wide verdict together with the model ids
 // it rests on. It is the single implementation of the rule: the request path
 // takes the verdict alone (providerOpen) and the status surfaces take both, so
-// the flag an operator reads and the models listed beside it can never disagree
+// the flag an operator reads and the models listed beside it cannot disagree
 // about a cooldown that elapsed between two separate walks.
 //
 // blocked is sorted, because it is printed in a provider detail that refetches
-// every few seconds and Go's map iteration order would otherwise reshuffle it.
+// every few seconds and Go's map iteration order would reshuffle it.
 //
-// pinned is the third thing the same walk already knows: whether any of the
-// blocking circuits is held dark by a quota pin. It is returned rather than
-// re-derived from the row's dominant circuit, because those two readings
-// disagree at exactly the shape this arm exists for — a provider indicted by a
-// pinned sibling while its most degraded circuit carries no pin would otherwise
-// be reported as skipped outright rather than as waiting for a quota window.
+// pinned says whether any blocking circuit is held dark by a quota pin. It comes
+// from this walk rather than from the row's dominant circuit, which would report
+// a provider indicted by a pinned sibling as skipped outright rather than as
+// waiting for a quota window.
 //
 // Must be called with cb.mu held (read lock suffices).
 func (cb *CircuitBreaker) providerReport(models modelCircuits, r *cooldownReads) (open bool, blocked []string, pinned bool) {
@@ -348,13 +329,11 @@ func (cb *CircuitBreaker) providerReport(models modelCircuits, r *cooldownReads)
 		}
 	}
 	slices.Sort(blocked)
-	// Only an ADVISOR pin indicts the provider on its own: the advisor
-	// measured the provider's account, so its verdict is provider-scoped by
-	// construction. A response-derived pin is inferred from one model's 429,
-	// and the refusal that made per-model keying necessary — a plan excluding
-	// ONE model, answered with a balance error — is exactly that shape: pinning
-	// it must darken that model for as long as the pin says, and nothing else.
-	// Corroboration across models (the span) still reaches the provider.
+	// Only an ADVISOR pin indicts the provider on its own: it measured the
+	// provider's account, so its verdict is provider-scoped. A response-derived
+	// pin is inferred from one model's 429 (a plan excluding ONE model, answered
+	// with a balance error), so it darkens that model alone. Corroboration across
+	// models (the span) still reaches the provider.
 	return advisorPinned || len(blocked) >= cb.effectiveSpan(), blocked, pinned
 }
 
@@ -383,9 +362,8 @@ func (cb *CircuitBreaker) stillDark(c *circuit, r *cooldownReads) bool {
 // reports: an open circuit whose cooldown has elapsed is "ready to probe" and
 // reads as half-open, even though the stored state only flips to StateHalfOpen
 // for the brief duration of an in-flight probe request. Without this the
-// half-open bucket is effectively unobservable (and the sidebar badge's middle
-// count never moves). Purely derived — it never mutates the circuit — so every
-// surface (Status, GetState, Reset) agrees on what a circuit is doing.
+// half-open bucket is effectively unobservable. Purely derived, never mutating
+// the circuit, so every surface (Status, GetState, Reset) agrees.
 //
 // Must be called with cb.mu held (read lock suffices).
 func (cb *CircuitBreaker) logicalState(c *circuit) State {
@@ -404,8 +382,7 @@ func (cb *CircuitBreaker) logicalStateWith(c *circuit, r *cooldownReads) State {
 // circuitRank orders one provider's circuits so the per-provider surfaces
 // (Status, Reset) can report a single row for a set of circuits. The most
 // degraded circuit wins: it is the one an operator is looking for, and with a
-// single model in play it is the only one, which keeps those surfaces reading
-// exactly as they did when the breaker was keyed on the provider alone.
+// single model in play it is the only one.
 type circuitRank struct {
 	model string
 	state int
@@ -444,11 +421,11 @@ func stateRank(s State) int {
 // dominant returns the circuit that represents a provider on the per-provider
 // surfaces, or nil when the provider tracks none.
 //
-// r carries the walk's settings, hoisted by the caller: every read in this walk
-// goes through the *With helpers, so ranking a provider's circuits reads
-// settings zero times however many circuits it holds. That matters because
-// Status runs this for every provider on every Prometheus scrape, under the
-// lock the request path takes, and an uncached settings read is a DB round trip.
+// r carries the walk's settings, hoisted by the caller: every read here goes
+// through the *With helpers, so ranking a provider's circuits reads settings
+// zero times. Status runs this for every provider on every Prometheus scrape,
+// under the lock the request path takes, and an uncached settings read is a DB
+// round trip.
 //
 // Must be called with cb.mu held (read lock suffices).
 func (cb *CircuitBreaker) dominant(models modelCircuits, r *cooldownReads) *circuit {
@@ -480,9 +457,8 @@ func (cb *CircuitBreaker) effectiveThreshold() int {
 }
 
 // effectiveSpan returns how many distinct open model circuits it takes to call
-// the provider down, reading from settings if available. The floor of 1 is the
-// escape hatch: it reproduces the provider-keyed behaviour the breaker had
-// before circuits were split per model.
+// the provider down, reading from settings if available. A span of 1 is the
+// escape hatch: any single open circuit indicts the provider.
 func (cb *CircuitBreaker) effectiveSpan() int {
 	span := cb.SpanModels
 	if cb.settings != nil {
@@ -511,15 +487,12 @@ func (cb *CircuitBreaker) effectiveCooldown() time.Duration {
 // the configured cooldown, the circuit's probe backoff when backoff is switched
 // on, and its quota pin when pinning is switched on.
 //
-// The longest, not a precedence order, because each of the three is a reason
-// the circuit must not be probed yet, and none of them is a reason it may be.
-// Taking the longest is also what makes the stored values safe against
-// everything that can change under them: a base raised above a stamped backoff
-// (the setting governs, and the row stops claiming a backoff), a switch flipped
-// between the moment a pin was floored and now (the backoff the pin was meant
-// to clear still holds), and a ceiling lowered after a pin was stamped. In
-// the ordinary course a pin is at least the backoff, because applyQuotaPin
-// floors it there, so the longest is simply the pin whenever one is in force.
+// The longest, not a precedence order, because each of the three is a reason the
+// circuit must not be probed yet and none is a reason it may be. It also keeps
+// the stored values safe against changes underneath them: a base raised above a
+// stamped backoff, a switch flipped after a pin was floored, a ceiling lowered
+// after a pin was stamped. applyQuotaPin floors a pin at the backoff, so the
+// longest is the pin whenever one is in force.
 func (cb *CircuitBreaker) effectiveCooldownForWith(c *circuit, r *cooldownReads) time.Duration {
 	cooldown := cb.unpinnedCooldownWith(c, r)
 	if cb.quotaPinnedForWith(c, r) && c.cooldownOverride > cooldown {
@@ -543,22 +516,20 @@ func (cb *CircuitBreaker) unpinnedCooldownWith(c *circuit, r *cooldownReads) tim
 // be called with cb.mu held, immediately after c transitions to Open and before
 // applyQuotaPin, which floors the pin at the value stamped here.
 //
-// The backoff is computed once, at the open transition, and stored, rather than
-// derived on every read from the count and the ceiling: every walk over circuits
-// reads the configured cooldown once and then takes the rest from the circuit,
-// and a ceiling read per circuit would put a DB round trip per circuit back
-// under the lock. What the stored value cannot know is a base raised after it
-// was stamped; effectiveCooldownForWith covers that by never serving less than
-// the base. Always stamped, gated only at read time by backedOffForWith, so the
-// kill switch acts at once in both directions.
+// The backoff is computed once, at the open transition, and stored rather than
+// derived on every read: a ceiling read per circuit would put a DB round trip
+// per circuit back under the lock. The stored value cannot know a base raised
+// after it was stamped, which effectiveCooldownForWith covers by never serving
+// less than the base. Always stamped, gated only at read time by
+// backedOffForWith, so the kill switch acts at once in both directions.
 //
 // A ceiling at or below the base is not a shorter cooldown: the ceiling bounds
 // what the backoff may add, and a backoff that could add nothing is left off.
 //
 // A circuit escalated to exhausted-without-a-phrase (see exhaustedEscalated)
-// gets the quota-pin ceiling instead when that reaches further: its probes are
-// live requests spent against a window that resets in hours, so the ordinary
-// 15-minute cap is exactly the re-probe churn the escalation exists to stop.
+// takes the quota-pin ceiling when that reaches further: its probes are live
+// requests spent against a window that resets in hours, which the ordinary
+// 15-minute cap would re-probe through.
 func (cb *CircuitBreaker) applyBackoff(c *circuit) {
 	c.cooldownBackoff = 0
 	if c.failedProbes == 0 {
@@ -573,11 +544,9 @@ func (cb *CircuitBreaker) applyBackoff(c *circuit) {
 		return
 	}
 	d := base
-	// Doubled step by step and stopped at the ceiling, never shifted by the
-	// count: a model that has failed its probe for a week has a count that would
-	// overflow a shift long before it reached anything a ceiling could clamp.
-	// The halfway test keeps the doubling itself inside int64 whatever the
-	// ceiling is.
+	// Doubled step by step and stopped at the ceiling, never shifted by the count:
+	// a week of failed probes gives a count that overflows a shift. The halfway
+	// test keeps the doubling inside int64 whatever the ceiling is.
 	for range c.failedProbes {
 		if d > ceiling/2 {
 			d = ceiling
@@ -588,17 +557,15 @@ func (cb *CircuitBreaker) applyBackoff(c *circuit) {
 	c.cooldownBackoff = d
 }
 
-// backedOffForWith reports whether a probe backoff is actually governing this
-// circuit right now: one is stamped, it reaches beyond the configured cooldown,
-// and backoff is switched on. Like quotaPinnedForWith, the kill switch is
-// re-read per walk rather than only when a circuit opens, so an operator who
-// disables backoff to get a provider back releases every backoff already in
-// force, not only the circuits that open afterwards. The "beyond the base" test
-// is what keeps the flag honest when the base is raised after the stamp: a row
-// must not claim a backoff for a cooldown identical to the setting. Every
-// surface that reports or enforces the backoff derives from this one predicate.
-// The flag says the backoff is in force, not that it is the longest; a pin can
-// reach further, and effectiveCooldownForWith decides which one the number is.
+// backedOffForWith reports whether a probe backoff is governing this circuit:
+// one is stamped, it reaches beyond the configured cooldown, and backoff is
+// switched on. Like quotaPinnedForWith, the kill switch is re-read per walk, so
+// disabling backoff releases every backoff already in force. The "beyond the
+// base" test keeps the flag honest when the base is raised after the stamp: a
+// row must not claim a backoff for a cooldown identical to the setting. Every
+// surface that reports or enforces the backoff derives from this predicate. The
+// flag says the backoff is in force, not that it is the longest; a pin can reach
+// further, and effectiveCooldownForWith decides which one the number is.
 func (cb *CircuitBreaker) backedOffForWith(c *circuit, r *cooldownReads) bool {
 	return c != nil && c.cooldownBackoff > r.base && r.backoffEnabled()
 }
@@ -620,26 +587,22 @@ func (cb *CircuitBreaker) backoffMax() time.Duration {
 	return defaultBackoffMax
 }
 
-// quotaPinnedForWith reports whether a quota pin is actually governing this
-// circuit right now. The kill switch is deliberately re-read per walk rather
-// than only at the moment a circuit opens: an operator who disables quota
-// pinning to recover a provider sidelined for hours expects every pin already
-// in force to be released at once, not only the circuits that open afterwards.
-// It is the fleet-wide lever; Reset is the per-provider one.
+// quotaPinnedForWith reports whether a quota pin is governing this circuit. The
+// kill switch is re-read per walk, so disabling quota pinning releases every pin
+// already in force. It is the fleet-wide lever; Reset is the per-provider one.
 //
-// Every surface derives from this one predicate — the cooldown the breaker
-// enforces, the CooldownMs/NextRetryAt the status API publishes, the
-// quota_pinned flag beside them, and the pin arm of the provider-wide verdict.
-// The flag says the pin is in force, not that it is the longest; a backoff can
-// reach further, and effectiveCooldownForWith decides which one the number is.
+// Every surface derives from this predicate: the cooldown the breaker enforces,
+// the CooldownMs/NextRetryAt the status API publishes, the quota_pinned flag
+// beside them, and the pin arm of the provider-wide verdict. The flag says the
+// pin is in force, not that it is the longest; a backoff can reach further, and
+// effectiveCooldownForWith decides which one the number is.
 func (cb *CircuitBreaker) quotaPinnedForWith(c *circuit, r *cooldownReads) bool {
 	return c != nil && c.cooldownOverride > 0 && r.pinEnabled()
 }
 
 // pinSourceForWith is the pin's provenance ("advisor" or "response"), reported
-// only while the pin is actually in force — the same predicate the
-// quota_pinned flag derives from, so a row can never name a source for a pin
-// it does not claim.
+// only while the pin is in force. It uses the predicate the quota_pinned flag
+// derives from, so a row cannot name a source for a pin it does not claim.
 func (cb *CircuitBreaker) pinSourceForWith(c *circuit, r *cooldownReads) string {
 	if !cb.quotaPinnedForWith(c, r) {
 		return ""

--- a/internal/frontdesk/configsync.go
+++ b/internal/frontdesk/configsync.go
@@ -16,14 +16,14 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// This file implements the Front Desk side of HA fleet config sync. It
-// orchestrates the member-side /api/config/export + /api/config/import endpoints
-// (see internal/api/configsync.go): pull the chosen primary's config, then push
-// it to every other member so the fleet converges to one configuration.
+// The Front Desk side of HA fleet config sync: it drives the member-side
+// /api/config/export and /api/config/import endpoints, pulling the chosen
+// primary's config and pushing it to every other member so the fleet converges
+// on one configuration.
 //
-// Config replace can remove providers/keys on a replica, so it is a deliberate,
-// primary-driven, double-confirmed action. No key material is ever returned to
-// the browser or logged; only names and counts.
+// A config replace can remove providers and keys on a replica, so it is a
+// deliberate, primary-driven, double-confirmed action. No key material reaches
+// the browser or the logs; only names and counts.
 
 const (
 	memberConfigExportPath = "/api/config/export"
@@ -31,16 +31,15 @@ const (
 
 	// fleetSourceGenHeader carries the monotonic source generation (auto_sync_gen)
 	// on a real import so the member's commit fence can refuse an out-of-order
-	// stale push. It must match internal/api.fleetSourceGenHeader. An older member
-	// ignores it, so sending it is always safe.
+	// stale push. It must match internal/api.fleetSourceGenHeader; a member that
+	// does not know the header ignores it.
 	fleetSourceGenHeader = "X-Fleet-Source-Gen"
 )
 
-// manualSyncReason is stamped on a member's last-config-sync marker (and the
-// audit event) when an operator drives the sync (vs the automatic loop). It
-// names who triggered it — a paired device or the dashboard — so the Members
-// table and event log attribute the run instead of the old anonymous "from the
-// wizard" phrasing, which read wrongly for a phone-initiated sync.
+// manualSyncReason is stamped on a member's last-config-sync marker and audit
+// event when an operator drives the sync rather than the automatic loop. It
+// names who triggered it, a paired device or the dashboard, so the Members
+// table and event log attribute the run.
 func manualSyncReason(actor string) string {
 	return "manual sync by " + actor
 }
@@ -64,19 +63,18 @@ type syncResultItem struct {
 	// it holds no such model, as provider/model_id. Rides alongside a successful
 	// result for the same reason as Partial.
 	UnappliedModels []string `json:"unapplied_models,omitempty"`
-	// TimedOut marks a push whose deadline expired before the member answered. The
-	// member may well have committed the config and just taken longer than
-	// memberSyncTimeout to say so, which is what a long member-side discovery looks
-	// like from here. Not on the wire: it only tells the auto-sync loop the member
-	// did receive the config, so the re-push is rate-limited.
+	// TimedOut marks a push whose deadline expired before the member answered.
+	// The member may have committed the config and simply taken longer than
+	// memberSyncTimeout to say so, which is what a long member-side discovery
+	// looks like from here. Not on the wire: it only tells the auto-sync loop the
+	// member did receive the config, so the re-push is rate-limited.
 	TimedOut bool `json:"-"`
 	// Unconfirmed marks a push whose answer was lost in either of the two ways a
 	// still-running import looks like a failure from here: the deadline expired
-	// (TimedOut), or a 5xx came back that can stand in front of a live import (a
-	// gateway timeout, or another 5xx after the call ran long enough for a proxy
-	// deadline to have cut it; see lostAnswer5xx). The import may have landed, so
-	// the auto-sync loop rate-limits the re-push the same way it does a timeout
-	// instead of restarting the member's import every tick. Not on the wire.
+	// (TimedOut), or a 5xx came back that can stand in front of a live import
+	// (lostAnswer5xx). The import may have landed, so the auto-sync loop
+	// rate-limits the re-push instead of restarting the member's import every
+	// tick. Not on the wire.
 	Unconfirmed bool `json:"-"`
 }
 
@@ -91,24 +89,22 @@ type memberImportResult struct {
 	// push). It is a benign, expected outcome, not a sync failure.
 	Stale bool `json:"stale,omitempty"`
 	// Incomplete is true when the member committed the config but could not
-	// materialise all of it. Absent on a member running older code, which
+	// materialise all of it. Absent on a member too old to report it, which
 	// decodes to false and reads as complete.
 	Incomplete bool `json:"incomplete,omitempty"`
 	// Unapplied names the custom failover groups the member did not build.
 	Unapplied []string `json:"unapplied,omitempty"`
 	// Partial names the custom failover groups the member built with fewer entries
 	// than the primary sent, because it holds fewer of their models. Travels with
-	// Incomplete = false: the member applied everything it was asked to. Divergence
-	// is decided by the hash; this only makes the alert specific.
+	// Incomplete = false: the member applied everything it was asked to.
 	Partial []string `json:"partial,omitempty"`
 	// UnappliedModels names per-model disables the member could not apply because
 	// it holds no such model. Same disposition as Partial: reported, not a failure.
 	UnappliedModels []string `json:"unapplied_models,omitempty"`
 	// ModelStateFailed is true when the member's per-model disable reconcile failed
-	// outright, so it is still routing to models the primary switched off. It is the
-	// other thing Incomplete can mean; without it an unbuilt failover group and a
-	// failed reconcile are indistinguishable, since only the former has names.
-	// Absent on a member running older code, which reads as false.
+	// outright, so it is still routing to models the primary switched off. It is
+	// the other fault Incomplete can mean, and the one with no names to report.
+	// Absent on a member too old to report it, which reads as false.
 	ModelStateFailed bool             `json:"model_state_failed,omitempty"`
 	Diff             memberConfigDiff `json:"diff"`
 }
@@ -127,7 +123,7 @@ type memberConfigDiff struct {
 	Users          memberEntityDiff `json:"users"`
 }
 
-// added/updated/removed total the diff across all entity kinds.
+// counts totals the diff across all entity kinds.
 func (d memberConfigDiff) counts() (added, updated, removed int) {
 	for _, e := range []memberEntityDiff{d.Providers, d.VirtualKeys, d.Settings, d.FailoverGroups, d.Users} {
 		added += len(e.Added)
@@ -141,25 +137,19 @@ func (d memberConfigDiff) counts() (added, updated, removed int) {
 // and reports whether the caller should proceed to applyMemberConfig. It returns
 // (item, proceed):
 //
-//   - proceed=true (item nil): either the member is reachable, syncable, and
-//     changing; or it is unreachable / version- or MASTER_KEY-blocked. In both
-//     cases the caller runs applyMemberConfig, which performs the authoritative
-//     import and reports the real outcome. A blocked or unreachable member cannot
-//     be destructively written (its import is refused), so letting it fall through
-//     costs nothing and yields a precise error.
+//   - proceed=true (item nil): the member is reachable, syncable and changing, or
+//     it is unreachable / version- or MASTER_KEY-blocked. Either way the caller
+//     runs applyMemberConfig, whose import is authoritative and reports the real
+//     cause; a blocked or unreachable member cannot be written destructively.
 //   - proceed=false (item set): the member is already converged, reported OK with
 //     no import. The caller skips applyMemberConfig and records item as-is.
 //
 // A member the dry run reports as converged is skipped rather than handed a no-op
-// import, which would run member-side model discovery for no reason. That skip is
-// rare: computeDiff keys on presence, so every entity the member and the primary
-// share counts as updated and a real fleet's diff is almost never empty. The
-// auto-syncer therefore leans on incompleteRetryInterval, not on this branch.
+// import, which would run member-side model discovery for no reason.
 //
-// Front Desk takes no snapshot before overwriting a member; members back themselves
-// up on their own schedule. The trade is deliberate: a bad config propagation cannot
-// be rolled back from a snapshot Front Desk just took, and in exchange no member
-// accumulates a pg_dump per sync run.
+// Front Desk takes no snapshot before overwriting a member; members back
+// themselves up on their own schedule, so a bad propagation cannot be rolled
+// back from here.
 func (s *Server) prepareMemberSync(ctx context.Context, m *Member, token string, export []byte) (*syncResultItem, bool) {
 	preview, status, err := s.pushMemberImport(ctx, m, token, export, true, 0) // dry-run: gen unused (no fence header)
 	if err != nil || status != http.StatusOK || !preview.SchemaVersionOK || !preview.MasterKeyOK {
@@ -184,8 +174,7 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 	for _, r := range results {
 		// An incomplete member counts as a config write: it committed the config and
 		// only failed to materialise part of it. Excluding it would freeze the fleet
-		// marker, which the staleness watchdog reads, for as long as one member
-		// stayed diverged.
+		// marker the staleness watchdog reads while one member stays diverged.
 		if r.OK || r.Incomplete {
 			changed = true
 			break
@@ -204,11 +193,11 @@ func (s *Server) recordFleetSyncRun(ctx context.Context, primary *Member, result
 // marker with reason (shown in the Members table), so both the wizard and the
 // auto-sync loop record why and when a member last converged.
 //
-// emitSuccessEvent separates the two callers' notion of success. The wizard sets it
-// true: an operator drove this sync, so it wants one event per member and the
+// emitSuccessEvent separates the two callers' notion of success. The wizard sets
+// it true: an operator drove this sync, so it wants one event per member and the
 // heartbeat moves with the write. The auto-syncer sets it false: it emits one
-// roll-up rather than toasting per member, and takes its heartbeat from its own hash
-// comparison. Failure events fire either way.
+// roll-up and takes its heartbeat from its own hash comparison. Failure events
+// fire either way.
 func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string, export []byte, reason string, emitSuccessEvent bool, sourceGen int64, pushedHash string) syncResultItem {
 	res := syncResultItem{MemberID: m.ID, Name: m.Name}
 	// How long the push ran separates a 5xx that cut a live import from one the
@@ -216,17 +205,16 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 	pushStart := time.Now()
 	out, status, err := s.pushMemberImport(ctx, m, token, export, false, sourceGen)
 	// Carried on the success path too: neither a group built short nor a disable
-	// the member has no model for is a failure to apply, so neither reaches the
-	// incomplete arm below, and the auto-sync loop needs the names for its
-	// divergence alert.
+	// the member has no model for is a failure to apply, and the auto-sync loop
+	// needs the names for its divergence alert.
 	res.Partial = out.Partial
 	res.UnappliedModels = out.UnappliedModels
 	switch {
 	case err != nil && status == 0 && isTimeout(err):
-		// The deadline expired with the member still working, so unlike a refusal or an
-		// unreachable host this push may have landed. Its own outcome, so the loop
-		// rate-limits the re-push instead of re-importing every tick and restarting the
-		// member-side discovery.
+		// The deadline expired with the member still working, so unlike a refusal
+		// or an unreachable host this push may have landed. Its own outcome, so the
+		// loop rate-limits the re-push instead of re-importing every tick and
+		// restarting the member-side discovery.
 		res.Error = "this member did not answer in time"
 		res.TimedOut = true
 		res.Unconfirmed = true
@@ -236,10 +224,9 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 	case err != nil && status == 0:
 		res.Error = "could not reach this member"
 	case err != nil:
-		// The member answered, just with a status we cannot apply: surface it so a
-		// wrong stored token or a member-side error is not mislabeled "offline",
-		// and with the member's own reason when it gave one, so a refused
-		// envelope names the field here rather than only in the member's log.
+		// The member answered, with a status we cannot apply: surface it so a wrong
+		// stored token or a member-side error is not mislabeled "offline", and
+		// carry the member's own reason when it gave one.
 		res.Error = fmt.Sprintf("this member rejected the request (HTTP %d)", status)
 		var refusal *memberRefusal
 		if errors.As(err, &refusal) && refusal.reason != "" {
@@ -249,50 +236,49 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 			// This 5xx is not proof the import failed: a reverse proxy between Front
 			// Desk and the member answers 502/504 when the import outlives its own
 			// read timeout, with the member still applying behind it. The hash
-			// binding covers the other slow 5xx source, the member's own import
-			// erroring before commit: nothing landed there, so it can only converge
-			// on this exact hash through an operator restoring precisely this config.
+			// binding covers the other slow 5xx source, an import that errored
+			// before commit: nothing landed there, so the member can only reach this
+			// exact hash if an operator restores precisely this config.
 			res.Error = fmt.Sprintf("this member's answer was lost (HTTP %d); it may still be applying", status)
 			res.Unconfirmed = true
 			s.markUnconfirmedPush(m.ID, pushedHash)
 		}
 	case !out.SchemaVersionOK:
 		// Schema is checked before MASTER_KEY: a 422 short-circuits before the
-		// canary, leaving master_key_ok an unevaluated false (see previewMemberConfig).
+		// decrypt canary, leaving master_key_ok an unevaluated false.
 		res.Error = "version mismatch with the primary"
 	case !out.MasterKeyOK:
 		res.Error = "MASTER_KEY does not match the primary"
 	case out.Stale:
 		// The member's commit fence refused this push because a newer source
-		// generation already applied. This is the expected, benign outcome of a
-		// rearm/repoint landing mid-flight: the superseding pass is authoritative,
-		// so do not stamp last-sync, do not count it as converged, and do not emit a
-		// failure event. res.OK stays false (with no Error) so the caller leaves the
-		// member for the newer pass; a soft note documents the disposition.
+		// generation already applied, the benign outcome of a rearm or repoint
+		// landing mid-flight. The superseding pass is authoritative, so this one
+		// does not stamp last-sync, does not count as converged, and emits no
+		// failure event; res.OK stays false so the caller leaves the member to the
+		// newer pass.
 		res.Error = "superseded by a newer sync"
 		debuglog.Debug("frontdesk: config sync superseded by a newer generation", "member", m.Name, "source_gen", sourceGen)
-		// Counted under its own label: a fence supersede is benign, and folding it
-		// into "err" would make routine rearms look like sync failures on a graph.
+		// Its own label: a fence supersede is benign, and folding it into "err"
+		// would make routine rearms look like sync failures on a graph.
 		recordConfigSync("superseded")
 		return res
 	case !out.Applied:
 		res.Error = "this member did not apply the config"
 	case out.Incomplete:
-		// The member committed the config but could not build part of it, so this push
-		// did not apply it: res.OK stays false, keeping the metric and the wizard's
-		// per-member result honest. The auto-sync loop does not depend on that, since
-		// the hash comparison decides convergence; what this report adds is the names
-		// below, which make the alert specific.
+		// The member committed the config but could not build part of it, so this
+		// push did not apply it and res.OK stays false. The auto-sync loop decides
+		// convergence from the hash instead; what this arm adds is the names that
+		// make its alert specific.
 		res.Error = incompleteMessage(out.Unapplied, out.ModelStateFailed)
 		res.Incomplete = true
 		res.Unapplied = out.Unapplied
 		recordConfigSync("incomplete")
 		// The member did commit this config, so its last-sync marker advances even
-		// though res.OK stays false. Otherwise a member that can never build one group
-		// shows "Last Config Sync" frozen at its last clean apply, and the staleness
-		// watchdog raises config.autosync_stale on top of the divergence alert already
-		// naming the real problem. A write failure is logged and dropped: the member is
-		// reported diverged either way.
+		// though res.OK stays false. Otherwise a member that can never build one
+		// group shows "Last Config Sync" frozen at its last clean apply, and the
+		// staleness watchdog raises config.autosync_stale on top of the divergence
+		// alert already naming the real problem. A write failure is logged and
+		// dropped: the member is reported diverged either way.
 		if err := s.store.SetMemberLastSync(ctx, m.ID, time.Now().UTC(), reason); err != nil {
 			debuglog.Warn("frontdesk: stamp member last-sync", "member", m.Name, "error", err)
 		} else {
@@ -327,19 +313,15 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		recordConfigSync("ok")
 		if emitSuccessEvent {
 			// The wizard's path: an operator drove this sync, so a completed write is
-			// what they asked to be told about.
-			//
-			// The auto-sync loop passes false and deliberately gets no stamp here. A
-			// successful write proves the member took the config, not that it ended up
-			// holding it. A member that can never converge commits every re-push, so
-			// stamping here would refresh "verified in sync" every
-			// incompleteRetryInterval beside the amber badge saying it does not match.
+			// what they asked to be told about. The auto-sync loop passes false and
+			// takes no stamp here: a successful write proves the member took the
+			// config, not that it ended up holding it.
 			s.poller.SetAutoSyncVerified(m.ID, time.Now().UTC())
 			s.emit(ctx, Event{
 				Type: "config.synced", Severity: "info", Source: "frontdesk",
 				Message: fmt.Sprintf("Config synced to %s", m.Name), MemberID: m.ID,
-				// reason carries who/why (e.g. "manual sync by Pixel (operator)" or
-				// "did not hold the primary's config"), so the event log attributes the run.
+				// reason carries who and why (e.g. "manual sync by Pixel (operator)"
+				// or "did not hold the primary's config") for the event log.
 				Metadata: map[string]any{"reason": reason},
 			})
 		}
@@ -347,14 +329,11 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 		recordConfigSync("err")
 		debuglog.Warn("frontdesk: config sync failed", "member", m.Name, "error", res.Error)
 		// An unconfirmed push (timed out, or 5xx'd in a way that can stand in front
-		// of a live import) is published at info, not warning. The type stays the
-		// same, because it is still the outcome of a push that did not converge the
-		// member and belongs in the same log, but alert dispatch derives its
-		// notification severity from the live event, and paging an operator at
-		// warning for a condition this very message describes as probably fine is
-		// noise. The caller agrees with the message: it stamps the push as received
-		// and rate-limits the re-push on exactly that reading. A member that is
-		// genuinely refusing, or unreachable, or mismatched, still warns.
+		// of a live import) is published at info, not warning: alert dispatch takes
+		// its notification severity from the live event, and paging an operator for
+		// a condition this message calls probably fine is noise. The type stays the
+		// same, since the push still did not converge the member. A genuine
+		// refusal, an unreachable member, or a mismatch still warns.
 		severity := "warning"
 		if res.Unconfirmed {
 			severity = "info"
@@ -363,10 +342,10 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 			Type: "config.sync_failed", Severity: severity, Source: "frontdesk",
 			Message: syncFailureMessage(m.Name, res.Error, res.TimedOut), MemberID: m.ID,
 			// error carries the specific cause the message renders; timed_out and
-			// unconfirmed are always present so a consumer reads one shape rather than
-			// testing for the keys. unconfirmed is what separates a lost answer, which
-			// is rate-limited and may prove itself landed on a later verification pass,
-			// from a genuine rejection.
+			// unconfirmed are always present so a consumer reads one shape rather
+			// than testing for the keys. unconfirmed separates a lost answer, which
+			// is rate-limited and may prove itself landed on a later verification
+			// pass, from a genuine rejection.
 			Metadata: map[string]any{"reason": reason, "error": res.Error, "timed_out": res.TimedOut, "unconfirmed": res.Unconfirmed},
 		})
 	}
@@ -375,12 +354,11 @@ func (s *Server) applyMemberConfig(ctx context.Context, m *Member, token string,
 
 // incompleteMessage renders what a member committed but could not materialise.
 //
-// Incomplete covers two faults, and they send the operator to different places: a
-// custom failover group that would not build (those models serve 404 for
+// Incomplete covers two faults, and they send the operator to different places:
+// a custom failover group that would not build (those models serve 404 for
 // hotel/<group>), and a per-model disable reconcile that failed (the member is
-// still routing to models the primary switched off). Only the first has names to
-// report, so naming groups whenever there were none reported the wrong fault for
-// the second.
+// still routing to models the primary switched off). Only the first has names,
+// so each fault gets its own clause.
 func incompleteMessage(unapplied []string, modelStateFailed bool) string {
 	var clauses []string
 	if len(unapplied) > 0 {
@@ -391,23 +369,21 @@ func incompleteMessage(unapplied []string, modelStateFailed bool) string {
 		clauses = append(clauses, "this member could not apply the primary's per-model settings")
 	}
 	if len(clauses) == 0 {
-		// Neither named: an older member reporting incomplete for a fault this build
-		// has no field for, or a whole group-build transaction that failed before any
-		// group was evaluated.
+		// Neither named: a member reporting incomplete for a fault this build has no
+		// field for, or a group-build transaction that failed before any group was
+		// evaluated.
 		return "applied, but this member could not materialise all of it"
 	}
 	return "applied, but " + strings.Join(clauses, ", and ")
 }
 
 // syncFailureMessage renders the operator-facing line for a push that did not
-// converge the member, from the specific cause rather than a bare "failed": the
-// causes range from an unreachable host to a MASTER_KEY mismatch, and each points
-// at different work.
+// converge the member, naming the specific cause: they range from an unreachable
+// host to a MASTER_KEY mismatch, and each points at different work.
 //
-// A timed-out push gets its own wording because it is not a refusal. The member
-// took the request and is very likely still importing; the caller stamps it as
-// received and rate-limits the re-push on exactly that reading. Calling it a
-// failure sends the operator after a member that is working.
+// A timed-out push gets its own wording because it is not a refusal: the member
+// took the request and is likely still importing, so calling it a failure sends
+// the operator after a member that is working.
 func syncFailureMessage(member, cause string, timedOut bool) string {
 	if timedOut {
 		return fmt.Sprintf("%s did not answer the config push in time; it may still be applying", member)
@@ -418,11 +394,11 @@ func syncFailureMessage(member, cause string, timedOut bool) string {
 	return fmt.Sprintf("Failed to sync config to %s: %s", member, cause)
 }
 
-// isTimeout reports whether a member call failed because its deadline expired, as
-// opposed to being refused, unreachable, or cancelled. Both shapes count: the
+// isTimeout reports whether a member call failed because its deadline expired,
+// as opposed to being refused, unreachable, or cancelled. Both shapes count: the
 // client's own Timeout, and an expired context deadline. A cancelled context is
-// deliberately not a timeout, so a pass aborted by a rearm is never mistaken for a
-// slow member.
+// deliberately not a timeout, so a pass aborted by a rearm is never mistaken for
+// a slow member.
 func isTimeout(err error) bool {
 	var nerr net.Error
 	if errors.As(err, &nerr) && nerr.Timeout() {
@@ -446,11 +422,10 @@ const unconfirmed5xxFloor = 10 * time.Second
 //
 // 504 qualifies on its own: a gateway timeout means an intermediary waited for
 // the member and gave up, however long that wait was configured to be. Any
-// other 5xx qualifies only after unconfirmed5xxFloor: an instant 502/500
-// cannot mean "still importing" — it is a proxy whose upstream is down, or a
-// member handler erroring on the spot — and treating it as maybe-landed would
-// rate-limit the re-push (see applyAutoSync) for a push that demonstrably did
-// nothing, where retrying next tick is right.
+// other 5xx qualifies only after unconfirmed5xxFloor. An instant 502 or 500
+// cannot mean "still importing": it is a proxy whose upstream is down, or a
+// member handler erroring on the spot, and treating it as maybe-landed would
+// rate-limit the re-push of a push that demonstrably did nothing.
 func lostAnswer5xx(status int, elapsed time.Duration) bool {
 	if status == http.StatusGatewayTimeout {
 		return true
@@ -464,11 +439,10 @@ func lostAnswer5xx(status int, elapsed time.Duration) bool {
 // would accept refuses an envelope the fleet could have synced, and reading more
 // buys nothing since the receiving member would reject it.
 //
-// It has to be its own limit rather than the shared maxMemberRespBody, which is
-// eight times smaller and sized for fixed-shape documents. An envelope grows with
-// the fleet's providers, virtual keys, users and groups, and this one is
-// load-bearing for every member: a refused read aborts the whole pass, so no
-// member converges.
+// It is its own limit rather than the shared maxMemberRespBody, which is eight
+// times smaller and sized for fixed-shape documents. An envelope grows with the
+// fleet's providers, virtual keys, users and groups, and a refused read aborts
+// the whole pass, so no member converges.
 const maxMemberConfigExportBody = 8 << 20
 
 // fetchMemberExport reads a member's config envelope as raw JSON so it can be
@@ -497,14 +471,14 @@ func (s *Server) pushMemberImport(ctx context.Context, m *Member, token string, 
 	var headers [][2]string
 	if dryRun {
 		path += "?dryRun=1"
-		// A dry run is read-only and never fenced, so the source-generation header
-		// is deliberately omitted: it carries no meaning for a preview.
+		// A dry run is read-only and never fenced, so it carries no
+		// source-generation header.
 	} else {
 		// Stamp the commit fence on the real import so the member can refuse a
 		// stale, out-of-order push (a primary repoint that lands mid-flight).
 		headers = append(headers, [2]string{fleetSourceGenHeader, strconv.FormatInt(sourceGen, 10)})
 	}
-	// The import client gets a longer deadline than the health probe: a real
+	// The import client has a longer deadline than the health probe: a real
 	// import runs model discovery on the member, which routinely exceeds the 4s
 	// probe timeout, and timing out there would mislabel a successful import as
 	// "could not reach this member".
@@ -525,11 +499,10 @@ func (s *Server) pushMemberImport(ctx context.Context, m *Member, token string, 
 }
 
 // memberRefusal is a member answering the import with a status Front Desk
-// cannot apply, carrying whatever reason the member gave. A member refuses
-// an envelope it will not write (a provider field its own admin API would
-// reject, a wrong token) with a 400 whose body names the field; without the
-// body the operator driving the fleet saw only the status, and the reason
-// lived in the member's own log.
+// cannot apply, carrying whatever reason the member gave. A member refuses an
+// envelope it will not write (a provider field its own admin API would reject,
+// a wrong token) with a 400 whose body names the field, so the operator driving
+// the fleet sees the reason and not just the status.
 type memberRefusal struct {
 	status int
 	reason string
@@ -558,9 +531,9 @@ const maxRefusalReasonRunes = 240
 // characters (bidi overrides, zero-width joiners), stripped of any userinfo
 // in a URL it quotes (a refused setting or base_url is echoed raw by
 // url.Parse, password included), key-shape masked, and bounded in runes.
-// The exact credential layer runs too but has nothing to match here: Front
-// Desk decrypts no provider key, so its held set is empty; the shape layer
-// is what does the work in this process.
+// The exact-credential layer runs too but has nothing to match here: Front
+// Desk decrypts no provider key, so its held set is empty and the shape layer
+// does the work in this process.
 func refusalReason(body []byte) string {
 	text := strings.TrimSpace(string(body))
 	if text == "" || strings.HasPrefix(text, "<") {

--- a/internal/frontdesk/configsync_manual.go
+++ b/internal/frontdesk/configsync_manual.go
@@ -79,7 +79,7 @@ func (run configSyncRun) repointedMessage() string {
 	return msg + ". Run the sync again from the new primary."
 }
 
-// interruptedMessage is the same line for a run cut short by shutdown, carried as
+// interruptedMessage is the same shape of message for a run cut short by shutdown, carried as
 // the error text of the 503.
 func (run configSyncRun) interruptedMessage() string {
 	msg := "front desk began shutting down during the sync, so it did not finish"

--- a/internal/frontdesk/configsync_manual.go
+++ b/internal/frontdesk/configsync_manual.go
@@ -11,15 +11,13 @@ import (
 
 // The operator-driven half of fleet config sync: the POST /api/config/sync
 // handler, the detached run it parks on, and the run's result shape. The member
-// plumbing both it and the automatic loop share (export, dry-run, import, the
-// per-member result) stays in configsync.go. Split out when that file crossed
-// the size ceiling.
+// plumbing this and the automatic loop share (export, dry-run, import, the
+// per-member result) lives in configsync.go.
 
 // errPrimaryExportUnreadable stops a run before any member is touched: the
-// primary's config could not be read, so there is nothing to push. It is a
-// sentinel rather than a message because the run happens away from the handler
-// that renders it, and this is the one failure that is a 502 (the primary
-// answered badly) rather than a store error.
+// primary's config could not be read, so there is nothing to push. A sentinel
+// because the run happens away from the handler that renders it, and this is
+// the one failure answered as a 502 rather than as a store error.
 var errPrimaryExportUnreadable = errors.New("could not read the primary's config")
 
 // The two refusals of the designation guard in runConfigSync. Sentinels so the
@@ -33,10 +31,10 @@ var (
 
 // Stable codes for the designation guard's answers. Coded rather than bare
 // text because Bellhop's error reader only surfaces the message from a coded
-// envelope, and because a bare 403 there reads as "this device is a monitor"
-// and hides the operator controls. A 409 is also the honest status: the request
-// conflicts with the fleet's designated state, and the remedy is to change that
-// state first, not to hold a different credential.
+// envelope, and a bare 403 there reads as "this device is a monitor" and hides
+// the operator controls. 409 is the honest status: the request conflicts with
+// the fleet's designated state, and the remedy is to change that state first,
+// not to hold a different credential.
 const (
 	primaryNotDesignatedCode = "primary_not_designated"
 	syncSourceNotPrimaryCode = "sync_source_not_primary"
@@ -69,10 +67,10 @@ type configSyncRun struct {
 	repointed bool
 }
 
-// interruptedMessage names what the operator is looking at: a partial run, how
-// much of the fleet it never reached, and what to do about it. It reaches the UI
-// as the error text of the 503, so it is written for a person.
-// repointedMessage is the same shape for a run the designation guard stopped.
+// repointedMessage names what the operator is looking at when the designation
+// guard stopped a run: a partial run, how much of the fleet it never reached,
+// and what to do about it. It reaches the UI as the error text of the 409, so
+// it is written for a person.
 func (run configSyncRun) repointedMessage() string {
 	msg := "the fleet primary was changed while this sync was running, so it stopped"
 	if run.notAttempted > 0 {
@@ -81,6 +79,8 @@ func (run configSyncRun) repointedMessage() string {
 	return msg + ". Run the sync again from the new primary."
 }
 
+// interruptedMessage is the same line for a run cut short by shutdown, carried as
+// the error text of the 503.
 func (run configSyncRun) interruptedMessage() string {
 	msg := "front desk began shutting down during the sync, so it did not finish"
 	if run.notAttempted > 0 {
@@ -134,9 +134,9 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 		defer close(done)
 		run = s.runConfigSync(ctx, req.PrimaryID)
 	}) {
-		// Shutdown has begun. The auto-sync kick simply goes unfired at this point;
-		// here the run is the response, so say so instead: a fleet-wide write started
-		// now would be cancelled a moment later with nowhere to record what it did.
+		// Shutdown has begun, and the run is the response here, so say so: a
+		// fleet-wide write started now would be cancelled a moment later with
+		// nowhere to record what it did.
 		http.Error(w, "front desk is shutting down; run the sync again once it is back", http.StatusServiceUnavailable)
 		return
 	}
@@ -161,11 +161,11 @@ func (s *Server) configSync(w http.ResponseWriter, r *http.Request) {
 			"primary_id": run.primaryID, "results": run.results,
 		})
 	case run.interrupted:
-		// The coded-error shape (code + error), with the partial results alongside
+		// The coded-error shape (code + error) with the partial results alongside
 		// it: a caller that only reads the message still learns the run was cut
 		// short and how much of the fleet it never reached, and one that reads the
-		// body still sees what did happen. Not a 200, which would be read as a
-		// complete run of a fleet this size.
+		// body sees what did happen. Not a 200, which would read as a complete run
+		// of a fleet this size.
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"code": syncInterruptedCode, "error": run.interruptedMessage(),
 			"primary_id": run.primaryID, "results": run.results,
@@ -190,18 +190,11 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 
 	// The source must be the primary the operator designated. Picking which
 	// member's config the fleet copies is an admin-token confirmed decision
-	// (putAutoSync -> SetAutoSyncGuarded, "confirm the admin token to change or
-	// clear the configured primary"), and this run reaches the identical outcome
-	// by another door: every other member, the designated primary included, is
-	// overwritten with the chosen member's config. Taking the id from the
-	// request unchecked let the operator tier - which can also disable auto-sync
-	// unaided, so the rollback sticks - roll the whole fleet back to a stale
-	// member's config.
-	//
-	// No shipped client loses anything: the web wizard designates through the
-	// guarded endpoint and awaits it before calling this, Bellhop sends the
-	// designated id, and the auto-sync loop reads the designation itself.
-	// "Repair the fleet from member X" is still the two steps it always was:
+	// (putAutoSync -> SetAutoSyncGuarded), and this run reaches the identical
+	// outcome by another door: every other member, the designated primary
+	// included, is overwritten with the chosen member's config. An unchecked id
+	// from the request would let the operator tier roll the whole fleet back to a
+	// stale member's config. "Repair the fleet from member X" is two steps:
 	// repoint (admin token), then sync.
 	cfg, err := s.store.GetAutoSync(ctx)
 	if err != nil {
@@ -215,11 +208,11 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 		return configSyncRun{err: errSyncSourceNotPrimary}
 	}
 	// gen is the generation the designation above was read WITH (one row, one
-	// scan), not a later re-read. It stamps every push so the members' commit
-	// fence can refuse a stale one, and it is what the repoint gate below compares
-	// against. A generation read after the guard would let a repoint landing in
-	// between stamp this run's pushes with the new generation, and the fence
-	// that exists to refuse a stale source would accept them.
+	// scan), never a later re-read. It stamps every push so the members' commit
+	// fence can refuse a stale one, and the repoint gate below compares against
+	// it. A generation read after the guard would let a repoint landing in
+	// between stamp this run's pushes with the new generation, and the fence that
+	// exists to refuse a stale source would accept them.
 	gen := cfg.Gen
 
 	primary, primaryToken, err := s.memberTokenOrErr(ctx, primaryID)
@@ -248,12 +241,11 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 
 	// The guard is held for the whole run, not just at admission: a run can last
 	// minutes (memberSyncTimeout per member), and an admin repointing in the
-	// meantime has made a decision this run must not undo. The same three-layer
-	// arrangement as applyAutoSync: a gate at the top of each member, a gate
-	// tightest to the mutation after the slow dry-run, and a watcher that cancels
-	// an import already in flight the instant a rearm moves the generation. A
-	// read error reports "not moved": a transient DB failure must not abort an
-	// otherwise valid run.
+	// meantime has made a decision this run must not undo. Three layers, as in
+	// applyAutoSync: a gate at the top of each member, a gate tightest to the
+	// mutation after the slow dry-run, and a watcher that cancels an import
+	// already in flight the instant a rearm moves the generation. A read error
+	// reports "not moved", so a transient DB failure does not abort a valid run.
 	moved := func() bool {
 		cur, err := s.store.GetAutoSync(ctx)
 		return err == nil && (cur.Gen != gen || cur.PrimaryID != primaryID)
@@ -271,9 +263,9 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 		if ctx.Err() != nil {
 			// The server is shutting down. Stop between members rather than push a
 			// config whose outcome nothing can record: the store is waiting on this
-			// goroutine to close. The members left here go unattempted and are
-			// counted, not silently dropped, so the answer can say how much of the
-			// fleet this run never reached.
+			// goroutine to close. The members left here are counted, not silently
+			// dropped, so the answer can say how much of the fleet this run never
+			// reached.
 			notAttempted = syncableCount(members[i:], primary.ID)
 			debuglog.Info("frontdesk: manual config sync stopped by shutdown",
 				"primary", primary.Name, "not_attempted", notAttempted)
@@ -325,11 +317,11 @@ func (s *Server) runConfigSync(ctx context.Context, primaryID string) configSync
 	// reaching the guards above: the member being pushed when shutdown lands (or
 	// when the watcher cancels for a repoint) takes the cancellation on its own
 	// HTTP call, and the loop then ends of its own accord with nothing left to
-	// skip. Either way the run did not finish, so it reports itself as such rather
-	// than as a clean sweep of the fleet.
+	// skip. Either way the run did not finish, so it reports itself as such
+	// rather than as a clean sweep of the fleet.
 	//
-	// The run marker is skipped with it. It is a write like any other, and a
-	// cancelled run is not a run the fleet's staleness watchdog should count.
+	// The run marker is skipped with it: it is a write like any other, and a
+	// cancelled run is not one the fleet's staleness watchdog should count.
 	if ctx.Err() != nil {
 		return configSyncRun{
 			primaryID: primary.ID, results: results,

--- a/internal/frontdesk/fleetstatus.go
+++ b/internal/frontdesk/fleetstatus.go
@@ -8,17 +8,17 @@ import (
 	"net/http"
 )
 
-// This file implements GET /api/fleet/status, the single probe that powers the
-// step-gated fleet-sync wizard. Relative to a chosen primary it reports, per
-// member: reachability, whether it can decrypt the primary's provider keys (the
-// MASTER_KEY match), and the config diff it would receive. The wizard gates each
-// step on these fields, so it never has to call several endpoints or guess.
+// GET /api/fleet/status, the single probe that powers the step-gated fleet-sync
+// wizard. Relative to a chosen primary it reports, per member: reachability,
+// whether it can decrypt the primary's provider keys (the MASTER_KEY match), and
+// the config diff it would receive. The wizard gates each step on these fields.
 //
-// Unlike config sync, fleetStatus NEVER returns a transport error for a single
-// bad member: an unreachable or wrong-token member is marked reachable:false with
-// a human note and the rest still report. Only a primary that cannot be used as a
-// source short-circuits, and even then it reports inline (primary_reachable:false)
-// rather than 502, so the wizard can explain the problem instead of a generic toast.
+// Unlike config sync, fleetStatus never returns a transport error for a single
+// bad member: an unreachable or wrong-token member is marked reachable:false
+// with a human note and the rest still report. Only a primary that cannot be
+// used as a source short-circuits, and it too reports inline
+// (primary_reachable:false) rather than 502, so the wizard can explain the
+// problem instead of showing a generic toast.
 
 // fleetMemberStatus is one member's convergence state against the primary.
 type fleetMemberStatus struct {
@@ -44,9 +44,9 @@ type fleetStatusResponse struct {
 	PrimaryNote      string              `json:"primary_note,omitempty"`
 	Members          []fleetMemberStatus `json:"members"`
 	// LBPort is the host port the load balancer (Traefik "web" entrypoint) is
-	// published on (LB_PORT in the HA .env). The wizard's final step pairs it with
-	// the browser's hostname to show the operator exactly where to send /v1
-	// traffic. Empty when Front Desk was not told the port.
+	// published on (LB_PORT in the HA .env). The wizard's final step pairs it
+	// with the browser's hostname to show where to send /v1 traffic. Empty when
+	// Front Desk was not told the port.
 	LBPort string `json:"lb_port,omitempty"`
 }
 
@@ -87,11 +87,10 @@ func (s *Server) fleetStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// A keyless primary has nothing to verify for MASTER_KEY: the member-side
-	// canary trivially passes (see canDecryptSample in internal/api/configsync.go),
-	// so reporting "matches" would mislead. Parse just enough of the export to count
-	// providers that actually carry an encrypted key, rather than scanning raw bytes
-	// for the literal "encrypted_key" (which would misfire if any string value, such
-	// as a description, ever contained that text).
+	// decrypt canary trivially passes, so reporting "matches" would mislead.
+	// Parse just enough of the export to count providers that carry an encrypted
+	// key, rather than scanning raw bytes for the literal "encrypted_key", which
+	// would misfire on any string value containing that text.
 	var exportShape struct {
 		Config struct {
 			Providers []struct {
@@ -104,10 +103,9 @@ func (s *Server) fleetStatus(w http.ResponseWriter, r *http.Request) {
 	_ = json.Unmarshal(export, &exportShape)
 
 	// An export with no providers, virtual keys, or settings is one every member
-	// will refuse (the member-side Import returns 400 rather than wipe itself
-	// clean). Detect it here and report it once as a primary-level problem,
-	// instead of probing every peer with a config they all reject, which would
-	// otherwise paint the whole reachable fleet as "offline".
+	// refuses (the member-side Import returns 400 rather than wipe itself clean).
+	// Reported once as a primary-level problem, instead of probing every peer
+	// with a config they all reject and painting the reachable fleet "offline".
 	if len(exportShape.Config.Providers) == 0 &&
 		len(exportShape.Config.VirtualKeys) == 0 &&
 		len(exportShape.Config.Settings) == 0 {
@@ -143,10 +141,9 @@ func (s *Server) fleetStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// fleetLastSync reports the last successful fleet-sync wizard run (timestamp +
-// the primary it converged onto), so the wizard can show it has run before
-// rather than looking untouched after a container rebuild. It returns 204 when
-// the wizard has never recorded a successful run.
+// fleetLastSync reports the last successful fleet-sync wizard run: the timestamp
+// and the primary it converged onto. It returns 204 when no successful run has
+// been recorded.
 func (s *Server) fleetLastSync(w http.ResponseWriter, r *http.Request) {
 	state, found, err := s.store.GetFleetSyncState(r.Context())
 	if err != nil {
@@ -186,16 +183,16 @@ func (s *Server) fleetStatusForMember(ctx context.Context, m *Member, primaryID 
 		item.Note = "no stored admin token; add it on the Members tab"
 		return item
 	}
-	// The dry-run import is the single probe: it doubles as the reachability check
-	// (a transport error or unexpected status means we cannot use this member as a
-	// sync target) and the source of the schema/MASTER_KEY/diff fields below. A 409
-	// or 422 is parsed into res, not returned as an error.
+	// The dry-run import is the single probe: it doubles as the reachability
+	// check (a transport error or unexpected status means this member cannot be a
+	// sync target) and the source of the schema, MASTER_KEY and diff fields
+	// below. A 409 or 422 is parsed into res, not returned as an error.
 	res, status, err := s.pushMemberImport(ctx, m, token, export, true, 0) // dry run: gen unused (no fence header)
 	if err != nil {
-		// status == 0 is a real transport failure (the member never answered).
-		// A non-zero status means the member answered with a code we do not treat
-		// as a convergence disposition (e.g. 401/403 wrong token, 500): report the
-		// real cause rather than a blanket "offline" that hides a fixable blocker.
+		// status == 0 is a real transport failure (the member never answered). A
+		// non-zero status means the member answered with a code that is not a
+		// convergence disposition (401/403 wrong token, 500): report the real cause
+		// rather than a blanket "offline" that hides a fixable blocker.
 		switch status {
 		case 0:
 			item.Note = "could not reach this member"
@@ -214,9 +211,8 @@ func (s *Server) fleetStatusForMember(ctx context.Context, m *Member, primaryID 
 	}
 	item.Reachable = true
 	// Schema is checked before MASTER_KEY: a 422 short-circuits the member before
-	// it runs the decrypt canary (see the member-side Import in
-	// internal/api/configsync.go), leaving master_key_ok an unevaluated false. So
-	// report a version skew on its own, never as a key mismatch.
+	// it runs the decrypt canary, leaving master_key_ok an unevaluated false. So
+	// a version skew is reported on its own, never as a key mismatch.
 	item.SchemaOK = res.SchemaVersionOK
 	if !res.SchemaVersionOK {
 		item.Note = "this member's app version is too old to sync with the primary"

--- a/internal/frontdesk/netguard.go
+++ b/internal/frontdesk/netguard.go
@@ -43,11 +43,11 @@ func newProbeClient(timeout time.Duration) *http.Client {
 		Timeout: timeout,
 		Transport: &http.Transport{
 			DialContext: dialer.DialContext,
-			// Matches http.DefaultTransport. Left at zero an idle connection is
-			// pooled indefinitely, so a sync or backup hours after the previous
-			// one reuses a long-dead connection and pays a wasted round trip to
-			// discover it; and the member listener closes an idle connection at
-			// 180s (httpx.IdleTimeout), so the pool has to give up first.
+			// Matches http.DefaultTransport. At zero an idle connection is pooled
+			// indefinitely, so a sync or backup hours later reuses a long-dead
+			// connection and pays a wasted round trip to discover it. The member
+			// listener closes an idle connection at 180s (httpx.IdleTimeout), so
+			// the pool has to give up first.
 			IdleConnTimeout: 90 * time.Second,
 		},
 		CheckRedirect: checkProbeRedirect,

--- a/internal/frontdesk/poller.go
+++ b/internal/frontdesk/poller.go
@@ -15,12 +15,12 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// This file holds the background pollers: a per-member /health probe (status +
-// latency, with up/down transition events), a poller for Traefik's own
-// serverStatus view (so the UI can show both "Front Desk sees up/down" and
-// "Traefik sees up/down" for split-brain diagnostics), a member version
-// fetcher, and the "Traefik hasn't polled config for > N seconds" watchdog,
-// which is the one silent failure mode of the HTTP-provider design.
+// The background pollers: a per-member /health probe (status and latency, with
+// up/down transition events), a poller for Traefik's own serverStatus view (so
+// the UI can show both "Front Desk sees up/down" and "Traefik sees up/down" for
+// split-brain diagnostics), a member version fetcher, and the "Traefik has not
+// polled config for > N seconds" watchdog, the one silent failure mode of the
+// HTTP-provider design.
 //
 // All control-plane facts are persisted to the event log AND published on the
 // SSE bus. No request or prompt content is ever read or logged.
@@ -60,8 +60,7 @@ type MemberStatus struct {
 	// Commit is the source commit the member's binary was built from, read from
 	// the same settings response as Version. It is what distinguishes two builds
 	// on a fleet whose images all report the "dev" placeholder version, so it is
-	// serialized as well as gated on: an operator looking at a held sync can see
-	// which build each side runs without a second call.
+	// serialized as well as gated on.
 	Commit string `json:"commit,omitempty"`
 	// AutoSyncVerifiedAt is the last time the auto-syncer confirmed this member
 	// matches the primary (a real write, a self-converged empty diff, or a quiet
@@ -88,8 +87,8 @@ type Poller struct {
 
 	// frontdeskID is this Front Desk's persistent identity, stamped onto every
 	// announce so a member can tell which Front Desk owns its fleet role. Set
-	// once at startup via SetFrontdeskID; empty means a legacy build (a member
-	// then accepts our announces unconditionally, preserving old behaviour).
+	// once at startup via SetFrontdeskID; current members reject an announce
+	// without it.
 	frontdeskID string
 
 	mu                    sync.RWMutex
@@ -128,7 +127,7 @@ func NewPoller(store *Store, bus *events.Bus, traefikAPI string) *Poller {
 
 // SetFrontdeskID records this Front Desk's persistent identity, stamped onto
 // every subsequent announce. Called once at startup after the ID is resolved
-// from the store. An empty ID leaves announces behaving like a legacy build.
+// from the store.
 func (p *Poller) SetFrontdeskID(id string) {
 	p.frontdeskID = id
 }
@@ -155,9 +154,7 @@ func (p *Poller) Snapshot() map[string]MemberStatus {
 // app_version and the commit that version was built from. Both are zero when
 // the member has never been polled or its last fetch failed. It is the read the
 // config-sync gates consult; an empty version means "cannot confirm", which
-// they treat as skewed (fail closed). Unexported along with memberBuild itself:
-// every caller is a gate in this package, and nothing outside it has ever asked
-// a Poller for a version.
+// they treat as skewed (fail closed).
 func (p *Poller) memberBuildOf(id string) memberBuild {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -166,7 +163,7 @@ func (p *Poller) memberBuildOf(id string) memberBuild {
 
 // buildOf reads a member's build out of a polled status. One extraction, so a
 // caller working from an already-taken snapshot cannot drift from
-// memberBuildOf if a third build field is ever added.
+// memberBuildOf.
 func buildOf(st MemberStatus) memberBuild {
 	return memberBuild{Version: st.Version, Commit: st.Commit}
 }
@@ -292,15 +289,14 @@ func (p *Poller) checkHealth(ctx context.Context, baseURL string) HealthStatus {
 
 // applyHealth records a health probe and emits an up/down transition event,
 // debounced so a member must miss `health_fail_threshold` polls in a row before
-// it is reported down (an error event plus, by default, an Apprise alert). This
+// it is reported down (an error event plus, by default, an Apprise alert). That
 // tolerates the brief unreachability of a routine container rebuild without
 // flapping. Recovery is immediate: the first healthy poll clears the count and,
 // if the member had been reported down, announces it back up.
 //
-// The reported badge follows the same rule as the version poller: during the
-// grace window (below threshold) the last known-good status is kept, so the
-// dashboard does not flicker red on every rebuild. A first observation that is
-// healthy is recorded silently (baseline).
+// During the grace window (below threshold) the badge keeps the last known-good
+// status, so the dashboard does not flicker red on every rebuild. A first
+// observation that is healthy is recorded silently as the baseline.
 func (p *Poller) applyHealth(ctx context.Context, m *Member, hs HealthStatus) {
 	threshold := p.healthFailThreshold(ctx)
 

--- a/internal/frontdesk/poller_circuits.go
+++ b/internal/frontdesk/poller_circuits.go
@@ -13,11 +13,10 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
-// The Members tab's circuits column: which member is dark for which model,
-// the question that needed four terminals on 2026-08-31. Each member's
-// breaker is local runtime state, so Front Desk reads every member's own
-// ledger (the ?detail=1 status the dashboard card reads) every three health
-// polls (15s at the defaults) and keeps only what the column shows. Not the
+// The Members tab's circuits column: which member is dark for which model. Each
+// member's breaker is local runtime state, so Front Desk reads every member's
+// own ledger (the ?detail=1 status the dashboard card reads) every three health
+// polls, 15s at the defaults, and keeps only what the column shows. Not the
 // health cadence itself: the member caches that status for 5s, so a 5s poll
 // would find the cache just expired every time and recompute the ledger, two
 // catalog queries and a breaker walk, on members with no dashboard open.
@@ -38,10 +37,9 @@ type MemberCircuits struct {
 }
 
 // maxOpenCircuits bounds the ledger a member status carries. The count is the
-// load-bearing number; the list is a hover aid, unusable past a few dozen
-// lines anyway, and /api/members is refetched every few seconds by every open
-// tab, so a provider-wide outage across a large catalog must not turn each
-// refetch into hundreds of rows per member.
+// load-bearing number; the list is a hover aid. /api/members is refetched every
+// few seconds by every open tab, so a provider-wide outage across a large
+// catalog must not turn each refetch into hundreds of rows per member.
 const maxOpenCircuits = 50
 
 // maxCircuitStatusBytes bounds the member's status response. The detail
@@ -65,11 +63,11 @@ type OpenCircuit struct {
 }
 
 // PollCircuitsOnce reads each tokened member's circuit ledger and stores the
-// non-closed circuits on its status. A member without a token, or one whose
-// read failed, shows no ledger at all rather than the last one it had: a
-// stale "1 open" would send the operator to a member that has recovered, and
-// a stale "none" would hide the one that has not. The UI is refreshed only
-// when the set changes, so a quiet fleet produces no events.
+// non-closed circuits on its status. A member without a token, or one whose read
+// failed, shows no ledger at all rather than the last one it had: a stale "1
+// open" would send the operator to a member that has recovered, and a stale
+// "none" would hide the one that has not. The UI is refreshed only when the set
+// changes, so a quiet fleet produces no events.
 func (p *Poller) PollCircuitsOnce(ctx context.Context) {
 	members, err := p.store.ListMembers(ctx)
 	if err != nil {
@@ -178,10 +176,10 @@ type memberCircuitStatus struct {
 
 // fetchMemberCircuits reads the member's detailed circuit status and returns
 // the circuits that are not closed, the first maxOpenCircuits of them listed
-// and all of them counted. A member from before circuits[] existed reports
-// rows without it and so an empty ledger, which the column shows as none
-// open: on such a member the row-level state is provider-wide and would
-// attribute one model's outage to every model of the provider.
+// and all of them counted. A member too old to report circuits[] yields an
+// empty ledger, which the column shows as none open: its row-level state is
+// provider-wide and would attribute one model's outage to every model of the
+// provider.
 func (p *Poller) fetchMemberCircuits(ctx context.Context, baseURL, token string) (*MemberCircuits, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+memberCircuitsPath, http.NoBody)
 	if err != nil {

--- a/internal/frontdesk/poller_versions.go
+++ b/internal/frontdesk/poller_versions.go
@@ -40,12 +40,12 @@ func (p *Poller) PollVersionsOnce(ctx context.Context) {
 		build, err := p.fetchMemberBuild(ctx, m.URL, token)
 		if err != nil {
 			p.noteVersionFetchFailure(ctx, m, err)
-			// A build we can no longer read is unknown, and the config-sync
+			// A build that can no longer be read is unknown, and the config-sync
 			// gates treat unknown as skewed (fail closed). Keeping the last good
 			// value would let a sync proceed on stale data while the member is
-			// mid-upgrade, which is exactly the window the gate exists for. The
-			// commit is cleared with the version: a commit kept beside a blank
-			// version would outlive the read that vouched for it.
+			// mid-upgrade, the window the gate exists for. The commit is cleared
+			// with the version: kept beside a blank version it would outlive the
+			// read that vouched for it.
 			if p.clearBuild(m.ID) {
 				p.publishMemberStatus(m.ID)
 			}
@@ -163,15 +163,14 @@ func (p *Poller) fetchMemberBuild(ctx context.Context, baseURL, token string) (m
 }
 
 // The three Traefik staleness checks below subtract raw, without the
-// util.TrustedAge guard the settings- and database-backed staleness checks use,
-// and that is deliberate. Both operands are time.Time values taken by
-// time.Now() in THIS process (p.now is time.Now; lastConfigPollAt is assigned in
-// RecordConfigPoll; Server.startedAt in NewServer), so each carries a monotonic
-// reading and Sub uses the monotonic clock. No wall-clock step can make those
-// differences negative, which is the failure the guard exists for. Anything
-// that crosses a boundary - parsed from RFC3339, read back from a row, or
-// passed through .UTC()/.Round()/.Truncate() - loses the reading and does need
-// the guard. util.TrustedAge's doc comment carries the full rule.
+// util.TrustedAge guard the settings- and database-backed staleness checks use.
+// Both operands are time.Time values taken by time.Now() in THIS process (p.now
+// is time.Now; lastConfigPollAt is assigned in RecordConfigPoll;
+// Server.startedAt in NewServer), so each carries a monotonic reading and Sub
+// uses the monotonic clock: no wall-clock step can make those differences
+// negative, which is the failure the guard exists for. A time that crosses a
+// boundary, parsed from RFC3339, read back from a row, or passed through
+// .UTC()/.Round()/.Truncate(), loses the reading and does need the guard.
 
 // checkConfigStaleness emits a single warning when Traefik has not polled the
 // dynamic config within the configured threshold. It resets on the next poll
@@ -216,11 +215,11 @@ func (p *Poller) ConfigPollStale(ctx context.Context) bool {
 }
 
 // ConfigPollWarm reports whether the Traefik staleness input has produced a
-// real observation this process: either Traefik has fetched the config at
-// least once, or a full staleness window has elapsed since `since` (process
-// start) without a fetch — at which point the silence is itself the
-// steady-state observation ConfigPollStale will keep reporting. Used by
-// fleetInputsWarm to keep a cold start from reading as a recovery.
+// real observation this process: either Traefik has fetched the config at least
+// once, or a full staleness window has elapsed since `since` (process start)
+// without a fetch, at which point the silence is itself the steady-state
+// observation ConfigPollStale keeps reporting. Used by fleetInputsWarm to keep
+// a cold start from reading as a recovery.
 func (p *Poller) ConfigPollWarm(ctx context.Context, since time.Time) bool {
 	p.mu.RLock()
 	armed := !p.lastConfigPollAt.IsZero()
@@ -229,13 +228,12 @@ func (p *Poller) ConfigPollWarm(ctx context.Context, since time.Time) bool {
 }
 
 // checkAutoSyncStale emits a single warning when auto-sync is off and the fleet
-// has not been synced within autoSyncStaleThreshold (see autoSyncStale for the
+// has not been synced within autoSyncStaleThreshold (autoSyncStale holds the
 // exact rule). Like checkConfigStaleness it de-dups on an in-memory flag so it
 // fires once per stale episode, not every tick; the flag disarms silently when
 // the condition clears (auto-sync re-enabled, or a fresh sync recorded), so a
-// later stale episode alerts again. On a restart the flag resets, so a fleet that
-// is already stale re-alerts once — the same best-effort trade-off as the health
-// and Traefik-staleness checks.
+// later stale episode alerts again. A restart resets the flag, so an
+// already-stale fleet re-alerts once, as with the other staleness checks.
 func (p *Poller) checkAutoSyncStale(ctx context.Context) {
 	cfg, err := p.store.GetAutoSync(ctx)
 	if err != nil {

--- a/internal/frontdesk/server_circuits.go
+++ b/internal/frontdesk/server_circuits.go
@@ -9,11 +9,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// The fleet-wide circuit-breaker reset: the operation the 2026-08-31 reset
-// loop performed by hand, member by member. Each member's breaker is local
-// runtime state that nothing syncs, so the only way to clear a group's circuits
-// across the fleet is to ask every member. Front Desk already holds the member
-// tokens for config sync; this reuses that path.
+// The fleet-wide circuit-breaker reset. Each member's breaker is local runtime
+// state that nothing syncs, so the only way to clear a group's circuits across
+// the fleet is to ask every member. Front Desk already holds the member tokens
+// for config sync; this reuses that path.
 
 // fleetCircuitResetRequest names the failover group whose entries to clear on
 // every member. An empty group_id clears every circuit on every member.
@@ -54,11 +53,10 @@ type memberCircuitResetResult struct {
 
 // fleetCircuitReset fans a circuit-breaker reset out to every member, in
 // sequence (a handful of members, one small POST each), and reports per member.
-// A member that fails does not stop the others: the operator wants the fleet
-// cleared, and the response says who was not. A member without a stored token
-// is listed too, as skipped: it is exactly the member that stays dark after the
-// round, so it cannot be left out, but a fleet that keeps one is a supported
-// configuration, and a warning event on every reset for it would be noise.
+// A member that fails does not stop the others: the response says who was not
+// cleared. A member without a stored token is listed as skipped: it is the
+// member that stays dark after the round, so it cannot be left out, but a fleet
+// that keeps one is a supported configuration and warning on it would be noise.
 func (s *Server) fleetCircuitReset(w http.ResponseWriter, r *http.Request) {
 	var req fleetCircuitResetRequest
 	if !decodeJSON(w, r, &req) {

--- a/internal/gemini/adapter.go
+++ b/internal/gemini/adapter.go
@@ -11,18 +11,16 @@ import (
 )
 
 // StreamAdapter re-frames an upstream Gemini streamGenerateContent alt=sse body
-// as chat.completion.chunk SSE bytes. The mechanics (event assembly, EOF
-// finish, poisoning on a bad chunk) are shared with the other dialects; see
+// as chat.completion.chunk SSE bytes, driving this dialect's StreamTranslator.
+// The mechanics (event assembly, EOF finish, poisoning on a bad chunk) live in
 // egress.StreamAdapter.
 //
 // Vertex streams carry no [DONE] sentinel: EOF is the natural end, so the
 // terminal chunk + [DONE] come from the translator's Finish() when upstream EOF
 // arrives.
 //
-// StreamAdapter is the shared egress adapter driving this dialect's
-// StreamTranslator. It is an alias, not a defined type: gemini,
-// anthropicegress and openairesponses all alias it, so a type switch cannot
-// tell them apart.
+// It is an alias, not a defined type: the other egress dialects alias the same
+// type, so a type switch cannot tell them apart.
 type StreamAdapter = egress.StreamAdapter
 
 // MaxEventBytes caps one Gemini SSE event. An image model streams its whole

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -1,9 +1,7 @@
 // Package gemini translates between the OpenAI chat-completions wire shape and
-// Google's Gemini generateContent shape. It is MH's first *egress* dialect
-// adapter (the mirror image of internal/anthropic, which translates on
-// ingress): Vertex AI express-mode API keys only work on the native
-// publisher routes, so requests leaving MH for a vertex-express provider are
-// rewritten here and the responses translated back.
+// Google's Gemini generateContent shape. Vertex AI express-mode API keys only
+// work on the native publisher routes, so requests leaving MH for a
+// vertex-express provider are rewritten here and the responses translated back.
 package gemini
 
 import (
@@ -63,22 +61,17 @@ type oaiContentPart struct {
 
 type oaiToolCall struct {
 	ID string `json:"id"`
-	// ExtraContent is where the signature travels on the OpenAI side, the
-	// shape Google's own compatibility layer uses and the chat path keeps
-	// verbatim (see proxy jsonextras): extra_content.google.thought_signature.
-	// Raw, read leniently: an ingress decoder must not fail a conversation
-	// on every retry over a member of a shape it did not expect, the rule
-	// util.ToolArguments below states for the arguments.
+	// ExtraContent is where the thought signature travels on the OpenAI side:
+	// extra_content.google.thought_signature. Raw, read leniently, so a
+	// member of an unexpected shape does not fail the conversation on every
+	// retry.
 	ExtraContent json.RawMessage `json:"extra_content"`
 	Function     struct {
 		Name string `json:"name"`
-		// util.ToolArguments, not a plain string: the spec says a JSON string and
-		// several providers send the object, so #808 taught the RESPONSE side to
-		// accept both — and an ingress decoder has no business being stricter
-		// than the decoder that produced the value. This gateway rewrites the
-		// object form on its own way out, so the client holding one got it from
-		// another gateway or SDK; rejecting it 400s that conversation on every
-		// retry, because each one replays the same transcript.
+		// util.ToolArguments, not a plain string: the spec says a JSON string
+		// and several providers send the object instead. Rejecting the object
+		// form 400s the conversation on every retry, since each one replays
+		// the same transcript.
 		Arguments util.ToolArguments `json:"arguments"`
 	} `json:"function"`
 }
@@ -151,9 +144,9 @@ type genTool struct {
 }
 
 // genFunctionDecl carries tool parameters as parametersJsonSchema, which
-// accepts standard JSON Schema verbatim (live-verified 2026-07-18, incl.
-// additionalProperties) — unlike the older `parameters` OpenAPI subset, so
-// strict-mode client schemas survive untouched.
+// accepts standard JSON Schema verbatim (additionalProperties included),
+// unlike the older `parameters` OpenAPI subset, so strict-mode client schemas
+// survive untouched.
 type genFunctionDecl struct {
 	Name                 string          `json:"name"`
 	Description          string          `json:"description,omitempty"`
@@ -200,7 +193,7 @@ var reasoningBudgets = map[string]int{
 
 // TranslateRequest converts an OpenAI chat-completions request body into a
 // Gemini generateContent request body. It returns the Gemini JSON, the model
-// string (verbatim — the caller builds the :generateContent /
+// string (verbatim: the caller builds the :generateContent or
 // :streamGenerateContent URL from it), and the stream flag.
 func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool, err error) {
 	var req oaiRequest
@@ -219,7 +212,7 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 	callNames := map[string]string{}
 
 	var systemParts []genPart
-	// True while the previously emitted content is a coalescing tool-response
+	// True while the last emitted content is a coalescing tool-response
 	// content; any other message kind breaks the run.
 	lastToolContent := false
 	for _, m := range req.Messages {
@@ -252,9 +245,8 @@ func TranslateRequest(body []byte) (geminiBody []byte, model string, stream bool
 			}
 			for _, tc := range m.ToolCalls {
 				callNames[tc.ID] = tc.Function.Name
-				// Gemini types functionCall.args as a Struct, so forwarding a
-				// non-object was a 400 from the provider where the other two
-				// egress paths quietly substituted something. One decision now.
+				// Gemini types functionCall.args as a Struct, so a non-object
+				// forwarded verbatim is a 400 from the provider.
 				args := util.ToolArgumentsObject(tc.Function.Arguments)
 				parts = append(parts, genPart{
 					FunctionCall:     &genFunctionCall{Name: tc.Function.Name, Args: args},
@@ -416,8 +408,8 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 	for _, p := range oaiParts {
 		switch p.Type {
 		case "text":
-			// An empty text part would marshal as {} (Text is omitempty),
-			// which Gemini rejects — drop it.
+			// An empty text part marshals as {} (Text is omitempty), which
+			// Gemini rejects.
 			if p.Text == "" {
 				continue
 			}

--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -16,13 +16,12 @@ import (
 
 type genResponse struct {
 	Candidates []genCandidate `json:"candidates"`
-	// Held raw and decoded on its own, so a usage block this package cannot read
-	// costs the usage and nothing else. Decoded inline it was part of the
-	// response object, and one count the provider spelled differently — quoted,
-	// or with a fraction on it because a relay did its arithmetic in floating
-	// point — failed the whole translation and cost the caller the answer the
-	// model had already produced. Since #812 it charged the provider's circuit
-	// breaker for it too.
+	// Held raw and decoded on its own, so a usage block this package cannot
+	// read costs the usage and nothing else. Decoded inline, one count the
+	// provider spells differently (quoted, or with a fraction on it because a
+	// relay did its arithmetic in floating point) fails the whole translation
+	// and costs the caller the answer, and charges the provider's circuit
+	// breaker for it.
 	UsageMetadata  json.RawMessage `json:"usageMetadata"`
 	PromptFeedback *struct {
 		BlockReason string `json:"blockReason"`
@@ -47,7 +46,7 @@ type genRespPart struct {
 	// a function call's signature is carried: Gemini 3 may sign a text or
 	// thought part too, but omitting those is not validated, and the OpenAI
 	// wire shape has no carrier on a message. Google spells the field both
-	// ways across its own documents, so both are read.
+	// ways across its documents, so both are read.
 	ThoughtSignature      string `json:"thoughtSignature"`
 	ThoughtSignatureSnake string `json:"thought_signature"`
 	// InlineData carries a generated image (an image model answering a
@@ -146,15 +145,15 @@ type oaiUsage struct {
 }
 
 // ErrPromptBlocked marks the one translation failure that is NOT the provider
-// malfunctioning: Gemini answered, and its answer was a refusal — promptFeedback
-// carries a blockReason and no candidate. The body is a good Gemini object and
-// the provider is plainly alive, so a caller deciding whether to hold it at
-// fault has to be able to tell this apart from bytes that merely lack candidates.
+// malfunctioning: Gemini answered, and its answer is a refusal, so
+// promptFeedback carries a blockReason and no candidate. A caller deciding
+// whether to hold the provider at fault tells this apart from bytes that
+// merely lack candidates.
 //
-// Keyed on the stated reason, not on candidate absence: {} , null and an
-// aggregator's 200 {"error":…} all unmarshal into genResponse with no
-// candidates, and exempting those left no non-streaming body a Gemini provider
-// could return that would ever charge its breaker.
+// It is keyed on the stated reason, not on candidate absence: {}, null and an
+// aggregator's 200 {"error":...} all unmarshal into genResponse with no
+// candidates, and exempting those would leave no non-streaming body that ever
+// charges the breaker.
 var ErrPromptBlocked = errors.New("gemini: prompt blocked")
 
 // BuildChatCompletion converts a non-streaming Gemini generateContent response
@@ -169,9 +168,9 @@ func BuildChatCompletion(body []byte, id, model string, created int64) ([]byte, 
 		if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
 			return nil, fmt.Errorf("gemini: prompt blocked: %s: %w", resp.PromptFeedback.BlockReason, ErrPromptBlocked)
 		}
-		// No candidates and no stated reason. That is not Gemini declining to
-		// answer, it is a body that does not carry one — an aggregator's error
-		// envelope, a bare {}, a null — all of which unmarshal into genResponse
+		// No candidates and no stated reason: not Gemini declining to answer,
+		// but a body that carries none at all (an aggregator's error envelope,
+		// a bare {}, a null), each of which unmarshals into genResponse
 		// without complaint.
 		return nil, fmt.Errorf("gemini: no candidates in response")
 	}
@@ -211,8 +210,8 @@ func translateCandidateParts(id string, parts []genRespPart) (string, []oaiToolC
 	var toolCalls []oaiToolCallOut
 	var images []oaiImageOut
 	for _, p := range parts {
-		// Thought parts first: an image model drafts interim images to test
-		// its composition, and those arrive as thought parts too.
+		// Thought parts are skipped first: an image model drafts interim
+		// images to test its composition, and those arrive as thought parts.
 		if p.Thought {
 			continue
 		}
@@ -269,14 +268,13 @@ func mapFinishReason(reason string, hasToolCalls bool) string {
 }
 
 // translateUsage maps usageMetadata to OpenAI usage. Thinking tokens are
-// billed output on Gemini, so completion_tokens includes them (this is what
-// MH's metering should count) with the split surfaced in
-// completion_tokens_details.reasoning_tokens, matching OpenAI's convention.
+// billed output on Gemini, so completion_tokens includes them, with the split
+// surfaced in completion_tokens_details.reasoning_tokens per OpenAI's
+// convention.
 func translateUsage(raw json.RawMessage) *oaiUsage {
 	// JSONMemberSet, not len(raw) > 0: a RawMessage for null is four non-empty
-	// bytes, where the *genUsage this replaced was nil for absent AND null
-	// alike. Reading only the length turned an omitted usage into a positive
-	// claim of zero tokens.
+	// bytes, so reading only the length turns a null usage into a positive claim
+	// of zero tokens.
 	if !util.JSONMemberSet(raw) {
 		return nil
 	}
@@ -284,8 +282,8 @@ func translateUsage(raw json.RawMessage) *oaiUsage {
 	// or absent; a SUMMED one is only as good as its addends, and a lost addend
 	// leaves a number that is wrong AND non-zero, which reads as authoritative
 	// and stops estimateMissingUsage replacing it. Dropping the whole block
-	// instead threw away counts that were never in doubt — and a completion
-	// count is what tells the breaker the provider answered at all.
+	// instead would throw away counts that were never in doubt, and a
+	// completion count is what tells the breaker the provider answered at all.
 	var u genUsage
 	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
 		return nil

--- a/internal/gemini/speech.go
+++ b/internal/gemini/speech.go
@@ -15,16 +15,16 @@ import (
 // Text-to-speech through generateContent.
 //
 // Google's OpenAI-compatibility layer does not serve /v1/audio/speech, so a
-// Gemini TTS model (gemini-2.5-flash-preview-tts and kin) is reached the way
-// LiteLLM reaches it: the OpenAI speech request becomes a generateContent
-// call asking for an AUDIO response with a speechConfig naming the voice, and
-// the audio comes back as an inlineData part of raw 16-bit PCM
-// (audio/L16;codec=pcm;rate=24000, mono). That is the only encoding the
-// model produces, so the OpenAI response_format is honoured for wav (the PCM
-// under a RIFF header) and pcm (the bytes as they are) and refused for the
-// compressed formats, which would need an encoder this gateway does not
-// carry. speed and instructions have no counterpart on the native call and
-// are ignored; Gemini takes delivery style from the text itself.
+// Gemini TTS model (gemini-2.5-flash-preview-tts and kin) is reached through
+// generateContent: the OpenAI speech request becomes a call asking for an
+// AUDIO response with a speechConfig naming the voice, and the audio comes
+// back as an inlineData part of raw 16-bit PCM (audio/L16;codec=pcm;rate=24000,
+// mono). That is the only encoding the model produces, so the OpenAI
+// response_format is honoured for wav (the PCM under a RIFF header) and pcm
+// (the bytes as they are) and refused for the compressed formats, which need
+// an encoder this gateway does not carry. speed and instructions have no
+// counterpart on the native call and are ignored; Gemini takes delivery style
+// from the text itself.
 
 // SpeechFormatWAV and SpeechFormatPCM are the response formats a Gemini TTS
 // model can honour.

--- a/internal/gemini/stream.go
+++ b/internal/gemini/stream.go
@@ -14,9 +14,9 @@ import (
 // (alt=sse: each data line is a full generateContent-shaped JSON chunk) into
 // an OpenAI chat.completion.chunk SSE stream ending in "data: [DONE]".
 //
-// It is the streaming counterpart of BuildChatCompletion and single-goroutine
-// by design: the proxy's egress loop feeds it one upstream data payload at a
-// time and forwards whatever bytes come back.
+// It is the streaming counterpart of BuildChatCompletion and single-goroutine:
+// the proxy's egress loop feeds it one upstream data payload at a time and
+// forwards whatever bytes come back.
 type StreamTranslator struct {
 	id      string
 	model   string
@@ -27,8 +27,8 @@ type StreamTranslator struct {
 	blocked      bool   // promptFeedback.blockReason seen
 	finishReason string // last Gemini finishReason observed
 	toolCalls    int    // tool_calls emitted so far (drives index + ids)
-	// Raw, for the reason given on genResponse.UsageMetadata: a count spelled
-	// differently must not cost the caller the stream.
+	// Raw, as on genResponse.UsageMetadata: a count spelled differently must
+	// not cost the caller the stream.
 	usage json.RawMessage
 }
 
@@ -111,9 +111,9 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 		return nil, fmt.Errorf("gemini: invalid stream chunk: %s", jsonfault.Describe(err, len(chunkJSON)))
 	}
 
-	// JSONMemberSet, for the reason on translateUsage: an explicit
-	// "usageMetadata": null is four bytes, and reading only the length let it
-	// overwrite the counts an earlier chunk had reported.
+	// JSONMemberSet, as in translateUsage: an explicit "usageMetadata": null
+	// is four bytes, so reading only the length lets it overwrite the counts
+	// an earlier chunk reported.
 	if util.JSONMemberSet(chunk.UsageMetadata) {
 		t.usage = chunk.UsageMetadata
 	}
@@ -141,10 +141,8 @@ func (t *StreamTranslator) Translate(chunkJSON []byte) ([]byte, error) {
 			continue
 		}
 		if p.FunctionCall != nil {
-			// The signature rides in the same part as the call: observed on
-			// Google AI Studio and Zen streams (one chunk carries both), and
-			// the tool_call delta is emitted here, so a signature arriving in
-			// a later part would not reach it.
+			// Upstreams carry the signature in the same part as the call; the
+			// tool_call delta is emitted here, so a later part could not reach it.
 			args := compactJSON(p.FunctionCall.Args)
 			if args == "" {
 				args = "{}"

--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -5,11 +5,10 @@ import (
 	"time"
 )
 
-// Listener posture shared by both binaries (cmd/server, cmd/frontdesk). Each
-// used to build its own http.Server with ReadHeaderTimeout alone, which left
-// two ways for a client to hold a goroutine and a file descriptor for free:
-// send the headers promptly and then trickle the body, or send one request and
-// then leave the keep-alive connection open. NewServer closes both.
+// Listener posture shared by both binaries (cmd/server, cmd/frontdesk). It
+// closes the two ways a client can hold a goroutine and a file descriptor for
+// free: sending the headers promptly and then trickling the body, or sending
+// one request and then leaving the keep-alive connection open.
 //
 // ReadHeaderTimeout bounds the request line and headers. IdleTimeout bounds a
 // keep-alive connection between requests; when it is unset net/http falls back
@@ -21,7 +20,7 @@ import (
 // default 90s transport (Front Desk's member clients pool at that value), and
 // the gateway's own 120s outbound pool (one Model Hotel is a valid provider
 // for another). Bellhop's OkHttp pool keeps a connection for five minutes and
-// is left above it on purpose: OkHttp checks a pooled socket's health before
+// stays above it on purpose: OkHttp checks a pooled socket's health before
 // reuse and retries a connection failure, and a listener idle timeout has to
 // stay bounded rather than chase every client's pool.
 //
@@ -47,13 +46,11 @@ const (
 // is declared, the connection is released after fifteen minutes.
 //
 // The length that earns time is the declared Content-Length clamped to the
-// largest body the listener accepts (NewServer's maxBody), and a body that
-// declares no length at all (Transfer-Encoding: chunked, which any Go client
-// streaming a file or pipe, a browser fetch with a stream body, and curl
-// uploading from a pipe with -T - all send) is budgeted as that largest body.
-// A chunked 25 MiB transcription upload therefore gets the same time as one
-// that declared its size, while a declared or undeclared length past what the
-// listener would accept anyway earns nothing beyond it.
+// largest body the listener accepts (NewServer's maxBody). A body that declares
+// no length at all (Transfer-Encoding: chunked, which a Go client streaming a
+// file or pipe, a browser fetch with a stream body, and curl uploading with
+// -T - all send) is budgeted as that largest body, so a chunked 25 MiB
+// transcription upload gets the same time as one that declared its size.
 const (
 	bodyReadBase  = 30 * time.Second
 	bodyReadFloor = int64(128 << 10)
@@ -113,13 +110,13 @@ func bodyBudgetFor(maxBody int64) func(contentLength int64) time.Duration {
 //
 // The budget starts when the handler chain is entered, not at the first body
 // byte, so the time routing and auth take before the handler reads counts
-// against it; today that is milliseconds. The same holds for a client that
-// sends Expect: 100-continue and waits for the handler's first read.
+// against it, which is milliseconds. The same holds for a client that sends
+// Expect: 100-continue and waits for the handler's first read.
 //
 // A body the handler stops reading before EOF keeps the deadline, which then
 // bounds net/http's post-handler drain of the remainder as well: a client that
-// declares a body, gets rejected before it is read (a 401 or a 404) and then
-// trickles the rest no longer holds the connection open through that drain.
+// declares a body, is rejected before it is read (a 401 or a 404) and then
+// trickles the rest cannot hold the connection open through that drain.
 type bodyDeadline struct {
 	next   http.Handler
 	budget func(contentLength int64) time.Duration

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,9 +2,8 @@
 // the request-outcome collectors, a circuit-breaker-state collector, and the
 // HTTP handler that serves the /metrics endpoint.
 //
-// Labels are deliberately low-cardinality — provider and model names yes,
-// virtual-key IDs or request IDs never. No prompt/request/response content ever
-// reaches a metric (consistent with the no-content logging rule).
+// Labels are low-cardinality: provider and model names yes, virtual-key IDs or
+// request IDs never. No prompt, request or response content reaches a metric.
 package metrics
 
 import (
@@ -105,7 +104,7 @@ type Observation struct {
 	CompletionTokens int
 	ReasoningTokens  int
 	// FailoverProviders names the provider of every attempt after the first
-	// (hedged launches included), in attempt order: one failover attempt each.
+	// (hedged launches included), in attempt order, one failover attempt each.
 	FailoverProviders []string
 }
 
@@ -135,9 +134,9 @@ func Record(o Observation) {
 
 // RecordUpstreamRateLimit counts one upstream 429 by the class the classifier
 // assigned it ("saturated", "exhausted", "unknown"). The caller owns that
-// vocabulary, as with RecordRetirementProbe: the class type lives in the proxy.
-// This is the counter that shows a provider's slot ceiling as a flat line of
-// saturated, where the request counter shows only 429s.
+// vocabulary, as with RecordRetirementProbe, because the class type lives in the
+// proxy. It shows a provider's slot ceiling as a flat line of saturated, where
+// the request counter shows only 429s.
 func RecordUpstreamRateLimit(provider, model, class string) {
 	upstreamRateLimitTotal.WithLabelValues(labelOrUnknown(provider), labelOrUnknown(model), class).Inc()
 }
@@ -172,30 +171,25 @@ func RecordResponsesReroute(provider, model, mode string) {
 // lives in the proxy and this package must stay importable by it.
 //
 // One series per (provider, model, verdict), and only for models the gateway
-// actually probed: a probe is rate-limited to one per model per cooldown, and
-// only a model drawing repeated gone-classified refusals is ever nominated. The
-// bound is the catalog, and in practice a small fraction of it.
+// probed: a probe is rate-limited to one per model per cooldown, and only a model
+// drawing repeated gone-classified refusals is nominated.
 //
 // The model label is the PROVIDER-SIDE id, while requestsTotal carries the name
 // the CLIENT asked for. For direct "provider/model" traffic those are the same
-// string — resolution matched the model row on that exact id, and the request
-// log keeps the post-slash part — so the two counters join. They diverge on
-// exactly two shapes: a request routed through a failover group is "hotel/<group>"
-// on requestsTotal and the real id here, and a validation failure is collapsed
-// there to "unresolved". A PromQL join is therefore sound but silently
-// incomplete, missing precisely the group-routed traffic.
+// string, so the two counters join. They diverge on two shapes: a request routed
+// through a failover group is "hotel/<group>" on requestsTotal and the real id
+// here, and a validation failure is collapsed there to "unresolved". A PromQL
+// join is sound but silently misses the group-routed traffic.
 //
-// Counting VERDICTS rather than retirements is deliberate. A retirement is
-// visible in the model row and in the model.auto_disabled_gone event; what
-// neither records is the probe that did NOT retire anything — a "served" is the
-// classifier having nominated a live model, and a run of "inconclusive" is the
-// gateway paying for an answer it is not getting. Those two are the reason this
-// metric exists, and they leave no other trace than a log line.
+// It counts VERDICTS rather than retirements. A retirement is visible in the
+// model row and in the model.auto_disabled_gone event; a probe that retired
+// nothing is not: a "served" means the classifier nominated a live model, and a
+// run of "inconclusive" means the gateway is paying for an answer it is not
+// getting.
 //
-// A refused verdict is not the same thing as a completed retirement: the write
-// that follows can still be superseded by a success, refused by the repository,
-// or reverted. Alert on the ratio between verdicts, not on refused as a
-// retirement count.
+// A refused verdict is not a completed retirement: the write that follows can be
+// superseded by a success, refused by the repository, or reverted. Alert on the
+// ratio between verdicts, not on refused as a retirement count.
 func RecordRetirementProbe(provider, model, verdict string) {
 	retirementProbesTotal.WithLabelValues(labelOrUnknown(provider), labelOrUnknown(model), verdict).Inc()
 }
@@ -207,8 +201,8 @@ func Handler() http.Handler {
 }
 
 // statusClass buckets an HTTP status into a low-cardinality label. 499 (client
-// closed request) is kept distinct so client disconnects are visible and not
-// conflated with provider 4xx.
+// closed request) stays distinct so client disconnects are not conflated with
+// provider 4xx.
 func statusClass(code int) string {
 	switch {
 	case code == 499:
@@ -240,7 +234,7 @@ type BreakerState struct {
 	State      int
 }
 
-// State numeric encoding for modelhotel_circuit_breaker_state.
+// Numeric state encoding for modelhotel_circuit_breaker_state.
 const (
 	BreakerClosed   = 0
 	BreakerHalfOpen = 1
@@ -248,12 +242,12 @@ const (
 )
 
 // RegisterBreakerCollector registers a scrape-time collector that reports the
-// circuit-breaker state per provider. collect is called on every scrape and
-// must be cheap and non-blocking; it returns the current states. Passing nil,
-// or calling more than once, is a no-op after the first registration.
+// circuit-breaker state per provider. collect runs on every scrape and must be
+// cheap and non-blocking. Passing nil, or calling more than once, is a no-op
+// after the first registration.
 //
-// A scrape-time collector (rather than an event-updated gauge) is used because
-// the open→half-open transition is time-based and would otherwise be missed.
+// Scrape-time rather than an event-updated gauge, because the open to half-open
+// transition is time-based and an event gauge would miss it.
 func RegisterBreakerCollector(collect func() []BreakerState) {
 	if collect == nil {
 		return
@@ -285,7 +279,7 @@ func (c *breakerCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-// compile-time guard: the collector implements prometheus.Collector.
+// Compile-time guard: the collector implements prometheus.Collector.
 var _ prometheus.Collector = (*breakerCollector)(nil)
 
 // InflightState is one provider's adaptive in-flight window for the gauges:

--- a/internal/openairesponses/detect.go
+++ b/internal/openairesponses/detect.go
@@ -8,8 +8,8 @@ import (
 // RequiresResponsesAPI reports whether an upstream 400 error body is the
 // OpenAI "use /v1/responses" rejection: newest models (gpt-5.4+, gpt-5.6)
 // refuse function tools combined with reasoning over chat-completions and
-// name the Responses API as the fix. Detection is deliberately conservative —
-// the message must mention responses AND reasoning AND tools — so ordinary
+// name the Responses API as the fix. Detection is deliberately conservative
+// (the message must mention responses AND reasoning AND tools), so ordinary
 // param-rejection 400s keep flowing to the param-strip self-heal.
 func RequiresResponsesAPI(errBody []byte) bool {
 	var envelope struct {
@@ -29,9 +29,9 @@ func RequiresResponsesAPI(errBody []byte) bool {
 // NeedsResponsesRouting reports whether a chat-completions request body
 // carries the combination that forces the Responses API on a flagged model:
 // tools present AND reasoning not explicitly disabled. Absent reasoning_effort
-// counts — these models reason by default, so tools-only requests without an
+// counts: these models reason by default, so tools-only requests without an
 // explicit "none" hit the same upstream 400. Tools-free or reasoning-off
-// requests keep the cheaper chat-completions path (plan §4.1).
+// requests keep the cheaper chat-completions path.
 func NeedsResponsesRouting(chatBody []byte) bool {
 	var probe struct {
 		Tools           []json.RawMessage `json:"tools"`

--- a/internal/openairesponses/request.go
+++ b/internal/openairesponses/request.go
@@ -68,7 +68,7 @@ type chatContentPart struct {
 // tool definitions are flattened, and reasoning_effort maps to reasoning
 // (with summary:"auto" so the model's reasoning summary can be surfaced back
 // as reasoning_content). store is always false: the gateway is stateless and
-// each turn re-sends the full transcript (plan §4.2).
+// each turn re-sends the full transcript.
 func TranslateChatToResponses(chatBody []byte, resolvedModel string) ([]byte, error) {
 	var req chatRequest
 	if err := json.Unmarshal(chatBody, &req); err != nil {
@@ -109,7 +109,7 @@ func TranslateChatToResponses(chatBody []byte, resolvedModel string) ([]byte, er
 
 	for _, t := range req.Tools {
 		if t.Type != "function" {
-			continue // built-in tool passthrough is out of scope for v1 (plan §2)
+			continue // only function tools translate; built-in tools are dropped
 		}
 		out.Tools = append(out.Tools, Tool{
 			Type:        "function",
@@ -137,8 +137,8 @@ func TranslateChatToResponses(chatBody []byte, resolvedModel string) ([]byte, er
 // translateChatMessages folds system/developer turns into instructions and
 // converts the rest of the transcript into Responses input items. Prior
 // reasoning items are NOT reconstructed (the gateway never sees encrypted
-// reasoning content); each turn reasons fresh from the transcript, matching
-// today's chat-completions behavior (plan §4.3).
+// reasoning content); each turn reasons fresh from the transcript, as the
+// chat-completions path does.
 func translateChatMessages(msgs []chatReqMessage) (string, []any, error) {
 	var sysParts []string
 	var input []any
@@ -167,9 +167,8 @@ func translateChatMessages(msgs []chatReqMessage) (string, []any, error) {
 			}
 			for _, tc := range m.ToolCalls {
 				// The Responses API types arguments as a string, so anything
-				// would forward — but a quoted array is garbage to the model,
-				// and the same input must not take a different fate here than on
-				// the other two egress paths.
+				// forwards, but a quoted array is garbage to the model. The
+				// object form is normalised here as on the other egress paths.
 				args := util.ToolArguments(util.ToolArgumentsObject(tc.Function.Arguments))
 				input = append(input, functionCallItem{
 					Type:      "function_call",

--- a/internal/openairesponses/stream.go
+++ b/internal/openairesponses/stream.go
@@ -20,8 +20,7 @@ import (
 // chat.completion.chunk SSE stream the rest of the pipeline (and the client)
 // speaks. It is single-goroutine: the StreamAdapter drives it from one read
 // loop. Events are dispatched on the JSON "type" field, so SSE "event:" lines
-// can be ignored; unknown event types are dropped silently (OpenAI adds new
-// ones over time, plan §13).
+// can be ignored; unknown event types are dropped silently.
 type StreamTranslator struct {
 	id      string
 	model   string

--- a/internal/openairesponses/types.go
+++ b/internal/openairesponses/types.go
@@ -1,15 +1,12 @@
 // Package openairesponses translates between the OpenAI chat-completions wire
 // format the gateway speaks and the OpenAI Responses API (/v1/responses).
 //
-// Direction is the mirror image of internal/anthropic: there the CLIENT speaks
-// a foreign dialect and the upstream speaks chat-completions; here the client
-// speaks chat-completions and the UPSTREAM demands the foreign dialect.
-// OpenAI's newest models (gpt-5.4+, the gpt-5.6 family) reject tool calling
-// combined with reasoning over /v1/chat/completions and require /v1/responses
-// (see plans/openai-responses-endpoint.md), and the pro tier (o1-pro, o3-pro,
-// gpt-5.x-pro) is served by /v1/responses alone, so the proxy translates the
-// request on the way out and the response/stream back on the way in. Like the
-// anthropic package this is a leaf: the proxy composes it, never the reverse.
+// The client speaks chat-completions and the UPSTREAM demands the foreign
+// dialect: OpenAI's newest models (gpt-5.4+, the gpt-5.6 family) reject tool
+// calling combined with reasoning over /v1/chat/completions and require
+// /v1/responses, and the pro tier (o1-pro, o3-pro, gpt-5.x-pro) is served by
+// /v1/responses alone, so the proxy translates the request on the way out and
+// the response or stream back on the way in.
 package openairesponses
 
 import (
@@ -35,7 +32,7 @@ type Request struct {
 	TopP              *float64        `json:"top_p,omitempty"`
 	Metadata          json.RawMessage `json:"metadata,omitempty"`
 	// Store is always false: MH is a stateless gateway and must not persist
-	// conversation state at OpenAI (no omitempty — the explicit false matters).
+	// conversation state at OpenAI. No omitempty: the explicit false matters.
 	Store  bool `json:"store"`
 	Stream bool `json:"stream,omitempty"`
 }
@@ -105,11 +102,10 @@ type Response struct {
 	IncompleteDetails *IncompleteDetails `json:"incomplete_details"`
 	Error             *ResponseError     `json:"error"`
 	Output            []OutputItem       `json:"output"`
-	// Held raw and decoded on its own, so a usage block this package cannot read
-	// costs the usage and nothing else. Decoded inline it was part of the
-	// response object, and one count the provider spelled differently — quoted,
-	// or with a fraction on it — failed the whole translation and cost the
-	// caller the answer the model had already produced.
+	// Held raw and decoded on its own, so a usage block this package cannot
+	// read costs the usage and nothing else. Decoded inline, one count the
+	// provider spells differently (quoted, or with a fraction on it) fails the
+	// whole translation and costs the caller the answer.
 	Usage json.RawMessage `json:"usage"`
 }
 
@@ -138,8 +134,8 @@ type OutputItem struct {
 	// function_call
 	CallID string `json:"call_id"`
 	Name   string `json:"name"`
-	// The provider's side of the same asymmetry: an object here failed the whole
-	// Response decode, so a tool call cost the caller the answer around it.
+	// util.ToolArguments: an object here would otherwise fail the whole
+	// Response decode, costing the caller the answer around the tool call.
 	Arguments util.ToolArguments `json:"arguments"`
 }
 
@@ -213,12 +209,9 @@ type chatToolCall struct {
 type chatToolCallFunc struct {
 	Name string `json:"name,omitempty"`
 	// util.ToolArguments, not a plain string: the spec says a JSON string and
-	// several providers send the object, so #808 taught the response side to
-	// accept both — and an ingress decoder has no business being stricter than
-	// the decoder that produced the value. This gateway rewrites the object form
-	// on its own way out, so a client holding one got it from another gateway or
-	// SDK. It marshals back as the spec's string either way, so the caller is
-	// still answered in the shape it asked for.
+	// several providers send the object instead. It marshals back as the
+	// spec's string either way, so the caller is answered in the shape it
+	// asked for.
 	Arguments util.ToolArguments `json:"arguments"`
 }
 

--- a/internal/provider/cap_note.go
+++ b/internal/provider/cap_note.go
@@ -7,12 +7,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// What Model Hotel cannot know about a provider, made explicit. Ollama Cloud
-// exposes no usage; a plain OpenAI-compatible endpoint exposes nothing at all.
-// For those the only quota signal the gateway ever sees is the 429 whose body
-// says the window or balance is spent. The cap ledger keeps the last of those
-// per provider, so the quota badge can say "no usage API; last cap message:
-// \"session usage limit\" at 14:51 (from a 429)" instead of staying blank.
+// Providers that expose no usage API (Ollama Cloud, a plain OpenAI-compatible
+// endpoint) leave the gateway one quota signal: the 429 whose body says the
+// window or balance is spent. The cap ledger keeps the last of those per
+// provider, so the quota badge can name it instead of staying blank.
 
 // CapNote is the last exhausted 429 a provider answered: the phrase the
 // classifier matched (the phrase-table key, never the body), the model that

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -75,8 +75,7 @@ const maxDiscoveryRetries = 3
 // credentialHeaders are the request headers a discovery family folds its key
 // into. secretsOf reads the key back off these, so the shared helpers can
 // scrub what an upstream says back without ever being handed the key as a
-// value. A family that authenticates through another header must add it here
-// AND to TestRequestSecrets_CoversEveryCredentialHeader.
+// value. A family that authenticates through another header must add it here.
 var credentialHeaders = []string{"Authorization", "X-Api-Key", "Api-Key", "X-Goog-Api-Key"}
 
 // credentialQueryParams are the query parameter names a key may travel in
@@ -94,9 +93,7 @@ var credentialQueryParams = map[string]bool{
 // receive the key as a value: the caller has already folded it into a header
 // or the query string. Reading it back is what lets the shared path cover
 // every family, including the custom and self-hosted gateways whose key
-// format no prefix regex anticipates; the vendor paths that each fixed this
-// for themselves had left this shared one uncovered (Strix vuln-0005,
-// 2026-09-01, the fourth site of the #836 class).
+// format no prefix regex anticipates.
 //
 // A header value is listed raw and, for a bearer, stripped, since an upstream
 // may quote either. A query value is listed decoded, percent-escaped, and as
@@ -137,9 +134,8 @@ func querySecrets(rawQuery string) []string {
 		// wrap in the middle, a DEL) is what makes a URL unparseable in the
 		// first place, and url.Error renders the URL with %q, so that byte
 		// shows escaped and the exact match on the raw value misses the
-		// visible text. The %q rendering IS the visible text: list it. It
-		// covers any control byte anywhere in the value, which trimming the
-		// ends did not.
+		// visible text. The %q rendering IS the visible text, so it is listed
+		// too, for a control byte anywhere in the value.
 		for _, v := range []string{seg, raw} {
 			if q := strconv.Quote(v); q[1:len(q)-1] != v {
 				secrets = append(secrets, q[1:len(q)-1])
@@ -321,10 +317,10 @@ var hostTypeRules = []struct {
 	{"neuralwatt", []string{"api.neuralwatt.com", "neuralwatt.com"}, []string{".neuralwatt.com"}},
 	// Azure AI Foundry ({res}.services.ai.azure.com) and classic Azure OpenAI
 	// ({res}.openai.azure.com) resources. Both expose the same OpenAI v1
-	// surface under /openai/v1 (Bearer auth, live-verified 2026-07-18).
+	// surface under /openai/v1, with Bearer auth.
 	{"azure", nil, []string{".services.ai.azure.com", ".openai.azure.com"}},
 	// Kimi Code subscription endpoint (api.kimi.com/coding). Subscription
-	// sk-kimi- keys ONLY work here — the pay-per-token platform
+	// sk-kimi- keys ONLY work here: the pay-per-token platform
 	// (api.moonshot.ai) is a separate key namespace and stays generic openai.
 	{"kimi-code", []string{"api.kimi.com", "kimi.com"}, []string{".kimi.com"}},
 	// MiniMax intl platform (api.minimax.io). Token Plan subscription sk-cp-
@@ -350,8 +346,8 @@ func detectByHost(host, path string) string {
 	// (bedrock-mantle.{region}.api.aws). Prefix+suffix must both match so
 	// bedrock-named hosts on unrelated domains stay generic. The classic
 	// bedrock-runtime endpoint is deliberately not detected: it serves chat
-	// only under /openai/v1 and has no /models listing at all (live-verified
-	// 2026-07-18), so discovery can never succeed against it.
+	// only under /openai/v1 and has no /models listing at all, so discovery
+	// can never succeed against it.
 	if strings.HasPrefix(host, "bedrock-mantle.") && strings.HasSuffix(host, ".api.aws") {
 		return "bedrock"
 	}
@@ -398,11 +394,10 @@ func TypeFromHostname(baseURL string) string {
 }
 
 // LegacyTypeFromURL derives a provider type from a base URL, including the
-// default-port rules for self-hosted servers. It exists only to give rows that
-// predate the stored provider_type column a type: the startup backfill and
-// TypeOf's fallback are its only callers, and those rows were created while
-// the port rules were in force. Provider type is chosen by the operator when
-// the provider is added, never guessed at request time.
+// default-port rules for self-hosted servers. It serves rows with no stored
+// provider_type: the startup backfill and TypeOf's fallback are its only
+// callers. Provider type is chosen by the operator when the provider is
+// added, never guessed at request time.
 func LegacyTypeFromURL(baseURL string) string {
 	u, err := url.Parse(strings.TrimSpace(baseURL))
 	if err != nil || u.Host == "" {
@@ -424,8 +419,7 @@ func LegacyTypeFromURL(baseURL string) string {
 
 // TypeOf returns the provider's stored type. Rows that have not been backfilled
 // yet (a restored dump, an import that landed after startup) fall back to the
-// legacy URL derivation so they keep behaving as they did before the column
-// existed.
+// legacy URL derivation.
 func TypeOf(p *Provider) string {
 	if p == nil {
 		return "openai"
@@ -481,9 +475,8 @@ func (d *DiscoveryService) DiscoverModels(ctx context.Context, provider *Provide
 		case "ollama":
 			return d.discoverOllama(ctx, provider, apiKey)
 		case "ollama-cloud":
-			// Ollama Cloud (ollama.com) reuses the same /api/tags + /api/show
-			// discovery endpoints as local Ollama. If the cloud API diverges
-			// in the future, this will need a dedicated discoverer.
+			// Ollama Cloud (ollama.com) serves the same /api/tags + /api/show
+			// discovery endpoints as local Ollama.
 			return d.discoverOllama(ctx, provider, apiKey)
 		case "opencode-zen":
 			return d.discoverOpenCodeZen(ctx, provider, apiKey)
@@ -688,7 +681,7 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 			debuglog.Info("discovery: retryable HTTP status for quota fetch", "type", providerType, "provider", providerName, "provider_id", providerID, "status", resp.StatusCode, "attempt", attempt+1)
 			continue
 		}
-		// Success or non-retryable status — return as-is.
+		// Success or non-retryable status: return as-is.
 		if recovered := circuit.recordSuccess(); recovered {
 			debuglog.Info("discovery: quota circuit breaker recovered", "type", providerType, "provider", providerName, "provider_id", providerID)
 		}

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -28,8 +28,8 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	//
 	// The credential is therefore IN THE URL, and a transport failure returns a
 	// *url.Error whose Error() quotes the whole URL back: Go redacts only
-	// userinfo passwords, not query parameters. Every rendering of that error
-	// below is scrubbed for exactly that reason; moving to the x-goog-api-key
+	// userinfo passwords, not query parameters. The transport error below is
+	// scrubbed for exactly that reason; moving to the x-goog-api-key
 	// header would remove the class instead of masking it.
 	url := fmt.Sprintf("%s/models?key=%s", nativeBaseURL, neturl.QueryEscape(apiKey))
 

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -29,10 +29,8 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	// The credential is therefore IN THE URL, and a transport failure returns a
 	// *url.Error whose Error() quotes the whole URL back: Go redacts only
 	// userinfo passwords, not query parameters. Every rendering of that error
-	// below is scrubbed for exactly that reason. Moving this endpoint to the
-	// x-goog-api-key header (which vertex-express already uses) would remove
-	// the class rather than mask it, and is worth doing separately, where the
-	// change can be exercised against the live API.
+	// below is scrubbed for exactly that reason; moving to the x-goog-api-key
+	// header would remove the class instead of masking it.
 	url := fmt.Sprintf("%s/models?key=%s", nativeBaseURL, neturl.QueryEscape(apiKey))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
@@ -226,10 +224,10 @@ func googleModalities(modelID string) (inputMods, outputMods string) {
 		// ("The requested combination of response modalities (TEXT) is not
 		// supported"). Text in and audio out derives the tts class, which
 		// keeps it out of the chat and arena pickers and stops /v1/models
-		// advertising vision or audio input; nothing gates a request by
+		// advertising vision or audio input. An audio-only output also
+		// exempts it from the model-gone strike. Nothing gates a request by
 		// modality on the way in, so a client naming it directly still gets
-		// Google's 400. An audio-only output also exempts it from the
-		// model-gone strike, the trade every non-chat class makes.
+		// Google's 400.
 		inputMods = `["text"]`
 		outputMods = `["audio"]`
 	}
@@ -261,5 +259,3 @@ func isGoogleAudioModel(modelID string) bool {
 func isGoogleEmbeddingModel(modelID string) bool {
 	return strings.Contains(strings.ToLower(modelID), "embedding")
 }
-
-// containsString removed — use slices.Contains from stdlib.

--- a/internal/provider/discovery_vertex.go
+++ b/internal/provider/discovery_vertex.go
@@ -71,7 +71,7 @@ func (d *DiscoveryService) discoverVertexExpress(ctx context.Context, provider *
 }
 
 // vertexCountTokensProbe issues one countTokens call for a candidate model and
-// returns the HTTP status. The response body is drained and discarded — only
+// returns the HTTP status. The response body is drained and discarded; only
 // reachability matters.
 func (d *DiscoveryService) vertexCountTokensProbe(ctx context.Context, baseURL, modelID, apiKey string) (int, error) {
 	endpoint := "/publishers/google/models/" + url.PathEscape(modelID) + ":countTokens"
@@ -87,9 +87,8 @@ func (d *DiscoveryService) vertexCountTokensProbe(ctx context.Context, baseURL, 
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		// Off the shared helpers, so scrubbed here: the key is header-only
-		// today, but a transport error quotes the URL and this is the one
-		// probe whose URL a future change could carry it in.
+		// The key is header-only, so the URL a transport error quotes carries
+		// none; scrubbed anyway in case that ever changes.
 		return 0, maskedRequestError(req, err)
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/provider/held_keys.go
+++ b/internal/provider/held_keys.go
@@ -11,16 +11,14 @@ import (
 // HoldKeys registers every provider key in the table with the credential
 // mask's held set (util.HoldSecret), whatever the row's enabled or
 // autodiscovery state. The mask exists for a relay that quotes the key of a
-// different provider row in its error body, and the row it quotes is, if
-// anything, more likely to be one the operator has disabled (a key being
-// rotated, a provider under suspicion) than one in use; so coverage cannot
-// depend on a key having been decrypted for a request, which a disabled
-// provider never is. Called at startup and after every import; the create
-// and update handlers register the plaintext they have in hand directly.
+// different provider row in its error body, and that row may well be one the
+// operator has disabled, so coverage cannot depend on a key having been
+// decrypted for a request. Called at startup and after every import; the
+// create and update handlers register the plaintext they hold directly.
 //
-// Decryption goes through the key cache, so a key already warmed costs a map
-// read and a cold one costs one Argon2 derivation; a large table is seconds
-// of CPU, which is why the callers run this off the request path.
+// Decryption goes through the key cache, so a warm key costs a map read and a
+// cold one an Argon2 derivation. A large table is seconds of CPU, so callers
+// run this off the request path.
 func HoldKeys(ctx context.Context, repo *Repository, masterKey string) (held, failed int) {
 	providers, err := repo.List(ctx)
 	if err != nil {

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -36,11 +36,11 @@ type modelsDevCanonical struct {
 	// Exclusive stops the lookup from falling back to the cross-provider index
 	// when the canonical entry misses. Set for single-vendor provider types:
 	// their API serves only their own models, so another models.dev provider's
-	// data for the same bare ID is by definition secondhand (e.g. OpenCode Go
-	// lists "glm-5.3" with a guessed price before Z.ai publishes one — that
-	// guess must not become the metered price on a Z.ai provider). Aggregator
-	// and catch-all types stay non-exclusive: their listings genuinely span
-	// many vendors, so the cross-provider index is legitimate gap coverage.
+	// data for the same bare ID is by definition secondhand (OpenCode Go lists
+	// "glm-5.3" with a guessed price before Z.ai publishes one, and that guess
+	// must not become the metered price on a Z.ai provider). Aggregator and
+	// catch-all types stay non-exclusive: their listings genuinely span many
+	// vendors, so the cross-provider index is legitimate gap coverage.
 	Exclusive bool
 }
 
@@ -169,12 +169,12 @@ var modelsDevCache = &ModelsDevCache{}
 
 // LoadModelsDev fetches the models.dev API and builds the in-memory index.
 // Each call fetches fresh data from the remote API and replaces the cache.
-// It is safe to call concurrently — the write is protected by a mutex.
+// It is safe to call concurrently: the write is protected by a mutex.
 //
 // This uses http.DefaultClient, which follows redirects without SSRF checks.
 // Production code must instead call LoadModelsDevWithClient with a client whose
-// transport is backed by a SafeDialer (see cmd/server/main.go); this bare form
-// is retained for tests that exercise the real fetch/error paths.
+// transport is backed by a SafeDialer; this bare form serves tests that
+// exercise the real fetch and error paths.
 func LoadModelsDev(ctx context.Context) error {
 	return modelsDevCache.load(ctx, http.DefaultClient)
 }
@@ -256,7 +256,7 @@ func (c *ModelsDevCache) load(ctx context.Context, client *http.Client) error {
 	// model ID appears under dozens of models.dev providers (official vendor
 	// plus resellers, each with its own prices), so the iteration order decides
 	// which spec a fallback lookup sees. Rank canonical providers (the values of
-	// modelsDevProviderForType — official vendor entries) ahead of everything
+	// modelsDevProviderForType, the official vendor entries) ahead of everything
 	// else, sorted within each group so the winner is deterministic across
 	// loads. Ranging over the providers map directly would pick a random winner
 	// per process start.
@@ -320,10 +320,10 @@ func (c *ModelsDevCache) LookupFuzzy(modelID string) *ModelsDevModelSpec {
 
 // lookupForProvider resolves a spec for a model discovered on a Model Hotel
 // provider of the given type. The canonical models.dev provider entry for that
-// type (see modelsDevProviderForType) is consulted first — it carries the
-// vendor's own official metadata and pricing — and only on a miss does the
-// lookup fall back to the cross-provider index. An empty or unmapped
-// providerType goes straight to the cross-provider index.
+// type (see modelsDevProviderForType) is consulted first, since it carries the
+// vendor's own official metadata and pricing; only on a miss does the lookup
+// fall back to the cross-provider index. An empty or unmapped providerType
+// goes straight to the cross-provider index.
 func (c *ModelsDevCache) lookupForProvider(providerType, modelID string) *ModelsDevModelSpec {
 	if c == nil {
 		return nil
@@ -341,8 +341,8 @@ func (c *ModelsDevCache) lookupForProvider(providerType, modelID string) *Models
 	return lookupFuzzyIn(c.byID, modelID)
 }
 
-// lookupFuzzyIn runs the exact-then-fuzzy match against one index map. Pure
-// helper — the caller holds whatever lock protects the map.
+// lookupFuzzyIn runs the exact-then-fuzzy match against one index map. The
+// caller holds whatever lock protects the map.
 func lookupFuzzyIn(index map[string]*ModelsDevModelSpec, modelID string) *ModelsDevModelSpec {
 	if len(index) == 0 {
 		return nil
@@ -482,7 +482,7 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 // Google's own docs, and the API answers JSON mode on every one of them with
 // a 400 (google-gemini/cookbook#1028); discovery leaves the flag off for
 // them, so the merge must not switch it back on. Reports whether it cleared
-// anything, which is what re-marshals the capabilities below.
+// anything.
 func clearRefusedCapabilities(providerType, modelID string, caps *model.Capability) bool {
 	if !caps.StructuredOutput || !googleServedImageModel(providerType, modelID) {
 		return false
@@ -554,8 +554,8 @@ func (c *ModelsDevCache) EnrichModel(m *model.Model, providerType string) bool {
 	spec := c.lookupForProvider(providerType, m.ModelID)
 	if spec == nil && m.Name != "" && m.Name != m.ModelID {
 		// Deployment-based providers (Azure) invoke by user-chosen alias but
-		// record the underlying base-model name in Name — match on that when
-		// the alias misses the catalog.
+		// record the underlying base-model name in Name, which is matched on
+		// when the alias misses the catalog.
 		spec = c.lookupForProvider(providerType, m.Name)
 	}
 	if spec == nil {
@@ -594,7 +594,7 @@ func (c *ModelsDevCache) EnrichModel(m *model.Model, providerType string) bool {
 	enriched = clearRefusedCapabilities(providerType, m.ModelID, &caps) || enriched
 
 	// Modality arrays: only set if currently empty. The modality *class* is
-	// not set here — NormalizeModelClassification derives it from the arrays
+	// not set here; NormalizeModelClassification derives it from the arrays
 	// after enrichment.
 	enriched = fillModalities(&m.InputModalities, spec.Modalities.Input) || enriched
 	enriched = fillModalities(&m.OutputModalities, spec.Modalities.Output) || enriched
@@ -634,16 +634,11 @@ func (c *ModelsDevCache) EnrichModels(models []*model.Model, providerType string
 // reportUnpricedModels logs any model that finished discovery with no per-token
 // price on either side.
 //
-// This exists because the embedded catalogs were shrunk to overrides only: a
-// row that merely restated models.dev was deleted, since a stale duplicate is
-// worse than none (the catalog wins over models.dev, which is how xAI's
-// retired-model pricing sat 6x wrong until an audit found it). The cost of that
-// is a heavier reliance on models.dev, and a model it does not know now yields
-// no price at all rather than a catalog fallback.
-//
-// An unpriced model still works; it just meters at zero, which is invisible
-// until someone reconciles a bill. Naming it here turns that into something an
-// operator can see and fix by adding a catalog override.
+// The embedded catalogs hold overrides only, so a model models.dev does not
+// know yields no price at all. Such a model still works; it just meters at
+// zero, which is invisible until someone reconciles a bill. Naming it here
+// turns that into something an operator can see and fix by adding a catalog
+// override.
 func reportUnpricedModels(models []*model.Model) {
 	var unpriced []string
 	for _, m := range models {
@@ -661,8 +656,6 @@ func reportUnpricedModels(models []*model.Model) {
 	debuglog.Warn("discovery: models have no pricing from catalog or models.dev; they will meter at zero",
 		"count", len(unpriced), "models", strings.Join(unpriced, ","))
 }
-
-// contains removed — use slices.Contains from stdlib.
 
 func isNumeric(s string) bool {
 	for _, c := range s {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -52,8 +52,8 @@ type UpdateProviderRequest struct {
 	Name    *string `json:"name"`
 	BaseURL *string `json:"base_url"`
 	// ProviderType corrects a provider's type. It is not something to change
-	// casually, but a row backfilled from the old URL rules can carry a type
-	// its operator never chose (a self-hosted server on a non-default port was
+	// casually, but a row backfilled from the legacy URL rules can carry a type
+	// its operator never chose (a self-hosted server on a non-default port is
 	// filed as generic OpenAI), and re-adding the provider would cascade away
 	// its models. A new self-hosted type is confirmed by probing, exactly as on
 	// create.
@@ -394,22 +394,19 @@ func (r *Repository) DisableDueScheduled(ctx context.Context) ([]*Provider, erro
 // what stops a failure between them leaving the provider gone with its id still
 // referenced, which is the exact dangling state the pruning exists to prevent.
 //
-// Concurrency note, because this changed when the transaction was introduced.
-// This used to be one autocommit statement holding its locks for the length of
-// that statement. It now holds them until commit, and the footprint is wider
+// Concurrency note: the locks are held until commit, over a footprint wider
 // than the three tables named in this file:
 //
 //   - providers, then virtual_keys, then users, written here directly;
 //   - models and provider_quota_snapshots, deleted by FK CASCADE;
 //   - request_logs, whose provider_id is set to NULL by FK (migration 010).
 //
-// That last one is the largest part of the change: request_logs is the
-// highest-volume table in the schema, every row belonging to this provider is
-// rewritten, and those row locks are now pinned across the two allow-list
-// UPDATEs as well instead of being released with the DELETE. It adds no
-// deadlock risk of its own, because the writer on the other side is a proxy log
-// insert, a single autocommit statement that takes only FOR KEY SHARE on the
-// provider row and so can never hold a lock while waiting for one of ours.
+// That last one weighs the most: request_logs is the highest-volume table in
+// the schema, every row belonging to this provider is rewritten, and those row
+// locks stay pinned across the two allow-list UPDATEs. It adds no deadlock risk
+// of its own, because the writer on the other side is a proxy log insert, a
+// single autocommit statement that takes only FOR KEY SHARE on the provider row
+// and so can never hold a lock while waiting for one of ours.
 //
 // A deadlock with a concurrent config-sync import IS possible, though the
 // window is narrow. Config-sync funnels through providers first: upsertProviders
@@ -433,13 +430,13 @@ func (r *Repository) DisableDueScheduled(ctx context.Context) ([]*Provider, erro
 //  7. T2 reaches upsertVirtualKeys, touches VK, and blocks on T1.
 //
 // Postgres detects the cycle and aborts one side with SQLSTATE 40P01. Both
-// operations are safely retriable, which is what keeps this a nuisance rather
-// than a correctness problem: the aborted transaction rolled back whole, so a
-// retried delete simply performs the delete (it returns pgx.ErrNoRows only if an
-// earlier attempt actually committed), and a member whose import was aborted is
-// re-pushed on the next auto-sync tick, because that tick reads the member's own
-// config hash and finds it still does not match the primary's. A one-off manual
-// sync from the wizard is NOT re-pushed and has to be repeated by the operator.
+// operations are safely retriable: the aborted transaction rolls back whole, so
+// a retried delete simply performs the delete (it returns pgx.ErrNoRows only if
+// an earlier attempt actually committed), and a member whose import was aborted
+// is re-pushed on the next auto-sync tick, because that tick reads the member's
+// own config hash and finds it still does not match the primary's. A one-off
+// manual sync from the wizard is NOT re-pushed and has to be repeated by the
+// operator.
 //
 // All of this is a property of config-sync's statement order rather than
 // anything enforced, so reordering internal/api/configsync_apply.go's apply()
@@ -482,11 +479,10 @@ func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// BackfillTypes gives a stored type to every provider row that has none:
-// rows created before provider_type existed, and rows arriving from an older
-// dump or fleet export. The type is derived once, from the URL rules that were
-// in force when those rows were written, so their behaviour does not change.
-// Idempotent, and a no-op once every row has a type.
+// BackfillTypes gives a stored type to every provider row that has none, such
+// as one arriving from an older dump or fleet export. The type is derived once,
+// from the legacy URL rules, so the row's behaviour does not change. Idempotent,
+// and a no-op once every row has a type.
 func (r *Repository) BackfillTypes(ctx context.Context) (int, error) {
 	rows, err := r.pool.Query(ctx, `SELECT id, base_url FROM providers WHERE provider_type = ''`)
 	if err != nil {

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -20,8 +20,8 @@ import (
 func (h *Handler) buildNativeAnthropicRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
 	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/messages")
 	// A Gemini thought signature riding on a tool_use id (see
-	// anthropic.StripSignedToolUseIDs) is dropped here: this provider has no
-	// use for it, and it is a kilobyte of prompt per call per turn.
+	// anthropic.StripSignedToolUseIDs) is dropped: this provider has no use for
+	// it, and it is a kilobyte of prompt per call per turn.
 	body := anthropic.RewriteModel(anthropic.StripSignedToolUseIDs(st.anthropicRawBody), candidate.model.ModelID)
 	debuglog.Debug("proxy: native anthropic passthrough", "target_url", targetURL, "model", candidate.model.ModelID, "provider", candidate.provider.Name)
 
@@ -35,10 +35,9 @@ func (h *Handler) buildNativeAnthropicRequest(ctx context.Context, st *requestSt
 }
 
 // handleNativeNonStreaming serves a non-streaming native Anthropic success
-// response (any 2xx):
-// the upstream body is already an Anthropic message, so it is forwarded verbatim
-// (through the verbatim-mode response writer). Token usage is read from the
-// Anthropic usage block for metering + quota, mirroring handleNonStreamingResponse.
+// response (any 2xx). The upstream body is already an Anthropic message, so it
+// is forwarded verbatim. Token usage is read from the Anthropic usage block for
+// metering and quota, mirroring handleNonStreamingResponse.
 func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Request, st *requestState, resp *http.Response, attempt int, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
 	defer func() {
@@ -51,12 +50,11 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		debuglog.Warn("proxy: native anthropic read failed", "error", err, "provider", logData.providerName)
-		// Finalize the log row so it does not orphan in the in-flight state: a
-		// read failure on a success body is a provider/transport fault — unless it
-		// was interrupted rather than broken, which the translated path already
-		// classifies and this one hard-coded past. The identical event logged
-		// provider_error here and client_disconnect there, decided by nothing but
-		// which dialect the request came in on.
+		// Finalize the log row so it does not orphan in the in-flight state. A
+		// read failure on a success body is a provider or transport fault,
+		// unless it was interrupted rather than broken, which cancelKind
+		// classifies the same way the translated path does: the identical event
+		// must not log provider_error here and client_disconnect there.
 		kind := KindProviderError
 		if cancelled, aborted := cancelKind(r.Context(), err); aborted {
 			kind = cancelled
@@ -77,10 +75,10 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body = logData.masker.maskExact(body)
 
 	usage := anthropic.ParseResponseUsage(body)
-	// The native prompt figure and its cache miss are sums of members the
-	// decoder bounded one at a time, so they arrive unbounded; every figure
-	// this function writes is clamped so the log row's five token columns,
-	// the estimate and the charge agree, and a rewrite is announced.
+	// The native prompt figure and its cache miss are sums of members the decoder
+	// bounded one at a time, so they arrive unbounded. Every figure this function
+	// writes is clamped, so the log row's five token columns, the estimate and
+	// the charge agree.
 	inputTokens, outputTokens, _ := h.clampReportedUsage(usage.PromptTokens, usage.CompletionTokens, 0, logData)
 	totalDuration := float64(time.Since(st.startTime).Microseconds()) / 1000.0
 
@@ -112,12 +110,12 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// front of a retired model returns between its refusals, and crediting it
 	// would stop the streak ever reaching three consecutive strikes. Tokens
 	// corroborate, for a provider that answers without reporting usage. Same
-	// judgement the OpenAI-shaped path makes with chatAnswerCarriesContent.
+	// judgement chatAnswerCarriesContent makes on the OpenAI-shaped path.
 	logData.deliveredContent = outputTokens > 0 || anthropic.ResponseCarriesContent(body)
 	// The question the breaker asks of the same body: did anything come back.
 	// ResponseCarriesContent reads block PRESENCE, which is the native analogue
-	// of the translated path's "any choice carrying something" — so on this path
-	// the two bars do coincide, and the negation is exact.
+	// of the translated path's "any choice carrying something", so on this path
+	// the two bars coincide and the negation is exact.
 	logData.emptyCompletion = outputTokens == 0 && !anthropic.ResponseCarriesContent(body)
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
@@ -133,24 +131,24 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	return outcomeServed
 }
 
-// emitRawData forwards one streaming data chunk verbatim (native Anthropic
-// passthrough), mirroring the no-transform branch of handleDataChunk. From the
-// same decode it (1) meters token usage, (2) records the terminal message_stop
-// so finalizeStream can tell a real completion from a mid-stream truncation, and
-// (3) captures a provider-sent error event into streamState so the request logs
-// as failed (deriveStreamError surfaces st.lastErrMsg) rather than silently
-// "completed" — the error frame is still forwarded to the client too, with
-// the provider's credential masked (the same credentialMasker scrub
-// handleDataChunk applies: exact key on every event, key shapes on errors).
+// emitRawData forwards one streaming data chunk verbatim on the native Anthropic
+// passthrough, mirroring the no-transform branch of handleDataChunk. From the
+// same decode it meters token usage, records the terminal message_stop so
+// finalizeStream can tell a real completion from a mid-stream truncation, and
+// captures a provider-sent error event into streamState so the request logs as
+// failed (deriveStreamError surfaces st.lastErrMsg) rather than "completed". The
+// error frame is still forwarded to the client, with the provider's credential
+// masked by the same credentialMasker scrub handleDataChunk applies: the exact
+// key on every event, key shapes on errors.
+//
 // Returns stop=true on a client write failure.
 func (h *Handler) emitRawData(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	info := anthropic.InspectStreamEvent([]byte(ev.payload))
-	// Judged like the translated path's observer, which REFUSES an
-	// out-of-range member rather than clamping it: on a stream there is an
-	// earlier reading to keep and an estimator to fall back on, so a chunk
-	// saying something absurd says nothing. Clamping here instead let the same
-	// figure that is discarded on an OpenAI-shaped stream charge the ceiling
-	// on this one, which is the attack surviving on one dialect.
+	// Judged like the translated path's observer, which REFUSES an out-of-range
+	// member rather than clamping it: on a stream there is an earlier reading to
+	// keep and an estimator to fall back on, so a chunk saying something absurd
+	// says nothing. Clamping here instead would let the figure that is discarded
+	// on an OpenAI-shaped stream charge the ceiling on this one.
 	if info.HasInput && isTokenReading(info.InputTokens) {
 		st.promptTokens = info.InputTokens
 		// Guarded like the translated path's observer: a later usage event

--- a/internal/proxy/anthropic_thinking_retry.go
+++ b/internal/proxy/anthropic_thinking_retry.go
@@ -20,11 +20,11 @@ import (
 //     (anthropicegress.ThinkingDialect); the proxy asks in its best-known shape
 //     and switches on the 400 that names the other.
 //   - A param the model has retired. Anthropic deprecates sampling params per
-//     model generation — claude-sonnet-5 and claude-opus-5 answer
-//     "`temperature` is deprecated for this model" while every 4.x model accepts
-//     it — and OpenAI clients send temperature as a matter of course.
+//     model generation, so claude-sonnet-5 and claude-opus-5 answer
+//     "`temperature` is deprecated for this model" where every 4.x model accepts
+//     it, and OpenAI clients send temperature as a matter of course.
 //
-// Either way the fact is learned for this provider+model and the request
+// Either way the fact is learned for this provider and model and the request
 // re-issued once, so the caller sees an answer rather than a 400 and no later
 // request to that model pays the round trip again.
 //
@@ -33,9 +33,9 @@ import (
 // rejects them alongside thinking), and a request that does not ask for thinking
 // cannot earn a dialect complaint.
 //
-// This cannot ride on retryWithStrippedParams. That path is skipped for every
+// This cannot ride on retryWithStrippedParams, which is skipped for every
 // dialect attempt (sentChatCompletionsBody) because it rebuilds an OpenAI body
-// and re-POSTs it, which /v1/messages would reject.
+// and re-POSTs it, and /v1/messages would reject that.
 
 // retryLearnableMessages400 handles a 400 from an Anthropic egress attempt. It
 // returns handled=false for any 400 it cannot learn from, leaving the response
@@ -63,8 +63,7 @@ func (h *Handler) retryLearnableMessages400(
 	// The same bounded read the other learners use: the body is decoded here and
 	// still has to be handed on readable when nothing can be learned from it.
 	body, readErr := readLearnable400(resp)
-	// No-op close on the buffered replacement, for bodyclose's benefit — see the
-	// identical note in retryWithResponses.
+	// A no-op close on the buffered replacement, for bodyclose's benefit.
 	_ = resp.Body.Close()
 	if readErr != nil {
 		return res, false
@@ -123,7 +122,7 @@ func (h *Handler) retryLearnableMessages400(
 
 	// The retry is still an egress attempt, so the response side keeps
 	// translating it. The guard flag stops a second round: what this self-heal
-	// can learn, it has learned, and a 400 after the re-issue is about something
+	// can learn it has learned, and a 400 after the re-issue is about something
 	// else.
 	st.messagesRetried = true
 	st.lastMessagesBody = rebuilt
@@ -136,14 +135,13 @@ func (h *Handler) retryLearnableMessages400(
 
 // learnAndRebuildMessages400 reads what a Messages 400 has to teach, records it,
 // and rebuilds the request accordingly. ok is false when the body teaches
-// nothing, or when what it teaches cannot change this particular request — in
-// which case re-issuing would send identical bytes and earn the identical 400.
+// nothing, or when what it teaches cannot change this particular request, where
+// re-issuing would send identical bytes and earn the identical 400.
 func (h *Handler) learnAndRebuildMessages400(st *requestState, candidate modelCandidate, providerType string, body []byte) (rebuilt []byte, model string, stream, ok bool) {
 	if dialect, isDialectError := anthropicegress.DialectFromError(body); isDialectError {
 		// Learn before deciding whether this request can be retried: a hedged
-		// attempt reaches the same learner, and the cached fact is what stops the
-		// next request repeating the mistake even when this one cannot be
-		// re-issued.
+		// attempt reaches the same learner, and the cached fact stops the next
+		// request repeating the mistake even when this one cannot be re-issued.
 		h.learnThinkingDialect(candidate, dialect)
 		rebuilt, model, stream, err := h.anthropicEgressBody(st, candidate, providerType, dialect)
 		if err != nil {
@@ -159,9 +157,9 @@ func (h *Handler) learnAndRebuildMessages400(st *requestState, candidate modelCa
 	}
 
 	// Param learning is scoped to anthropic-messages, whose ONLY route is
-	// Messages. The learned strip is keyed by provider+model and consulted by
-	// every build for that key, so learning one on an `anthropic` provider —
-	// whose default route is the OpenAI-compat endpoint — would let a name read
+	// Messages. The learned strip is keyed by provider and model and consulted
+	// by every build for that key, so learning one on an `anthropic` provider,
+	// whose default route is the OpenAI-compat endpoint, would let a name read
 	// out of a Messages 400 strip a param from compat traffic that accepts it.
 	if providerType != "anthropic-messages" {
 		return nil, "", false, false
@@ -170,9 +168,9 @@ func (h *Handler) learnAndRebuildMessages400(st *requestState, candidate modelCa
 	if len(rejected) == 0 {
 		return nil, "", false, false
 	}
-	// The names shared by the two dialects are exactly the ones the translator
-	// forwards unchanged (temperature, top_p, top_k), so a name learned here
-	// means the same thing it would on the compat path.
+	// The names shared by the two dialects are the ones the translator forwards
+	// unchanged (temperature, top_p, top_k), so a name learned here means the
+	// same thing it would on the compat path.
 	h.learnRejectedParams(candidate, body)
 	rebuilt, model, stream, err := h.anthropicEgressBody(st, candidate, providerType, h.thinkingDialectFor(candidate))
 	if err != nil {

--- a/internal/proxy/attempt_trail.go
+++ b/internal/proxy/attempt_trail.go
@@ -11,9 +11,9 @@ import (
 )
 
 // The per-attempt trail (request_logs.attempts): one element per failover
-// attempt, written once at terminal time. It exists because request_logs kept
-// only the TERMINAL attempt, so on 2026-08-31 every Neuralwatt 429 that was
-// attempt 0 of a request another provider then served left no trace at all.
+// attempt, written once at terminal time. The flat request_logs columns carry
+// only the TERMINAL attempt, so without the trail a 429 on attempt 0 of a
+// request another provider then served leaves no trace at all.
 //
 // Lifecycle: every attempt path opens a record when it commits to a candidate
 // (beginAttempt, the hedged launch, the breaker skip at resolve time) and
@@ -41,8 +41,8 @@ type attemptRecord struct {
 	// never request content (see attemptDetail).
 	Detail string `json:"detail,omitempty"`
 	// Phrase is the rate-limit phrase-table entry a 429 matched, when one did.
-	// It is what the phrase staleness report counts: a phrase absent from
-	// every trail for 90 days has stopped earning its place in the table.
+	// The phrase staleness report counts these: a phrase absent from every
+	// trail for 90 days no longer belongs in the table.
 	Phrase     string  `json:"phrase,omitempty"`
 	DurationMs float64 `json:"duration_ms"`
 	TTFTMs     float64 `json:"ttft_ms,omitempty"`
@@ -65,9 +65,7 @@ const (
 )
 
 // maxAttemptDetailRunes bounds attemptRecord.Detail. A provider's error code
-// or first sentence fits; a provider quoting the prompt back does not, which
-// with the credential masker is the second of the two fences the design asks
-// for.
+// or first sentence fits; a provider quoting the prompt back does not.
 const maxAttemptDetailRunes = 160
 
 // attemptDetail reduces an upstream error text to what the trail may carry:
@@ -92,8 +90,8 @@ func attemptDetail(masker credentialMasker, s string) string {
 // instant, not when its result arrived). cbEnabled false records the breaker
 // as disabled up front, because no verdict site will run to say otherwise.
 //
-// Every method here tolerates a nil receiver: unit tests drive attempt paths
-// with a bare requestState, and a trail nobody will read is not worth a panic.
+// Every method here tolerates a nil receiver: an attempt path can run against
+// a bare requestState, and a trail nobody reads is not worth a panic.
 func (l *requestLogData) openAttemptRecord(attempt int, candidate modelCandidate, hedged bool, startedAt time.Time, cbEnabled bool) {
 	if l == nil {
 		return
@@ -264,8 +262,7 @@ func (l *requestLogData) appendSkip(providerID uuid.UUID, providerName, model, d
 
 // attemptsJSON renders the trail for the request_logs.attempts column: nil (a
 // SQL NULL) when the request never committed to a candidate, so a validation
-// failure or an unknown model leaves the column exactly as an older binary
-// would.
+// failure or an unknown model leaves the column empty.
 func (l *requestLogData) attemptsJSON() []byte {
 	if l == nil || len(l.attempts) == 0 {
 		return nil
@@ -273,7 +270,7 @@ func (l *requestLogData) attemptsJSON() []byte {
 	// Skips first, then by attempt index: a hedged race appends its losers in
 	// arrival order and the winner last, so attempt 0 can follow attempt 1.
 	// Stable, so the saturation retry keeps its place behind the attempt it
-	// repeats. The column is documented as being in order; this is where.
+	// repeats. This is what puts the column in the order it documents.
 	sort.SliceStable(l.attempts, func(i, j int) bool { return l.attempts[i].Attempt < l.attempts[j].Attempt })
 	b, err := json.Marshal(l.attempts)
 	if err != nil {

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -12,46 +12,44 @@ import (
 )
 
 // The circuit-breaker verdict for a non-streaming attempt lives here, beside
-// the failover loop that produces it rather than inside it — the streaming
-// verdict has the same arrangement in stream_finalize.go, and keeping the two
-// policies in named places is what stops a second opinion growing at a call
-// site. Split out of proxy_failover.go when that file hit the size ceiling.
+// the failover loop that produces it rather than inside it. The streaming
+// verdict has the same arrangement in stream_finalize.go: keeping the two
+// policies in named places stops a second opinion growing at a call site.
 
 // recordBreakerOutcome records the circuit-breaker result for a completed
 // upstream attempt (phase D8). It is a no-op when the breaker is disabled.
 //
-// The verdict is recorded against the candidate's RESOLVED UPSTREAM model, which
-// is the key every other breaker site on this request uses — the skip in
+// The verdict is recorded against the candidate's RESOLVED UPSTREAM model, the
+// key every other breaker site on this request uses: the skip in
 // resolveCandidates, the success in recordAnswerOutcome, the stream verdict in
-// finalizeStream. Two of them disagreeing is silent: RecordFailure creates
-// whatever circuit it is handed, so the ledger fills up under a key nothing ever
-// reads and the failing model stays in rotation.
+// finalizeStream. Two of them disagreeing is silent, because RecordFailure
+// creates whatever circuit it is handed, so the ledger fills up under a key
+// nothing ever reads and the failing model stays in rotation.
 //
 // For a failover-eligible status it applies the breakerRecordAction mapping
 // (failure / no-op / success), refined for a CLASSIFIED 429 by rl:
 //
-//   - saturated: a breaker NO-OP, like 404/499 — neither charge nor credit. A
+//   - saturated: a breaker NO-OP, like 404/499, neither charge nor credit. A
 //     provider at its concurrency ceiling is alive, and charging it benches
 //     the very slots that are all busy serving. Not a success either:
 //     RecordSuccess resets consecutiveFails, and a provider alternating 500 /
 //     429-busy / 500 must still open. On a half-open probe this leaves the
-//     circuit half-open with failedProbes untouched — a busy signal is not a
-//     failed probe, and doubling the backoff for it is how a healthy provider
-//     stayed benched for 10 minutes on 2026-08-31.
+//     circuit half-open with failedProbes untouched: a busy signal is not a
+//     failed probe, and doubling the backoff for it benches a healthy provider
+//     for the whole cooldown.
 //   - exhausted: charged to the threshold at once (RecordExhausted), so one
 //     spent-window 429 opens the circuit instead of wasting a second request
-//     confirming it — unless circuit_breaker_open_on_exhaustion is OFF, which
+//     confirming it, unless circuit_breaker_open_on_exhaustion is OFF, which
 //     demotes it to an unclassified charge.
-//   - unknown: today's behaviour, via RecordRateLimited so the breaker can
-//     still escalate a circuit that only ever opens on 429s.
+//   - unknown: charged via RecordRateLimited, so the breaker can still
+//     escalate a circuit that only ever opens on 429s.
 //
 // A 2xx is a status, not an answer, and these headers arrive before a byte of
 // the body has been read. The verdict is deferred to whoever reads it:
 // judgeStreamForBreaker once the stream ends, recordAnswerOutcome once the
-// completion is decoded. Crediting here meant a provider answering
-// {"choices":[]} to every request recorded a success every time — and
-// RecordSuccess resets consecutiveFails, so its circuit could never open. #805
-// made that argument for streams and this is the same argument for completions.
+// completion is decoded. Crediting here would record a success for a provider
+// answering {"choices":[]} to every request, and RecordSuccess resets
+// consecutiveFails, so its circuit could never open.
 func (h *Handler) recordBreakerOutcome(ctx context.Context, st *requestState, candidate modelCandidate, statusCode int, isFailoverEligible bool, rl rateLimitVerdict) {
 	if !st.circuitBreakerEnabled {
 		return
@@ -82,18 +80,18 @@ func (h *Handler) recordBreakerOutcome(ctx context.Context, st *requestState, ca
 			debuglog.Warn("proxy: recording circuit breaker failure", "reason", "upstream status", "status", statusCode, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
 			st.logData.noteBreaker(breakerCharge)
 			if statusCode == http.StatusTooManyRequests && rl.classified {
-				// Unclassifiable rate limit: charged exactly as before, and
-				// the breaker additionally counts the open (if one results)
-				// toward the 429-only escalation. Only while classification
-				// is on — its master switch must restore today's behaviour
-				// bit for bit, escalation included.
+				// Unclassifiable rate limit: charged like any other failure,
+				// and the breaker additionally counts the open (if one
+				// results) toward the 429-only escalation. Only while
+				// classification is on: its master switch gates the
+				// escalation too.
 				h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(statusCode, "unrecognised"))
 				return
 			}
 			h.circuitBreaker.RecordFailure(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(statusCode, ""))
 		case breakerActionNoOp:
 			// Model-specific client error (404/499): provider is alive
-			// but rejecting this request. No-op for the breaker — neither
+			// but rejecting this request. No-op for the breaker: neither
 			// failure nor success. Recording success would erase real 5xx
 			// failure history (resetting consecutiveFails in Closed state)
 			// and could prematurely close a half-open circuit based on a
@@ -103,18 +101,18 @@ func (h *Handler) recordBreakerOutcome(ctx context.Context, st *requestState, ca
 			// Not reached for failover-eligible codes: shouldFailover only
 			// returns true for {5xx,429,401,403,402,404,499}, which map to
 			// failure or no-op above. Retained so the switch stays exhaustive
-			// over breakerAction — if the shouldFailover/breakerRecordAction
+			// over breakerAction: if the shouldFailover/breakerRecordAction
 			// mappings ever diverge, a success is recorded rather than dropped.
 			st.logData.noteBreaker(breakerSuccess)
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
 		}
 		return
 	}
-	// Not a 2xx. A success of ANY 2xx defers its verdict to whoever reads the
-	// body — recordAnswerOutcome or judgeStreamForBreaker — for the reason the
-	// comment above gives: RecordSuccess resets consecutiveFails, so crediting
-	// here at header time erases the charge the answer verdict is about to make
-	// and the circuit can never open above a threshold of one.
+	// Not a 2xx. Any 2xx defers its verdict to whoever reads the body
+	// (recordAnswerOutcome or judgeStreamForBreaker): RecordSuccess resets
+	// consecutiveFails, so crediting here at header time erases the charge the
+	// answer verdict is about to make and the circuit can never open above a
+	// threshold of one.
 	//
 	// RecordAlive, not RecordSuccess: a plain 400 proves the provider alive
 	// (same credit) but served nothing, and the 429 behavioural fallback must
@@ -162,15 +160,15 @@ func (h *Handler) recordRateLimitOutcome(ctx context.Context, st *requestState, 
 // restores the ordinary charge here too rather than leaving one exhaustion path
 // still opening at once.
 //
-// What this does NOT do is confine the damage to one model. The charge lands on
-// the model that drew the refusal, but SpanModels defaults to 2, so the second
-// model to take a 402 darkens the whole provider — and if the quota advisor
-// already holds an exhaustion reading for it, applyQuotaPin prefers the advisor
-// source and the provider-wide arm can trip on the first one. That is the right
-// default for a billing block, which is account-wide by nature; it is the wrong
-// one for a provider that returns 402 per-request (OpenRouter answers 402 when
-// a single request's max cost exceeds the balance), where two large requests
-// can bench models that would have served. The operator's lever for that is
+// This does NOT confine the damage to one model. The charge lands on the model
+// that drew the refusal, but SpanModels defaults to 2, so the second model to
+// take a 402 darkens the whole provider, and if the quota advisor already holds
+// an exhaustion reading for it, applyQuotaPin prefers the advisor source and the
+// provider-wide arm can trip on the first one. That is the right default for a
+// billing block, which is account-wide by nature, and the wrong one for a
+// provider that returns 402 per-request (OpenRouter answers 402 when a single
+// request's max cost exceeds the balance), where two large requests can bench
+// models that would have served. The operator's lever for that is
 // circuit_breaker_open_on_exhaustion.
 func (h *Handler) recordPaymentRequiredOutcome(ctx context.Context, st *requestState, candidate modelCandidate) {
 	st.logData.noteBreaker(breakerCharge)
@@ -187,15 +185,14 @@ func (h *Handler) recordPaymentRequiredOutcome(ctx context.Context, st *requestS
 // non-streaming attempt, and is the completion-side sibling of
 // judgeStreamForBreaker.
 //
-// The bar is emptyCompletion — did ANYTHING come back — and deliberately not the
+// The bar is emptyCompletion (did ANYTHING come back) and deliberately not the
 // retirement verdict's bar two lines from each call site. See
 // answerCarriesSomething for why the two questions differ and why the answer to
 // this one cannot be `len(Choices) == 0`.
 //
 // A state other than "completed" means the attempt failed after the headers: a
 // body read that died, a body the gateway could not decode, an upstream that
-// sent a success shape behind a failure status. The old code had already
-// credited every one of those before the read was even attempted.
+// sent a success shape behind a failure status.
 //
 // status is the status the UPSTREAM answered, handed in by the caller rather
 // than read back off logData: a failure handler may have replaced
@@ -207,8 +204,7 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 		return
 	}
 	// Read here rather than at the call sites: two copies of the same expression
-	// is how one of them comes to be missing it, which is what happened to the
-	// third charge site this change added.
+	// is how one of them comes to be missing it.
 	if logData.state != "completed" {
 		// The attempt failed after the headers.
 		//
@@ -216,12 +212,9 @@ func (h *Handler) recordAnswerOutcome(st *requestState, candidate modelCandidate
 		// the headers already has one: a caller hanging up, this gateway's own
 		// request_timeout, a body it could not decode, a body that died on the
 		// wire. providerAtFault excludes all but the last, which is the same
-		// predicate judgeStreamForBreaker uses.
-		//
-		// A separate client-gone guard used to sit here as well. It read the
-		// CLIENT's context, so it was blind to a failover-timeout cancel, and it
-		// was a second rule that had to agree with the first — the shape three
-		// review rounds kept finding a hole in.
+		// predicate judgeStreamForBreaker uses. No second client-gone guard
+		// belongs here: one reading the CLIENT's context is blind to a
+		// failover-timeout cancel and has to agree with this rule anyway.
 		if !providerAtFault(logData.errorKind) {
 			return
 		}
@@ -255,8 +248,7 @@ func judgeAnswerNow(logData *requestLogData) {
 
 // chargeBreaker records one breaker failure with its cause in the log. The
 // cause is worth the line: a breaker that opens on anything other than an
-// upstream status has no other record of why, which is the gap the
-// "recording circuit breaker failure" warn was added to close.
+// upstream status has no other record of why.
 //
 // The charge lands on the candidate's resolved upstream model, the same key the
 // success sites and the routing skip use. status is the upstream status the
@@ -274,19 +266,16 @@ func (h *Handler) chargeBreaker(st *requestState, candidate modelCandidate, stat
 // rejectUntranslatableBody is the single outcome all three egress adapters have
 // for a success whose body they cannot turn into a completion.
 //
-// One place because the outcome has four parts — the log, the breaker charge,
-// the request error and the failover — and three copies of it is how the charge
-// came to be missing from all three: a 200 was credited at header time, before
-// any translation was attempted, and each adapter's own comment already called
-// this a provider fault. Mutation testing then showed two of the three copies
-// had no test behind them.
+// One place because the outcome has four parts (the log, the breaker charge,
+// the request error and the failover), and three copies of it is how the charge
+// comes to be missing from one.
 //
 // status is the 2xx the upstream answered before its body failed translation;
 // logData has not been stamped with it at this point.
 func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, status int, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
 	// The translators read the body under the attempt's context, so an
-	// interrupted request arrives here as a translation failure — a caller
+	// interrupted request arrives here as a translation failure: a caller
 	// hanging up or this gateway's own request_timeout, and neither is the
 	// provider's doing.
 	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
@@ -302,10 +291,10 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 // adapter expects" from "the provider answered, and its answer was a refusal".
 //
 // A Gemini prompt blocked by its safety filter returns 200 with an empty
-// candidate list, which BuildChatCompletion cannot turn into a completion — but
+// candidate list, which BuildChatCompletion cannot turn into a completion, but
 // the body is a perfectly good Gemini object and the provider is plainly alive.
-// Charging for it took a healthy provider out of rotation for every tenant after
-// five blocked prompts, which is exactly what a client retries.
+// Charging for it would take a healthy provider out of rotation for every tenant
+// after five blocked prompts, which is exactly what a client retries.
 //
 // The speech adapter's refusals are the same two shapes: an answer without an
 // audio part (a blocked prompt, a text reply) is the model answering, and a
@@ -322,16 +311,12 @@ func translationIsProviderFault(err error) bool {
 // Deliberately NOT chatAnswerCarriesContent, which backs the retirement verdict
 // and stays narrow: `refusal` is the likeliest field for an aggregator to write
 // "this model is gone" into behind a 200, and letting the retirement bar count
-// it would clear such a provider's gone-strikes forever. That bar gained exactly
-// one thing on this branch — it reads ReasoningDetails, which it had been
-// judging BEFORE the normalisation that folds them into ReasoningContent, so a
-// reasoning-only answer read as nothing at all.
+// it would clear such a provider's gone-strikes forever.
 //
-// And deliberately not `len(Choices) == 0` either, which is what this was first
-// narrowed to. Every egress translator synthesises a one-element Choices literal
-// on success, so an emptied Gemini, Anthropic-egress or Responses answer always
-// had a choice and the charge could never fire for any of them — the fix was a
-// no-op for three whole dialects.
+// And deliberately not `len(Choices) == 0` either: every egress translator
+// synthesises a one-element Choices literal on success, so an emptied Gemini,
+// Anthropic-egress or Responses answer always has a choice and the charge could
+// never fire for any of them.
 //
 // The bar is therefore: did any choice come back with SOMETHING in it. An
 // allowlist for the unmodelled shapes rather than "any member that carries",
@@ -351,7 +336,7 @@ func answerCarriesSomething(out ChatCompletionResponse) bool {
 
 func choiceCarriesSomething(choice Choice) bool {
 	// A stop reason the provider reported about its own output. A filtered
-	// answer is the provider answering — Gemini's SAFETY maps here too — and a
+	// answer is the provider answering (Gemini's SAFETY maps here too), and a
 	// length cut means there was output to cut.
 	if choice.FinishReason != nil {
 		switch *choice.FinishReason {
@@ -376,12 +361,8 @@ func choiceCarriesSomething(choice Choice) bool {
 	// object on a speech completion, a legacy function_call, OpenRouter's
 	// generated `images`, Perplexity's `citations`, an Anthropic-shaped relay's
 	// `thinking_blocks`. For the image and citation models those members are the
-	// WHOLE answer, so a relay forwarding one without a usage block would have
-	// had a correct answer charged against it.
-	//
-	// An allowlist rather than "any member that carries", because a relay
-	// stamping a bookkeeping field on the assistant message would otherwise make
-	// the breaker inert with nothing to show for it.
+	// WHOLE answer, so a relay forwarding one without a usage block would have a
+	// correct answer charged against it.
 	for _, key := range []string{"refusal", "audio", "function_call", "annotations", "images", "citations", "thinking_blocks"} {
 		if util.ValueCarries(msg.Extra[key]) {
 			return true

--- a/internal/proxy/content_fence.go
+++ b/internal/proxy/content_fence.go
@@ -9,44 +9,38 @@ import (
 	"unicode/utf8"
 )
 
-// The content fence: the request log stores fragments of upstream error text
+// The content fence. The request log stores fragments of upstream error text
 // (request_logs.error_message, and attempts[].detail in the per-attempt
-// trail), sanitized for credentials and UUIDs and bounded in length. None of
-// that stops a provider that quotes the prompt back in its error message
-// ("rate limit exceeded while processing: <the user's text>") from putting
-// request content into a column the logs API returns and the dashboard
-// renders, which breaks the one invariant the request log makes: request and
-// prompt content is never logged.
+// trail), sanitized for credentials and UUIDs and bounded in length. That does
+// not stop a provider quoting the prompt back in its error message ("rate
+// limit exceeded while processing: <the user's text>") from putting request
+// content into a column the logs API returns, which would break the invariant
+// that request and prompt content is never logged.
 //
-// The fence closes that exactly rather than heuristically. The gateway holds
-// the request body, so an echo of its content is, by definition, a substring
-// of a string the client sent. Every stored fragment is checked against the
-// request's content strings, and any run of contentEchoWindow or more runes
-// that both share is replaced by "[content]". The provider's own words (its
-// error code, its phrase, a reset timestamp) do not come from the request, so
-// they survive; only what the client wrote is removed. That keeps the
-// fragments useful for the work they exist for (reading an unrecognised 429
-// body to extend the phrase table) while making the invariant true by
-// construction.
+// The gateway holds the request body, so an echo of its content is by
+// definition a substring of a string the client sent. Every stored fragment is
+// checked against the request's content strings, and any run of
+// contentEchoWindow or more runes that both share is replaced by "[content]".
+// The provider's own words (its error code, its phrase, a reset timestamp) do
+// not come from the request, so they survive and the fragments stay useful for
+// reading an unrecognised 429 body.
 //
 // Each content string is indexed in the forms a stored fragment can carry it:
 // as written; whitespace-collapsed, because attemptDetail collapses the
-// trail's detail and a prompt with indented code or double spaces would
-// otherwise stop matching at every run of spaces; and the JSON-escaped
-// rendering of both, because error_message stores the provider's body as sent
-// and an echo inside a JSON string member carries \" and \n where the request
-// had a quote and a newline.
+// trail's detail and a prompt with indented code would otherwise stop matching
+// at every run of spaces; and the JSON-escaped rendering of both, because
+// error_message stores the provider's body as sent and an echo inside a JSON
+// string member carries \" and \n where the request had a quote and a newline.
 //
-// Limits, all deliberate: an echo shorter than the window is not caught (a
-// twelve-character secret quoted alone survives; the length cap on every
-// fragment bounds what that can be), a provider that re-cases or otherwise
-// rewrites the text breaks the match at each change (the runs either side
-// still fall), and encoded payloads are not indexed, since a fragment of an
-// image is not a disclosure and indexing megabytes of it would cost seconds
-// per failure. Content is content: a prompt that quotes a provider's error
-// text back at the gateway ("why do I get 'Rate limit exceeded for ...'") is
-// fenced when the provider says the same words, and that is the invariant
-// holding, not a false positive.
+// Accepted limits: an echo shorter than the window is not caught (the length
+// cap on every fragment bounds what that can be), a provider that re-cases or
+// otherwise rewrites the text breaks the match at each change (the runs either
+// side still fall), and encoded payloads are not indexed, since a fragment of
+// an image is not a disclosure and indexing megabytes of it would cost seconds
+// per failure. A prompt that quotes a provider's error text back at the
+// gateway ("why do I get 'Rate limit exceeded for ...'") is fenced when the
+// provider says the same words: that is the invariant holding, not a false
+// positive.
 
 const (
 	// contentEchoWindow is the shortest shared run (in runes) the fence
@@ -61,10 +55,9 @@ const (
 	// request whose forms all differ, about four million windows hashed and
 	// sorted once (windowSet, about 110ms) and then a few microseconds per
 	// fenced text, with the window set retained for the failure's lifetime.
-	// The walk
-	// visits the content-bearing members first (contentFirstKeys) and every
-	// map in sorted key order, so what the cap leaves out is deterministic
-	// and is the tail of the request.
+	// The walk visits the content-bearing members first (contentFirstKeys)
+	// and every map in sorted key order, so what the cap leaves out is
+	// deterministic and is the tail of the request.
 	contentIndexCap = 1 << 20
 	// contentBlobProbe is how many runes into a long string the walk looks
 	// before deciding it is an encoded payload rather than text.
@@ -98,8 +91,8 @@ var contentRoutingKeys = map[string]bool{
 // never parses its body a second time. Nil is a request with no content to
 // fence (nothing parsed, or a multipart upload with no text fields), and
 // every method tolerates it. The parse is guarded by a Once: the fence is
-// shared between the log entry and the stream state, and though every caller
-// today runs on the serving goroutine, nothing should depend on that.
+// shared between the log entry and the stream state, so nothing may depend on
+// both callers running on the serving goroutine.
 type contentFence struct {
 	body  []byte
 	extra []string
@@ -108,10 +101,9 @@ type contentFence struct {
 	// windows is the sorted, deduplicated hash of every content window,
 	// built once on the first mask (windowSet) and reused by every later
 	// one: the streaming error attribute fences once per SSE error frame,
-	// and walking the content again for each was the cost that scaled with
-	// the prompt rather than with the frame. Once built, the content strings
-	// themselves are released; nothing on the request path reads them
-	// again.
+	// and walking the content again for each costs with the prompt rather
+	// than with the frame. Once built, the content strings themselves are
+	// released; nothing on the request path reads them again.
 	winOnce sync.Once
 	windows []uint64
 }
@@ -125,10 +117,9 @@ func newContentFence(body []byte, extra ...string) *contentFence {
 	return &contentFence{body: body, extra: extra}
 }
 
-// strings returns the request's content strings in every indexed form. It is
-// for windowSet and for tests, and only before the first mask: windowSet
-// releases the strings once the set is built, and reading them from another
-// goroutine while it does is a race. Nothing on the request path calls it.
+// strings returns the request's content strings in every indexed form. Valid
+// only before the first mask: windowSet releases the strings once the set is
+// built, and reading them from another goroutine while it does is a race.
 func (f *contentFence) strings() [][]rune {
 	f.once.Do(f.parse)
 	return f.strs
@@ -265,13 +256,10 @@ func isBase64Rune(r rune) bool {
 
 // windowHash is an FNV-1a over the runes of one window, computed per
 // position without building a string. A hit is taken on the 64-bit hash
-// alone. Two distinct windows collide with probability 2^-64, so a lookup
-// against a set of N windows is wrong with probability N/2^64 (2^-42 at the
-// four-million-window ceiling), and a false hit costs a masked run of
-// provider text (sixteen runes, or more where it bridges two real masks),
-// never a leak: a genuine echo has the same hash by construction, so no
-// echo is ever missed. That is not worth keeping every content window in
-// memory for a rune-by-rune check.
+// alone: a lookup against a set of N windows is wrong with probability
+// N/2^64 (2^-42 at the four-million-window ceiling), and a false hit costs a
+// masked run of provider text, never a leak, since a genuine echo has the
+// same hash by construction and no echo is ever missed.
 func windowHash(r []rune) uint64 {
 	h := uint64(14695981039346656037)
 	for _, c := range r {
@@ -284,14 +272,10 @@ func windowHash(r []rune) uint64 {
 // windowSet returns the sorted, deduplicated hashes of every window of the
 // request's content, built once. Eight bytes per window: a 10 KB prompt is
 // 80 KB, and the largest request the index budget admits is about 32 MB,
-// held only for the failure's lifetime. That is about twice what the old
-// design retained (the content strings themselves, 16 MB at the ceiling,
-// which are released once the set exists), bought for a walk that no longer
-// scales with the prompt; a hash table would build faster still but retain
-// about twice as much again, and retained bytes are what several large
-// failures at once add up. The sort is a radix sort: a comparison sort of
-// four million hashes cost more than the walk it replaced, so a single-frame
-// failure would have paid for the memo without using it.
+// held only for the failure's lifetime. A hash table would build faster but
+// retain about twice as much, and retained bytes are what several large
+// failures at once add up to. The sort is a radix sort: a comparison sort of
+// four million hashes costs more than a single-frame failure saves by memoing.
 func (f *contentFence) windowSet() []uint64 {
 	f.winOnce.Do(func() {
 		strs := f.strings()
@@ -328,9 +312,8 @@ func compactCopy(sorted []uint64) []uint64 {
 // radixSort sorts hashes in place with an LSD radix sort, eight passes of
 // eight bits, which is linear in the count where a comparison sort of the
 // same four million values is not: on the largest request the index admits
-// the sort is about 100ms, the hashing about 15ms, and the old per-call
-// walk this replaces was about 70ms, so the first fence of such a request
-// costs somewhat more than before and every later one costs microseconds.
+// the sort is about 100ms and the hashing about 15ms, so the first fence of
+// such a request carries the cost and every later one costs microseconds.
 // Measured against the standard sort it is already ahead from about a
 // thousand values (a one-kilobyte prompt), so there is no small-input
 // fallback. The scratch buffer is transient.

--- a/internal/proxy/dial_timing.go
+++ b/internal/proxy/dial_timing.go
@@ -11,15 +11,13 @@ import (
 
 // dialTiming is the per-attempt slot the SafeDialer writes DNS+TCP time into
 // and the attempt reads back. It is atomic because the writer and the reader
-// are different goroutines with no ordering between them: http.Transport
-// dials on its own goroutine, and that goroutine can outlive the Do call
-// that started it. A request cancelled mid-dial returns from Do at once while
-// the dial goroutine finishes a moment later and records its time; a spare
-// connection the transport raced against an idle one lands the same way. A
-// plain *float64 in the context was a data race on exactly that shape, which
-// the race detector caught on master in the client-disconnect-during-backoff
-// test. A late write after take() is attributed nowhere, which is right: it
-// was not this attempt's wait.
+// are different goroutines with no ordering between them: http.Transport dials
+// on its own goroutine, and that goroutine can outlive the Do call that started
+// it. A request cancelled mid-dial returns from Do at once while the dial
+// goroutine finishes a moment later and records its time; a spare connection
+// the transport raced against an idle one lands the same way. A late write
+// after take() is attributed nowhere, which is right: it was not this attempt's
+// wait.
 type dialTiming struct {
 	bits atomic.Uint64
 }

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -22,19 +22,18 @@ var errEgressBodyOversized = errors.New("upstream response body exceeds the non-
 
 // translateEgressResponseBody swaps a non-streaming native 200 body for its
 // chat.completion translation so handleNonStreamingResponse can meter and
-// forward it unchanged. The dialect differs only in the builder, so every
-// egress adapter shares this body: read, translate, re-seat.
+// forward it unchanged. The dialect differs only in the builder, so every egress
+// adapter shares this body: read, translate, re-seat.
 //
-// resp.Body is always left readable — an empty reader on failure — so a caller
+// resp.Body is always left readable, an empty reader on failure, so a caller
 // that surfaces the error still hands the pipeline a closed-once, drainable
 // response.
 func translateEgressResponseBody(resp *http.Response, model string, build chatCompletionBuilder) error {
-	// Bounded like the plain non-streaming read: cap+1 is read, and a body
-	// that reaches it is refused with errEgressBodyOversized rather than
-	// translated, so one upstream cannot hold more than the cap (twice,
-	// original and translated) per concurrent request. The refusal is this
-	// gateway's policy and not the provider failing, which
-	// translationIsProviderFault knows.
+	// Bounded like the plain non-streaming read: cap+1 is read, and a body that
+	// reaches it is refused with errEgressBodyOversized rather than translated,
+	// so one upstream cannot hold more than the cap (twice over, original and
+	// translated) per concurrent request. The refusal is this gateway's policy
+	// and not the provider failing, which translationIsProviderFault knows.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
 	_ = resp.Body.Close()
 	if err != nil {

--- a/internal/proxy/failover_exhausted.go
+++ b/internal/proxy/failover_exhausted.go
@@ -14,13 +14,12 @@ import (
 )
 
 // The exhaustion terminal of the failover loop: every candidate failed, or the
-// deadline was hit. Split out of proxy_failover.go when that file reached the
-// size ceiling.
+// deadline was hit.
 
-// failAllExhausted handles phase E: every candidate failed (or the overall
-// deadline was hit). It logs the exhaustion, records a 502 failure row, and
+// failAllExhausted ends a request whose candidates are all spent, or whose
+// overall deadline expired. It logs the exhaustion, records the failure row and
 // writes the failover-vs-single-provider error response. numCandidates is the
-// resolved candidate count (for the failRequest attempt index).
+// resolved candidate count, used for the failRequest attempt index.
 func (h *Handler) failAllExhausted(w http.ResponseWriter, st *requestState, numCandidates int) {
 	last := st.lastReqErr
 	status := last.terminalStatus()
@@ -30,9 +29,8 @@ func (h *Handler) failAllExhausted(w http.ResponseWriter, st *requestState, numC
 	clientMsg := last.terminalClientMessage(st.reqModel, st.isFailover)
 	if st.isFailover {
 		debuglog.Error("proxy: all providers exhausted", "model", st.logData.modelID, "provider", st.logData.providerName, "error", logMsg, "kind", string(last.Kind), "status", status, "candidates", numCandidates, "failover_timeout", st.failoverTimeout)
-		// all_busy is the exhaustion the 2026-08-31 incident was made of: the
-		// last candidate alive and at capacity. Anything else it said, and the
-		// failover deadline, is all_failed.
+		// all_busy means the last candidate was alive and at capacity; any other
+		// cause, and the failover deadline, is all_failed.
 		reason := "all_failed"
 		if last.Kind == KindProviderSaturated {
 			reason = "all_busy"
@@ -43,12 +41,11 @@ func (h *Handler) failAllExhausted(w http.ResponseWriter, st *requestState, numC
 	} else {
 		debuglog.Error("proxy: provider request failed", "model", st.logData.modelID, "provider", st.logData.providerName, "error", logMsg, "kind", string(last.Kind), "status", status, "request_timeout", st.failoverTimeout)
 	}
-	// Honest status for an all-busy exhaustion: every provider is alive and at
-	// capacity, and OpenAI SDKs back off and retry on a 429 where a 502 is a
-	// coin toss. The Retry-After is the last provider's own ask (or the class
-	// default), so the client's backoff lines up with the slot actually
-	// freeing. Behind failover_exhaustion_status_429 for any client that has
-	// learnt to read the 502.
+	// An all-busy exhaustion answers 429 rather than 502: every provider is
+	// alive and at capacity, and OpenAI SDKs back off and retry on a 429.
+	// Retry-After carries the last provider's own ask, or the class default, so
+	// the client's backoff lines up with a slot actually freeing.
+	// Switching failover_exhaustion_status_429 off restores the 502.
 	if last.Kind == KindProviderSaturated && h.settingsRepo.GetBool(context.Background(), "failover_exhaustion_status_429", true) {
 		status = http.StatusTooManyRequests
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds(st.rateLimit.retryAfter)))
@@ -59,8 +56,8 @@ func (h *Handler) failAllExhausted(w http.ResponseWriter, st *requestState, numC
 }
 
 // retryAfterSeconds renders a wait as the whole seconds a Retry-After header
-// carries: rounded up so a positive wait never becomes 0 ("retry now"), with
-// the saturated class default standing in for an absent one.
+// carries, rounded up so a positive wait never becomes 0 ("retry now"). An
+// absent wait falls back to the saturated class default.
 func retryAfterSeconds(d time.Duration) int {
 	if d <= 0 {
 		d = defaultSaturatedRetryAfter

--- a/internal/proxy/gemini_egress.go
+++ b/internal/proxy/gemini_egress.go
@@ -15,12 +15,12 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// The vertex-express egress adapter. Vertex AI express-mode API keys only work
-// on Google's native publisher routes, so a chat-completions request bound for
-// a vertex-express provider is translated to generateContent shape on the way
-// out (internal/gemini) and the response translated back on the upstream side
-// of the pipeline — the same trick as the /v1/responses re-route, so the TTFT
-// probe, stall watchdog, transforms and metering all run unchanged.
+// The gemini egress adapter. Vertex AI express-mode API keys only work on
+// Google's native publisher routes, so a chat-completions request bound for
+// such a provider is translated to generateContent shape on the way out
+// (internal/gemini) and the response translated back on the upstream side of
+// the pipeline, leaving the TTFT probe, stall watchdog, transforms and metering
+// to run unchanged.
 
 // isGeminiEgressAttempt reports whether this candidate is served through the
 // gemini egress adapter: a plain chat-completions request (no explicit endpoint
@@ -90,7 +90,7 @@ func geminiEgressEndpoint(providerType, model string, stream bool) string {
 // Zen's Gemini passthrough answers a Bearer token with
 // {"type":"AuthError","message":"Missing API key."}. Only x-goog-api-key works,
 // which is why this cannot go through SetProviderAuthHeaders for Zen or
-// Google AI Studio — that switches on provider type alone, and Zen's other
+// Google AI Studio: that switches on provider type alone, and Zen's other
 // families and Google's compat layer do need Bearer.
 func setGeminiEgressAuth(req *http.Request, providerType, apiKey string) {
 	if providerType == "opencode-zen" || providerType == "google" {
@@ -102,12 +102,12 @@ func setGeminiEgressAuth(req *http.Request, providerType, apiKey string) {
 	util.SetProviderAuthHeaders(req, providerType, apiKey)
 }
 
-// buildGeminiRequest builds the upstream request for a vertex-express attempt.
+// buildGeminiRequest builds the upstream request for a gemini egress attempt.
 // The chat body goes through the shared rewrite path first (model rename,
-// learned strips; isStreaming=false so no stream_options is injected — Gemini
-// has no such knob), then chat -> generateContent translation. The model
-// string returned by the translation picks the :generateContent or
-// :streamGenerateContent route.
+// learned strips; isStreaming=false, since Gemini has no stream_options knob to
+// inject), then chat -> generateContent translation. The model string the
+// translation returns picks the :generateContent or :streamGenerateContent
+// route.
 func (h *Handler) buildGeminiRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
 	cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
 	body, model, stream, err := gemini.TranslateRequest(cleaned)
@@ -119,7 +119,7 @@ func (h *Handler) buildGeminiRequest(ctx context.Context, st *requestState, cand
 	baseURL := candidate.provider.BaseURL
 	if providerType == "google" {
 		// The provider is configured with the /v1beta/openai compat base;
-		// the native routes live one segment up, as discovery already knows.
+		// the native routes live one segment up.
 		baseURL = provider.GoogleNativeBaseURL(baseURL)
 	}
 	targetURL := util.BuildProviderTargetURL(baseURL, providerType, endpoint)

--- a/internal/proxy/gemini_speech.go
+++ b/internal/proxy/gemini_speech.go
@@ -18,27 +18,22 @@ import (
 
 // Gemini text-to-speech: /v1/audio/speech on a provider whose TTS models are
 // served by generateContent alone. Google's OpenAI-compatibility layer has no
-// speech route, so the pass-through that serves every other provider's TTS
-// answered a 404 for a Gemini TTS model; the request is translated to the
-// native call instead and the audio part it answers with is delivered as
-// the wav or pcm the client asked for (see internal/gemini/speech.go for
-// what the model can and cannot produce).
+// speech route, so the request is translated to the native call and the audio
+// part it answers with is delivered as the wav or pcm the client asked for.
 
 // speechEndpointPath is the pass-through endpoint the adapter serves.
 const speechEndpointPath = "/audio/speech"
 
 // speechBodyCap bounds the generateContent answer read for a speech request:
-// base64 of 16-bit 24 kHz mono is 64 KB per second of speech, so the cap
-// holds several minutes, past which a client is streaming an audiobook and
-// should ask for it in chapters.
+// base64 of 16-bit 24 kHz mono is 64 KB per second of speech, so the cap holds
+// several minutes.
 const speechBodyCap = 32 << 20
 
 // isGeminiSpeechAttempt reports a speech request landing on a provider whose
-// TTS models are served by Google's native route: Google AI Studio and
-// Vertex AI express, the two that hold Gemini TTS models. A model whose
-// discovered output modalities name no audio is not one of them and keeps
-// the pass-through (which Google answers with its 404); a model discovery
-// left without modalities is given the benefit of the doubt.
+// TTS models are served by Google's native route: Google AI Studio and Vertex
+// AI express. A model whose discovered output modalities name no audio keeps
+// the pass-through; a model discovery left without modalities is treated as
+// audio-capable.
 func isGeminiSpeechAttempt(st *requestState, providerType, outputModalities string) bool {
 	if st.endpointPath != speechEndpointPath || (providerType != "google" && providerType != "vertex-express") {
 		return false
@@ -47,13 +42,11 @@ func isGeminiSpeechAttempt(st *requestState, providerType, outputModalities stri
 	return len(declared) == 0 || slices.Contains(declared, "audio")
 }
 
-// speechRequestRefusal is the reason a Gemini speech attempt cannot serve
-// the request as asked, or empty: a response format the model does not
-// produce (the compressed ones need an encoder the gateway does not carry),
-// or a request the translation cannot read (no input). Checked before the
-// attempt is made, so a group mixing a Gemini TTS model with one that does
-// produce mp3 lets the request fail over to the one that can; when no
-// candidate can, the refusal is the client's 400.
+// speechRequestRefusal is the reason a Gemini speech attempt cannot serve the
+// request as asked, or empty: a response format the model does not produce
+// (the compressed ones need an encoder the gateway does not carry), or a
+// request the translation cannot read. Checked before the attempt is made, so
+// the request can fail over to a candidate that can serve it.
 func speechRequestRefusal(st *requestState, candidate modelCandidate) string {
 	if !isGeminiSpeechAttempt(st, provider.TypeOf(candidate.provider), candidate.model.OutputModalities) {
 		return ""
@@ -64,10 +57,9 @@ func speechRequestRefusal(st *requestState, candidate modelCandidate) string {
 	return ""
 }
 
-// refuseSpeechRequest answers a speech request no candidate can serve as
-// asked with the client's 400 before any attempt is made: every candidate is
-// a Gemini TTS model and each refuses the request. Reports whether the
-// request was answered.
+// refuseSpeechRequest answers a speech request with a 400 before any attempt
+// is made when every candidate refuses it. Reports whether the request was
+// answered.
 func (h *Handler) refuseSpeechRequest(w http.ResponseWriter, st *requestState, candidates []modelCandidate) bool {
 	if st.endpointPath != speechEndpointPath || len(candidates) == 0 {
 		return false
@@ -111,13 +103,11 @@ func (h *Handler) buildGeminiSpeechRequest(ctx context.Context, st *requestState
 // serveGeminiSpeechResponse delivers a speech attempt's 2xx: the
 // generateContent answer is read whole (bounded), its audio part becomes the
 // wav or pcm the client asked for, and the bytes go out through the
-// pass-through's own binary path, which owns the commit point, the breaker
-// credit, the request log and the metering. The usage the answer reported
-// rides along on the request state, since a binary body carries none. An
-// answer without audio is the model's refusal (a blocked prompt, a text
-// reply), handed to the loop as an untranslatable body: it fails over, and
-// the breaker is charged only when the body was not a generateContent
-// object at all.
+// pass-through's binary path, which owns the commit point, the breaker credit,
+// the request log and the metering. The usage the answer reported rides along
+// on the request state, since a binary body carries none. An answer without
+// audio (a blocked prompt, a text reply) is handed to the loop as an
+// untranslatable body and fails over.
 func (h *Handler) serveGeminiSpeechResponse(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64) candidateOutcome {
 	body, readErr := io.ReadAll(io.LimitReader(resp.Body, speechBodyCap+1))
 	_ = resp.Body.Close()
@@ -142,12 +132,11 @@ func (h *Handler) serveGeminiSpeechResponse(w http.ResponseWriter, r *http.Reque
 }
 
 // errSpeechBodyOversized reports a generateContent answer past speechBodyCap:
-// this gateway's own limit, never a provider fault for the breaker, as the
-// chat adapter's errEgressBodyOversized is not.
+// this gateway's own limit, never a provider fault for the breaker.
 var errSpeechBodyOversized = fmt.Errorf("gemini speech response exceeds %d bytes", speechBodyCap)
 
 // passthroughUsage is the usage a translating adapter read off a provider's
-// answer before re-shaping it into a body that carries none; the binary
+// answer before re-shaping it into a body that carries none. The binary
 // pass-through path meters from it in place of the estimate.
 type passthroughUsage struct {
 	prompt, completion int

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -43,11 +43,10 @@ type Handler struct {
 	// first use, so a Handler built as a literal has one too.
 	capLedger     *provider.CapLedger
 	capLedgerOnce sync.Once
-	// inflight is the adaptive per-provider concurrency learner (see
-	// inflight.go). Nil (tests building Handler{} directly) admits everything
-	// and learns nothing. NewHandler registers its scrape-time gauges; the
-	// registration is once-guarded, so like the breaker collector it reports
-	// the first handler's state — one handler exists outside tests.
+	// inflight is the adaptive per-provider concurrency learner. Nil admits
+	// everything and learns nothing. NewHandler registers its scrape-time
+	// gauges under a once-guard, so the gauges report the first handler's
+	// state.
 	inflight *inflightLimiter
 	// upstreamTransport is a shared Transport for all outbound proxy
 	// requests.  Reusing one Transport avoids creating a fresh Transport
@@ -55,7 +54,7 @@ type Handler struct {
 	upstreamTransport *http.Transport
 	// shutdown is closed by Close so in-flight streams can end with a
 	// well-formed error frame instead of a cut connection when the process
-	// is stopping; nil (tests building Handler{} directly) never fires.
+	// is stopping; a nil channel never fires.
 	shutdown     chan struct{}
 	shutdownOnce sync.Once
 
@@ -75,11 +74,10 @@ type Handler struct {
 	// param caches use. Value: anthropicegress.ThinkingDialect.
 	//
 	// Only models that answered a 400 appear here; everything else takes the
-	// adaptive default. In-memory and per-instance on purpose, like the param
-	// caches: the cost of relearning after a restart is one 400 on the first
-	// thinking request to a budget-dialect model, and the alternative is a
-	// persisted fact that goes stale the next time Anthropic moves a model
-	// between dialects.
+	// adaptive default. In-memory and per-instance like the param caches: a
+	// restart costs one 400 on the first thinking request to a budget-dialect
+	// model, while a persisted fact would go stale the next time Anthropic moves
+	// a model between dialects.
 	thinkingDialectCache sync.Map
 	// goneStrikes counts consecutive KindProviderModelGone responses per model
 	// UUID, so a model the provider has retired is probed and then disabled
@@ -87,17 +85,17 @@ type Handler struct {
 	// per-instance; see noteModelGone for why it is not persisted.
 	//
 	// Value: *goneStreak, not a plain int. A retired model is precisely the one
-	// taking concurrent refusals, so the increment has to be atomic or racing
+	// taking concurrent refusals, so the increment must be atomic or racing
 	// strikes overwrite each other and the streak never lands. The struct also
-	// carries the time of the last strike, which bounds how far apart the
-	// refusals in one streak may be, and the tombstone a success uses to stand
-	// down a disable that has been decided but not yet written.
+	// carries the time of the last strike, bounding how far apart the refusals
+	// in one streak may be, and the tombstone a success uses to stand down a
+	// disable that has been decided but not yet written.
 	goneStrikes sync.Map
 	// goneProbeSlots bounds how many pre-retirement probes may be in flight
 	// against one provider at once, keyed by provider UUID. Value: a
 	// chan struct{} of goneProbeMaxConcurrent capacity, used as a non-blocking
-	// semaphore (see acquireProbeSlot). Per gateway instance, like goneStrikes
-	// beside it: the cap describes what THIS gateway will aim at a provider.
+	// semaphore. Per gateway instance, like goneStrikes beside it: the cap
+	// describes what this gateway will aim at a provider.
 	goneProbeSlots sync.Map
 	// responsesRequiredCache remembers models whose upstream refused
 	// chat-completions and demanded /v1/responses, keyed by
@@ -117,9 +115,9 @@ type virtualKeyRepoAdapter struct {
 	repo *virtualkey.Repository
 }
 
-// WrapVirtualKeyRepo wraps a *virtualkey.Repository to implement the VirtualKeyRepository interface.
-// This is needed because the proxy package uses VirtualKeyInfo (a subset of virtualkey.VirtualKey)
-// and the interface signatures may diverge from the concrete repository.
+// WrapVirtualKeyRepo wraps a *virtualkey.Repository to implement the
+// VirtualKeyRepository interface, whose signatures use VirtualKeyInfo, a subset
+// of virtualkey.VirtualKey.
 func WrapVirtualKeyRepo(repo *virtualkey.Repository) VirtualKeyRepository {
 	return &virtualKeyRepoAdapter{repo: repo}
 }
@@ -256,23 +254,21 @@ func (h *Handler) Close() {
 // Register mounts the OpenAI-compatible surface. afterAuth are the caller's
 // middlewares that must see only authenticated requests: the server's
 // body-peeking timeout middleware buffers the whole request body (up to
-// MAX_REQUEST_SIZE) to read the stream flag and the model, and mounting it
-// ahead of the key check let an unauthenticated client make the gateway hold
-// that allocation for the duration of its upload. They run after the key is
-// verified and before the per-key limiters, which read nothing from the body.
-// The gateway itself then reads nothing of an unauthenticated body; net/http
-// still discards up to 256 KiB of it after the 401, under the body read
-// deadline, so that is the bound on how long such a connection is held.
+// MAX_REQUEST_SIZE) to read the stream flag and the model, so ahead of the key
+// check an unauthenticated client could make the gateway hold that allocation
+// for the duration of its upload. They run after the key is verified and before
+// the per-key limiters, which read nothing from the body. The gateway itself
+// reads nothing of an unauthenticated body; net/http still discards up to
+// 256 KiB of it after the 401, under the body read deadline, which bounds how
+// long such a connection is held.
 func (h *Handler) Register(r chi.Router, afterAuth ...func(http.Handler) http.Handler) {
 	r.Use(h.ipLimiter.Middleware)
 	r.Use(h.ProxyKeyMiddleware)
 	r.Use(afterAuth...)
 	r.Use(h.rateLimiter.Middleware(h.cfg.RateLimitEnabled))
 	// TPM admission runs after RPS: a key must pass the request-rate gate before
-	// its token budget is checked. This is the full two-stage gate (per-key
-	// budget, plus the owner's aggregate budget when the key is owned); admin
-	// chat has no virtual key and so runs only the owner stage, see
-	// RegisterAdminChat.
+	// its token budget is checked. This is the full two-stage gate: the per-key
+	// budget, plus the owner's aggregate budget when the key is owned.
 	r.Use(h.tpmLimiter.Middleware(h.cfg.RateLimitEnabled))
 
 	r.Get("/models", h.ListModels)
@@ -308,9 +304,9 @@ func (h *Handler) RegisterAdminChat(r chi.Router) {
 	// TPM admission after RPS, mirroring Register. Only the owner stage applies
 	// here: this surface authenticates a dashboard session, so there is no
 	// virtual key to carry a per-key budget, and the per-key stage's fallback
-	// bucket (the resolved client address) has no debit path. The caller's own aggregate cap is
-	// published by api.ChatUserContextMiddleware, which main.go mounts ahead of
-	// this group; without both middlewares a user with a TPM cap would meter
+	// bucket (the resolved client address) has no debit path. The caller's own
+	// aggregate cap is published by api.ChatUserContextMiddleware, mounted ahead
+	// of this group; without both middlewares a user with a TPM cap meters
 	// nothing here while their /v1 traffic is capped.
 	r.Use(h.tpmLimiter.UserMiddleware(h.cfg.RateLimitEnabled))
 
@@ -328,9 +324,9 @@ const keyLookupTimeout = 10 * time.Second
 func (h *Handler) ProxyKeyMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// A refusal closes the connection. net/http drains an unread request
-		// body before it sends a keep-alive response, so without this a
-		// client trickling a body with no valid key was told 401 only when
-		// the body deadline cut the drain; a caller with no key has no
+		// body before it sends a keep-alive response, so without the close a
+		// client trickling a body with no valid key hears the 401 only once
+		// the body deadline cuts the drain; a caller with no key has no
 		// keep-alive worth keeping. The IP limiter's 429 ahead of this check
 		// deliberately does not close: it also fronts the dashboard routes,
 		// where a throttled client is legitimate and retries on the same
@@ -341,7 +337,7 @@ func (h *Handler) ProxyKeyMiddleware(next http.Handler) http.Handler {
 		}
 		token, ok := util.ParseProxyKey(r)
 		if !ok {
-			// Client error, not a server fault — Warn keeps the Error stream
+			// Client error, not a server fault: Warn keeps the Error stream
 			// reserved for things the operator must act on.
 			debuglog.Warn("auth: missing authorization header", "remote_addr", clientip.From(r))
 			refuse("missing authorization header: expected \"Authorization: Bearer <virtual key>\" or \"x-api-key: <virtual key>\"")
@@ -349,9 +345,9 @@ func (h *Handler) ProxyKeyMiddleware(next http.Handler) http.Handler {
 		}
 
 		keyHash := virtualkey.Hash(token)
-		// Bounded on its own: the timeout middleware used to wrap this lookup
-		// and now runs behind it, so a wedged database must not park every
-		// request here until the client gives up.
+		// Bounded on its own, since the timeout middleware runs behind this
+		// lookup: a wedged database must not park every request here until the
+		// client gives up.
 		lookupCtx, lookupCancel := context.WithTimeout(r.Context(), keyLookupTimeout)
 		vk, err := h.virtualKeyRepo.FindByKeyHash(lookupCtx, keyHash)
 		lookupCancel()

--- a/internal/proxy/hedging.go
+++ b/internal/proxy/hedging.go
@@ -63,8 +63,8 @@ type hedgeResult struct {
 const minHedgeDelay = 100 * time.Millisecond
 
 // probeFn probes a single candidate to a ready-to-stream-or-failover state WITHOUT
-// writing to the client. It is the unit-test seam for runHedgedStreaming (mirroring
-// the attemptFn seam used by runFailoverLoop); the real implementation is
+// writing to the client. runHedgedStreaming takes it as a parameter, mirroring the
+// attemptFn seam runFailoverLoop takes; the real implementation is
 // probeStreamingCandidate.
 type probeFn func(ctx context.Context, st *requestState, candidate modelCandidate, attempt int, ttftTimeout, stallTimeout time.Duration) hedgeResult
 
@@ -134,7 +134,7 @@ func (h *Handler) runHedgedStreaming(w http.ResponseWriter, r *http.Request, st 
 		// endpointType is load-bearing, not decoration: a losing candidate's
 		// refusal is classified against this throwaway (see
 		// probeStreamingCandidate), and an empty endpoint family switches
-		// auto-retirement off SILENTLY — noteModelGone's family gate rejects it
+		// auto-retirement off SILENTLY: noteModelGone's family gate rejects it
 		// before recording a strike and says so only at Debug. It is safe to copy
 		// where the rest is not, because ingest stamps it once and nothing writes
 		// it afterwards, so it cannot race serveHedgeWinner the way providerName
@@ -338,7 +338,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 
 	// MiniMax reports business errors (rate limit, exhausted plan balance,
 	// auth failures) inside an HTTP 200 envelope; remap them to an effective
-	// status so the breaker/failover paths below — all keyed on status codes —
+	// status so the breaker/failover paths below, all keyed on status codes,
 	// see the failure. The slot rides the body only from here, with the
 	// remapped status deciding the clean flag: losers are drained and closed
 	// by the orchestrator, the winner's stream closes at its end, and either
@@ -380,8 +380,8 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 			}
 		}
 		// A hedged race drops every candidate but the winner here, so without
-		// this a dead model in a hedged group accrued strikes only on the runs it
-		// happened to win — almost never, since a model answering 404 loses the
+		// this a dead model in a hedged group accrues strikes only on the runs it
+		// happens to win, almost never, since a model answering 404 loses the
 		// TTFT contest to anything that works. Same classification the sequential
 		// and pass-through loops do, on a body being discarded either way.
 		errBodyMsg := util.SanitizeLogBody(string(errBody), 10000)
@@ -399,7 +399,7 @@ func (h *Handler) probeStreamingCandidate(ctx context.Context, st *requestState,
 		// path): translate the upstream stream back to chat chunks before the
 		// TTFT probe so the whole hedged pipeline sees chat-completions SSE.
 		// st is this attempt's private snapshot, so the flag set by
-		// buildCandidateRequest is visible right here — no shared-state race.
+		// buildCandidateRequest is visible right here: no shared-state race.
 		resp.Body = openairesponses.NewStreamAdapter(resp.Body, st.reqModel)
 	}
 	if st.geminiAttempt {
@@ -564,12 +564,11 @@ func (h *Handler) serveHedgeWinner(w http.ResponseWriter, r *http.Request, st *r
 	h.noteStreamOutcome(logData, candidate)
 }
 
-// failHedgeDisconnect handles r.Context() cancellation during a hedged race. It
-// reuses the PR #258 classification: if the most recent attempt was a zero-token
-// provider stall, the silent connection was most likely dropped by an intermediary
-// (reverse proxy / LB / CDN) rather than the client, so the provider stall is
-// preserved as the terminal cause (502); otherwise it is a genuine client
-// disconnect (499).
+// failHedgeDisconnect handles r.Context() cancellation during a hedged race: if
+// the most recent attempt was a zero-token provider stall, the silent connection
+// was most likely dropped by an intermediary (reverse proxy / LB / CDN) rather
+// than the client, so the provider stall is preserved as the terminal cause
+// (502); otherwise it is a genuine client disconnect (499).
 func (h *Handler) failHedgeDisconnect(w http.ResponseWriter, st *requestState, launched int, providerStall reqError) {
 	// Prefer a provider stall seen at any point in the race over whatever happens
 	// to be the most recent result: a later non-stall failure must not relabel a
@@ -605,8 +604,8 @@ func hedgeProbeLog(entry *requestLogData, candidate modelCandidate) *requestLogD
 // path. A hedged probe cannot retry in-race (a second upstream round-trip
 // inside one race slot would skew the TTFT contest), but it can still LEARN
 // what the sequential path would: the /v1/responses requirement from the
-// tools+reasoning 400 or the pro tier's 404, so every subsequent request —
-// hedged or sequential — routes preemptively, and the params a 400 names, so
+// tools+reasoning 400 or the pro tier's 404, so every subsequent request
+// (hedged or sequential) routes preemptively, and the params a 400 names, so
 // the next request is built without them. Both readings are only valid on a
 // chat-completions attempt, judged by the same isLearnableRefusal the
 // sequential path uses: a dialect 400 names that dialect's fields, and a

--- a/internal/proxy/inflight.go
+++ b/internal/proxy/inflight.go
@@ -22,8 +22,8 @@ import (
 // costs one counter increment per request.
 //
 // State is per provider (slots are an account property; the circuit breaker
-// stays per model — the two answer different questions, full vs broken), per
-// member, in memory: runtime health, not config, never synced. Four members
+// stays per model, since the two answer different questions, full vs broken),
+// per member, in memory: runtime health, not config, never synced. Four members
 // each learn their own allowance against a shared pool and the sum converges
 // because each member's cuts are driven by the 429s it draws itself.
 //
@@ -47,9 +47,8 @@ type inflightWindow struct {
 	lastCut  time.Time // when the allowance was last cut (may sit in the near future: a Retry-After defers the forget clock)
 }
 
-// inflightLimiter holds every provider's window. All methods are nil-safe:
-// a nil limiter admits everything and learns nothing, which is what the
-// handler-literal test fixtures get.
+// inflightLimiter holds every provider's window. All methods are nil-safe: a
+// nil limiter admits everything and learns nothing.
 type inflightLimiter struct {
 	mu      sync.Mutex
 	windows map[uuid.UUID]*inflightWindow
@@ -110,8 +109,8 @@ func (l *inflightLimiter) canAdmit(providerID uuid.UUID, ceiling int) bool {
 // (a 2xx that was consumed to its end), which is what grows a capped window:
 // +1 per growAfter consecutive clean completions, and back to uncapped once
 // the window has gone forgetAfter without a cut. Failures only reset the
-// clean-run count — shrinking is the cut's job, and only a saturated 429
-// proves the allowance too high.
+// clean-run count: shrinking is the cut's job, and only a saturated 429 proves
+// the allowance too high.
 func (l *inflightLimiter) release(providerID uuid.UUID, clean bool, growAfter int, forgetAfter time.Duration) {
 	if l == nil {
 		return
@@ -152,12 +151,11 @@ func (l *inflightLimiter) release(providerID uuid.UUID, clean bool, growAfter in
 
 // cut shrinks the provider's allowance after a SATURATED 429: the pool is
 // provably smaller than the load that included the refused request. The CALLER
-// settles the drawing request's own slot before cutting (see
-// recordRateLimitOutcome), so w.inflight here is exactly the load that fit -
-// the spec's "inflight - 1" with the subtraction made deterministic instead of
-// racing the body reader that may already have released the drawer. retryAfter,
-// when the provider sent one, pushes lastCut into the future so the forget
-// clock starts after the wait the provider asked for.
+// settles the drawing request's own slot before cutting, so w.inflight here is
+// exactly the load that fit rather than a count racing the body reader that may
+// already have released the drawer. retryAfter, when the provider sent one,
+// pushes lastCut into the future so the forget clock starts after the wait the
+// provider asked for.
 func (l *inflightLimiter) cut(providerID uuid.UUID, retryAfter time.Duration) {
 	if l == nil {
 		return
@@ -276,13 +274,13 @@ func (s *attemptSlot) settle(clean bool) {
 }
 
 // inflightRelease wraps an upstream body so the attempt's slot settles when
-// the response has actually been consumed - the window counts requests
+// the response has actually been consumed: the window counts requests
 // "between send and last byte", and releasing at header time would let the
 // gateway hold more streams open than the learned allowance. On EOF or Close,
-// whichever comes first: every attempt path closes the body on every exit
-// (client disconnect and hedge loss included), so a leaked count - a slow
-// self-inflicted saturation - would need a leaked body, which the bodyclose
-// lint already forbids.
+// whichever comes first; every attempt path closes the body on every exit
+// (client disconnect and hedge loss included), so a leaked count, a slow
+// self-inflicted saturation, would need a leaked body, which the bodyclose
+// lint forbids.
 type inflightRelease struct {
 	io.ReadCloser
 	slot  *attemptSlot

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -24,40 +24,39 @@ func isTerminalLogState(state string) bool {
 
 // updateLogOption configures updateRequestLog behavior.
 type updateLogOption struct {
-	// skipWaitForInsert skips the WaitForInsert call before the UPDATE.
-	// Used for all log updates that run before the response is written to the
-	// client, to avoid adding up to 5s INSERT-wait latency under DB stress.
+	// skipWaitForInsert skips the WaitForInsert call before the UPDATE, for the
+	// log updates that run before the response is written to the client, so
+	// they do not add up to 5s of INSERT-wait latency under DB stress.
 	//
 	// It is honoured as given: nothing waits before the first UPDATE. A terminal
-	// update that then finds no row waits and retries once — see
-	// updateRequestLog — so the wait is paid only where skipping it would have
+	// update that then finds no row waits and retries once (see
+	// updateRequestLog), so the wait is paid only where skipping it would have
 	// stranded the request at 'pending'.
 	skipWaitForInsert bool
 }
 
-// insertRequestLogAsync pre-generates the log ID and fires off the DB
-// insert in a goroutine so the handler is not blocked by the write. The ID
-// is assigned synchronously so updateRequestLog can reference it later. If
-// the insert fails, the error is logged but does not fail the request —
-// the update will simply be a no-op.
+// insertRequestLogAsync pre-generates the log ID and fires off the DB insert in
+// a goroutine so the handler is not blocked by the write. The ID is assigned
+// synchronously so updateRequestLog can reference it later. A failed insert is
+// logged but does not fail the request; the update is then simply a no-op.
 //
-// Note: The SSE "request.started" event is NOT published here because
-// modelID may be empty when this is called (before body parsing). Call
-// publishRequestStartedEvent after modelID is resolved.
+// The SSE "request.started" event is NOT published here: modelID may still be
+// empty at this point (before body parsing). Call publishRequestStartedEvent
+// once modelID is resolved.
 func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	logEntry.id = uuid.New().String()
 	logEntry.requestHash = generateRequestHash()
 
-	// Skip DB operations when no pool is available (unit tests without DB).
+	// Skip DB operations when no pool is configured.
 	if h.dbPool == nil {
 		return
 	}
 
 	logEntry.insertWg.Add(1)
 
-	// Capture values before spawning goroutine to avoid data races.
-	// The handler modifies logEntry fields after this function returns,
-	// so the goroutine must read from local copies, not the shared struct.
+	// Capture values before spawning the goroutine to avoid data races: the
+	// handler modifies logEntry fields after this function returns, so the
+	// goroutine reads local copies rather than the shared struct.
 	id := logEntry.id
 	requestHash := logEntry.requestHash
 	modelID := logEntry.modelID
@@ -90,15 +89,14 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 		}
 		// owner_user_id is stored ONLY for keyless rows (dashboard chat/arena,
 		// which authenticate a session instead of a virtual key). A keyed row
-		// leaves it NULL and keeps resolving through the key's CURRENT owner, so
-		// reassigning a key still moves its whole log history; see migration 067
-		// for why the two row shapes are attributed differently.
+		// leaves it NULL and keeps resolving through the key's current owner, so
+		// reassigning a key moves its whole log history with it.
 		var ownerID any
 		if vkID == nil && ownerUserID != "" {
 			ownerID = ownerUserID
 		}
-		// NULL (not "") when the ingest path had no client address, so old and
-		// address-less rows look the same to the dashboard.
+		// NULL (not "") when the ingest path had no client address, so
+		// address-less rows all look the same to the dashboard.
 		var ip any
 		if clientIP != "" {
 			ip = clientIP
@@ -114,10 +112,8 @@ func (h *Handler) insertRequestLogAsync(logEntry *requestLogData) {
 	}()
 }
 
-// publishRequestStartedEvent emits the SSE "request.started" event.
-// Call this after modelID is resolved so the event always carries the
-// correct model (previously this was embedded in insertRequestLogAsync,
-// which could fire before body parsing had set modelID).
+// publishRequestStartedEvent emits the SSE "request.started" event. Call it
+// after modelID is resolved so the event always carries the correct model.
 func publishRequestStartedEvent(logEntry *requestLogData) {
 	events.Publish(events.Event{
 		Type:     "request.started",
@@ -135,14 +131,12 @@ func publishRequestStartedEvent(logEntry *requestLogData) {
 }
 
 // publishRequestStreamingEvent emits the SSE "request.streaming" event once the
-// proxy has committed to a provider and started forwarding the upstream stream
-// (including reasoning/thinking tokens). Until this point a live dashboard row
-// only knows the requested model and shows "Resolving" for the provider; this
-// event tells the dashboard to refetch the row so it can swap in the real
-// provider mid-stream instead of waiting for the terminal request.completed
-// event. Metadata mirrors request.completed (the frontend refetches by id
-// rather than reading these fields, so resolved_model_id, which is only set for
-// failover-routed requests, is intentionally omitted).
+// proxy has committed to a provider and started forwarding the upstream stream.
+// Until this point a live dashboard row knows only the requested model and
+// shows "Resolving" for the provider; the event tells the dashboard to refetch
+// the row and swap in the real provider mid-stream. Metadata mirrors
+// request.completed; the frontend refetches by id rather than reading these
+// fields, so resolved_model_id is omitted.
 func publishRequestStreamingEvent(logEntry *requestLogData) {
 	events.Publish(events.Event{
 		Type:     "request.streaming",
@@ -159,9 +153,8 @@ func publishRequestStreamingEvent(logEntry *requestLogData) {
 	})
 }
 
-// WaitForInsert blocks until the async INSERT goroutine has completed (or
-// timed out). Callers should invoke this before
-// updateRequestLog to guarantee the row exists in the database.
+// WaitForInsert blocks until the async INSERT goroutine has completed, or timed
+// out. Call it before updateRequestLog to guarantee the row exists.
 func (h *Handler) WaitForInsert(logEntry *requestLogData) {
 	done := make(chan struct{})
 	go func() {
@@ -179,10 +172,9 @@ func (h *Handler) WaitForInsert(logEntry *requestLogData) {
 	}
 }
 
-// execRequestLogUpdate runs the terminal/interim UPDATE and reports how many
-// rows it touched. Separated from updateRequestLog because that function runs it
-// twice: a row count of zero means the UPDATE arrived before its own INSERT, and
-// the retry has to send exactly the same statement.
+// execRequestLogUpdate runs the terminal or interim UPDATE and reports how many
+// rows it touched. updateRequestLog runs it twice: a row count of zero means the
+// UPDATE arrived before its own INSERT, and the retry sends the same statement.
 func (h *Handler) execRequestLogUpdate(logEntry *requestLogData) (int64, error) {
 	var providerID any
 	if logEntry.providerID != uuid.Nil {
@@ -251,10 +243,9 @@ func (h *Handler) execRequestLogUpdate(logEntry *requestLogData) (int64, error) 
 }
 
 // maxLogMessageRunes bounds request_logs.error_message and the
-// request.completed event built from it. Every current writer already passes
-// a bounded message (a constant, errString's cap, or a SanitizeLogBody body);
-// the bound lives at the sink so a future writer cannot miss it. It matches
-// the 10,000-character budget SanitizeLogBody gives upstream bodies.
+// request.completed event built from it. The bound lives at the sink so no
+// writer can miss it, and matches the 10,000-character budget SanitizeLogBody
+// gives upstream bodies.
 const maxLogMessageRunes = 10000
 
 // truncateLogMessage caps s at maxLogMessageRunes runes, cutting on a rune
@@ -267,19 +258,13 @@ func truncateLogMessage(s string) string {
 }
 
 func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOption) {
-	// Guard: if the log entry was never assigned an ID (insertRequestLogAsync
-	// not called), there is no row to update. An empty string is not a valid
-	// UUID and would cause "invalid input syntax for type uuid" errors.
-	// Note: if insertRequestLogAsync was called but the async INSERT failed,
-	// the ID will still be set (assigned synchronously), and the UPDATE will
-	// simply affect 0 rows (logged as a warning below).
 	// The terminal write closes the attempt in flight from the flat columns, so
-	// every terminal path in the package gets a trail record without knowing
-	// the trail exists. The deferred answer verdict runs first: it is what says
-	// whether this attempt charged or credited the circuit, and a verdict that
-	// landed after the write would be missing from the record for good. Both
-	// happen before the id and pool checks, so a handler with no row to write
-	// (a unit test) still reaches the breaker and builds the same trail.
+	// every terminal path in the package gets a trail record without knowing the
+	// trail exists. The deferred answer verdict runs first: it says whether this
+	// attempt charged or credited the circuit, and a verdict landing after the
+	// write would be missing from the record for good. Both run before the id
+	// and pool checks, so a handler with no row to write still reaches the
+	// breaker and builds the same trail.
 	if isTerminalLogState(logEntry.state) {
 		if judge := logEntry.judgeAnswer; judge != nil {
 			logEntry.judgeAnswer = nil
@@ -288,32 +273,34 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		logEntry.closeTerminalAttempt()
 	}
 
+	// An entry with no ID was never inserted, so there is no row to update; an
+	// empty string is not a valid UUID and Postgres would reject it. An entry
+	// whose async INSERT failed still has its ID and simply affects 0 rows.
 	if logEntry.id == "" {
 		debuglog.Warn("proxy: skipping updateRequestLog — log entry has no ID")
 		return
 	}
 
 	// Bound the message here, at the one place every terminal write and the
-	// request.completed event pass through. failRequest is not that place:
-	// four paths assign errorMessage directly and call this function
-	// themselves (the native Anthropic and non-streaming readers, the stream
-	// finaliser, the multimodal passthrough), so a clamp in failRequest would
-	// be a guarantee only some callers get.
+	// request.completed event pass through. failRequest is not that place: four
+	// paths assign errorMessage directly and call this function themselves (the
+	// native Anthropic and non-streaming readers, the stream finaliser, the
+	// multimodal passthrough), so a clamp there would only cover some callers.
 	logEntry.errorMessage = truncateLogMessage(logEntry.errorMessage)
 	// Then the content fence, for the same reason and at the same place: the
 	// error message and every attempt detail came from an upstream body that
 	// may quote the prompt back, and this is where all of them are written.
 	logEntry.fenceContent()
 
-	// Skip DB operations when no pool is available (unit tests without DB).
+	// Skip DB operations when no pool is configured.
 	if h.dbPool == nil {
 		return
 	}
 
 	// The interim "streaming" state update runs on the hot path before the first
-	// streamed byte, and blocking it on the DB INSERT delays the client by up to
-	// waitInsertTimeout (5s). That is what the flag is for, and it is honoured as
-	// given: nothing waits before the first UPDATE.
+	// streamed byte, where blocking on the DB INSERT would delay the client by
+	// up to waitInsertTimeout (5s). The flag is honoured as given: nothing waits
+	// before the first UPDATE.
 	skipWait := false
 	for _, o := range opts {
 		if o.skipWaitForInsert {
@@ -329,33 +316,29 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 	logEntry.latencyMs = logEntry.durationMs - logEntry.proxyOverheadMs
 	rows, err := h.execRequestLogUpdate(logEntry)
 
-	// Nothing touches the row after a terminal update, so a terminal update that
-	// loses the race with its own INSERT hits 0 rows and leaves the request at
-	// 'pending': no status, no duration, no error, and a row the dashboard shows
-	// as still in flight until a cleanup pass relabels it "request interrupted
-	// (stale)" up to half an hour later.
+	// Nothing touches the row after a terminal update, so one that loses the race
+	// with its own INSERT hits 0 rows and leaves the request at 'pending': no
+	// status, no duration, no error, and a row the dashboard shows as still in
+	// flight until a cleanup pass relabels it "request interrupted (stale)".
 	//
-	// The flag's reasoning — "the INSERT has the entire provider round-trip to
-	// complete" — holds for a request that reached a provider and fails for one
-	// that did not. An unknown model, an invalid model format or a rejected key
-	// updates microseconds after the insert is queued, so for those it was never
-	// a low-probability race; it was the normal case, and those are exactly the
-	// rows whose error message is the only thing worth reading.
+	// An unknown model, an invalid model format or a rejected key updates
+	// microseconds after the insert is queued, so for those the race is the
+	// normal case rather than a rarity, and those are exactly the rows whose
+	// error message is worth reading.
 	//
-	// Waiting up front would fix that and charge every request for it, because
-	// the terminal update runs BEFORE the response body is written. So the wait
-	// is paid where it buys something instead: 0 rows IS the race, and from there
-	// the row either appears while we wait or the INSERT itself failed, which no
-	// amount of waiting up front would have repaired either.
+	// Waiting up front would charge every request for it, since the terminal
+	// update runs BEFORE the response body is written. The wait is paid where it
+	// buys something instead: 0 rows IS the race, and from there the row either
+	// appears while we wait or the INSERT itself failed, which waiting up front
+	// would not have repaired either.
 	//
-	// 0 rows is not the only way a row is left behind, and this repairs only that
-	// one. An UPDATE that ERRORS — an exhausted pool, a reset connection — has no
-	// row count to believe and no insert to wait for, so it strands the same row
-	// by a different door and only staleLogCleanupPass will reach it.
+	// This repairs only the 0-rows case. An UPDATE that errors (an exhausted
+	// pool, a reset connection) has no row count to believe and no insert to
+	// wait for, so it strands the row for staleLogCleanupPass to reach.
 	if err == nil && rows == 0 && skipWait && isTerminalLogState(logEntry.state) {
-		// Debug, not Warn: this is the repair working, and on the paths that
-		// strand it is the normal case rather than an incident. What is worth a
-		// Warn is the retry ALSO finding no row, which falls through below.
+		// Debug, not Warn: this is the repair working, and the normal case on the
+		// paths that strand. The retry ALSO finding no row is what earns a Warn,
+		// and falls through below.
 		debuglog.Debug("proxy: terminal log update arrived before its own insert", "request_id", logEntry.id, "state", logEntry.state)
 		h.WaitForInsert(logEntry)
 		rows, err = h.execRequestLogUpdate(logEntry)
@@ -367,9 +350,9 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 		debuglog.Warn("proxy: updateRequestLog no rows affected", "request_id", logEntry.id)
 	}
 
-	// Publish request lifecycle event for terminal states
+	// Publish the request lifecycle event for terminal states.
 	if isTerminalLogState(logEntry.state) {
-		// Single Prometheus recording seam: every terminal request passes
+		// The single Prometheus recording seam: every terminal request passes
 		// through here exactly once with its provider/model/status/tokens.
 		metrics.Record(metrics.Observation{
 			Provider:          logEntry.providerName,
@@ -419,9 +402,9 @@ func (h *Handler) updateRequestLog(logEntry *requestLogData, opts ...updateLogOp
 
 // metricModelLabel is the model label the request-outcome metrics carry: the
 // name the client asked for, with two bounds on it. A validation failure
-// collapses to "unresolved" (the raw string is unbounded), and a hotel/ group
-// is lower-cased after the prefix the way the group lookup lower-cases it, so
-// a client's spelling of the group cannot mint one series per casing.
+// collapses to "unresolved", since the raw string is unbounded, and a hotel/
+// group is lower-cased after the prefix the way the group lookup lower-cases
+// it, so a client's spelling cannot mint one series per casing.
 func metricModelLabel(modelID string, kind ErrorKind) string {
 	if kind == KindValidation {
 		return "unresolved"

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -277,10 +277,8 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	// circuit past its cooldown already reads as half-open here. A nil breaker
 	// means nobody has an opinion, which is not a reason to postpone.
 	//
-	// Unlike every other breaker consultation in the proxy, this gate does not
-	// also check the circuit_breaker_enabled setting, because reading it means
-	// calling h.settingsRepo.GetBool and h.settingsRepo can be nil on this
-	// path. The failure mode is bounded: an operator who
+	// Like the auto-disable gate in model_gone.go, this reads the circuit state
+	// without the circuit_breaker_enabled setting. The failure mode is bounded: an operator who
 	// disables the breaker after a circuit has opened sees that model's probes
 	// deferred until the breaker's own cooldown clears, and a deferred probe can
 	// only leave a model enabled longer.

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -18,30 +18,30 @@ import (
 
 // goneProbeMaxTokens is the probe's output budget. Deliberately not 1: a
 // reasoning model spends a 1-token budget on thinking, returns an empty
-// completion, and some providers wrap that in a 400 — a manufactured false
+// completion, and some providers wrap that in a 400, a manufactured false
 // failure.
 //
-// Best-effort, and knowingly so. The probe goes through the real egress builder
-// (see newProbeState), which strips params this provider+model has LEARNED the
-// upstream rejects, so a model that once answered 400 for max_tokens is probed
-// with no cap at all. Keeping the cap would mean a bespoke body that skips the
-// rewrite, and a probe that is easier to satisfy than the requests it
-// adjudicates is worse than no probe. The cost is one uncapped completion per
-// retirement decision, at goneProbeCooldown apiece.
+// Best-effort, knowingly. The probe goes through the real egress builder (see
+// newProbeState), which strips params this provider and model have LEARNED the
+// upstream rejects, so a model that answered 400 for max_tokens is probed with
+// no cap at all. Keeping the cap would mean a bespoke body that skips the
+// rewrite, and a probe easier to satisfy than the requests it adjudicates is
+// worse than no probe. The cost is one uncapped completion per retirement
+// decision, at goneProbeCooldown apiece.
 const goneProbeMaxTokens = 64
 
 // goneProbeMaxBody bounds how much of a probe answer is read into memory.
 //
-// Applied to resp.Body itself rather than at each read site: remapMiniMaxBusinessError
-// and both dialect translators consume the body whole from other packages, so a
-// cap that only covered the judgement functions would leave every MiniMax,
-// vertex-express and Responses probe unbounded. The read happens on a detached
-// goroutine with no client backpressure behind it.
+// Applied to resp.Body itself rather than at each read site:
+// remapMiniMaxBusinessError and both dialect translators consume the body whole
+// from other packages, so a cap covering only the judgement functions would
+// leave every MiniMax, vertex-express and Responses probe unbounded. The read
+// happens on a detached goroutine with no client backpressure behind it.
 //
 // A megabyte rather than the few hundred bytes a refusal needs, because the
 // embeddings family shares the constant: a 3072-dimension embedding at full
 // float precision runs past 60 KiB, so a tighter cap would truncate legitimate
-// answers from exactly the models being adjudicated.
+// answers from the models being adjudicated.
 //
 // The value is not load-bearing for correctness in either direction, which is
 // what judgeProbeFailure's explicit length check is for: a truncated body
@@ -68,9 +68,9 @@ const (
 // provider still serves it.
 //
 // Three-way, and the zero value is the one that matters: every path that cannot
-// establish anything — an unprobeable family, a request that would not build, a
-// connection that never landed, a deadline, a body that will not parse — lands
-// on probeInconclusive, and the caller postpones the retirement on it.
+// establish anything (an unprobeable family, a request that would not build, a
+// connection that never landed, a deadline, a body that will not parse) lands on
+// probeInconclusive, and the caller postpones the retirement on it.
 type probeVerdict int
 
 const (
@@ -87,8 +87,8 @@ const (
 // conversion keeps the rendered name independent of whether Debug is enabled.
 //
 // The default renders the number rather than folding into "inconclusive",
-// because noteModelGone's default arm exists to surface a verdict nobody has
-// handled and logs this string.
+// because noteModelGone's default arm surfaces a verdict nobody has handled and
+// logs this string.
 func (v probeVerdict) String() string {
 	switch v {
 	case probeInconclusive:
@@ -114,14 +114,13 @@ func (v probeVerdict) String() string {
 //
 // Rerank is excluded on weaker grounds: a /rerank call with one document is as
 // cheap as an embeddings call, but it would need its own request body, answer
-// shape and content judgement, and shipping an unexercised third judgement path
-// is a worse trade than leaving rerank models enabled until an operator disables
-// one. Cheap to reverse: add the family here plus a body and a content check.
+// shape and content judgement, and an unexercised third judgement path is a
+// worse trade than leaving rerank models enabled until an operator disables one.
+// Cheap to reverse: add the family here plus a body and a content check.
 //
-// Where a family cannot be probed cheaply, the correct outcome is to not
+// Where a family cannot be probed cheaply, the correct outcome is not to
 // auto-retire that family at all. Falling back to the prose classifier would
-// leave the retirement running unsupervised precisely where it is least
-// observed.
+// leave the retirement running unsupervised where it is least observed.
 //
 // The empty string and any unknown family are unprobeable for the same reason:
 // nothing can be substantiated about them, so nothing is claimed.
@@ -140,7 +139,7 @@ func probeEndpointForFamily(endpointType string) (endpoint string, ok bool) {
 // closes the transport's own body underneath.
 //
 // The Closer half is the point: an io.NopCloser would leave nothing holding the
-// real body, and every reader downstream — including the two in other packages —
+// real body, so every reader downstream, including the two in other packages,
 // would read through a cap while the connection leaked.
 type cappedBody struct {
 	io.Reader
@@ -179,23 +178,23 @@ type probeEmbeddingsRequest struct {
 //     so the native path would have to be handed an invented one. Anthropic's
 //     compat layer serves the same catalog, so a live model answers on both
 //     surfaces and a retired one is refused by name on both; if the compat layer
-//     itself is the problem the probe draws an error that is not a retirement and
-//     returns probeInconclusive.
+//     itself is the problem the probe draws an error that is not a retirement
+//     and returns probeInconclusive.
 //   - endpointPath is left empty for the chat families even though
 //     probeEndpointForFamily names "/chat/completions". Empty IS chat to the
-//     builder, while a non-empty endpointPath means "this is a multimodal
-//     endpoint" and both dialect re-routes refuse to fire when it is set.
+//     builder, while a non-empty endpointPath means a multimodal endpoint and
+//     both dialect re-routes refuse to fire when it is set.
 //   - reqModel is left empty. It is the model the CLIENT asked for, and the
 //     builder's rewrite gate is `st.reqModel != candidate.model.ModelID || ...`
 //     (proxy_failover.go), so naming the upstream model here closes every
 //     disjunct and paramrewrite.BuildUpstreamBody never runs. The probe would
-//     then skip the learned renames real traffic gets — an OpenAI reasoning model
-//     that has learned max_tokens -> max_completion_tokens would be probed with
-//     the very parameter it rejects and answer 400 forever.
+//     then skip the learned renames real traffic gets, and an OpenAI reasoning
+//     model that has learned max_tokens -> max_completion_tokens would be probed
+//     with the very parameter it rejects and answer 400 forever.
 //
 // The marshal errors are discarded because both payloads are fixed structs of
 // strings and ints: encoding/json has no failure to report, and threading an
-// error nothing can produce would add a branch no test could reach.
+// error nothing can produce would add an unreachable branch.
 func newProbeState(candidate modelCandidate, endpointType, endpoint string) *requestState {
 	modelID := candidate.model.ModelID
 	st := &requestState{
@@ -220,7 +219,7 @@ func newProbeState(candidate modelCandidate, endpointType, endpoint string) *req
 		}
 		// Set to the same payload even though makeUpstreamBody supersedes it:
 		// several things downstream of the builder read the request body, and
-		// none of them should be looking at an empty one.
+		// none should be looking at an empty one.
 		st.bodyBytes = body
 		return st
 	}
@@ -236,9 +235,9 @@ func newProbeState(candidate modelCandidate, endpointType, endpoint string) *req
 
 // probeModel asks the provider directly whether it still serves this model.
 //
-// classifyUpstreamError reads the words a provider chose on the day it wrote
-// them; this reads what the provider actually does when asked for the model. The
-// probe is the adjudicator, the classifier only nominates.
+// classifyUpstreamError reads the words a provider chose; this reads what the
+// provider does when asked for the model. The probe is the adjudicator, the
+// classifier only nominates.
 //
 // It is an upstream call the operator did not make, so it is deliberately NOT
 // run through doUpstream: no circuit-breaker outcome, no request log, no
@@ -257,20 +256,18 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		return probeInconclusive
 	}
 	// Kept although probeForRetirement checks first, because this function takes
-	// a candidate and dereferences it. The tests drive probeModel directly, which
-	// is also how any future caller would.
+	// a candidate and dereferences it, and it can be called directly.
 	if candidate.model == nil || candidate.provider == nil {
 		return probeInconclusive
 	}
 
-	// Skipping the breaker's ACCOUNTING is argued above; skipping its CHECK is a
-	// separate decision and not one this makes. If the gateway has already
-	// sidelined this model, a probe to it is a guaranteed-wasted call whose
-	// answer would be inconclusive anyway.
+	// The breaker's ACCOUNTING is skipped for the reason given above; its CHECK
+	// is not. If the gateway has already sidelined this model, a probe to it is
+	// a guaranteed-wasted call whose answer would be inconclusive anyway.
 	//
-	// This model's own circuit, keyed the way every charge site keys it. A
+	// This model's own circuit, keyed the way every charge site keys it: a
 	// provider dark for other models says nothing about whether this one still
-	// answers, and that is precisely the question the probe exists to settle.
+	// answers, which is the question the probe exists to settle.
 	//
 	// GetState rather than IsOpen, and the difference is what makes the check
 	// safe. IsOpen is the routing gate: it takes a write lock and performs the
@@ -280,14 +277,13 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	// circuit past its cooldown already reads as half-open here. A nil breaker
 	// means nobody has an opinion, which is not a reason to postpone.
 	//
-	// Unlike every other breaker consultation in the proxy this gate does not
+	// Unlike every other breaker consultation in the proxy, this gate does not
 	// also check the circuit_breaker_enabled setting, because reading it means
-	// calling h.settingsRepo.GetBool and h.settingsRepo is nil on the path the
-	// probe unit tests exercise. The failure mode is bounded and safe: an
-	// operator who disables the breaker after a circuit has opened sees that
-	// model's probes deferred until the breaker's own cooldown clears, and a
-	// deferred probe can only leave a model enabled longer. If a later change
-	// threads a testable settings source through here, honor the setting then.
+	// calling h.settingsRepo.GetBool and h.settingsRepo can be nil on this
+	// path. The failure mode is bounded: an operator who
+	// disables the breaker after a circuit has opened sees that model's probes
+	// deferred until the breaker's own cooldown clears, and a deferred probe can
+	// only leave a model enabled longer.
 	if h.circuitBreaker != nil && h.circuitBreaker.GetState(candidate.provider.ID, candidate.model.ModelID) == failover.StateOpen {
 		debuglog.Debug("proxy: retirement probe skipped, the model's circuit is open", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
 		return probeInconclusive
@@ -305,13 +301,13 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 	// gets: a provider that redirects must not be able to walk this request's
 	// credential to another host just because it arrived off the request path.
 	//
-	// The nil check has to exist — upstreamTransport is a concrete
-	// *http.Transport, so assigning a nil one produces a non-nil interface
-	// holding a nil pointer and net/http panics inside RoundTrip — and leaving
-	// the field unset instead is not the harmless alternative: an unset Transport
-	// IS http.DefaultTransport, which carries no DialContext, so the SafeDialer's
-	// guard against a provider URL resolving into the gateway's own network would
-	// be silently absent for exactly the request nobody is watching.
+	// The nil check has to exist, because upstreamTransport is a concrete
+	// *http.Transport and assigning a nil one produces a non-nil interface
+	// holding a nil pointer, on which net/http panics inside RoundTrip. Leaving
+	// the field unset is not the harmless alternative: an unset Transport IS
+	// http.DefaultTransport, which carries no DialContext, so the SafeDialer's
+	// guard against a provider URL resolving into the gateway's own network
+	// would be silently absent for the request nobody is watching.
 	if h.upstreamTransport == nil {
 		debuglog.Debug("proxy: retirement probe has no upstream transport to make a guarded request with", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "verdict", probeInconclusive.String())
 		return probeInconclusive
@@ -349,28 +345,28 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		//
 		// This bounds the copy, not the total: the judgement has already taken
 		// its own goneProbeMaxBody, so a large answer is pulled off the socket
-		// twice. What the constant promises is memory, and that still holds —
-		// this streams to io.Discard through one 32 KiB buffer.
+		// twice. The constant promises memory, and that still holds, since this
+		// streams to io.Discard through one 32 KiB buffer.
 		//
 		// Knowingly a no-op on some paths: MiniMax and both dialect translators
 		// read the body to EOF and CLOSE it themselves, so there this copy reads
 		// an already-closed body and discards the error. A body those paths could
-		// finish was already drained by them, and one they could not finish is
-		// past the cap, where the connection is forfeit either way.
+		// finish they already drained, and one they could not finish is past the
+		// cap, where the connection is forfeit either way.
 		_, _ = io.Copy(io.Discard, io.LimitReader(rawBody, goneProbeMaxBody))
 		// Whatever is in the field: the cap above on every path, or the NopCloser
-		// remapMiniMaxBusinessError leaves behind — and that path has already
+		// remapMiniMaxBusinessError leaves behind, and that path has already
 		// closed the cap, and through it the transport's own body. The real body
 		// is closed exactly once either way.
 		_ = resp.Body.Close()
 	}()
 
 	// MiniMax reports refusals inside a 200 envelope, so the status has to be
-	// normalised before it is judged — exactly as attemptCandidate does.
+	// normalised before it is judged, exactly as attemptCandidate does.
 	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
 
 	// Any 2xx is an answer, so the model is plainly still served. Reading a 201
-	// as a probe FAILURE would let a relay that answers 201 push a live model
+	// as a probe failure would let a relay that answers 201 push a live model
 	// towards retirement.
 	if !servedSuccessStatus(resp.StatusCode) {
 		return judgeProbeFailure(resp, candidate, endpointType)
@@ -381,24 +377,24 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 // judgeProbeFailure turns a non-2xx probe response into a verdict.
 //
 // Only the classifier's retirement verdict retires. Everything else postpones,
-// and that single line is what keeps a provider incident from becoming a mass
-// retirement: 429s, 402s, quota and entitlement failures, bad-request verdicts
-// and every 5xx are things that happen to models that are alive. Deliberately
-// no status-code shortcut around the classifier — a bare "404 means gone" would
+// which is what keeps a provider incident from becoming a mass retirement: 429s,
+// 402s, quota and entitlement failures, bad-request verdicts and every 5xx are
+// things that happen to models that are alive. There is deliberately no
+// status-code shortcut around the classifier: a bare "404 means gone" would
 // retire every model behind a misconfigured base URL.
 func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointType string) probeVerdict {
 	// One byte past the cap on purpose. This is the one place in this file where
-	// a body we did not receive in full could RETIRE a model: a surviving prefix
-	// that names the model beside a gone-phrase classifies exactly like a real
-	// refusal, and the classifier only sees the first 10 000 characters.
+	// a body received incomplete could RETIRE a model: a surviving prefix naming
+	// the model beside a gone-phrase classifies exactly like a real refusal, and
+	// the classifier sees only the first 10 000 characters.
 	//
 	// Reading exactly goneProbeMaxBody could not tell either: io.ReadAll returns
-	// a nil error when a LimitReader is exhausted, so the err branch below catches
-	// genuine transport failures and never catches truncation.
+	// a nil error when a LimitReader is exhausted, so the err branch below
+	// catches genuine transport failures and never catches truncation.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody+1))
 	switch {
 	case err != nil:
-		// A body we could not finish reading is not the provider saying
+		// A body that could not be read to the end is not the provider saying
 		// anything, so it postpones like every other unproven case.
 		debuglog.Debug("proxy: retirement probe could not read the provider's answer", "endpoint", endpointType, "provider", candidate.provider.Name, "model", candidate.model.ModelID, "status", resp.StatusCode, "verdict", probeInconclusive.String(), "error", err)
 		return probeInconclusive
@@ -422,9 +418,9 @@ func judgeProbeFailure(resp *http.Response, candidate modelCandidate, endpointTy
 
 // judgeProbeSuccess turns a success (any 2xx) probe response into a verdict.
 //
-// A success that carries nothing is NOT a success: a stream can open, emit nothing
-// and end cleanly. It is not a refusal either — the provider did not say the
-// model is gone — so an empty answer postpones like every other unproven case.
+// A success that carries nothing is NOT a success: a stream can open, emit
+// nothing and end cleanly. It is not a refusal either, since the provider did
+// not say the model is gone, so an empty answer postpones.
 func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCandidate, endpointType string) probeVerdict {
 	// The dialect re-routes answer in their own wire format. Translate first, for
 	// the same reason attemptCandidate does: everything downstream judges the
@@ -436,11 +432,11 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 	}
 
 	// Both the read error and the cap are ignored here, unlike in
-	// judgeProbeFailure, because of what an incomplete body can produce. There, a
-	// surviving prefix naming the model beside a gone-phrase would RETIRE, so it
-	// has to be detected; here the worst a partial body can do is fail to parse
-	// (probeDeliveredContent returns false and the probe postpones) or carry
-	// content, which can only PREVENT a disable.
+	// judgeProbeFailure, because of what an incomplete body can produce there: a
+	// surviving prefix naming the model beside a gone-phrase would RETIRE. Here
+	// the worst a partial body can do is fail to parse (probeDeliveredContent
+	// returns false and the probe postpones) or carry content, which can only
+	// PREVENT a disable.
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, goneProbeMaxBody))
 	verdict := probeInconclusive
 	if probeDeliveredContent(endpointType, body) {
@@ -461,11 +457,10 @@ func judgeProbeSuccess(resp *http.Response, st *requestState, candidate modelCan
 // traffic through the adapter, and for no probe of an "anthropic" one, whose
 // re-route requires a document part the probe body has no reason to carry. The
 // Responses case fires for a pro-tier model on OpenAI's own host, which lives
-// behind /v1/responses for every request including this text-only probe; a
-// model learned to refuse tools+reasoning is not re-routed, as the probe body
+// behind /v1/responses for every request including this text-only probe; a model
+// learned to refuse tools plus reasoning is not re-routed, since the probe body
 // carries neither. A probe that skipped the translation would read a dialect
-// object as an empty chat completion and postpone those retirements forever,
-// silently.
+// object as an empty chat completion and postpone those retirements forever.
 func translateProbeDialect(resp *http.Response, st *requestState, modelID string) error {
 	// The upstream model id, NOT st.reqModel: the served path passes the name the
 	// client asked for, and a probe has no client (st.reqModel is empty by design,
@@ -489,14 +484,14 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 // an unreadable answer is not the provider saying the model is gone.
 func probeDeliveredContent(endpointType string, body []byte) bool {
 	if endpointType == endpointTypeEmbeddings {
-		// The vector is left undecoded on purpose. Typing it as []float64 made
-		// the whole document fail to parse when a provider answered with
-		// base64-encoded embeddings — a JSON string where the struct wanted an
-		// array — so a live embeddings model came back inconclusive forever.
+		// The vector is left undecoded on purpose. Typing it as []float64 makes
+		// the whole document fail to parse when a provider answers with
+		// base64-encoded embeddings, a JSON string where the struct wants an
+		// array, so a live embeddings model comes back inconclusive forever.
 		//
 		// Raw and non-empty is still a real bar: an absent vector, a null, an
 		// empty array and an empty string are all "the provider answered with
-		// nothing". What it stops doing is judging the ENCODING, which is the
+		// nothing". What it does not judge is the ENCODING, which is the
 		// provider's choice and says nothing about whether the model exists.
 		var out struct {
 			Data []struct {
@@ -520,8 +515,8 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 // null, an array with no elements, or a string with no characters.
 //
 // Structural rather than a comparison against the spellings encoding/json
-// happens to emit. `[]` and `[ ]` are the same empty array, and the
-// exact-string version of this read `[ ]` as content.
+// happens to emit: `[]` and `[ ]` are the same empty array, and an exact-string
+// test reads `[ ]` as content.
 func jsonValueIsEmpty(raw json.RawMessage) bool {
 	v := bytes.TrimSpace(raw)
 	if len(v) == 0 || bytes.Equal(v, []byte("null")) {
@@ -538,9 +533,9 @@ func jsonValueIsEmpty(raw json.RawMessage) bool {
 //
 // Shared with the non-streaming request path, which asks the same question of
 // the same shape for the same reason: a 200 that carries nothing is not the
-// model answering, and crediting one would let a provider intermittently
-// returning an empty completion reset a retired model's strike count forever.
-// One judgement rather than two, so the probe and the traffic cannot drift.
+// model answering, and crediting one lets a provider intermittently returning an
+// empty completion reset a retired model's strike count forever. One judgement
+// rather than two, so the probe and the traffic cannot drift.
 //
 // The completion-token fallback is what admits a reasoning model that
 // legitimately spends the whole budget thinking and returns an empty visible
@@ -551,22 +546,22 @@ func chatAnswerCarriesContent(out ChatCompletionResponse) bool {
 			return true
 		}
 		// Content is `any` because a provider may answer with content PARTS
-		// rather than a string. Non-empty is the whole test — the parts are the
+		// rather than a string. Non-empty is the whole test: the parts are the
 		// model's output whatever their shape, and reaching into them to find a
-		// non-empty text field would be judging providers' part vocabularies from
-		// here.
+		// non-empty text field would be judging providers' part vocabularies
+		// from here.
 		if parts, ok := choice.Message.Content.([]any); ok && len(parts) > 0 {
 			return true
 		}
 		if choice.Message.ReasoningContent != "" || choice.Message.Reasoning != "" {
 			return true
 		}
-		// The one thing this bar gained: read here rather than after the
-		// reasoning normalisation that folds it into ReasoningContent, which
-		// runs several statements LATER than the caller judging this — so a
-		// reasoning-only OpenRouter answer read as nothing at all. A modelled
-		// field the model plainly produced, unlike the overflow members that
-		// belong to the breaker's bar alone (see answerCarriesSomething).
+		// Read here rather than after the reasoning normalisation that folds it
+		// into ReasoningContent, which runs several statements LATER than the
+		// caller judging this, so a reasoning-only OpenRouter answer would read
+		// as nothing at all. A modelled field the model plainly produced, unlike
+		// the overflow members that belong to the breaker's bar alone (see
+		// answerCarriesSomething).
 		if len(choice.Message.ReasoningDetails) > 0 {
 			return true
 		}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -20,10 +20,10 @@ import (
 // image generation/edits/variations, text-to-speech, and speech-to-text.
 //
 // These endpoints reuse the chat pipeline phases (ingest, resolve, failover
-// config, failover loop) but replace the chat-specific per-attempt dispatch
-// with a transparent pass-through: the upstream response is forwarded to the
-// client verbatim (JSON, SSE, or binary), with only token usage metadata
-// extracted for metering. No request or response content is ever logged.
+// config, failover loop) but replace the chat-specific per-attempt dispatch with
+// a transparent pass-through: the upstream response is forwarded to the client
+// verbatim (JSON, SSE, or binary), with only token usage metadata extracted for
+// metering. No request or response content is logged.
 
 // Embeddings proxies OpenAI-compatible POST /v1/embeddings requests.
 func (h *Handler) Embeddings(w http.ResponseWriter, r *http.Request) {
@@ -88,9 +88,8 @@ func (h *Handler) serveJSONPassthrough(w http.ResponseWriter, r *http.Request, e
 	st.endpointPath = endpointPath
 	st.longRunning = isLongRunningEndpoint(endpointType)
 	// ingestRequest sizes the prompt with the chat rule, which finds no
-	// "messages" in these bodies and so returns zero for every one of them.
-	// Size them by their own shape instead, or the metering estimate below is
-	// silently no charge at all.
+	// "messages" in these bodies and returns zero for every one. They are sized
+	// by their own shape instead, or the metering estimate charges nothing.
 	st.logData.promptTextBytes = passthroughPromptTextBytes(st.bodyBytes, endpointType)
 	st.makeUpstreamBody = makeJSONModelRewriter(st.bodyBytes, st.reqModel)
 	h.servePassthroughPipeline(w, r, st)
@@ -208,12 +207,13 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 	}
 	isSSE := strings.HasPrefix(contentType, "text/event-stream")
 	// An embeddings answer is JSON by definition, so it takes the buffered branch
-	// whatever an aggregator or CDN in front of the provider labelled it. Letting
-	// the content type decide sent an unlabelled one to the streamed twin, which
-	// commits on the first byte and cannot judge what it never holds — so
-	// `{"data":[]}` is eleven bytes and clears the streak, routing around the
-	// check passthroughAnswered exists to make. Embeddings is the only
-	// pass-through family that can be auto-retired, hence the only one named.
+	// whatever an aggregator or CDN in front of the provider labelled it.
+	// Letting the content type decide sends an unlabelled one to the streamed
+	// twin, which commits on the first byte and cannot judge what it never
+	// holds, so `{"data":[]}` is eleven bytes that clear the streak and route
+	// around the check passthroughAnswered exists to make. Embeddings is the
+	// only pass-through family that can be auto-retired, hence the only one
+	// named.
 	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
 
 	if isJSON {
@@ -224,20 +224,20 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 }
 
 // serveBufferedJSONPassthrough handles the application/json shape: bounded
-// buffering for usage extraction with streamed forwarding beyond the cap.
-// The circuit breaker commits only once the buffered read succeeds — a 200
-// whose body dies mid-read records a failure, not a success — and response
-// headers are only written after that point, so the read-error path emits a
-// clean OpenAI error response.
+// buffering for usage extraction, with streamed forwarding beyond the cap. The
+// circuit breaker commits only once the buffered read succeeds, so a 200 whose
+// body dies mid-read records a failure rather than a success, and response
+// headers are written only after that point, leaving the read-error path free to
+// emit a clean OpenAI error response.
 func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64) {
 	logData := st.logData
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
 	if err != nil {
-		// Not when the read was interrupted rather than broken: it runs under
-		// the attempt's context, so a caller hanging up or this gateway's own
-		// request_timeout both surface here as a failed read, and neither is the
-		// provider's doing. cancelKind is the package's classifier for that.
+		// Not charged when the read was interrupted rather than broken: it runs
+		// under the attempt's context, so a caller hanging up and this gateway's
+		// own request_timeout both surface here as a failed read, and neither is
+		// the provider's doing. cancelKind is the package's classifier for that.
 		if _, aborted := cancelKind(r.Context(), err); !aborted {
 			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
@@ -248,33 +248,30 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	}
 	// The commit point is where the model has proved it is alive, so it is where
 	// its gone-strike streak stops being current. Without it "three CONSECUTIVE
-	// refusals" is not true on this path: embeddings strikes would only expire
-	// with goneStrikeWindow, so three refusals scattered across half an hour of
+	// refusals" is not true on this path: embeddings strikes expire only with
+	// goneStrikeWindow, so three refusals scattered across half an hour of
 	// otherwise healthy traffic would reach the threshold and spend a probe.
 	//
 	// Here rather than on the 200 headers, because the read above is what
-	// distinguishes a provider that served the model from one that promised to: a
-	// body that died mid-read is the failure branch, and clearing the streak
-	// there would put a model that never actually answers out of reach of a
-	// retirement forever.
+	// distinguishes a provider that served the model from one that promised to.
+	// A body that died mid-read is the failure branch, and clearing the streak
+	// there would put a model that never answers out of reach of retirement.
 	//
 	// Not gated on circuitBreakerEnabled, unlike its neighbour: the breaker is an
 	// operator's routing choice, and whether a model still exists is not.
 	//
 	// Family-gated inside noteModelServed, exactly as the strike is, so an
 	// embeddings 200 says nothing about the chat surface and an image or TTS 200
-	// says nothing about either. And gated on bytes having arrived, judged by the
-	// same rule the probe uses — see passthroughAnswered.
+	// says nothing about either. Also gated on bytes having arrived, judged by
+	// the rule the probe uses (passthroughAnswered).
 	answered := passthroughAnswered(logData.endpointType, body)
 	if answered {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
-	// The breaker verdict reads the same answer, and until now it did not: the
-	// success was recorded the moment the read succeeded, so an embeddings
-	// provider replying 200 {"data":[]} to every request recorded a success
-	// every time and its circuit could never open. That is the chat-path bug
-	// this change fixes, on the surface whose detection function was already
-	// written and used for the streak alone.
+	// The breaker verdict reads the same answer. Recording a success the moment
+	// the read succeeds instead lets an embeddings provider replying
+	// 200 {"data":[]} to every request record a success every time, so its
+	// circuit could never open.
 	switch {
 	case r.Context().Err() != nil:
 		// The request was interrupted; nothing here is the provider's doing.
@@ -285,17 +282,16 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		}
 	case bodilessSuccessStatus(resp.StatusCode):
 		// 204/205 legitimately carry no body, so an empty one proves nothing
-		// either way — and this is a NO-OP rather than the credit it used to be.
+		// either way and this is a no-op rather than a credit.
 		//
-		// The credit is the harm. The breaker is keyed (provider, resolved
+		// The credit is the harm. The breaker is keyed by (provider, resolved
 		// upstream model) and NOT by endpoint family, so a model served on two
-		// surfaces shares one circuit: crediting an empty 204 here resets the
-		// consecutiveFails the chat path charges for that same model, which
-		// charges this same shape. A tenant sending both to one relay that
-		// answers 204 to everything had each chat charge erased by the next
-		// embeddings call, and the circuit never opened. Same argument as the 404
-		// no-op in breakerRecordAction: recording a success erases real failure
-		// history.
+		// surfaces shares one circuit: crediting an empty 204 here would reset
+		// the consecutiveFails the chat path charges for that same model. A
+		// tenant sending both to one relay that answers 204 to everything would
+		// have each chat charge erased by the next embeddings call, and the
+		// circuit would never open. Same argument as the 404 no-op in
+		// breakerRecordAction: recording a success erases real failure history.
 	case !servedSuccessStatus(resp.StatusCode):
 		// A definitive non-2xx: the provider is plainly alive and answered.
 		if st.circuitBreakerEnabled {
@@ -329,30 +325,29 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		}
 		// Skipping usage EXTRACTION must not mean skipping metering: the
 		// provider billed for this request and the client got the whole
-		// response, so recording (0,0) here charged it against nothing — not
-		// the key's tokens_used counter, not its TPM budget. The cap is 8 MiB
-		// and a batch embeddings call clears it at around 140 inputs, so the
-		// free requests were the routine ones, not the exotic ones.
+		// response, so recording (0,0) would charge it against nothing, neither
+		// the key's tokens_used counter nor its TPM budget. The cap is 8 MiB and
+		// a batch embeddings call clears it at around 140 inputs, so the free
+		// requests would be the routine ones.
 		//
 		// Only the prompt is estimated. The streaming path derives output from
 		// delivered bytes because those bytes are text; here they are float
 		// vectors or base64 image data, so the same arithmetic would invent
 		// roughly two million completion tokens for one 8 MiB embeddings
-		// response. Undercharging the output is the deliberate choice, and it
-		// is still strictly better than charging nothing.
-		// The log keeps the provider's figures, which here are none: usage was
-		// never extracted, so nothing was measured. The estimate charges the
-		// quota WITHOUT being reported as measured usage, matching what the
-		// chat and streaming paths do (they update the log before calling
-		// estimateMissingUsage) and keeping the stats pages honest.
+		// response. Undercharging the output is deliberate, and still better
+		// than charging nothing.
 		//
-		// Charged through the same helper as every other pass-through branch,
-		// rather than hand-rolled here. Hand-rolling it is what left this branch
-		// free: it carried its own `if estimated > 0` guard, so the zero-prompt
-		// families skipped the debit exactly as they did below. /images/variations
-		// has no prompt field at all, and four b64_json images clear the 8 MiB cap
-		// routinely, so the endpoint that motivated the floor was still free on
-		// precisely the requests the provider bills most for.
+		// The log keeps the provider's figures, which here are none: usage was
+		// never extracted. The estimate charges the quota WITHOUT being reported
+		// as measured usage, matching the chat and streaming paths, which update
+		// the log before calling estimateMissingUsage, and keeping the stats
+		// pages honest.
+		//
+		// Charged through the same helper as every other pass-through branch:
+		// hand-rolling the debit here means a private `if estimated > 0` guard
+		// under which the zero-prompt families pay nothing, and
+		// /images/variations has no prompt field at all while four b64_json
+		// images clear the 8 MiB cap routinely.
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
 		estimated, _ := h.chargePassthroughUsage(st, 0, 0, answered)
 		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "estimated_prompt_tokens", estimated)
@@ -377,9 +372,9 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 
 	// Charge the quota even when the provider reported no usage at all. Image
 	// generation and text-to-speech routinely omit the usage block, so guarding
-	// the debit on "did it report something" left those families unmetered on
-	// every ordinary request, not merely on the oversized ones the sibling
-	// branch above handles. Reported figures always win; the estimate only
+	// the debit on "did it report something" would leave those families
+	// unmetered on every ordinary request, not merely the oversized ones the
+	// sibling branch above handles. Reported figures always win; the estimate
 	// fills a total absence, and only for the prompt, for the same reason the
 	// oversized branch does not size a response of vectors or base64 as text.
 	charged, estimatedPrompt := h.chargePassthroughUsage(st, promptTokens, completionTokens, answered)
@@ -390,37 +385,33 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 // the prompt when the provider reported no usage at all.
 //
 // Every pass-through family needs this and they do not share a branch: JSON
-// bodies are metered in serveBufferedJSONPassthrough, while audio/mpeg and
-// other binary shapes go to serveStreamedPassthrough, where the SSE tail that
-// carries usage is not even allocated. Guarding the debit on "did the provider
-// report something" therefore left image generation unmetered on the JSON side
-// and text-to-speech unmetered on the binary side, on every ordinary request.
+// bodies are metered in serveBufferedJSONPassthrough, while audio/mpeg and other
+// binary shapes go to serveStreamedPassthrough, where the SSE tail that carries
+// usage is never even allocated. Guarding the debit on "did the provider report
+// something" would leave image generation unmetered on the JSON side and
+// text-to-speech unmetered on the binary side, on every ordinary request.
 //
 // delivered gates the estimate, not the reported figures: a provider that
 // answers 200 with nothing (an aggregator in front of a retired model returning
-// `{"data":[]}`) has cost nothing, and charging a full prompt estimate for it
-// would bill the caller for every empty answer. This is the same rule
-// estimateMissingUsage states for streams: nothing is estimated when no output
-// was delivered.
+// `{"data":[]}`) has cost nothing, and charging a full prompt estimate would
+// bill the caller for every empty answer. Same rule estimateMissingUsage states
+// for streams: nothing is estimated when no output was delivered.
 //
 // Only the prompt is ever estimated. A pass-through response body is float
-// vectors or base64 or audio, not text, so sizing it the way the streaming path
-// sizes delivered text would invent an enormous completion charge.
+// vectors, base64 or audio rather than text, so sizing it the way the streaming
+// path sizes delivered text would invent an enormous completion charge.
 //
-// A delivered request that reaches this helper is never charged zero. (Every
-// pass-through branch does reach it -- the oversized-JSON one was hand-rolling
-// its own debit and was the last exception.) The estimate legitimately sizes to
-// nothing on the multipart families: multipartPromptTextBytes counts only the
-// "prompt" form field, which is optional on transcriptions and translations and
-// absent entirely from /images/variations, so the ordinary shape of those
-// requests carries no promptable text at all. Without the floor a served
-// transcription cost the key nothing — no tokens_used, no TPM draw — on every
-// request. The upload is still not measured, for the reason given on
-// multipartPromptTextBytes, so this is deliberately a floor and not a
-// proportional estimate: it makes the request countable, not priced. A provider
-// that reports real usage always displaces it, and per-key RPS limiting -- on by
-// default over the whole /v1 group, though an operator can set rps <= 0 for
-// unlimited -- bounds request volume independently.
+// A delivered request that reaches this helper is never charged zero, and every
+// pass-through branch reaches it. The estimate legitimately sizes to nothing on
+// the multipart families: multipartPromptTextBytes counts only the "prompt" form
+// field, which is optional on transcriptions and translations and absent from
+// /images/variations, so the ordinary shape of those requests carries no
+// promptable text. Without the floor a served transcription costs the key
+// nothing, no tokens_used and no TPM draw. The upload is still not measured, for
+// the reason given on multipartPromptTextBytes, so the floor makes the request
+// countable rather than priced. A provider that reports real usage always
+// displaces it, and per-key RPS limiting, on by default over the whole /v1 group
+// unless an operator sets rps <= 0, bounds request volume independently.
 //
 // Returns what was charged and whether the prompt was estimated, for the log.
 func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, completionTokens int, delivered bool) (charged int, estimated bool) {
@@ -441,19 +432,18 @@ func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, complet
 	return chargePrompt + chargeCompletion, estimated
 }
 
-// serveStreamedPassthrough handles SSE and binary shapes: probe the first
-// body byte before committing (breaker failure on a dead 200, clean 502
-// since no headers have been written), then stream through — flushing
-// per-write for SSE only — while retaining an SSE tail for usage metering.
+// serveStreamedPassthrough handles SSE and binary shapes: probe the first body
+// byte before committing (a breaker failure on a dead 200, and a clean 502 since
+// no headers have been written), then stream through, flushing per write for SSE
+// only, while retaining an SSE tail for usage metering.
 func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, isSSE bool, attempt int, responseHeaderMs float64) {
 	logData := st.logData
 
-	// Commit-point probe: a success whose body errors — or ends — before the
-	// first byte is a provider failure, not a success: SSE and binary successes
-	// promise content (audio bytes, events), so an empty body means the
-	// provider broke after committing the status. Only 204/205 legitimately
-	// carry an empty body, and only those pass through — a 201 or 202 promises
-	// content exactly as a 200 does.
+	// Commit-point probe: a success whose body errors or ends before the first
+	// byte is a provider failure. SSE and binary successes promise content
+	// (audio bytes, events), so an empty body means the provider broke after
+	// committing the status. Only 204/205 legitimately carry an empty body and
+	// only those pass through; a 201 or 202 promises content as a 200 does.
 	firstByte := make([]byte, 1)
 	n, readErr := resp.Body.Read(firstByte)
 	emptyBodyIsFailure := !bodilessSuccessStatus(resp.StatusCode) || !errors.Is(readErr, io.EOF)
@@ -474,14 +464,13 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 		h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
 	}
 	// The streamed commit point, matching the buffered one: a first byte out of
-	// the provider is where a 200 stops being a promise. See the twin call in
-	// serveBufferedJSONPassthrough.
+	// the provider is where a 200 stops being a promise.
 	//
 	// Gated on a byte having arrived, which the breaker call above deliberately
-	// is not: they answer different questions. A 204 carrying nothing is a
-	// legitimate HTTP success and the provider is plainly alive, so it belongs in
-	// the breaker's ledger, but it says nothing about whether this MODEL is still
-	// served — the same rule judgeProbeSuccess applies to the probe's own 200s.
+	// is not, because they answer different questions. A 204 carrying nothing is
+	// a legitimate HTTP success and the provider is plainly alive, so it belongs
+	// in the breaker's ledger, but it says nothing about whether this MODEL is
+	// still served, the same rule judgeProbeSuccess applies to the probe's 200s.
 	if n > 0 {
 		h.noteModelServed(candidate.model, logData.endpointType)
 	}
@@ -500,7 +489,7 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 
 	// SSE needs an immediate flush per write (event latency) and a trailing
 	// tail buffer for usage extraction; binary streams use the ResponseWriter's
-	// own buffering — per-chunk flushes would just multiply syscalls.
+	// own buffering, since per-chunk flushes would only multiply syscalls.
 	var tail *tailBuffer
 	var dst io.Writer = w
 	var masker *sseErrorMaskWriter
@@ -550,9 +539,9 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "failed", errMsg)
 		// The provider billed whatever it produced, whether or not the client
 		// stayed to receive it. Bytes reached the client, so an absent usage
-		// report is estimated rather than treated as free: this is the path
+		// report is estimated rather than treated as free. This is the path
 		// audio/mpeg takes, where the SSE tail that would carry usage is never
-		// even allocated, so the report is structurally always absent.
+		// allocated, so the report is structurally always absent.
 		h.chargePassthroughUsage(st, promptTokens, completionTokens, written > 0)
 		return
 	}
@@ -592,8 +581,8 @@ func (h *Handler) finalizePassthroughLog(st *requestState, statusCode, attempt i
 	logData.failoverAttempt = attempt
 	logData.errorMessage = errMsg
 	logData.state = state
-	// Fire-and-forget: skip WaitForInsert to avoid blocking the response path
-	// (mirrors handleNonStreamingResponse).
+	// Fire-and-forget: skip WaitForInsert so the response path is not blocked,
+	// as handleNonStreamingResponse does.
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 }
 
@@ -603,10 +592,11 @@ func (h *Handler) finalizePassthroughLog(st *requestState, statusCode, attempt i
 // usage.total_tokens, used as a last-resort prompt count (Cohere's native
 // rerank bills in search units, not tokens, and meters as zero). Only the
 // usage object is decoded; the response content itself is never inspected.
-// The usage member is lifted out before its counts are read, for two reasons.
-// util.DecodeCounts re-parses the document it is given on each coercion pass,
-// and an embeddings body is large; and reading only those bytes is what makes
-// the sentence above literally true rather than merely intended.
+//
+// The usage member is lifted out before its counts are read, for two reasons:
+// util.DecodeCounts re-parses the document it is given on each coercion pass and
+// an embeddings body is large, and reading only those bytes is what makes the
+// no-content rule above literally true.
 func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 	var envelope struct {
 		Usage json.RawMessage `json:"usage"`
@@ -621,18 +611,18 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 		OutputTokens     int `json:"output_tokens"`
 		TotalTokens      int `json:"total_tokens"`
 	}
-	// util.DecodeCounts, and a shape error keeps what did read, for the reason
-	// given on Usage.UnmarshalJSON: a count quoted or written with a fraction on
-	// it is still a count, and one member this gateway cannot read must not cost
-	// the request every count beside it. Metering a served request as zero is a
-	// quota the caller never spends.
+	// util.DecodeCounts, and a shape error keeps whatever did read, for the
+	// reason given on Usage.UnmarshalJSON: a count quoted or written with a
+	// fraction is still a count, and one unreadable member must not cost the
+	// request every count beside it. Metering a served request as zero is quota
+	// the caller never spends.
 	if err := util.DecodeCounts(envelope.Usage, &usage); err != nil && shapeError(envelope.Usage, err) == nil {
 		return 0, 0
 	}
 	// The fallback stops at the first member the provider SENT, readable or not.
-	// Falling past an unreadable one reported total_tokens as the prompt when
-	// prompt_tokens was the member lost — the same wrong-but-non-zero figure the
-	// translators refuse, and it stops the estimator replacing it.
+	// Falling past an unreadable one reports total_tokens as the prompt when
+	// prompt_tokens is the member lost: a wrong-but-non-zero figure, which also
+	// stops the estimator replacing it.
 	promptTokens = firstSentCount(envelope.Usage,
 		count{"prompt_tokens", usage.PromptTokens},
 		count{"input_tokens", usage.InputTokens},
@@ -679,7 +669,7 @@ type count struct {
 
 // firstSentCount walks a fallback chain and stops at the first member the
 // provider actually sent. A member that was sent but could not be read yields
-// zero rather than deferring to the next: it was meant to carry this figure, and
+// zero rather than deferring to the next: it was meant to carry this figure and
 // the next one is a different number.
 func firstSentCount(raw json.RawMessage, chain ...count) int {
 	for _, c := range chain {

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -11,32 +11,24 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// The multimodal pass-through's per-candidate attempt, split out of
-// multimodal.go when that file hit the size ceiling. The serve pipeline that
-// dispatches a successful attempt stays there.
-
 // attemptPassthroughCandidate runs one failover attempt for a multimodal
 // request: build and send the upstream request, record the circuit-breaker
 // outcome, and either fail over to the next candidate, forward a terminal
-// error, or stream the response through. It is the multimodal counterpart of
-// attemptCandidate, without the chat-specific 400 param-strip auto-retry and
-// SSE transform pipeline.
+// error, or stream the response through.
 func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, attempt, totalCandidates int) candidateOutcome {
 	logData := st.logData
 	// Per-attempt DNS resolution timing, written by SafeDialer via context.
 	var dialMs float64
 	failoverCtx, failoverCancel := context.WithTimeout(r.Context(), st.failoverTimeout)
-	// Own the request context: fires on every return path, after the
-	// pass-through dispatch below has consumed the body.
+	// Fires on every return path, after the pass-through dispatch has
+	// consumed the body.
 	defer failoverCancel()
 	failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
 
-	// A Gemini TTS candidate asked for a response format it cannot produce
-	// is skipped before any request is built, so a group holding a model
-	// that can produce it serves the request; the pre-flight in
-	// servePassthroughPipeline answers the client when no candidate can.
-	// Nothing was contacted, so the skip is recorded on the trail like a
-	// breaker skip and pays no failover backoff.
+	// A Gemini TTS candidate that cannot produce the requested format is
+	// skipped before any request is built, so another candidate in the group
+	// can serve it. Nothing was contacted, so the skip is recorded on the
+	// trail like a breaker skip and pays no failover backoff.
 	if reason := speechRequestRefusal(st, candidate); reason != "" {
 		st.setReqErr(reqError{Kind: KindProviderBadRequest, Attempt: attempt, Provider: candidate.provider.Name, Underlying: reason})
 		logData.failoverAttempt = attempt
@@ -54,11 +46,8 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	}
 
 	// MiniMax reports business errors (rate limit, exhausted plan balance, auth
-	// failures) inside an HTTP 200 envelope, so the status has to be normalised
-	// before anything is judged from it — as attemptCandidate,
-	// probeStreamingCandidate and probeModel all do. This loop was the one that
-	// did not, and the 2xx branch below now clears the model's gone-strike
-	// streak, so a refusal wrapped in a 200 was recorded as the model answering.
+	// failures) inside an HTTP 200 envelope, so the status is normalised before
+	// anything is judged from it.
 	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
 	h.finishAttemptAdmission(st, candidate, resp)
 	logData.noteAttemptStatus(resp.StatusCode)
@@ -71,17 +60,12 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 
 	if isFailoverEligible {
 		if hasMoreCandidates {
-			// The body is discarded anyway, so classify it on the way out — what
-			// attemptCandidate does for chat, and for the same reason: a retired
-			// model usually answers 404, which is failover-eligible, so without
-			// this the "model gone" signal is lost precisely when there is another
-			// candidate to fall back to. Only the LAST candidate in a group
-			// reached forwardUpstreamError and struck, so an embeddings model
-			// anywhere else in a multi-candidate group accrued no strikes at all.
-			//
-			// Bounded, and the cap matters more here than on the chat path that
-			// shares it: these are the multimodal endpoints, where the body behind
-			// an error status can be an image payload rather than a sentence.
+			// The body is discarded anyway, so classify it on the way out: a
+			// retired model usually answers 404, which is failover-eligible, so
+			// without this the "model gone" signal is lost whenever there is
+			// another candidate to fall back to. The read is capped because on
+			// multimodal endpoints the body behind an error status can be an
+			// image payload rather than a sentence.
 			drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
@@ -96,19 +80,18 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 			logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, drainedMsg, rl.phrase, 0)
 			return outcomeFailover
 		}
-		// A saturated 429 on the LAST candidate: wait the seconds the provider
-		// asked for and retry it once, exactly as the chat loop does.
+		// A saturated 429 on the last candidate: wait the seconds the provider
+		// asked for and retry it once.
 		if rl.class == rateLimitSaturated && !st.saturationRetried {
 			return h.deferSaturatedRetry(st, candidate, resp, attempt)
 		}
 	}
 
 	if !servedSuccessStatus(resp.StatusCode) {
-		// A definitive non-failover-eligible error (e.g. 400) means the
-		// provider is alive: credit the circuit before forwarding, matching
-		// chat's recordBreakerOutcome for non-eligible statuses. RecordAlive,
-		// not RecordSuccess: nothing was served, so the 429 behavioural
-		// fallback must not count it as a recent serve.
+		// A non-failover-eligible error (e.g. 400) means the provider is alive:
+		// credit the circuit before forwarding. RecordAlive, not RecordSuccess:
+		// nothing was served, so the 429 behavioural fallback must not count it
+		// as a recent serve.
 		if !isFailoverEligible && st.circuitBreakerEnabled {
 			logData.noteBreaker(breakerAlive)
 			h.circuitBreaker.RecordAlive(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), resp.StatusCode)
@@ -116,12 +99,11 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, isFailoverEligible, responseHeaderMs)
 	}
 
-	// Breaker success for 2xx is recorded inside servePassthroughResponse at
-	// the commit point (the buffered read for JSON, the first body byte for
-	// SSE/binary), so a provider that returns 200 and then stalls or dies
-	// before producing any data still accrues breaker failures. The
-	// gone-strike streak is cleared at those same two points and for the same
-	// reason: 200 headers are a promise, not evidence.
+	// Breaker success for 2xx and the gone-strike clear both happen inside
+	// servePassthroughResponse at the commit point (the buffered read for
+	// JSON, the first body byte for SSE/binary), so a provider that returns
+	// 200 headers and then stalls before producing data still accrues breaker
+	// failures.
 	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"))
 	if st.speechFormat != "" {
 		return h.serveGeminiSpeechResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
@@ -133,27 +115,19 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 // passthroughAnswered reports whether a buffered pass-through response is the
 // model answering, for the purpose of clearing its gone-strike streak.
 //
-// Embeddings is judged on content, by the same function the probe uses. It is
-// the only pass-through family that can be auto-retired, so it is the only one
-// where getting this wrong has a consequence: a provider alternating gone-shaped
-// 404s with 200 {"data":[]} would otherwise reset the count on every empty
-// answer and the model would never be nominated. Same failure
-// chatAnswerCarriesContent closes on the chat path.
-//
-// Everything else is judged on bytes, deliberately: this path forwards image and
-// audio answers verbatim and has no business parsing them. Being generous there
-// costs nothing, because noteModelServed clears the streak for the surface the
-// response arrived on and those surfaces have no streak to clear.
+// Embeddings is judged on content, since it is the only pass-through family
+// that can be auto-retired: a provider alternating gone-shaped 404s with
+// 200 {"data":[]} would otherwise reset the count on every empty answer.
+// Everything else is judged on bytes, because image and audio answers are
+// forwarded verbatim and are not parsed here.
 func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false
 	}
-	// Past the buffer cap, body is a PREFIX: the caller read
-	// passthroughJSONBufferCap+1 bytes and streams the remainder. Truncated JSON
-	// never parses, so handing it to the content check below would report that a
-	// provider which just produced megabytes had answered with nothing — and a
-	// batch embeddings call clears 8 MiB at around 140 inputs of 3072 dimensions,
-	// which is ordinary document-indexing traffic.
+	// Past the buffer cap, body is a prefix: the caller read
+	// passthroughJSONBufferCap+1 bytes and streams the remainder. Truncated
+	// JSON never parses, so the content check below would report a provider
+	// that produced megabytes as having answered with nothing.
 	if len(body) > passthroughJSONBufferCap {
 		return true
 	}

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -51,10 +51,10 @@ func parseMultipartParts(body []byte, boundary string) ([]multipartPart, string,
 			data:        data,
 		}
 		if part.fieldName == "model" && part.fileName == "" {
-			// The form field is raw bytes. The JSON paths get valid UTF-8 for
-			// free from encoding/json; here an invalid byte would reach the
+			// The form field is raw bytes, where the JSON paths get valid UTF-8
+			// for free from encoding/json. An invalid byte would reach the
 			// request-log INSERT verbatim and Postgres refuses it, losing the
-			// row. Replace it the way the JSON decoder would.
+			// row, so it is replaced the way the JSON decoder would.
 			model = strings.ToValidUTF8(strings.TrimSpace(string(data)), "�")
 		}
 		parts = append(parts, part)
@@ -134,8 +134,8 @@ func newMultipartBodyBuilder(parts []multipartPart) func(string) ([]byte, string
 // prompt is the context hint the model conditions on.
 //
 // An allowlist rather than a denylist, because everything else on these forms is
-// configuration -- language, temperature, response_format, size, n, voice,
-// timestamp_granularities -- and charging for it would bill the caller for their
+// configuration (language, temperature, response_format, size, n, voice,
+// timestamp_granularities) and charging for it would bill the caller for their
 // own options. A denylist gets that wrong by default every time a provider adds
 // a parameter, which is the wrong direction for a billing decision to fail in.
 var multipartPromptFields = map[string]bool{"prompt": true}
@@ -184,8 +184,8 @@ func multipartPromptTextBytes(parts []multipartPart) int {
 func (h *Handler) ingestMultipartRequest(w http.ResponseWriter, r *http.Request, endpointType string) (*requestState, []multipartPart, bool) {
 	startTime := time.Now()
 
-	// Create the log entry early so early-return paths can record failures.
-	// modelID gets updated after the multipart form is parsed.
+	// The log entry is created early so early-return paths can record failures;
+	// modelID is filled in once the multipart form is parsed.
 	logData, vkHash := h.newPendingRequestLog(r, endpointType, "", false)
 
 	// Multipart bodies are never buffered by streamingAwareTimeout (the
@@ -239,12 +239,12 @@ func (h *Handler) ingestMultipartRequest(w http.ResponseWriter, r *http.Request,
 	debuglog.Info("proxy: multipart request start", "client_ip", clientip.From(r), "endpoint", endpointType, "model", reqModel, "key", logData.virtualKeyName, "parts", len(parts))
 
 	// bodyBytes stays nil: the parsed parts are the upstream-body source for
-	// multipart requests (via makeUpstreamBody), so retaining the raw body
-	// would pin a redundant full copy of the upload for the request lifetime.
-	// Size the text form fields, skipping the upload itself. Without this
-	// logData.promptTextBytes stays at its zero value for every multipart
-	// request, so the metering estimate downstream silently charges nothing --
-	// the same no-op that the chat-only sizer produced for the JSON families.
+	// multipart requests (via makeUpstreamBody), so retaining the raw body would
+	// pin a redundant full copy of the upload for the request lifetime.
+	//
+	// The text form fields are sized here, skipping the upload itself. Without
+	// it logData.promptTextBytes stays zero for every multipart request and the
+	// metering estimate downstream silently charges nothing.
 	logData.promptTextBytes = multipartPromptTextBytes(parts)
 	logData.content = newContentFence(nil, multipartTextFields(parts)...)
 

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -16,26 +16,23 @@ import (
 )
 
 // This file is the non-streaming half of the proxy: reading an upstream answer
-// once, deciding whether it is a completion, and serving or failing it. Moved
-// here verbatim from proxy.go, which the 2xx-metering change pushed past the
-// 800-line ceiling. The same commit then changed what moved, so read the diff
-// rather than trusting the move to be inert.
+// once, deciding whether it is a completion, and serving or failing it.
 
 // nonStreamingFailureDetail decides what a response that is not a 2xx
 // completion may say about itself: the message stored in the request log
 // (dashboard-visible), the detail handed to the classifier and the debug log,
 // the error kind and the client-facing reason.
 //
-// It takes every response that is not a 2xx completion — any non-2xx whatever
-// its body decodes as, plus a 2xx that is not a chat completion — and the two
-// are NOT treated the same way. Do not merge them back together:
+// It takes every response that is not a 2xx completion (any non-2xx whatever its
+// body decodes as, plus a 2xx that is not a chat completion) and the two are NOT
+// treated the same way. Do not merge them:
 //
 //   - A 2xx body is a completion. It failed to decode (a relay answering 200
 //     with "created":"1699…" or "total_tokens":"12" as a string is the usual
 //     cause) but it still holds the model's generated text, and this gateway
-//     logs no prompt or response content, ever. Only non-content diagnostics
-//     are reported: the decode error, the body length, the content type. The
-//     body itself goes nowhere near the request log or the debug log.
+//     logs no prompt or response content. Only non-content diagnostics are
+//     reported: the decode error, the body length, the content type. The body
+//     itself goes nowhere near the request log or the debug log.
 //
 //   - A non-2xx carries no completion. Its body is the provider's error
 //     document, and that text is the whole reason such a row is worth reading,
@@ -45,34 +42,32 @@ func nonStreamingFailureDetail(ctx context.Context, resp *http.Response, body []
 		if readErr != nil {
 			// A read the provider did not break is not the provider failing. The
 			// body is read under the attempt's context, so a caller hanging up
-			// AND this gateway's own request_timeout both arrive here as read
-			// errors — and reporting either as a provider fault put someone
-			// else's cancellation on the provider's row and, once the breaker
-			// started reading these, its circuit. cancelKind is the package's own
-			// classifier; hand-rolling a narrower one here is what dropped the
-			// deadline case.
+			// and this gateway's own request_timeout both arrive here as read
+			// errors, and reporting either as a provider fault puts someone
+			// else's cancellation on the provider's row and on its circuit.
+			// cancelKind is the package's classifier for that.
 			if kind, aborted := cancelKind(ctx, readErr); aborted {
 				detail = "the request was interrupted before the response was read"
 				return detail, detail, kind, "the request was interrupted"
 			}
 			// A body that died on the wire is not a body this gateway could not
-			// parse, and the two were collapsed into one kind. The parse failure
-			// is provider_bad_request because the answer is probably still in
-			// there; a transport failure is the provider breaking after it
-			// committed the status, which is what the breaker exists to catch —
-			// and classifying it as the parse failure left it uncharged.
+			// parse. The parse failure is provider_bad_request because the answer
+			// is probably still in there; a transport failure is the provider
+			// breaking after it committed the status, which is what the breaker
+			// exists to catch.
 			detail = fmt.Sprintf("upstream body read error: %s (body_bytes=%d)", errString(readErr), len(body))
 			return detail, detail, KindProviderError, "the provider stopped sending its response"
 		}
 		detail = fmt.Sprintf("response decode error: %s (body_bytes=%d, content_type=%q)",
 			errString(decodeErr), len(body), resp.Header.Get("Content-Type"))
 		// Not "upstream provider returned HTTP 200": reporting the status as the
-		// failure sent operators hunting a provider outage that never happened.
+		// failure sends operators hunting a provider outage that is not
+		// happening.
 		return detail, detail, KindProviderBadRequest, "the provider returned a response the gateway could not decode"
 	}
 	detail = util.SanitizeLogBody(string(body), 10000)
 	// The prefix names which of the two ways in led here, so the row does not
-	// report a decode failure for a body that decoded perfectly well.
+	// report a decode failure for a body that decoded.
 	logMsg = fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, detail)
 	if decodeErr != nil {
 		logMsg = fmt.Sprintf("response decode error: %s", detail)
@@ -85,13 +80,13 @@ func nonStreamingFailureDetail(ctx context.Context, resp *http.Response, body []
 // nonStreamingBodyCap bounds the non-streaming completion body held in memory
 // for decoding. Unlike the caps on error bodies (failoverErrorClassifyCap,
 // responsesLearnBodyCap, miniMaxEnvelopeCap) this one guards a legitimate
-// payload, so it is set far above any real answer rather than just above any
-// real error message: 128k output tokens of text is well under 1MB, and the
-// outliers are chat completions carrying base64 image parts, several of which
-// still fit. It is 4x the multimodal pass-through's passthroughJSONBufferCap,
-// which can degrade to an unbuffered stream when a body is too large — this
-// path cannot, since it must decode to meter and normalise, so exceeding the
-// cap fails the request and it is set with that much more headroom.
+// payload, so it sits far above any real answer rather than just above any real
+// error message: 128k output tokens of text is well under 1MB, and the outliers
+// are chat completions carrying base64 image parts, several of which still fit.
+// It is 4x the multimodal pass-through's passthroughJSONBufferCap, which can
+// degrade to an unbuffered stream when a body is too large; this path cannot,
+// since it must decode to meter and normalise, so exceeding the cap fails the
+// request and the cap carries that much more headroom.
 const nonStreamingBodyCap = 32 << 20 // 32MB
 
 func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, proxyOverhead, parseMs, failoverLookupMs, modelLookupMs, providerLookupMs, keyDecryptMs, dialMs, settingsReadMs, responseHeaderMs float64, vkHash string, attempt int) {
@@ -122,11 +117,11 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 	body, chatResp, readErr, decodeErr := readNonStreamingBody(resp, logData.masker)
 
 	// Only a 2xx that decodes is a completion. Some upstreams (OpenCode Zen and
-	// OpenCode Go both do this) answer a failed request with a non-2xx carrying a
-	// complete chat.completion envelope and no error object at all, which decodes
-	// cleanly; forwarding that leaves the caller with a failure status and nothing
-	// to read `.error.message` off. Status decides, the body only says whether the
-	// success shape is even available.
+	// OpenCode Go both do this) answer a failed request with a non-2xx carrying
+	// a complete chat.completion envelope and no error object at all, which
+	// decodes cleanly, and forwarding that leaves the caller with a failure
+	// status and nothing to read `.error.message` off. The status decides; the
+	// body only says whether the success shape is available.
 	switch {
 	case decodeErr == nil && servedSuccessStatus(resp.StatusCode):
 		totalDuration := float64(time.Since(startTime).Microseconds()) / 1000.0
@@ -135,15 +130,14 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		if chatResp.Usage.CompletionTokensDetails != nil && chatResp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			reasoningTokens = chatResp.Usage.CompletionTokensDetails.ReasoningTokens
 		}
-		// Clamped into locals, leaving chatResp alone: the body is re-encoded
-		// to the caller further down, and rewriting a provider's usage block on
-		// the way through is not this gateway's job. The native Anthropic path
-		// forwards the provider's bytes untouched and is the right precedent;
-		// a partial rewrite is worse than none, because the block carries nine
-		// token members and clamping the three the meter reads hands the caller
-		// an arithmetic no provider produced. What the gateway owns is its OWN
-		// state, so the bound applies to the log row, the TPS math and the
-		// charge below, all of which read these locals.
+		// Clamped into locals, leaving chatResp alone: the body is re-encoded to
+		// the caller further down, and rewriting a provider's usage block on the
+		// way through is not this gateway's job, as the native Anthropic path's
+		// untouched forward shows. A partial rewrite is worse than none, since
+		// the block carries nine token members and clamping the three the meter
+		// reads hands the caller an arithmetic no provider produced. The gateway
+		// owns its OWN state, so the bound applies to the log row, the TPS math
+		// and the charge below, all of which read these locals.
 		promptTokens, completionTokens, reasoningTokens := h.clampReportedUsage(chatResp.Usage.PromptTokens, chatResp.Usage.CompletionTokens, reasoningTokens, logData)
 		totalOutputTokens := completionTokens + reasoningTokens
 		generationDuration := totalDuration - responseHeaderMs
@@ -174,34 +168,34 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
 		logData.failoverAttempt = attempt
 		logData.state = "completed"
-		// Whether the model actually answered, judged where the decoded body is in
-		// hand. The failover loop clears the gone-strike streak on it (see
-		// attemptCandidate): a 200 is a status, and a decodable-but-empty
+		// Whether the model actually answered, judged where the decoded body is
+		// in hand. The failover loop clears the gone-strike streak on it (see
+		// attemptCandidate): a 200 is only a status, and a decodable-but-empty
 		// completion is what an aggregator in front of a retired model returns,
-		// resetting the count so the model is never nominated.
+		// which would reset the count so the model is never nominated.
 		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
-		// And the different question the breaker asks of the same body: see
+		// The different question the breaker asks of the same body: see
 		// answerCarriesSomething.
 		logData.emptyCompletion = !answerCarriesSomething(chatResp)
-		// Fire-and-forget: skip WaitForInsert to avoid blocking TTFB.
-		// The async INSERT is very likely complete by now; if not, the
-		// UPDATE simply affects 0 rows (harmless, logged as warning).
+		// Fire-and-forget: skip WaitForInsert so TTFB is not blocked. The async
+		// INSERT is very likely complete by now; if not, the UPDATE affects 0
+		// rows and is logged as a warning.
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 
 		promptTokens, completionTokens, reasoningTokens = estimateMissingUsage(promptTokens, completionTokens, reasoningTokens, logData, chatAnswerBytes(chatResp))
 		h.recordTokenUsage(vkHash, logData, promptTokens, completionTokens, reasoningTokens)
 
-		// Normalize reasoning fields in the response message so that
-		// reasoning_content is always populated regardless of upstream
-		// provider format (Ollama's reasoning, OpenRouter's reasoning_details,
-		// MiniMax's <thinking> tags in content).
+		// Normalize the reasoning fields in the response message so
+		// reasoning_content is always populated whatever the upstream format
+		// (Ollama's reasoning, OpenRouter's reasoning_details, MiniMax's
+		// <thinking> tags in content).
 		for i := range chatResp.Choices {
 			msg := &chatResp.Choices[i].Message
-			// Rule 1: reasoning → reasoning_content
+			// Rule 1: reasoning to reasoning_content.
 			if msg.Reasoning != "" && msg.ReasoningContent == "" {
 				msg.ReasoningContent = msg.Reasoning
 			}
-			// Rule 2: reasoning_details text → reasoning_content
+			// Rule 2: reasoning_details text to reasoning_content.
 			if msg.ReasoningContent == "" && len(msg.ReasoningDetails) > 0 {
 				var texts []string
 				for _, rd := range msg.ReasoningDetails {
@@ -213,7 +207,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 					msg.ReasoningContent = strings.Join(texts, "")
 				}
 			}
-			// Rule 3: <thinking> tags in content → reasoning_content
+			// Rule 3: <thinking> tags in content to reasoning_content.
 			if c, ok := msg.Content.(string); ok && c != "" {
 				if thinking, remaining, found := extractThinkingFromContent(c); found {
 					if msg.ReasoningContent == "" {
@@ -226,19 +220,18 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 			}
 		}
 
-		// A success status the provider chose is kept. The body is the
-		// gateway's own re-encoding either way, but rewriting 201 to 200 would
-		// be this gateway overruling a provider about whether its own answer
-		// was created or merely returned.
+		// A success status the provider chose is kept. The body is the gateway's
+		// own re-encoding either way, but rewriting 201 to 200 would overrule
+		// the provider about whether its own answer was created or merely
+		// returned.
 		if resp.StatusCode != http.StatusOK {
 			w.WriteHeader(resp.StatusCode)
 		}
 		if err := json.NewEncoder(w).Encode(chatResp); err != nil {
 			debuglog.Error("proxy: failed to encode response", "model", logData.modelID, "provider", logData.providerName, "error", err)
 		}
-		// reported_*, because these are the provider's own figures and the row
-		// carries what was recorded: the two differ whenever the bound bit, and
-		// an operator comparing them needs to know which is which.
+		// reported_*, because these are the provider's own figures while the row
+		// carries what was recorded: the two differ whenever the bound bit.
 		debuglog.Info("proxy: non-streaming completed", "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "duration_ms", totalDuration, "reported_prompt_tokens", chatResp.Usage.PromptTokens, "reported_completion_tokens", chatResp.Usage.CompletionTokens)
 	case bodilessSuccessStatus(resp.StatusCode):
 		// A success whose status forbids a body. There is nothing to decode and
@@ -247,8 +240,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// successful, under a status that may not carry one.
 		//
 		// Keyed on the STATUS, not on the body being empty. A 200 with an empty
-		// body is a provider that answered nothing and must keep failing as it
-		// always has (TestHandleNonStreamingResponse_EmptyBody); only 204/205
+		// body is a provider that answered nothing and must fail; only 204/205
 		// promise no body. Any other 2xx carrying something that is not a
 		// completion falls through to the failure branch exactly as a 200 does:
 		// the caller asked for a chat completion, and a success status alone is
@@ -264,13 +256,12 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// Completed, and empty. recordAnswerOutcome credits the provider for a
 		// completed answer unless told otherwise, so without this a relay
 		// answering 204 to every request would be credited a breaker success
-		// each time and its circuit could never open — the group would route to
+		// each time, its circuit could never open, and the group would route to
 		// a black hole for ever.
 		//
-		// deliveredContent is deliberately not set alongside it: it is already
-		// false, and every site that sets it sits on a terminal path that cannot
-		// precede this branch, so writing it here would be a line no mutation
-		// could kill.
+		// deliveredContent is not set alongside it: it is already false, and
+		// every site that sets it sits on a terminal path that cannot precede
+		// this branch.
 		logData.emptyCompletion = true
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 		w.WriteHeader(resp.StatusCode)
@@ -295,7 +286,8 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.errorKind = kind
 		logData.failoverAttempt = attempt
 		logData.state = "failed"
-		// Fire-and-forget: skip WaitForInsert to avoid blocking before error response.
+		// Fire-and-forget: skip WaitForInsert so the error response is not
+		// blocked.
 		h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
 		if debuglog.Level() <= slog.LevelDebug {
 			// Fenced only when the line will be written: the fence's first
@@ -303,8 +295,8 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 			// should not pay for.
 			debuglog.Debug("proxy: non-streaming error details", "status", resp.StatusCode, "error_kind", kind, "model", logData.modelID, "provider", logData.providerName, "error", logData.content.maskOne(detail), "duration_ms", totalDuration)
 		}
-		// The ROW keeps resp.StatusCode above: what the upstream said is the
-		// diagnostic. Only what the CLIENT is told changes.
+		// The row keeps resp.StatusCode above, since what the upstream said is
+		// the diagnostic. Only what the CLIENT is told changes.
 		writeOpenAIError(w, upstreamClientMessage(logData.providerName, resp.StatusCode, reason), nonCompletionClientStatus(resp.StatusCode))
 	}
 }
@@ -316,24 +308,24 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 // A 2xx becomes 502, because the gateway's own error envelope must never travel
 // under a success status. An OpenAI SDK does not raise on a 2xx: it unmarshals
 // the envelope, finds no choices, and hands the caller an empty answer instead
-// of an error. A relay answering 200 with something that is not a completion
-// therefore leaves the request log reading "failed" beside a client that
-// believes it succeeded, and nothing retries and nothing alerts.
+// of an error, so a relay answering 200 with something that is not a completion
+// leaves the request log reading "failed" beside a client that believes it
+// succeeded, with nothing retrying and nothing alerting.
 //
-// 502 rather than any other code because the multimodal pass-through already
-// answers exactly that for the same shape (serveBufferedJSONPassthrough on a
-// broken read, serveStreamedPassthrough on an empty body). The upstream status
-// still reaches the request-log row either way, and reaches the CLIENT only when
-// the provider is named: upstreamClientMessage appends it to the message with
-// the provider, and returns the bare reason without one.
+// 502 rather than another code because the multimodal pass-through answers
+// exactly that for the same shape (serveBufferedJSONPassthrough on a broken
+// read, serveStreamedPassthrough on an empty body). The upstream status still
+// reaches the request-log row either way, and reaches the CLIENT only when the
+// provider is named: upstreamClientMessage appends it to the message with the
+// provider, and returns the bare reason without one.
 //
-// The non-2xx return is defensive rather than live. Every caller reaches this
-// handler through attemptCandidate, which sends anything that is not a 2xx to
-// forwardUpstreamError first (proxy_failover.go), so in production only the 2xx
-// branch runs; the other keeps the function total for a handler driven directly.
+// The non-2xx return is defensive. Every caller reaches this handler through
+// attemptCandidate, which sends anything that is not a 2xx to
+// forwardUpstreamError first (proxy_failover.go), so only the 2xx branch runs in
+// production; the other keeps the function total for a handler driven directly.
 //
-// This is not reached for 204/205, which are served by their own branch, nor for
-// a 2xx that decodes as a completion.
+// This is not reached for 204/205, which have their own branch, nor for a 2xx
+// that decodes as a completion.
 func nonCompletionClientStatus(upstreamStatus int) int {
 	if servedSuccessStatus(upstreamStatus) {
 		return http.StatusBadGateway
@@ -357,9 +349,9 @@ func bodilessSuccessStatus(code int) bool {
 // cap+1 is refused rather than decoded, because a truncated completion
 // re-encoded as a valid one would hand the client silently mutilated content.
 // That refusal is THIS gateway's policy and not the provider failing, so it is
-// reported as a decode failure — folding it into readErr had an oversized answer
-// reported as "the provider stopped sending its response" and its provider's
-// circuit breaker charged for sending too much.
+// reported as a decode failure: folding it into readErr would report an
+// oversized answer as "the provider stopped sending its response" and charge its
+// provider's circuit breaker for sending too much.
 //
 // json.Decoder, not json.Unmarshal: a decoder stops at the end of the first JSON
 // value, so a completion with trailing bytes after it still decodes.
@@ -367,9 +359,9 @@ func bodilessSuccessStatus(code int) bool {
 // The decode is attempted even when the read errored, because JSON is
 // self-delimiting: a provider that sent the whole document and then dropped the
 // connection without its terminal chunk yields ErrUnexpectedEOF from a body that
-// parses perfectly. Discarding that threw away a complete answer and charged the
-// provider for it. If the bytes really were cut short the decode fails too, and
-// the read error is what gets reported. Same salvage rule as #810.
+// parses perfectly, and discarding that throws away a complete answer and
+// charges the provider for it. If the bytes really were cut short the decode
+// fails too, and the read error is what gets reported.
 func readNonStreamingBody(resp *http.Response, masker credentialMasker) (body []byte, chatResp ChatCompletionResponse, readErr, decodeErr error) {
 	body, readErr = io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
 	if readErr == nil && len(body) > nonStreamingBodyCap {
@@ -389,8 +381,8 @@ func readNonStreamingBody(resp *http.Response, masker credentialMasker) (body []
 		return body, chatResp, readErr, err
 	}
 	// readErr is returned as it was rather than cleared. It is only ever
-	// consulted alongside a decode failure — a clean decode means the 2xx branch
-	// serves the answer and never looks at it — so clearing it claimed a
-	// meaning it did not have.
+	// consulted alongside a decode failure, since a clean decode means the 2xx
+	// branch serves the answer without looking at it, so clearing it would claim
+	// a meaning it does not have.
 	return body, chatResp, readErr, nil
 }

--- a/internal/proxy/openai_responses.go
+++ b/internal/proxy/openai_responses.go
@@ -16,17 +16,17 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// The OpenAI Responses re-route (plan: plans/openai-responses-endpoint.md).
+// The OpenAI Responses re-route.
 //
 // OpenAI's newest models reject tools+reasoning over /v1/chat/completions with
 // a 400 that names /v1/responses as the forward path. The proxy self-heals the
 // same way the param-strip retry does (learn from the 400, retry once), then
 // caches the requirement per model so subsequent tools+reasoning requests for
-// that model route to /v1/responses preemptively — hybrid strategy C of the
-// plan: no repeated 400 round-trips. The pro tier is served by /v1/responses
-// alone and refuses the chat endpoint with a 404; that refusal is learned the
-// same way for every request to the model, and the tier's names route there
-// from the first request on OpenAI's own host (see responsesRequirement).
+// that model route to /v1/responses preemptively, without repeating the 400
+// round-trip. The pro tier is served by /v1/responses alone and refuses the
+// chat endpoint with a 404; that refusal is learned the same way for every
+// request to the model, and the tier's names route there from the first request
+// on OpenAI's own host.
 
 // responsesCacheKey mirrors the paramrewrite cache keying.
 func responsesCacheKey(providerType, modelID string) string {
@@ -53,7 +53,7 @@ func (h *Handler) shouldUseResponsesAttempt(st *requestState, candidate modelCan
 	return false
 }
 
-// The two learned requirements (see responsesRequiredCache).
+// The two requirements responsesRequiredCache can hold for a model.
 const (
 	responsesForTools = "tools"
 	responsesAlways   = "always"
@@ -91,10 +91,9 @@ func isOpenAIHost(baseURL string) bool {
 }
 
 // buildResponsesRequest builds the upstream request for a /v1/responses
-// attempt. The chat body is pre-cleaned through the shared rewrite path first
-// so learned param strips/renames (e.g. an unsupported temperature, max_tokens
-// -> max_completion_tokens) still apply before translation — the Responses
-// path has no param-strip self-heal of its own.
+// attempt. The chat body is pre-cleaned through the shared rewrite path first,
+// so learned param strips and renames (e.g. an unsupported temperature,
+// max_tokens -> max_completion_tokens) apply before translation.
 func (h *Handler) buildResponsesRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
 	targetURL := util.BuildProviderTargetURL(candidate.provider.BaseURL, providerType, "/responses")
 	body, err := h.translateResponsesRequestBody(st, candidate, providerType)
@@ -114,9 +113,9 @@ func (h *Handler) buildResponsesRequest(ctx context.Context, st *requestState, c
 }
 
 // translateResponsesRequestBody produces the /v1/responses body for one
-// candidate: shared chat rewrite (model rename, learned strips/renames;
-// isStreaming=false so no stream_options is injected — the Responses API has
-// its own streaming usage semantics), then chat -> Responses translation.
+// candidate: shared chat rewrite (model rename, learned strips and renames,
+// isStreaming=false so no stream_options is injected, since the Responses API
+// has its own streaming usage semantics), then chat to Responses translation.
 func (h *Handler) translateResponsesRequestBody(st *requestState, candidate modelCandidate, providerType string) ([]byte, error) {
 	cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
 	return openairesponses.TranslateChatToResponses(cleaned, candidate.model.ModelID)
@@ -124,12 +123,12 @@ func (h *Handler) translateResponsesRequestBody(st *requestState, candidate mode
 
 // retryWithResponses handles a chat-completions refusal that demands the
 // Responses API, the tools+reasoning 400 or the pro tier's 404: learn the
-// requirement into responsesRequiredCache, rebuild the request
-// as a /v1/responses call and re-issue it once, marking the attempt so the
-// response dispatch translates the answer back. Returns handled=false — with
-// the 400 body restored on resp for the param-strip retry to inspect — when
-// the error is not the Responses rejection (or the request would not re-route
-// anyway). The result contract matches retryWithStrippedParams.
+// requirement into responsesRequiredCache, rebuild the request as a
+// /v1/responses call and re-issue it once, marking the attempt so the response
+// dispatch translates the answer back. When the error is not the Responses
+// rejection (or the request would not re-route anyway) it returns
+// handled=false, with the 400 body restored on resp for the param-strip retry
+// to inspect. The result contract matches retryWithStrippedParams.
 func (h *Handler) retryWithResponses(
 	r *http.Request,
 	st *requestState,
@@ -153,7 +152,7 @@ func (h *Handler) retryWithResponses(
 	// first.
 	body, readErr := readLearnable400(resp)
 	// The helper closed the upstream body and left a buffered reader in its
-	// place, so this close is a no-op — it is here because bodyclose only
+	// place, so this close is a no-op. It is here because bodyclose only
 	// recognises a close applied to the response value in the function that
 	// received it, not the one inside readLearnable400.
 	_ = resp.Body.Close()
@@ -230,7 +229,7 @@ func responsesTargetURL(candidate modelCandidate, providerType string) string {
 // when it is the Responses rejection on a request that would re-route, records
 // the requirement in responsesRequiredCache. Shared by the sequential retry
 // (which then re-issues in place) and the hedged probe, which cannot retry
-// in-race — there the learned flag makes every subsequent request, hedged or
+// in-race: there the learned flag makes every subsequent request, hedged or
 // sequential, route preemptively instead of 400ing again.
 func (h *Handler) learnResponsesRequirement(st *requestState, candidate modelCandidate, providerType string, errBody []byte) bool {
 	if st.responsesAttempt || providerType != "openai" || st.endpointPath != "" || st.makeUpstreamBody != nil {

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -18,34 +18,29 @@ import (
 )
 
 // responsesLearnBodyCap bounds a 400 that has to be parsed rather than scanned.
-// A learnable 404 is read at the classifier's cap instead: the pro tier's
-// refusal is a couple of hundred bytes, and a 404 of any other make is a
-// body the pipeline discards.
-//
-// openairesponses.RequiresResponsesAPI json.Unmarshals the whole error document,
-// so the classifier's window is the wrong size for it: a body cut off mid-JSON
-// does not parse, and the /v1/responses requirement would silently stop being
-// learned. A megabyte is far past any real 400 and still bounded.
+// openairesponses.RequiresResponsesAPI json.Unmarshals the whole error
+// document, so a body cut off mid-JSON does not parse and the /v1/responses
+// requirement is silently not learned. A megabyte is far past any real 400 and
+// still bounded. A learnable 404 is read at the classifier's cap instead.
 const responsesLearnBodyCap = 1 << 20
 
-// paramRetryResult is the outcome of the 400 param-stripping auto-retry
-// (retryWithStrippedParams). It tells the failover loop how to proceed:
-//   - resp: the response to continue handling with — the last retry's response
+// paramRetryResult is the outcome of the 400 param-stripping auto-retry. It
+// tells the failover loop how to proceed:
+//   - resp: the response to continue handling with, the last retry's response
 //     once any retry was issued, otherwise the original 400. Every 400 that
-//     leaves here carries a restored body, so normal non-200 handling can read
-//     it whether it is the original or the one a retry earned.
+//     leaves here carries a restored body.
 //   - retryCancel: the retry context's cancel func, non-nil only when a retry
-//     response is live and its body has NOT yet been consumed. The caller must
+//     response is live and its body has not yet been consumed. The caller must
 //     call it after consuming the body.
 //   - streamCancelOrigin: "retry_timeout" once a retry was issued, otherwise
 //     the caller's original value, unchanged.
 //   - retried: true once a retry request was issued and answered, whatever it
-//     answered with — the caller must fold the retries' dial time into the
-//     running totals.
+//     answered with. The caller folds the retries' dial time into the running
+//     totals.
 //   - lastReqErr: set only when cont is true; the structured cause the caller
 //     records via st.setReqErr before failing over.
-//   - cont: true => the caller should `continue` to the next candidate (a retry
-//     request could not be created or failed).
+//   - cont: true means the caller should continue to the next candidate (a
+//     retry request could not be created or failed).
 type paramRetryResult struct {
 	resp               *http.Response
 	retryCancel        context.CancelFunc
@@ -66,18 +61,13 @@ func learnedScopeFor(candidate modelCandidate) string {
 	return candidate.provider.ID.String()
 }
 
-// candidateModelID reads a candidate's upstream model id for diagnostics.
-// recordBreakerOutcome is reached on paths that only carry the provider, so the
-// model must never be assumed present.
+// candidateModelID reads a candidate's upstream model id for diagnostics. Some
+// paths carry only the provider, so the model is never assumed present.
 //
-// The empty string it falls back to is not inert: the breaker keys a circuit by
-// this id, so a modelless candidate charges the "" circuit, and that circuit
-// counts toward the span that indicts the provider. Every candidate the failover
-// loop routes carries a model, so reaching this branch means a candidate was
-// assembled without one and the breaker is now attributing that provider's
-// health to a key nothing routes by. It is logged at error, with routing
-// metadata only, because nothing downstream can tell the operator which model
-// went missing.
+// The empty-string fallback is not inert: the breaker keys a circuit by this
+// id, so a modelless candidate charges the "" circuit, which counts toward
+// the provider-wide span (SpanModels). Every candidate the
+// failover loop routes carries a model, so the fallback is logged at error.
 func candidateModelID(candidate modelCandidate) string {
 	if candidate.model == nil {
 		providerName, providerID := "", ""
@@ -91,36 +81,29 @@ func candidateModelID(candidate modelCandidate) string {
 }
 
 // retryLearnable400 picks the self-heal that fits what this attempt actually
-// sent, and reports handled=false when none does. Each family can only read the
+// sent, and reports handled=false when none does. Each family may only read the
 // dialect it speaks: a 400 names the fields of the request that earned it, so a
-// reading taken from the wrong dialect is not merely useless but harmful — a
 // param mislearned from a Messages 400 would poison the compat path for that
 // model on every later request.
 //
 // Chat-completions attempts get two, in this order: retryWithResponses runs
-// BEFORE the param retry because a Responses-required 400 names
-// reasoning_effort, which the param parser would otherwise learn as a strip
-// (useless on reason-by-default models). The param retry itself works
-// universally — any LLM API naming "temperature" or "top_p" in a 400 can only
-// mean the sampling parameter — but it rebuilds the OpenAI-shaped st.bodyBytes
-// and re-POSTs it to the same targetURL, which for a native /v1/messages or
-// generateContent route would be a malformed request.
+// before the param retry, because a Responses-required 400 names
+// reasoning_effort, which the param parser would otherwise learn as a strip.
+// The param retry rebuilds the OpenAI-shaped st.bodyBytes and re-POSTs it to
+// the same targetURL, which for a native /v1/messages or generateContent route
+// would be malformed.
 //
-// A /v1/responses attempt gets the param retry too: OpenAI names the
-// parameter there by the same quoted name it uses on chat-completions
-// ("Unsupported parameter: 'temperature' is not supported with this model"),
-// and the retry rebuilds the body in the Responses dialect. A pro-tier model
-// is served by that route alone, so without this a client sending
-// temperature could never reach it at all. What keeps a Responses-only
-// field from being mislearned onto the compat path is that the Responses
-// body is a closed struct (openairesponses.Request) sharing only the
-// sampling names with chat-completions, plus one exception handled by name:
-// see responsesRejectedParams. The reroute learned on this very attempt gets
-// it as well, on the 400 its rebuilt request may earn.
+// A /v1/responses attempt gets the param retry too: OpenAI names the parameter
+// there by the same quoted name it uses on chat-completions ("Unsupported
+// parameter: 'temperature' is not supported with this model"), and the retry
+// rebuilds the body in the Responses dialect. A pro-tier model is served by
+// that route alone, so without this a client sending temperature cannot reach
+// it. responsesRejectedParams keeps the one ambiguous name from being
+// mislearned onto the compat path.
 //
 // Anthropic egress attempts get the one 400 that route can fix by asking
-// differently: a model refusing the extended-thinking shape it was asked in
-// (anthropic_thinking_retry.go). Every other Messages 400 is left alone.
+// differently: a model refusing the extended-thinking shape it was asked in.
+// Every other Messages 400 is left alone.
 func (h *Handler) retryLearnable400(
 	r *http.Request,
 	st *requestState,
@@ -142,18 +125,14 @@ func (h *Handler) retryLearnable400(
 			res = h.retryWithStrippedParams(r, st, candidate, providerType, targetURL, resp, attempt, dialMs, failoverCancel, streamCancelOrigin)
 		case res.retried && res.resp != nil && res.resp.StatusCode == http.StatusBadRequest:
 			// The rebuilt Responses request was refused in turn. It is a
-			// Responses attempt now (retryWithResponses marked it), so this
-			// is the same self-heal the responsesAttempt case below runs
-			// for a preemptively routed request, on the reroute's own 400:
-			// a first request to a pro-tier model that carries temperature
-			// otherwise came back 400 once and healed only from the second.
-			// The reroute's context owns the body being read; the learner
-			// releases it once the body is buffered, as it does the
-			// attempt's own context on the direct path.
+			// Responses attempt now (retryWithResponses marked it), so the
+			// param self-heal runs on the reroute's own 400, letting a
+			// first request to a pro-tier model carrying temperature heal
+			// inside one attempt. The reroute's context owns the body being
+			// read; the learner releases it once the body is buffered.
 			res = h.retryWithStrippedParams(r, st, candidate, providerType, responsesTargetURL(candidate, providerType), res.resp, attempt, dialMs, res.retryCancel, res.streamCancelOrigin)
 			// The reroute was a retry whatever the chained self-heal did
-			// next; its fresh result must not report the attempt as never
-			// re-issued (the caller folds the dial time on that).
+			// next, and the caller folds the retries' dial time on this flag.
 			res.retried = true
 		}
 		return res, true
@@ -165,20 +144,19 @@ func (h *Handler) retryLearnable400(
 
 // learnRejectedParams caches the params and renames a 400 body names, so later
 // requests to the same provider+model are built without them. It is the
-// learning half of retryWithStrippedParams, split out for callers that cannot
-// retry in place (a hedged probe, which must not spend a second round-trip
-// inside one race slot).
+// learning half of retryWithStrippedParams, for callers that cannot retry
+// in place (a hedged probe, which must not spend a second round-trip inside one
+// race slot).
 func (h *Handler) learnRejectedParams(candidate modelCandidate, body []byte) {
 	h.mergeLearnedParams(candidate, paramrewrite.ParseProviderParamError(body), paramrewrite.ParseProviderParamRename(body))
 }
 
-// responsesRejectedParams reads a Responses-dialect 400 for the param
-// learner. "reasoning" is the one name both dialects carry that means
-// different things: on chat-completions it is a caller's object, on the
-// Responses body the translator regenerates it from reasoning_effort on every
-// request, so a strip learned from that 400 would delete the caller's object
-// on the compat path (the learned scope is provider+model, shared by both
-// dialects) and never fix the Responses request that taught it.
+// responsesRejectedParams reads a Responses-dialect 400 for the param learner.
+// "reasoning" is the one name both dialects carry that means different things:
+// on chat-completions it is a caller's object, on the Responses body the
+// translator regenerates it from reasoning_effort. The learned scope is
+// provider+model and shared by both dialects, so a strip learned from that 400
+// would delete the caller's object on the compat path.
 func responsesRejectedParams(body []byte) map[string]bool {
 	rejected := paramrewrite.ParseProviderParamError(body)
 	delete(rejected, "reasoning")
@@ -212,11 +190,10 @@ func (h *Handler) mergeLearnedParams(candidate modelCandidate, rejected map[stri
 // to something this self-heal cannot fix, and the 400 belongs to the client.
 const paramRetryRounds = 2
 
-// retryMinRound is the least budget a self-heal round is issued with. A
-// round cut shorter than this cannot finish a connect and a first byte,
-// so issuing it only has the provider start work the gateway then abandons
-// and turns the refusal in hand into a timeout; the loop's own smallest
-// interval is the same 100ms (failoverBackoff).
+// retryMinRound is the least budget a self-heal round is issued with. A round
+// cut shorter than this cannot finish a connect and a first byte, so it would
+// only have the provider start work the gateway then abandons. 100ms matches
+// failoverBackoff, the loop's own smallest interval.
 const retryMinRound = 100 * time.Millisecond
 
 // issueParamRetry rebuilds the upstream body with strip applied on top of the
@@ -236,12 +213,11 @@ func (h *Handler) issueParamRetry(
 	attempt int,
 	dialMs *float64,
 ) (*http.Response, context.CancelFunc, *reqError) {
-	// Rebuild the request body using the shared rewrite path. This ensures
-	// stream_options injection, provider injection, universal/learned param
-	// stripping, and learned renaming are all applied on retry, preventing drift
-	// from the initial attempt path. The renames just cached are picked up from
-	// paramRenameCache; the rejected params learned so far are also passed as
-	// extraStrip so the retry drops them even before the cache writes are observed.
+	// Rebuild through the shared rewrite path, so stream_options injection,
+	// provider injection, universal and learned param stripping and learned
+	// renaming all apply on retry too. The renames just cached come from
+	// paramRenameCache; the rejected params learned so far are passed as
+	// extraStrip so the retry drops them before the cache writes are observed.
 	rebuilt, err := h.rebuildForParamRetry(st, candidate, providerType, strip)
 	if err != nil {
 		return nil, nil, &reqError{Kind: KindInternal, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)}
@@ -283,11 +259,11 @@ func (h *Handler) issueParamRetry(
 	return retryResp, rc, nil
 }
 
-// rebuildForParamRetry is the retry's body in the attempt's dialect. The
-// Responses translation runs on the rewritten chat body the same way
-// translateResponsesRequestBody does for a first attempt (no stream_options,
-// the Responses API has its own streaming usage semantics), with the params
-// just learned stripped ahead of the cache writes being observed.
+// rebuildForParamRetry builds the retry's body in the attempt's dialect, with
+// the params just learned stripped ahead of the cache writes being observed.
+// The Responses translation runs on the rewritten chat body and injects no
+// stream_options, since the Responses API has its own streaming usage
+// semantics.
 func (h *Handler) rebuildForParamRetry(st *requestState, candidate modelCandidate, providerType string, strip map[string]bool) ([]byte, error) {
 	if st.responsesAttempt {
 		cleaned := paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, false, &h.deprecationCache, &h.paramRenameCache, strip, learnedScopeFor(candidate))
@@ -297,14 +273,11 @@ func (h *Handler) rebuildForParamRetry(st *requestState, candidate modelCandidat
 }
 
 // retryContext is the context one self-heal round runs under: the attempt's
-// failover budget, cut at the request's overall deadline. Every round opens
-// a fresh budget, and an attempt can chain several (the Responses reroute
-// and up to paramRetryRounds strips, or the Messages thinking retry), while
-// the loop consults the overall deadline only between attempts; without the
-// cut, one candidate could hold the request for several budgets past the
-// point the loop would have given up. A state that never set the deadline
-// keeps the plain budget; every request the handlers build sets it, so that
-// case is the unit tests' bare state.
+// failover budget, cut at the request's overall deadline. Every round opens a
+// fresh budget and an attempt can chain several, while the loop consults the
+// overall deadline only between attempts, so without the cut one candidate
+// could hold the request for several budgets past the point the loop would have
+// given up. A state that never set the deadline keeps the plain budget.
 func retryContext(r *http.Request, st *requestState) (context.Context, context.CancelFunc) {
 	deadline := time.Now().Add(st.failoverTimeout)
 	if !st.overallDeadline.IsZero() && st.overallDeadline.Before(deadline) {
@@ -316,15 +289,13 @@ func retryContext(r *http.Request, st *requestState) (context.Context, context.C
 
 // readLearnable400 consumes a 400 body for the param self-heal: it reads what
 // the learner can parse, drains the rest so the connection stays reusable,
-// closes the original body and restores a readable one in its place — the
+// closes the original body and restores a readable one in its place. The
 // response is handed on to whoever renders the client's error, so it must never
 // leave here empty.
 //
-// The bound is the parse-sized responsesLearnBodyCap rather than the
-// scan-sized failoverErrorClassifyCap: learning json.Unmarshals the whole
-// document, so a body cut mid-JSON parses to nothing and teaches nothing. The
-// cap sits far past any real provider error, and everything above it is
-// discarded rather than held.
+// The bound is the parse-sized responsesLearnBodyCap rather than the scan-sized
+// failoverErrorClassifyCap: learning json.Unmarshals the whole document, so a
+// body cut mid-JSON teaches nothing. Everything above the cap is discarded.
 func readLearnable400(resp *http.Response) ([]byte, error) {
 	limit := int64(responsesLearnBodyCap)
 	if resp.StatusCode != http.StatusBadRequest {
@@ -338,13 +309,12 @@ func readLearnable400(resp *http.Response) ([]byte, error) {
 }
 
 // retryWithStrippedParams handles a 400 from an upstream: it reads and restores
-// the error body, cancels the original (now-finished) request context, and — if
-// the body is a recognizable param-rejection — learns the rejected params and
-// renames into the deprecation/rename caches, rebuilds the request with them
-// applied, and re-issues it. A retry that is itself rejected with a 400 is read
-// and learned from in exactly the same way, and re-issued once more when it
-// names a param the retry did not already carry. See paramRetryResult for how
-// the loop interprets the return value.
+// the error body, cancels the original (now-finished) request context, and,
+// when the body is a recognizable param rejection, learns the rejected params
+// and renames into the deprecation/rename caches, rebuilds the request with
+// them applied and re-issues it. A retry that is itself rejected with a 400 is
+// read and learned from the same way, and re-issued once more when it names a
+// param the retry did not already carry.
 //
 // failoverCancel is the original request's cancel func; it is invoked here once
 // the 400 body has been consumed. dialMs is the per-request dial-timing pointer
@@ -373,16 +343,16 @@ func (h *Handler) retryWithStrippedParams(
 
 	// Everything applied to the outgoing body so far, accumulated across rounds:
 	// strip holds the rejected params (dropped), renamed the moves (value kept
-	// under the new name). They are also the termination guard — a round is only
+	// under the new name). They are also the termination guard: a round is only
 	// worth issuing when a 400 names something outside these sets.
 	strip := map[string]bool{}
 	renamed := map[string]string{}
 
-	// A 400 can ask us to drop a param (rejected → strip) and/or move a param to
-	// a new name (rename → preserve value). Both feed the same self-heal: learn,
-	// cache for future preemptive application, and retry. learnFrom does the
-	// learning half for one 400 body and reports whether that body named anything
-	// the request does not already carry — i.e. whether re-issuing could help.
+	// A 400 can ask for a param to be dropped and/or moved to a new name (value
+	// preserved). Both feed the same self-heal: learn, cache for future
+	// preemptive application, and retry. learnFrom does the learning half for
+	// one 400 body and reports whether that body named anything the request does
+	// not already carry, that is, whether re-issuing could help.
 	learnFrom := func(errBody []byte) bool {
 		var rejected map[string]bool
 		if st.responsesAttempt {
@@ -395,9 +365,8 @@ func (h *Handler) retryWithStrippedParams(
 			return false
 		}
 		// Cache the learned rejections and renames for future preemptive
-		// application. Each cache is merged with any existing entries via
-		// CompareAndSwap to avoid data races from concurrent goroutines mutating
-		// the same map.
+		// application. Each cache merges with its existing entries via
+		// CompareAndSwap, so concurrent goroutines never mutate the same map.
 		h.mergeLearnedParams(candidate, rejected, renames)
 		progressed := false
 		for p := range rejected {
@@ -418,15 +387,13 @@ func (h *Handler) retryWithStrippedParams(
 	// Two guards, both required, so the loop always terminates: at most
 	// paramRetryRounds rounds, and a round only when the current 400 names
 	// something the request does not already carry (learnFrom's report), which
-	// makes strip∪renamed grow strictly on every iteration.
+	// makes strip and renamed grow strictly on every iteration.
 	//
-	// learnFrom runs before the round check on purpose — it is the left operand,
-	// so it is evaluated even on the iteration that ends the loop. That is what
-	// makes the last 400 learned rather than discarded: the round it would have
-	// paid for is refused, but the next request still starts with what it named.
-	//
-	// The first 400 that names nothing recognisable falls straight out here and
-	// is handed back untouched.
+	// learnFrom is the left operand so it is evaluated even on the iteration
+	// that ends the loop, which is what makes the last 400 learned rather than
+	// discarded: the round it would have paid for is refused, but the next
+	// request still starts with what it named. A 400 that names nothing
+	// recognisable falls straight out and is handed back untouched.
 	for round := 0; learnFrom(body) && round < paramRetryRounds && st.retryBudgetLeft(); round++ {
 		res.streamCancelOrigin = "retry_timeout"
 		retryResp, rc, retryErr := h.issueParamRetry(r, st, candidate, providerType, targetURL, strip, attempt, dialMs)
@@ -436,8 +403,8 @@ func (h *Handler) retryWithStrippedParams(
 			return res
 		}
 		if retryResp.StatusCode != http.StatusBadRequest {
-			// rc must NOT be called here — retryResp.Body is read by the caller.
-			// It is returned for deferred cleanup after body consumption.
+			// rc must not be called here: retryResp.Body is read by the caller,
+			// which cancels once it has consumed the body.
 			res.resp = retryResp
 			res.retryCancel = rc
 			res.retried = true

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -61,7 +61,8 @@ func learnedScopeFor(candidate modelCandidate) string {
 	return candidate.provider.ID.String()
 }
 
-// candidateModelID reads a candidate's upstream model id for diagnostics. Some
+// candidateModelID reads a candidate's upstream model id for the breaker key,
+// the metrics and the attempt trail. Some
 // paths carry only the provider, so the model is never assumed present.
 //
 // The empty-string fallback is not inert: the breaker keys a circuit by this
@@ -142,11 +143,11 @@ func (h *Handler) retryLearnable400(
 	return paramRetryResult{resp: resp, streamCancelOrigin: streamCancelOrigin}, false
 }
 
-// learnRejectedParams caches the params and renames a 400 body names, so later
+// learnRejectedParams caches the params and renames that a 400 body names, so later
 // requests to the same provider+model are built without them. It is the
-// learning half of retryWithStrippedParams, for callers that cannot retry
-// in place (a hedged probe, which must not spend a second round-trip inside one
-// race slot).
+// learning half of retryWithStrippedParams, for callers that cannot use it:
+// a hedged probe, which must not spend a second round-trip inside one race
+// slot, and the Messages path, which rebuilds in its own dialect.
 func (h *Handler) learnRejectedParams(candidate modelCandidate, body []byte) {
 	h.mergeLearnedParams(candidate, paramrewrite.ParseProviderParamError(body), paramrewrite.ParseProviderParamRename(body))
 }

--- a/internal/proxy/passthrough_sse_mask.go
+++ b/internal/proxy/passthrough_sse_mask.go
@@ -36,11 +36,11 @@ func (t *tailBuffer) Bytes() []byte {
 	return t.buf
 }
 
-// sseErrorMaskEventCap bounds how much of one SSE event the masking writer
-// holds back before giving up on it and passing the rest of that event
-// through raw. It matches the per-line cap of the chat stream reader; a sane
-// error frame is orders of magnitude smaller, and a partial-image event that
-// long is not something the mask should ever touch.
+// sseErrorMaskEventCap bounds how much of one SSE event the masking writer holds
+// back before giving up and passing the rest of that event through raw. It
+// matches the per-line cap of the chat stream reader: a sane error frame is
+// orders of magnitude smaller, and a partial-image event that long is not
+// something the mask should touch.
 const sseErrorMaskEventCap = 4 << 20
 
 // sseErrorMaskWriter is an io.Writer that forwards a pass-through SSE stream
@@ -51,14 +51,14 @@ const sseErrorMaskEventCap = 4 << 20
 // key-shape regex on error frames.
 //
 // It works per event rather than per line because SSE lets one payload span
-// several `data:` lines (joined with "\n"); judging each line alone would let
-// an error object split across two lines through unmasked. An event is held
+// several `data:` lines (joined with "\n"), and judging each line alone would
+// let an error object split across two lines through unmasked. An event is held
 // until its blank-line delimiter, then either forwarded byte-identical (the
-// common case: content events, multi-MB base64 partial images that must never
-// meet the mask's prefix regex) or, when the joined payload is a JSON object
-// carrying an "error" member and masking changes it, re-emitted with its
-// non-data lines intact and canonical "data: " lines. An event that
-// grows past sseErrorMaskEventCap is passed through raw from that point.
+// common case: content events, and multi-MB base64 partial images that must
+// never meet the mask's prefix regex) or, when the joined payload is a JSON
+// object carrying an "error" member and masking changes it, re-emitted with its
+// non-data lines intact and canonical "data: " lines. An event that grows past
+// sseErrorMaskEventCap is passed through raw from that point.
 //
 // Write returns len(p) on success. On a downstream error it returns only the
 // input bytes whose event was fully written, so the caller's byte count is a
@@ -162,11 +162,11 @@ func (m *sseErrorMaskWriter) Flush() error {
 }
 
 // spill abandons masking for the event in progress: everything buffered goes
-// downstream raw and the remainder of the event is passed through as it
-// arrives. Only reached when an event outgrows sseErrorMaskEventCap. Raw
-// mode keeps the candidate's key out (rawOut) and nothing else: an error
-// event past 4 MiB is not a shape any provider sends, so that is a
-// documented limit rather than a path worth a held-set pass per chunk.
+// downstream raw and the remainder of the event passes through as it arrives.
+// Only reached when an event outgrows sseErrorMaskEventCap. Raw mode keeps the
+// candidate's key out (rawOut) and nothing else: an error event past 4 MiB is
+// not a shape any provider sends, so that is a documented limit rather than a
+// path worth a held-set pass per chunk.
 func (m *sseErrorMaskWriter) spill() error {
 	var out []byte
 	for _, l := range m.event {
@@ -193,8 +193,8 @@ func (m *sseErrorMaskWriter) emitEvent(delimiter []byte) error {
 			out = append(out, l...)
 		}
 		// An event whose data is not a JSON object is not content this
-		// gateway forwards (content frames are JSON); a bare "error: bad api
-		// key ..." line is error text, so every held provider key is masked
+		// gateway forwards, since content frames are JSON; a bare "error: bad
+		// api key ..." line is error text, so every held provider key is masked
 		// out of it. Exact keys only: no regex over prose here.
 		if payload := sseDataPayload(lines); len(payload) > 0 && payload[0] != '{' && !bytes.Equal(payload, []byte("[DONE]")) {
 			out = m.cred.maskAll(out)
@@ -222,10 +222,10 @@ func isSSEBlankLine(line []byte) bool {
 
 // maskSSEErrorEvent joins the event's `data:` payloads per the SSE spec and,
 // when the result is a JSON object with a non-null "error" member that
-// cred.mask changes, returns the event re-serialised: non-data lines
-// in their original order and framing, then canonical "data: " lines carrying
-// the masked payload, one per physical line of the original. ok is false when the event is to be forwarded
-// verbatim.
+// cred.mask changes, returns the event re-serialised: non-data lines in their
+// original order and framing, then canonical "data: " lines carrying the masked
+// payload, one per physical line of the original. ok is false when the event is
+// to be forwarded verbatim.
 func maskSSEErrorEvent(lines [][]byte, cred credentialMasker) (out []byte, ok bool) {
 	payload, eol, dataLines := sseDataPayloadEOL(lines)
 	if dataLines == 0 || len(payload) == 0 || payload[0] != '{' || !bytes.Contains(payload, []byte(`"error"`)) {

--- a/internal/proxy/phrase_staleness.go
+++ b/internal/proxy/phrase_staleness.go
@@ -11,21 +11,18 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
-// The rate-limit phrase table is data, and data rots: a provider rewrites its
-// error text and the entry keeps matching nothing, silently. The attempt trail
-// records which phrase decided each 429 (attemptRecord.Phrase), so once a day
-// the table is checked against it and any phrase that has matched nothing in
-// PhraseStalenessHorizon is named in the app log, where an operator reads it
-// as a maintenance report rather than finding out from the next incident.
+// The attempt trail records which phrase decided each 429
+// (attemptRecord.Phrase). This file checks the rate-limit phrase table against
+// that trail daily and names any phrase that has matched nothing in
+// PhraseStalenessHorizon, which points at a provider that rewrote its error
+// text.
 
 // PhraseStalenessHorizon is how long a phrase may go unmatched before it is
-// reported. Ninety days: long enough to cover a provider an operator only
-// touches quarterly, short enough that a rewritten error text is noticed
-// inside a season.
+// reported. Ninety days covers a provider an operator only touches quarterly.
 const PhraseStalenessHorizon = 90 * 24 * time.Hour
 
-// StalePhrase is one table entry the report names: the phrase, who it was
-// observed on and when it was added.
+// StalePhrase is one table entry the report names: the phrase, the provider it
+// was observed on and when it was added.
 type StalePhrase struct {
 	Phrase   string
 	Provider string
@@ -34,9 +31,7 @@ type StalePhrase struct {
 
 // StalePhrases lists the phrase-table entries that have matched no attempt in
 // the horizon ending at now. An entry added inside the horizon is never stale:
-// it has not had the horizon to prove itself, and the table's own dates are
-// the only evidence from before the trail existed. Each phrase costs one
-// indexed containment probe on request_logs.attempts.
+// it has not had the horizon to prove itself.
 func StalePhrases(ctx context.Context, pool *pgxpool.Pool, now time.Time) ([]StalePhrase, error) {
 	since := now.Add(-PhraseStalenessHorizon)
 	var stale []StalePhrase
@@ -56,11 +51,11 @@ func StalePhrases(ctx context.Context, pool *pgxpool.Pool, now time.Time) ([]Sta
 }
 
 // phraseMatchedSince reports whether any attempt trail written since the
-// instant names the phrase. The containment predicate is what the GIN index on
-// attempts serves; created_at bounds the scan the way the logs page does.
+// instant names the phrase. The containment predicate is served by the GIN
+// index on attempts; created_at bounds the scan.
 func phraseMatchedSince(ctx context.Context, pool *pgxpool.Pool, phrase string, since time.Time) (bool, error) {
 	// json.Marshal, not %q: Go's quoting is not JSON quoting, and a phrase
-	// with a byte outside JSON's escapes would abort the whole daily report.
+	// with a byte outside JSON's escapes would abort the report.
 	needle, err := json.Marshal([]map[string]string{{"phrase": phrase}})
 	if err != nil {
 		return false, err
@@ -75,8 +70,7 @@ func phraseMatchedSince(ctx context.Context, pool *pgxpool.Pool, phrase string, 
 }
 
 // ReportStalePhrases runs the check once and logs the result: one Warn naming
-// every stale phrase, or a Debug saying the table is healthy. It is the daily
-// maintenance report the phrase table's design asks for.
+// every stale phrase, or a Debug saying the table is healthy.
 func ReportStalePhrases(ctx context.Context, pool *pgxpool.Pool, now time.Time) {
 	stale, err := StalePhrases(ctx, pool, now)
 	if err != nil {
@@ -95,8 +89,7 @@ func ReportStalePhrases(ctx context.Context, pool *pgxpool.Pool, now time.Time) 
 }
 
 // PhraseStalenessLoop reports once shortly after start and then daily, until
-// ctx ends. Started from the server's background loops beside the stale-log
-// sweep.
+// ctx ends.
 func PhraseStalenessLoop(ctx context.Context, pool *pgxpool.Pool) {
 	phraseStalenessLoop(ctx, pool, 10*time.Minute, 24*time.Hour)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -22,10 +22,10 @@ import (
 // newRequestWithContext is injectable for testing request creation errors.
 var newRequestWithContext = http.NewRequestWithContext
 
-// failRequest populates logData with failure details and updates the request log.
-// Always populates all timing fields from timings - if zero-valued, they record as 0ms.
-// kind is the machine-readable classification (a required argument so no failure
-// path can silently omit it); it is stored in request_logs.error_kind.
+// failRequest populates logData with failure details and updates the request
+// log. Every timing field is written from timings, recording 0ms when unset.
+// kind is the machine-readable classification stored in
+// request_logs.error_kind, required so no failure path can omit it.
 func (h *Handler) failRequest(logData *requestLogData, statusCode int, kind ErrorKind, errMsg string, attempt int, startTime time.Time, parseMs float64, timings resolveTimings, cacheHits resolveCacheHits, proxyOverhead float64) {
 	logData.statusCode = statusCode
 	logData.errorKind = kind
@@ -82,8 +82,8 @@ type attemptFn func(w http.ResponseWriter, r *http.Request, st *requestState, ca
 // candidate, and the all-exhausted failure path.
 func (h *Handler) runFailoverLoop(w http.ResponseWriter, r *http.Request, st *requestState, candidates []modelCandidate, attemptOne attemptFn) {
 	// Candidates skipped at their provider's learned in-flight window: no
-	// request was made, so when everything else is spent too they are worth
-	// waiting for — a slot freeing on any of them is the request's way through.
+	// request was made, so when everything else is spent they are worth waiting
+	// for, since a slot freeing on any of them is the request's way through.
 	var busyCandidates []modelCandidate
 	// contacted counts candidates a request was actually sent to: the
 	// exponential backoff protects providers that answered with failures, and
@@ -132,7 +132,7 @@ func (h *Handler) runFailoverLoop(w http.ResponseWriter, r *http.Request, st *re
 				debuglog.Info("proxy: client disconnected during failover backoff", "model", st.logData.modelID, "provider", st.logData.providerName, "attempt", attempt+1)
 				// Carry the prior attempt's provider error (if any) so the log
 				// shows what was failing when the client gave up. 499 (client
-				// closed request) on both the log and the wire — see plan §7.
+				// closed request) on both the log and the wire.
 				st.setReqErr(reqError{Kind: KindClientDisconnect, Attempt: attempt - 1, Provider: st.logData.providerName, Underlying: st.lastReqErr.Underlying})
 				h.failRequest(st.logData, statusClientClosedRequest, KindClientDisconnect, st.lastErr, attempt-1, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
 				writeOpenAIError(w, "client disconnected", statusClientClosedRequest)
@@ -173,12 +173,11 @@ func (h *Handler) runFailoverLoop(w http.ResponseWriter, r *http.Request, st *re
 
 // retryAfterSlotFrees is the all-busy arm of the loop: every remaining live
 // candidate sat at its provider's learned in-flight window, so instead of
-// failing a request nothing upstream refused, wait for the first slot to free
-// on ANY of them (bounded by rate_limit_saturation_max_wait and the overall
-// deadline) and send there. This is the only place strict priority order is
-// not honoured, and only because the preferred entry had no slot to honour it
-// with: the walk below still prefers earlier entries whenever both have room.
-// Reports true when the request was answered.
+// failing a request nothing upstream refused, it waits for the first slot to
+// free on any of them (bounded by rate_limit_saturation_max_wait and the
+// overall deadline) and sends there. This is the only place strict priority
+// order is not honoured; the walk below still prefers earlier entries whenever
+// both have room. Reports true when the request was answered.
 func (h *Handler) retryAfterSlotFrees(w http.ResponseWriter, r *http.Request, st *requestState, busy []modelCandidate, numCandidates int, attemptOne attemptFn) bool {
 	deadline := time.Now().Add(h.settingsRepo.GetDuration(r.Context(), "rate_limit_saturation_max_wait", defaultSaturationMaxWait))
 	if st.overallDeadline.Before(deadline) {
@@ -224,7 +223,7 @@ func (h *Handler) retryAfterSlotFrees(w http.ResponseWriter, r *http.Request, st
 // failWaitDisconnect ends a request whose client hung up while the loop was
 // waiting (for a saturated provider's Retry-After, or for an in-flight slot):
 // 499 and client_disconnect, the same rule the ordinary failover backoff
-// applies. Always returns true — the response is written.
+// applies. Always returns true, since the response is written.
 func (h *Handler) failWaitDisconnect(w http.ResponseWriter, st *requestState, attempt int, providerName string) bool {
 	debuglog.Info("proxy: client disconnected while waiting out saturation", "model", st.logData.modelID, "provider", providerName)
 	st.setReqErr(reqError{Kind: KindClientDisconnect, Attempt: attempt, Provider: providerName, Underlying: st.lastReqErr.Underlying})
@@ -236,7 +235,7 @@ func (h *Handler) failWaitDisconnect(w http.ResponseWriter, st *requestState, at
 // retrySaturatedCandidate is the one extra attempt a saturated last candidate
 // earns: wait the provider's Retry-After (capped at
 // rate_limit_saturation_max_wait and at the remaining overall deadline), then
-// send the same candidate again. One retry, never a loop — the attempt fn
+// send the same candidate again. One retry, never a loop: the attempt fn
 // consults st.saturationRetried and cannot return outcomeRetrySaturated twice.
 // The retry is an ordinary failover attempt: its index is one past the
 // candidate list, so the request log shows it as a further failover_attempt.
@@ -276,23 +275,21 @@ func (h *Handler) retrySaturatedCandidate(w http.ResponseWriter, r *http.Request
 	}
 }
 
-// upstreamFrameError reports that the provider's first SSE data frame carried an
-// error envelope rather than a token. It is distinct from every other probe
+// upstreamFrameError reports that the provider's first SSE data frame carried
+// an error envelope rather than a token. It is distinct from every other probe
 // failure because the provider answered: the fault is never the client's, so it
-// is charged to the provider whatever the downstream connection was doing. See
-// classifyProbeError.
+// is charged to the provider whatever the downstream connection was doing.
 type upstreamFrameError struct{ msg string }
 
 func (e *upstreamFrameError) Error() string { return e.msg }
 
-// emptyStreamError reports that the provider's stream ended at its very FIRST
-// data frame — a bare [DONE] with no chunk before it — so it produced nothing at
-// all. Like upstreamFrameError it means the provider answered, so it is charged
-// to the provider rather than blamed on the client.
+// emptyStreamError reports that the provider's stream ended at its first data
+// frame (a bare [DONE] with no chunk before it), so it produced nothing at all.
+// Like upstreamFrameError it means the provider answered, so it is charged to
+// the provider rather than blamed on the client.
 //
-// The bar is deliberately "no chunks whatever". A provider that sends any real
-// frame and then finishes has answered, even if the answer is empty, and keeps
-// its win.
+// The bar is "no chunks whatever": a provider that sends any real frame and
+// then finishes has answered, even if the answer is empty, and keeps its win.
 type emptyStreamError struct{}
 
 func (e *emptyStreamError) Error() string {
@@ -303,15 +300,15 @@ func (e *emptyStreamError) Error() string {
 // is an error envelope instead of a token, and ok == false for every ordinary
 // frame.
 //
-// Whether the frame IS an error is util.ErrorMemberCarries. question, not a second
-// opinion: this package already decided what counts (a populated error member of
-// any shape, including Ollama's bare string; not null/{}/""/[]/false/0, which
-// leave a caller nothing to read). Answering it twice is how the two drift, and
-// either direction is a bug — a miss lets a broken provider win a hedged race, a
-// false positive fails over a healthy stream.
+// Whether the frame is an error is util.ErrorMemberCarries' decision alone (a
+// populated error member of any shape, including Ollama's bare string; not
+// null/{}/""/[]/false/0, which leave a caller nothing to read). Deciding it a
+// second time here is how the two drift, and either direction is a bug: a miss
+// lets a broken provider win a hedged race, a false positive fails over a
+// healthy stream.
 //
-// Only the message is extracted here, and util.ErrorMemberMessage renders shapes
-// wider than {"error":{"message":...}}, so its fallbacks are not decoration.
+// Only the message is extracted here, by util.ErrorMemberMessage, which renders
+// shapes wider than {"error":{"message":...}}.
 func errorEnvelopeMessage(content string) (msg string, ok bool) {
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(content), &envelope); err != nil {
@@ -331,16 +328,14 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 type probeFrame int
 
 const (
-	// probeFrameNotAToken is a data line carrying nothing — an empty or
+	// probeFrameNotAToken is a data line carrying nothing: an empty or
 	// whitespace-only field. Skipped exactly like a keepalive comment: it is not
 	// a token, but it is not a verdict either, so a real frame after it wins.
 	//
-	// This exists because the probe and the stream reader used to disagree about
-	// what a chunk IS. streamReader.classify treats a bare "data:" as a comment
-	// and an empty payload as delivering nothing, while the probe accepted any
-	// non-[DONE] content — so a stream of "data:" then "data: [DONE]" won the
-	// race while producing zero chunks downstream. That is the empty-stream bug
-	// wearing a different spelling.
+	// It keeps the probe agreeing with streamReader.classify, which treats a
+	// bare "data:" as a comment and an empty payload as delivering nothing.
+	// Counting such a frame as a token would let a stream of "data:" then
+	// "data: [DONE]" win a hedged race while producing zero chunks downstream.
 	probeFrameNotAToken probeFrame = iota
 	// probeFrameToken is a real first token: the provider is answering.
 	probeFrameToken
@@ -355,8 +350,7 @@ const (
 // is only populated for probeFrameError.
 //
 // One classifier, used by both the main scanner loop and the scanner-error
-// recovery branch, so the two cannot drift — and the recovery branch is the one
-// no test can reach.
+// recovery branch, so the two cannot drift.
 func classifyProbeFrame(content string) (probeFrame, string) {
 	switch content {
 	case "":
@@ -370,13 +364,8 @@ func classifyProbeFrame(content string) (probeFrame, string) {
 	return probeFrameToken, ""
 }
 
-// recoverProbeFrame finds the first COMPLETE, meaningful SSE data line in a
+// recoverProbeFrame finds the first complete, meaningful SSE data line in a
 // probe buffer and classifies it. found is false when the buffer holds none.
-//
-// Extracted from probeFirstToken's scanner-error recovery branch so the logic
-// can be tested at all: that branch needs the watchdog to close the body in the
-// same instant the scanner yields a line, which no test can arrange
-// deterministically. The decision is testable even where the path is not.
 func recoverProbeFrame(bufStr string) (verdict probeFrame, msg string, found bool) {
 	for rawLine := range strings.SplitSeq(bufStr, "\n") {
 		l := strings.TrimSpace(rawLine)
@@ -405,12 +394,8 @@ func recoverProbeFrame(bufStr string) (verdict probeFrame, msg string, found boo
 // return triple. recovered is false when the buffer holds nothing usable, and
 // the caller falls through to its ordinary error returns.
 //
-// This is the whole recovery branch, extracted so it can be tested. The branch
-// is reached only when the watchdog closes the body in the same instant the
-// scanner yields a line — a race no test can arrange deterministically (see
-// TestProbeFirstToken_ScannerErrorRecovery_PipeRace, which documents the same
-// thing). Leaving it inline meant every verdict it can reach was unverifiable,
-// and reverting it left the whole package green.
+// The branch it serves is reached only when the watchdog closes the body in the
+// same instant the scanner yields a line.
 //
 //nolint:revive // the error is one of four coordinated results, not a trailing status
 func recoverFirstToken(buf *bytes.Buffer, startTime time.Time, scanErr error) (probeBuf *bytes.Buffer, ttftMs float64, err error, recovered bool) {
@@ -446,14 +431,14 @@ func recoverFirstToken(buf *bytes.Buffer, startTime time.Time, scanErr error) (p
 // "event:", "id:", and "retry:" directives are skipped but still captured in
 // probeBuf for replay.
 //
-// Both exclusions exist for the same reason and have the same consequence: a
-// provider that reports an error, and one that finishes without producing a
-// single chunk, have each given the caller nothing.
+// Both exclusions exist for the same reason: a provider that reports an error,
+// and one that finishes without producing a single chunk, have each given the
+// caller nothing.
 //
-// The error-envelope case exists because this probe picks the winner of a hedged
-// race. Treating a provider's error frame as a first token means the fastest
-// FAILURE wins: the broken candidate is committed to, every healthy rival still
-// in flight is cancelled as superseded, and the request has no second chance.
+// This probe picks the winner of a hedged race, so treating a provider's error
+// frame as a first token would let the fastest failure win: the broken
+// candidate is committed to, every healthy rival still in flight is cancelled
+// as superseded, and the request has no second chance.
 func (h *Handler) probeFirstToken(
 	ctx context.Context,
 	body io.ReadCloser,
@@ -485,7 +470,7 @@ func (h *Handler) probeFirstToken(
 	go func() {
 		select {
 		case <-probeDone:
-			// Probe finished — don't touch the body.
+			// Probe finished: leave the body alone.
 			return
 		case <-probeCtx.Done():
 			// Double-check: probe may have just finished between the
@@ -521,34 +506,32 @@ func (h *Handler) probeFirstToken(
 				// below rather than on any "data:" prefix.
 				continue
 			}
-			// Signal the goroutine — a frame that MEANS something was found, so
-			// the body must not be closed underneath us. Kept as early as
-			// possible so the goroutine sees it even if the timer fires at the
-			// same instant; the scanner-error recovery below covers the rest of
+			// Signal the goroutine that a meaningful frame was found, so the
+			// body is not closed underneath the read. Set as early as possible
+			// so the goroutine sees it even if the timer fires at the same
+			// instant; the scanner-error recovery below covers the rest of
 			// that window.
 			probeSucceeded.Store(true)
 			if verdict == probeFrameEmptyStream {
-				// The stream ended before producing a single chunk. This used to
-				// count as a win, which meant an instantly-empty provider beat a
-				// slower one that would really have answered — the same way an
-				// error frame did, and with the same consequence: every healthy
-				// rival still racing is cancelled and the caller gets nothing.
-				// Nothing is as good as an error, so it loses the same way.
+				// The stream ended before producing a single chunk, so it loses
+				// the race the way an error frame does: counting it as a win
+				// would cancel every healthy rival still racing and leave the
+				// caller with nothing.
 				debuglog.Warn("proxy: TTFT probe saw [DONE] before any first token", "ttft_ms", float64(time.Since(startTime).Microseconds())/1000.0)
 				closeProbe()
 				return nil, 0, &emptyStreamError{}
 			}
 			if verdict == probeFrameError {
 				msg := envelopeMsg
-				// The provider answered, but with its own failure. Counting
-				// this as a first token is what lets a broken provider win a
-				// hedged race against a working one.
-				// The provider's own text is NOT logged here. This function never
-				// saw the api key, so it cannot mask it, and a provider is free
-				// to quote the credential back inside its error. Key-SHAPE
-				// masking is not enough — it only catches tokens that look like
-				// keys, and an operator's key need not. Both callers log the
-				// message one line later, exact-masked by classifyProbeError.
+				// The provider answered, but with its own failure, which must
+				// not win a hedged race against a working provider.
+				//
+				// The provider's own text is never logged here: this function
+				// never saw the api key, so it cannot mask it, and a provider
+				// is free to quote the credential back inside its error.
+				// Key-shape masking is not enough, since an operator's key
+				// need not look like one. Both callers log the message one
+				// line later, exact-masked by classifyProbeError.
 				debuglog.Warn("proxy: TTFT probe saw an error envelope instead of a first token", "message_bytes", len(msg))
 				closeProbe()
 				return nil, 0, &upstreamFrameError{msg: msg}
@@ -559,27 +542,24 @@ func (h *Handler) probeFirstToken(
 			closeProbe()
 			return &buf, ttft, nil
 		}
-		// Unknown line format — skip but captured in buf.
+		// Unknown line format: skipped, but captured in buf.
 	}
 
-	// Scanner exited — body closed (timeout) or read error.
-	// bufio.Scanner never returns io.EOF from Err(); on clean EOF,
-	// Scan() returns false with Err() == nil, handled by the fallback
-	// after this block.
+	// Scanner exited: body closed (timeout) or read error. bufio.Scanner never
+	// returns io.EOF from Err(); on clean EOF, Scan() returns false with
+	// Err() == nil, handled by the fallback after this block.
 	if scanErr := scanner.Err(); scanErr != nil {
 		// Race recovery: the goroutine may close the body between the
 		// scanner reading a complete data line and probeSucceeded being
 		// checked. TeeReader writes to buf before scanner.Scan() returns,
-		// so the data is captured. Only return success if the probe context
-		// is still valid — if it expired, the goroutine closed the body and
-		// returning success would give the caller a closed body, causing
-		// handleStreamingResponse to truncate the stream after buffer replay.
+		// so the data is captured. Success is only returned while the probe
+		// context is still valid: once it expires the goroutine has closed the
+		// body, and returning success would hand the caller a closed body,
+		// truncating the stream after buffer replay.
 		if probeCtx.Err() == nil {
 			probeSucceeded.Store(true) // mirror the main loop: store before any processing
-			// Every outcome logs, including the ones that refuse. This branch
-			// cannot be reached from a test (see
-			// TestProbeFirstToken_ScannerErrorRecovery_PipeRace), so the log is
-			// the only way an operator ever learns it fired.
+			// Every outcome logs, including the ones that refuse: the log is
+			// the only way an operator learns this branch fired.
 			if probeBuf, ttft, err, recovered := recoverFirstToken(&buf, startTime, scanErr); recovered {
 				return probeBuf, ttft, err
 			}
@@ -590,22 +570,21 @@ func (h *Handler) probeFirstToken(
 		return nil, 0, fmt.Errorf("TTFT probe read error: %w", scanErr)
 	}
 
-	// Scanner finished without error and without finding data — body EOF.
+	// Scanner finished without error and without finding data: body EOF.
 	return nil, 0, fmt.Errorf("TTFT probe: body closed before first data chunk")
 }
 
-// See util.BuildProviderTargetURL for URL construction and util.SetProviderAuthHeaders for auth.
-
-// mapKeys returns the keys of a map[string]bool for logging.
-// failoverBackoff calculates exponential backoff with jitter between failover attempts.
-// base is the starting delay, capacity is the maximum delay, attempt is the 1-indexed attempt number.
-// Jitter of [0, base) is added to spread retries from concurrent requests hitting the same cascade.
+// failoverBackoff calculates exponential backoff with jitter between failover
+// attempts. base is the starting delay, capacity is the maximum delay, attempt
+// is the 1-indexed attempt number. Jitter of [0, base) spreads retries from
+// concurrent requests hitting the same cascade.
 func failoverBackoff(base, capacity time.Duration, attempt int) time.Duration {
 	exp := min(time.Duration(float64(base)*math.Pow(2, float64(attempt-1))), capacity)
 	jitter := time.Duration(rand.Int64N(int64(base)))
 	return exp + jitter
 }
 
+// mapKeys returns the keys of a map[string]bool for logging.
 func mapKeys(m map[string]bool) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -622,10 +601,10 @@ func writeOpenAIError(w http.ResponseWriter, message string, statusCode int) {
 }
 
 // humanReadableCancelOrigin maps internal cancel origin identifiers to
-// human-readable descriptions for error messages and request logs.
-// Raw Go errors like "context canceled" and "context deadline exceeded" are
-// opaque — callers need to know whether the client disconnected, the failover
-// timeout expired, or a param-strip retry timed out.
+// human-readable descriptions for error messages and request logs. Raw Go
+// errors like "context canceled" are opaque, while a caller needs to know
+// whether the client disconnected, the failover timeout expired, or a
+// param-strip retry timed out.
 func humanReadableCancelOrigin(origin string) string {
 	switch origin {
 	case "client_disconnect":

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -26,18 +26,13 @@ import (
 )
 
 // failoverErrorClassifyCap bounds how much of a discarded failover error body is
-// held in memory long enough to be classified.
+// held in memory long enough to be classified. The client is served by the next
+// candidate, and the only thing still wanted from the body is whether the
+// provider said the model is retired, so everything above the cap is read and
+// discarded rather than retained.
 //
-// The client is served by the next candidate, and the only thing still wanted
-// from the body is whether the provider said the model is retired.
-// classifyUpstreamError never sees more than util.SanitizeLogBody's own 10 000
-// characters, so everything above this cap is read and discarded rather than
-// retained.
-//
-// Shared by the chat loop and the multimodal pass-through loop, which run the
-// same drain-and-classify block. Sixteen kibibytes is comfortably above any
-// error message and well below the multi-megabyte bodies the image endpoints can
-// answer with.
+// Sixteen kibibytes is comfortably above any error message and well below the
+// multi-megabyte bodies the image endpoints can answer with.
 const failoverErrorClassifyCap = 16 << 10
 
 // attemptCandidate runs one failover attempt against a single candidate (phase
@@ -48,8 +43,8 @@ const failoverErrorClassifyCap = 16 << 10
 // It owns the per-attempt request contexts: failoverCtx is cancelled via a
 // deferred call (and the retry context, once created, via a second deferred
 // call), so no exit path can leak a context. The deferred cancels fire as the
-// method returns — i.e. AFTER the streaming/non-streaming dispatch has consumed
-// the body — preserving the "cancel only after the body is consumed" ordering.
+// method returns, after the streaming or non-streaming dispatch has consumed
+// the body, keeping the "cancel only after the body is consumed" ordering.
 //
 // Accumulating state (dial time, proxy overhead, lastErr, failoverAttempt) is
 // written back to st so the loop's deadline/backoff checks and the exhaustion
@@ -90,12 +85,10 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return outcomeFailover
 	}
 
-	// Auto-retry learnable 400s (see retryLearnable400 for which are learnable in
-	// which dialect). A 400 nothing can learn from is left exactly as it arrived,
-	// to fail over or be forwarded to the client. OpenAI's Responses-only
-	// refusal ("not a chat model") is a 404, so a chat-completions 404 from an
-	// OpenAI provider takes the same path; one nothing can learn from is left
-	// as it arrived just the same.
+	// Auto-retry learnable 400s. A 400 nothing can learn from is left exactly as
+	// it arrived, to fail over or be forwarded to the client. OpenAI's
+	// Responses-only refusal ("not a chat model") is a 404, so a
+	// chat-completions 404 from an OpenAI provider takes the same path.
 	if isLearnableRefusal(resp.StatusCode, providerType, candidate.provider.BaseURL, st) {
 		res, handled := h.retryLearnable400(r, st, candidate, providerType, targetURL, resp, attempt, &dialMs, failoverCancel, streamCancelOrigin)
 		if handled {
@@ -121,10 +114,10 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	// MiniMax reports business errors (rate limit, exhausted plan balance,
-	// auth failures) inside an HTTP 200 envelope; remap them to an effective
-	// status so the breaker/failover/error paths below — all keyed on status
-	// codes — see the failure. The in-flight slot rides the body only from
-	// here, with the remapped status deciding the clean flag.
+	// auth failures) inside an HTTP 200 envelope, so they are remapped to an
+	// effective status and the breaker, failover and error paths below, all
+	// keyed on status codes, see the failure. The in-flight slot rides the body
+	// only from here, with the remapped status deciding the clean flag.
 	resp = remapMiniMaxBusinessError(providerType, candidate.provider.Name, resp)
 	h.finishAttemptAdmission(st, candidate, resp)
 	logData.noteAttemptStatus(resp.StatusCode)
@@ -141,23 +134,20 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 
 	if shouldFailoverNow {
 		// Read only what can be classified, then drain the rest straight to
-		// Discard so the connection stays reusable without the body being held in
-		// memory. Everything above the cap was being retained to be thrown away —
-		// once per concurrent failing request, on the request path, at whatever
-		// size the provider chose to send.
+		// Discard so the connection stays reusable without the body being held
+		// in memory at whatever size the provider chose to send.
 		drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 		// The body is being discarded anyway, so classify it on the way out.
 		// A retired model usually answers 404, which is failover-eligible, so
-		// without this the "model gone" signal would be lost precisely when
-		// there is another candidate to fall back to.
+		// without this the "model gone" signal would be lost whenever there is
+		// another candidate to fall back to.
 		//
-		// The whole candidate goes through, not just the model: the retirement is
-		// adjudicated by a real request to this provider, so it needs the provider
-		// and the decrypted key already in hand here. The endpoint family comes
-		// off the log entry and decides whether the refusal can be adjudicated at
-		// all.
+		// The whole candidate goes through, not just the model: the retirement
+		// is adjudicated by a real request to this provider, so it needs the
+		// provider and the decrypted key. The endpoint family comes off the log
+		// entry and decides whether the refusal can be adjudicated at all.
 		drainedMsg := util.SanitizeLogBody(string(drained), 10000)
 		kind, _ := classifyUpstreamError(resp.StatusCode, drainedMsg, candidate.model.ModelID)
 		if kind == KindProviderModelGone {
@@ -170,22 +160,20 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return outcomeFailover
 	}
 
-	// A saturated 429 on the LAST candidate: the provider asked for a wait of
-	// seconds, so give it that instead of a terminal error. Once per request.
+	// A saturated 429 on the last candidate: the provider asked for a wait of
+	// seconds, so it gets that instead of a terminal error. Once per request.
 	if isFailoverEligible && !hasMoreCandidates && rl.class == rateLimitSaturated && !st.saturationRetried {
 		return h.deferSaturatedRetry(st, candidate, resp, attempt)
 	}
 
-	// The 2xx RANGE, not a bare 200. A relay or aggregator may answer a chat
-	// completion 201 or 202, and routing those to forwardUpstreamError served
-	// the client a complete answer while writing the row as state="failed" and
-	// metering nothing at all: no tokens against the virtual key, no TPM debit.
-	// The pass-through families already routed on the range (see multimodal).
-	// servedSuccessStatus is now that one definition, asked here and at every
-	// other site that judges an upstream status — the breaker, the hedge race,
-	// the retirement probe and the Anthropic ingress writer — because a 201 that
-	// was a success to one of them and a failure to another is how this bug got
-	// in.
+	// The whole 2xx range, not a bare 200: a relay or aggregator may answer a
+	// chat completion 201 or 202, and routing those to forwardUpstreamError
+	// would serve the client a complete answer while writing the row as
+	// state="failed" and metering nothing, neither tokens against the virtual
+	// key nor a TPM debit. servedSuccessStatus is the one definition, asked here
+	// and at every other site that judges an upstream status (the breaker, the
+	// hedge race, the retirement probe, the Anthropic ingress writer), so a 201
+	// cannot be a success to one and a failure to another.
 	if !servedSuccessStatus(resp.StatusCode) {
 		return h.forwardUpstreamError(w, st, candidate, resp, attempt, isFailoverEligible, responseHeaderMs)
 	}
@@ -193,9 +181,9 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	debuglog.Debug("proxy: upstream responded OK, dispatching to handler", "stream", st.isStreaming, "native_anthropic", st.anthropicNativeAttempt, "responses_api", st.responsesAttempt, "model", logData.modelID, "provider", logData.providerName, "provider_id", candidate.provider.ID, "status", resp.StatusCode)
 	if st.responsesAttempt {
 		// Translate the /v1/responses answer back to the chat-completions
-		// shape on the UPSTREAM side, so the streaming pipeline (TTFT probe,
+		// shape on the upstream side, so the streaming pipeline (TTFT probe,
 		// stall watchdog, transforms, metering) and the non-streaming handler
-		// below run unchanged on what they already understand.
+		// below run on what they already understand.
 		if st.isStreaming {
 			resp.Body = openairesponses.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateResponsesResponseBody(resp, st.reqModel); err != nil {
@@ -228,23 +216,23 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	}
 
 	// A non-streaming answer clears any gone-strike streak the model had, judged
-	// AFTER the handler on what the handler decoded rather than on the 200 that
+	// after the handler on what the handler decoded rather than on the 200 that
 	// preceded it. Both halves of that placement are load-bearing:
 	//
 	//   - Below the dialect translations, because either of them can read the
-	//     body, fail, and send the attempt to FAILOVER. A provider that answered
-	//     200 with something that is not a Responses object or a Gemini answer has
-	//     not served the model.
+	//     body, fail, and send the attempt to failover. A provider that answered
+	//     200 with something that is not a Responses object or a Gemini answer
+	//     has not served the model.
 	//   - Below the handler, because a status is not an answer. `200
-	//     {"choices":[]}` decodes and is forwarded as a normal completion, and is
-	//     what an aggregator in front of a retired model returns between its
-	//     gone-shaped 404s — resetting the count so three never land
+	//     {"choices":[]}` decodes and is forwarded as a normal completion, and
+	//     is what an aggregator in front of a retired model returns between its
+	//     gone-shaped 404s, resetting the count so three never land
 	//     consecutively and the model is never nominated.
 	//
-	// producedOutput is where that line is drawn.
-	// The breaker verdict is deferred to the handler's terminal write, so the
-	// attempt trail's record carries it (see requestLogData.judgeAnswer);
-	// judgeAnswerNow is the fallback for a handler exit that wrote nothing.
+	// producedOutput is where that line is drawn. The breaker verdict is
+	// deferred to the handler's terminal write so the attempt trail's record
+	// carries it; judgeAnswerNow is the fallback for a handler exit that wrote
+	// nothing.
 	h.deferAnswerJudgement(st, candidate, logData, resp.StatusCode)
 	if st.anthropicNativeAttempt {
 		outcome := h.handleNativeNonStreaming(w, r.WithContext(failoverCtx), st, resp, attempt, responseHeaderMs)
@@ -255,10 +243,9 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return outcome
 	}
 
-	// The handler reads the upstream body, and that read runs under failoverCtx —
-	// so that is the context it must judge an interrupted read by. Handing it the
-	// bare client request made this gateway's own request_timeout look like the
-	// provider dying.
+	// The handler reads the upstream body under failoverCtx, so that is the
+	// context it judges an interrupted read by. With the bare client request
+	// instead, this gateway's own request_timeout looks like the provider dying.
 	h.handleNonStreamingResponse(w, r.WithContext(failoverCtx), logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings.failoverLookupMs, st.timings.modelLookupMs, st.timings.providerLookupMs, st.timings.keyDecryptMs, st.timings.dialMs, st.timings.settingsReadMs, responseHeaderMs, st.vkHash, attempt)
 	judgeAnswerNow(logData)
 	if producedOutput(logData) {
@@ -267,24 +254,13 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 	return outcomeServed
 }
 
-// classifyProbeFailure decides how a zero-token TTFT probe failure is recorded.
-// Reaching a probe failure means the provider produced no "data:" token within
-// the window. The provider is at fault — provider_timeout, recorded against the
-// breaker and eligible for failover — when either our own TTFT timer fired
-// (clientGone == false) or the downstream connection was closed only after the
-// provider had already stayed silent past the stall timeout. A faster downstream
-// close with zero tokens is treated as a genuine client disconnect and is not
-// charged to the provider. When the connection was closed downstream while the
-// provider was stalling, the error carries a hint that an upstream reverse proxy,
-// load balancer, or CDN idle-read timeout is the likely cause (Model Hotel sends
-// nothing downstream during the probe, so a silent connection looks idle).
 // classifyProbeError maps any TTFT probe failure to the error recorded for the
 // attempt and whether the provider is charged for it. It is the single entry
 // point both the sequential and the hedged path use, so the two cannot drift.
 //
 // An error envelope in the first frame, and a stream that ends at that frame,
-// are split out from the zero-token cases below: the provider did answer, so
-// this is its failure and never the client's.
+// are split out from the zero-token cases classifyProbeFailure handles: the
+// provider did answer, so this is its failure and never the client's.
 func classifyProbeError(probeErr error, providerName string, masker credentialMasker, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
 	// The provider answered, but with nothing the caller can use: either it
 	// reported an error, or it ended the stream without a single chunk. Neither
@@ -309,15 +285,11 @@ func classifyProbeError(probeErr error, providerName string, masker credentialMa
 	}
 	var emptyErr *emptyStreamError
 	if errors.As(probeErr, &emptyErr) {
-		// Charged, exactly like an error frame. A zero-token answer is not a
+		// Charged, exactly like an error frame: a zero-token answer is not a
 		// valid one in almost any real use, so a provider that keeps producing
-		// them belongs out of rotation.
-		//
-		// This was once left uncharged on the reasoning that silence is a
-		// function of the PROMPT, which the caller controls, so one virtual key
-		// could darken a provider for every tenant. That risk is real and
-		// accepted: a caller deliberately coercing a model into saying nothing
-		// is not a case worth keeping a provider in rotation for.
+		// them belongs out of rotation. Silence is partly a function of the
+		// prompt, so a caller can darken a provider for every tenant by
+		// coercing a model into saying nothing; that risk is accepted.
 		//
 		// Gateway-authored text, so nothing to mask.
 		return answered(emptyErr.Error())
@@ -325,6 +297,15 @@ func classifyProbeError(probeErr error, providerName string, masker credentialMa
 	return classifyProbeFailure(providerName, errString(probeErr), clientGone, elapsed, stallTimeout, ttftTimeout, attempt)
 }
 
+// classifyProbeFailure decides how a zero-token TTFT probe failure is recorded.
+// The provider is at fault (provider_timeout, charged to the breaker and
+// eligible for failover) when the gateway's own TTFT timer fired, or when the
+// downstream connection closed only after the provider had already stayed
+// silent past the stall timeout. A faster downstream close with zero tokens is
+// a genuine client disconnect and is not charged. A close during a provider
+// stall carries a hint naming an upstream reverse proxy, load balancer or CDN
+// idle-read timeout, since nothing is sent downstream during the probe and a
+// silent connection looks idle.
 func classifyProbeFailure(providerName, underlying string, clientGone bool, elapsed, stallTimeout, ttftTimeout time.Duration, attempt int) (re reqError, recordFailure bool) {
 	if clientGone && elapsed < stallTimeout {
 		// Fast downstream close with zero tokens: a genuine client cancel.
@@ -375,9 +356,9 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 		// TTFT probe: read until first real data chunk.
 		probeBuf, trueTtftMs, probeErr := h.probeFirstToken(r.Context(), resp.Body, ttftTimeout, st.startTime)
 		if probeErr != nil {
-			// Timeout or read error — failover. probeFirstToken may
-			// or may not have closed the body (only on DeadlineExceeded);
-			// close it unconditionally to release the connection.
+			// Timeout or read error, so fail over. probeFirstToken may or may
+			// not have closed the body (only on DeadlineExceeded); close it
+			// unconditionally to release the connection.
 			_ = resp.Body.Close()
 			// Reaching here means zero "data:" tokens arrived from the provider.
 			// classifyProbeFailure decides whether that is a provider stall
@@ -394,35 +375,33 @@ func (h *Handler) dispatchStreaming(w http.ResponseWriter, r *http.Request, st *
 			logData.failoverAttempt = attempt
 			logData.responseHeaderMs = responseHeaderMs
 			logData.closeAttemptRecord(resp.StatusCode, re.Kind, re.Underlying, "", 0)
-			// "kind", not "provider_stalled": a probe can now fail because the
+			// "kind", not "provider_stalled": a probe can fail because the
 			// provider reported its own error rather than because it went
 			// silent, and calling that a stall sends the operator hunting the
 			// wrong thing. charged says what the breaker was told either way.
 			debuglog.Warn("proxy: TTFT probe failed", "attempt", attempt+1, "provider", candidate.provider.Name, "client_gone", clientGone, "elapsed", elapsed, "kind", string(re.Kind), "charged", recordFailure, "error", logData.content.maskOne(re.Underlying))
 			return outcomeFailover
 		}
-		// First token confirmed. No breaker success is
-		// recorded here: a first token is not a served stream, and recording one
-		// zeroes consecutiveFails on every request, which left the finalizer's
-		// own failure charges unable to ever reach the threshold. finalizeStream
-		// owns the verdict for a streaming 200 — see judgeStreamForBreaker.
+		// First token confirmed. No breaker success is recorded here: a first
+		// token is not a served stream, and recording one would zero
+		// consecutiveFails on every request, so the finalizer's own failure
+		// charges could never reach the threshold. finalizeStream owns the
+		// verdict for a streaming 200.
 		opts.preReadBuf = probeBuf
 		opts.trueTtftMs = trueTtftMs
 	}
 
 	h.handleStreamingResponse(w, r, logData, resp, st.startTime, opts)
 
-	// Judge the model only now. deriveStreamError classifies any in-stream SSE
-	// error into logData.errorKind, so a provider that returns 200 headers and
-	// then reports the model gone mid-stream is caught here rather than being
-	// credited with a success. Without this the streak could never accumulate on
-	// that path: the 200 would have cleared it before the error even arrived.
+	// The model is judged only once the stream has ended. deriveStreamError
+	// classifies any in-stream SSE error into logData.errorKind, so a provider
+	// that returns 200 headers and then reports the model gone mid-stream is
+	// caught here rather than credited with a success.
 	//
-	// The three cases are deliberately distinct. A stream that failed for any
-	// OTHER reason (transient provider error, client disconnect, stall) is not
-	// evidence either way, so it must leave the streak alone: clearing it there
-	// would let a retired model stay routable indefinitely, since its own
-	// failures would keep resetting the count.
+	// A stream that failed for any other reason (transient provider error,
+	// client disconnect, stall) is not evidence either way and leaves the streak
+	// alone: clearing it there would let a retired model stay routable
+	// indefinitely, since its own failures would keep resetting the count.
 	h.noteStreamOutcome(logData, candidate)
 	return outcomeServed
 }
@@ -484,7 +463,7 @@ func (h *Handler) beginAttempt(failoverCtx context.Context, st *requestState, ca
 		logData.closeAttemptRecord(0, st.lastReqErr.Kind, st.lastReqErr.Underlying, "", 0)
 		return nil, providerType, targetURL, false, false
 	}
-	// The held slot is NOT handed to the body here: the caller does that via
+	// The held slot is not handed to the body here: the caller does that via
 	// finishAttemptAdmission after the MiniMax status remap, so a business
 	// error dressed as a 200 never counts as a clean completion.
 	return resp, providerType, targetURL, false, true
@@ -526,12 +505,12 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	debuglog.Debug("proxy: provider type", "provider_type", providerType, "base_url", util.SanitizeBaseURL(candidate.provider.BaseURL))
 
 	// Native Anthropic passthrough: an Anthropic-in request resolved to an
-	// Anthropic-family provider forwards the ORIGINAL Messages body to the
-	// provider's native /v1/messages (max fidelity: thinking blocks,
-	// cache_control, fine-grained tool streaming survive). Every non-Anthropic
-	// candidate in the same failover group still goes through translation, so a
-	// single hotel/claude-* request can fail over from native to translated
-	// seamlessly. The flag is read by the response dispatch + writer.
+	// Anthropic-family provider forwards the original Messages body to the
+	// provider's native /v1/messages, so thinking blocks, cache_control and
+	// fine-grained tool streaming survive. Every non-Anthropic candidate in the
+	// same failover group still goes through translation, so a single
+	// hotel/claude-* request can fail over from native to translated. The flag
+	// is read by the response dispatch and writer.
 	st.anthropicNativeAttempt = st.anthropicIn && isAnthropicFamily(providerType)
 	// Per-attempt flags: a failover group can mix an OpenAI candidate that
 	// needs /v1/responses (or a vertex-express one) with providers that
@@ -542,24 +521,23 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	st.speechFormat = ""
 	st.passthroughUsage = nil
 	// The Messages self-heal is per candidate too. Within one attempt it cannot
-	// fire twice — attemptCandidate consults it from a single branch, not a loop
-	// — so carrying the flag forward would only deny the NEXT candidate a
-	// self-heal it has not used yet, which is precisely the multi-provider case
-	// a failover group exists for. Each candidate is a different model behind a
-	// different endpoint, with its own facts to learn.
+	// fire twice, since attemptCandidate consults it from a single branch rather
+	// than a loop, so carrying the flag forward would only deny the next
+	// candidate a self-heal it has not used yet. Each candidate is a different
+	// model behind a different endpoint, with its own facts to learn.
 	st.messagesRetried = false
 	st.lastMessagesBody = nil
 	if st.anthropicNativeAttempt {
 		return h.buildNativeAnthropicRequest(ctx, st, candidate, providerType)
 	}
-	if isGeminiSpeechAttempt(st, providerType, candidate.model.OutputModalities) { // Gemini TTS via generateContent, see gemini_speech.go
+	if isGeminiSpeechAttempt(st, providerType, candidate.model.OutputModalities) { // Gemini TTS via generateContent
 		return h.buildGeminiSpeechRequest(ctx, st, candidate, providerType)
 	}
 
 	// OpenAI Responses re-route: a model learned (from a prior 400) to reject
 	// tools+reasoning over chat-completions is served via /v1/responses, with
 	// the request translated out and the response translated back by the
-	// dispatch (see openai_responses.go).
+	// dispatch.
 	if h.shouldUseResponsesAttempt(st, candidate, providerType) {
 		st.responsesAttempt = true
 		return h.buildResponsesRequest(ctx, st, candidate, providerType)
@@ -567,19 +545,17 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 
 	// Gemini egress adapter: chat requests to a vertex-express provider, a
 	// Zen Gemini model or a Google AI Studio image model are translated to
-	// generateContent on the way out and back on the response side (see
-	// gemini_egress.go).
+	// generateContent on the way out and back on the response side.
 	if isGeminiEgressAttempt(st, providerType, candidate.model.ModelID, candidate.model.OutputModalities) {
 		st.geminiAttempt = true
 		return h.buildGeminiRequest(ctx, st, candidate, providerType)
 	}
 
 	// Anthropic egress adapter: a chat request is translated to Anthropic's
-	// native Messages shape on the way out and back on the response side (see
-	// anthropic_egress.go). Every chat request to an anthropic-messages
-	// provider takes this route; for anthropic, only one carrying a document
-	// does, and text and image requests stay on the cheaper compat endpoint
-	// below.
+	// native Messages shape on the way out and back on the response side. Every
+	// chat request to an anthropic-messages provider takes this route; for
+	// anthropic, only one carrying a document does, and text and image requests
+	// stay on the cheaper compat endpoint below.
 	if isAnthropicEgressAttempt(st, providerType) {
 		st.anthropicEgressAttempt = true
 		return h.buildAnthropicEgressRequest(ctx, st, candidate, providerType)
@@ -626,10 +602,10 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 
 // resolveCancelOrigin names the cause behind a context error on an upstream
 // attempt. A deadline reads the origin the derived context was created with
-// (failover vs retry). A cancellation is the client hanging up UNLESS the
-// hedging orchestrator abandoned this attempt because a faster candidate won —
-// that cancellation is ours, and reporting it as a client disconnect describes
-// a request the client is still happily receiving.
+// (failover vs retry). A cancellation is the client hanging up, unless the
+// hedging orchestrator abandoned this attempt because a faster candidate won:
+// that cancellation is the gateway's own, and reporting it as a client
+// disconnect describes a request the client is still receiving.
 func resolveCancelOrigin(ctx context.Context, err error) string {
 	if errors.Is(err, context.DeadlineExceeded) {
 		if s, ok := ctx.Value(ctxkeys.CancelOriginKey).(string); ok && s != "" {
@@ -644,14 +620,14 @@ func resolveCancelOrigin(ctx context.Context, err error) string {
 }
 
 // doUpstream executes the built request against the shared upstream transport
-// (phase D): inject the per-request dial-timing pointer, run the request —
+// (phase D): inject the per-request dial-timing pointer, run the request,
 // retrying up to maxTransientRetries times against the same provider on
-// transient network errors (see isRetryableUpstreamError) — fold each try's
-// dial sample into the running timings, and recompute proxy overhead. Retries
-// share the per-attempt failover timeout, replay the body via GetBody, and
-// back off briefly between tries. On final failure it classifies the cause —
-// client disconnect vs failover/retry timeout vs provider error — and records a
-// breaker failure only for real provider errors, never for context cancellation.
+// transient network errors, fold each try's dial sample into the running
+// timings, and recompute proxy overhead. Retries share the per-attempt failover
+// timeout, replay the body via GetBody, and back off briefly between tries. On
+// final failure it classifies the cause (client disconnect, failover or retry
+// timeout, provider error) and records a breaker failure only for real provider
+// errors, never for context cancellation.
 // Returns (resp, true) on a usable response; (nil, false) after setting
 // st.lastErr on a failover-worthy failure. The caller retains ownership of ctx
 // cancellation.
@@ -679,11 +655,9 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	var resp *http.Response
 	var err error
 	// lastTransportErr preserves the real provider/transport error that drove
-	// the retry loop, so that if a client disconnect or timeout later overwrites
-	// `err` with a context error (below), the original cause is not lost — it is
-	// carried into the structured error as Underlying. This is the fix for the
-	// "provider request failed: client disconnected" bug where the real provider
-	// error was silently dropped.
+	// the retry loop, so when a client disconnect or timeout later overwrites
+	// `err` with a context error the original cause is still carried into the
+	// structured error as Underlying.
 	var lastTransportErr error
 	for try := 0; ; try++ {
 		// Track whether any request bytes reached the wire on this try, so
@@ -725,7 +699,7 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		// Client disconnect or failover timeout during backoff: stop retrying
 		// and surface the context error so the classification below does not
 		// penalize the circuit breaker. Checked outside the select because when
-		// both channels are ready Go picks a branch at random — the timer
+		// both channels are ready Go picks a branch at random, and the timer
 		// branch must not leave the transport error in err.
 		if ctxErr := dialCtx.Err(); ctxErr != nil {
 			err = ctxErr
@@ -734,11 +708,10 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 	}
 	st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
 	if err != nil {
-		// Determine the origin of context cancellation for actionable errors.
-		// "context canceled" is opaque — we need to know whether the client
-		// disconnected, the hedging orchestrator abandoned this attempt for a
-		// faster one, or a deadline expired. resolveCancelOrigin owns that
-		// classification.
+		// "context canceled" is opaque, so the origin decides the error the
+		// caller sees: a client disconnect, the hedging orchestrator abandoning
+		// this attempt for a faster one, or an expired deadline.
+		// resolveCancelOrigin owns that classification.
 		isContextErr := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 		if isContextErr {
 			cancelOrigin := resolveCancelOrigin(dialCtx, err)
@@ -761,13 +734,11 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 			})
 			debuglog.Warn("proxy: upstream request failed", "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "error", err)
 		}
-		// Client-initiated cancellations and deadline exceeded are not
-		// provider failures. If the caller disconnected (Canceled) or
-		// the request timed out (DeadlineExceeded), we must not penalize
-		// the circuit breaker for that. Real provider errors record exactly
-		// one breaker failure per candidate attempt — here, after any
-		// transient retries are exhausted — so a blip that self-heals on
-		// retry never counts against the provider.
+		// Client-initiated cancellations and deadline exceeded are not provider
+		// failures, so the circuit breaker is not charged for them. Real
+		// provider errors record exactly one breaker failure per candidate
+		// attempt, here, after any transient retries are exhausted, so a blip
+		// that self-heals on retry never counts against the provider.
 		if !isContextErr {
 			if st.circuitBreakerEnabled {
 				// No status: the request never completed, so there is none.

--- a/internal/proxy/proxy_request.go
+++ b/internal/proxy/proxy_request.go
@@ -16,18 +16,17 @@ import (
 // maxModelNameRunes bounds the client-supplied `model` routing field.
 //
 // The field is routing metadata, and the pipeline persists it before it
-// validates it: the pending request-log row carries it, the request.started
-// event carries it, the "request start" app-log line carries it, and the
-// resolve failures quote it back in the error response. None of those sinks
-// had a bound of its own, so a multi-megabyte model inside the (legal, capped)
-// request body was a multi-megabyte write to every one of them, from one
-// virtual key. Real routing targets are "provider/model" or "hotel/group";
+// validates it: the pending request-log row, the request.started event, the
+// "request start" app-log line and the resolve failures all carry it. None of
+// those sinks has a bound of its own, so an unbounded model inside a legal,
+// capped request body would be a multi-megabyte write to each of them from one
+// virtual key. Real routing targets are "provider/model" or "hotel/group", and
 // the admin write paths cap display models at 128 characters, so 512 is far
 // above anything that can resolve.
 const maxModelNameRunes = 512
 
-// modelTooLongMessage is the constant refusal for an oversized model. A test
-// pins the number it spells to maxModelNameRunes so the two cannot drift.
+// modelTooLongMessage is the constant refusal for an oversized model. The
+// number it spells must match maxModelNameRunes.
 const modelTooLongMessage = "model exceeds maximum length of 512 characters"
 
 // modelExcerptRunes is how much of an oversized model the request-log row
@@ -52,15 +51,15 @@ func modelExcerpt(model string) string {
 	return string([]rune(model)[:modelExcerptRunes]) + "…"
 }
 
-// rejectOversizedModel is the one outcome every ingest path has for a model
-// past maxModelNameRunes: the pending row (already inserted by the caller) is
-// closed as a validation failure carrying the excerpt rather than the field,
-// subscribers see the started/completed pair every other early guard emits,
-// and the caller gets the constant message back. The response never quotes
-// the field. It takes the raw model and derives the excerpt itself so no
-// ingest path can put the field on the row at the refusal by forgetting to;
-// the middleware-preparsed path must still hand the excerpt to its own
-// pending INSERT, which runs before this can.
+// rejectOversizedModel is the one outcome every ingest path has for a model past
+// maxModelNameRunes: the pending row the caller already inserted is closed as a
+// validation failure carrying the excerpt rather than the field, subscribers see
+// the started/completed pair every other early guard emits, and the caller gets
+// the constant message back. The response never quotes the field.
+//
+// It takes the raw model and derives the excerpt itself, so no ingest path can
+// put the field on the row by forgetting to. The middleware-preparsed path must
+// still hand the excerpt to its own pending INSERT, which runs before this can.
 func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLogData, model string, startTime time.Time, parseMs float64) {
 	logData.modelID = modelExcerpt(model)
 	publishRequestStartedEvent(logData)
@@ -77,7 +76,7 @@ func (h *Handler) rejectOversizedModel(w http.ResponseWriter, logData *requestLo
 //
 // On success it returns a populated *requestState and true. On any guard
 // failure it records the failure, writes the OpenAI error response, and returns
-// (nil, false) — the caller must simply return.
+// (nil, false), on which the caller simply returns.
 func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpointType string) (*requestState, bool) {
 	startTime := time.Now()
 
@@ -85,9 +84,9 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 	var reqModel string
 	var isStreaming bool
 
-	// Read pre-parsed values from middleware context when available.
-	// streamingAwareTimeout already read the body and extracted model+stream,
-	// so we skip the redundant json.Unmarshal that previously measured as parseMs.
+	// Read pre-parsed values from the middleware context when available:
+	// streamingAwareTimeout has already read the body and extracted model and
+	// stream, so the json.Unmarshal below is skipped.
 	if v := r.Context().Value(ctxkeys.RequestBodyParseMsKey); v != nil {
 		if ms, ok := v.(float64); ok {
 			parseMs = ms
@@ -104,8 +103,8 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 		}
 	}
 
-	// Fallback: if middleware did not provide pre-parsed values (e.g. route
-	// not covered by streamingAwareTimeout), parse from body directly.
+	// Fallback for a route streamingAwareTimeout does not cover, where the
+	// middleware provided no pre-parsed values: parse the body directly.
 	var bodyBytes []byte
 
 	// The middleware-provided model is what the pending INSERT below would
@@ -149,8 +148,8 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 		reqModel = req.Model
 		isStreaming = req.Stream
 	} else {
-		// Middleware provided model+stream; still need body bytes for
-		// stream_options injection and upstream forwarding.
+		// The middleware provided model and stream; the body bytes are still
+		// needed for stream_options injection and upstream forwarding.
 		if cached, ok := r.Context().Value(ctxkeys.RequestBodyKey).([]byte); ok {
 			bodyBytes = cached
 		}
@@ -165,12 +164,13 @@ func (h *Handler) ingestRequest(w http.ResponseWriter, r *http.Request, endpoint
 		return nil, false
 	}
 
-	// Update log entry with model resolved from body parsing (if not set by middleware).
+	// Update the log entry with the model body parsing resolved, when the
+	// middleware did not set one.
 	logData.modelID = reqModel
 	logData.streaming = isStreaming
 
-	// Publish the SSE "request.started" event after modelID is resolved
-	// so subscribers always see the correct model (not an empty string).
+	// The SSE "request.started" event goes out after modelID is resolved, so
+	// subscribers always see the real model rather than an empty string.
 	publishRequestStartedEvent(logData)
 
 	if reqModel == "" {
@@ -214,10 +214,10 @@ func (h *Handler) newPendingRequestLog(r *http.Request, endpointType, modelID st
 	if v := r.Context().Value(VirtualKeyHashKey); v != nil {
 		vkHash, _ = v.(string)
 	}
-	// The owning user's UUID (empty for unowned keys) scopes the SSE request
-	// events to that user, and is persisted on the log row itself when there is
-	// no virtual key to resolve an owner through (dashboard chat/arena), which is
-	// what lets the owner-scoped logs REST API see those rows at all.
+	// The owning user's UUID, empty for unowned keys, scopes the SSE request
+	// events to that user. It is persisted on the log row itself when there is
+	// no virtual key to resolve an owner through (dashboard chat/arena), which
+	// is what lets the owner-scoped logs REST API see those rows.
 	var ownerUserID string
 	if v := r.Context().Value(ctxkeys.VirtualKeyOwnerIDKey); v != nil {
 		ownerUserID, _ = v.(string)
@@ -274,9 +274,9 @@ func (h *Handler) resolveCandidates(w http.ResponseWriter, r *http.Request, st *
 			writeOpenAIError(w, err.Error(), http.StatusNotFound)
 			return nil, false
 		}
-		// The candidates the breaker refused lead the attempt trail: an
-		// operator reading "Neuralwatt 429 → Ollama 200" also wants to know
-		// that Z.ai was never asked, and why.
+		// The candidates the breaker refused lead the attempt trail, so an
+		// operator reading it also sees which providers were never asked, and
+		// why.
 		for _, s := range skips.skipped {
 			st.logData.appendBreakerSkip(s.providerID, s.providerName, s.model)
 		}
@@ -300,12 +300,11 @@ func (h *Handler) resolveCandidates(w http.ResponseWriter, r *http.Request, st *
 		return nil, false
 	}
 
-	// Store cache hit data from resolve phase into the log entry.
 	st.logData.cacheHits = cacheHits
 
-	// Normalize logData fields after resolution: split the raw request model
-	// (e.g. "NanoGPT/deepseek-ai/DeepSeek-R1-0528") into provider name and
-	// model-only components so log lines are human-readable.
+	// Normalize logData after resolution: split the raw request model (say
+	// "NanoGPT/deepseek-ai/DeepSeek-R1-0528") into provider name and model so
+	// log lines are readable.
 	if parts := strings.SplitN(st.reqModel, "/", 2); len(parts) == 2 && !strings.HasPrefix(st.reqModel, "hotel/") {
 		st.logData.providerName = parts[0]
 		st.logData.modelID = parts[1]
@@ -337,12 +336,11 @@ func (h *Handler) resolveCandidates(w http.ResponseWriter, r *http.Request, st *
 		}
 		// owner_capped records whether the owner HAS a cap, not which side did
 		// the narrowing: the two lists are intersected before this runs and the
-		// result no longer says where each member came from. It is still the
-		// field worth having, because a key that has always worked can start
-		// refusing purely because its owner's cap moved, and this is the only
-		// signal that an account cap is in play at all. The response body
-		// deliberately says none of it: a proxy client learns it lacks access,
-		// not whose rule denied it.
+		// result no longer says where each member came from. It is the only
+		// signal that an account cap is in play, which matters because a key
+		// that has always worked can start refusing purely because its owner's
+		// cap moved. The response body says none of it: a proxy client learns it
+		// lacks access, not whose rule denied it.
 		debuglog.Info("proxy: filtered candidates by allowed_providers",
 			"before", len(candidates), "after", len(filtered),
 			"owner_capped", ownerAllowed != nil, "key", st.logData.virtualKeyName)
@@ -360,14 +358,14 @@ func (h *Handler) resolveCandidates(w http.ResponseWriter, r *http.Request, st *
 // restriction; a non-nil list restricts to exactly its members INCLUDING when
 // empty, which is what makes the pair fail-closed.
 //
-// This is the enforcement point for the per-user provider cap, and it is the
-// only one that runs on every request. The write-time check in
-// internal/api/virtualkeys.go merely produces a friendly refusal on the two
-// dashboard write paths, so a stored list wider than its owner's cap is a
-// normal state, not a corruption: upsertVirtualKeys in
+// This is the enforcement point for the per-user provider cap, and the only one
+// that runs on every request. The write-time check in
+// internal/api/virtualkeys.go only produces a friendly refusal on the two
+// dashboard write paths, so a stored list wider than its owner's cap is a normal
+// state rather than a corruption: upsertVirtualKeys in
 // internal/api/configsync_apply.go writes virtual_keys rows straight from a
-// fleet import without consulting the cap, and narrowing users.allowed_providers
-// updates only the users row, leaving that owner's existing keys untouched.
+// fleet import without consulting the cap, and narrowing
+// users.allowed_providers updates only the users row.
 func effectiveAllowedProviders(key, owner *[]string) *[]string {
 	switch {
 	case key == nil && owner == nil:
@@ -392,35 +390,33 @@ func effectiveAllowedProviders(key, owner *[]string) *[]string {
 
 // loadFailoverConfig performs phase C of ChatCompletions: finalize the
 // accumulated settings-read time, compute the initial proxy-overhead estimate,
-// and read the per-request failover knobs (request timeout — 10× for streaming,
-// circuit-breaker enablement, and the overall request deadline). The results
-// are stored on st for the failover loop. The loop recomputes proxyOverhead
-// after each dial, so the value set here is only the pre-loop estimate.
+// and read the per-request failover knobs (the request timeout, 10x for
+// streaming, circuit-breaker enablement, and the overall request deadline). The
+// results are stored on st for the failover loop, which recomputes
+// proxyOverhead after each dial, so the value set here is a pre-loop estimate.
 func (h *Handler) loadFailoverConfig(r *http.Request, st *requestState) {
-	// Re-read accumulated settings read time from context pointer.
-	// The initial read captured the rate limiter's contribution,
-	// but resolve handlers called AddSettingsReadMs for circuit breaker and
-	// failover settings. The pointer now holds the total.
+	// Re-read the accumulated settings-read time from the context pointer, which
+	// now holds the rate limiter's contribution plus the circuit-breaker and
+	// failover reads the resolve handlers added.
 	if v := r.Context().Value(ctxkeys.SettingsReadMsKey); v != nil {
 		if p, ok := v.(*float64); ok {
 			st.timings.settingsReadMs = *p
 		}
 	}
 
-	// Initial overhead estimate (dialMs=0 — not yet populated).
-	// proxyOverhead is recomputed after each dial inside the failover loop
-	// so that all exit paths (backoff disconnect, error, failRequest) use
-	// the current accumulated total.
+	// Initial overhead estimate, with dialMs still 0. The failover loop
+	// recomputes proxyOverhead after each dial so every exit path (backoff
+	// disconnect, error, failRequest) uses the current accumulated total.
 	st.proxyOverhead = st.timings.proxyOverheadMs(st.parseMs)
 
-	// Non-streaming timeout is configurable via request_timeout setting (default 1m).
-	// Streaming requests get 10× the non-streaming timeout to accommodate
-	// thinking/reasoning models that can take several minutes before first token.
-	// Long-running multimodal endpoints (image generation, audio) get the same
-	// extended budget: their legitimate latencies and response transfers also
-	// run for minutes without carrying a chat-style stream flag.
-	// Read once before the loop so all attempts within a single request use
-	// the same timeout, avoiding inconsistency if the setting changes mid-request.
+	// The non-streaming timeout comes from the request_timeout setting, default
+	// 1m. Streaming requests get 10x that, to accommodate reasoning models that
+	// can take minutes before the first token, and so do the long-running
+	// multimodal endpoints (image generation, audio), whose legitimate latencies
+	// run just as long without carrying a chat-style stream flag.
+	//
+	// Read once before the loop so every attempt in a request uses the same
+	// timeout even if the setting changes mid-request.
 	rtStart := time.Now()
 	baseTimeout := h.settingsRepo.GetDuration(r.Context(), "request_timeout", time.Minute)
 	ctxkeys.AddSettingsReadMs(r.Context(), rtStart)
@@ -429,7 +425,8 @@ func (h *Handler) loadFailoverConfig(r *http.Request, st *requestState) {
 		st.failoverTimeout = baseTimeout * 10
 	}
 
-	// Read circuit_breaker_enabled once before the loop to avoid repeated settings reads.
+	// Read circuit_breaker_enabled once before the loop, to avoid repeated
+	// settings reads.
 	cbStart2 := time.Now()
 	st.circuitBreakerEnabled = h.settingsRepo.GetBool(r.Context(), "circuit_breaker_enabled", true)
 	// Same once-per-request read for the adaptive in-flight limiter; a nil
@@ -444,18 +441,15 @@ func (h *Handler) loadFailoverConfig(r *http.Request, st *requestState) {
 	st.hedgeDelay = max(h.settingsRepo.GetDuration(r.Context(), "hedge_delay", 4*time.Second), minHedgeDelay)
 	ctxkeys.AddSettingsReadMs(r.Context(), hedgeStart)
 
-	// Overall request deadline: caps total time across all failover candidates
-	// to prevent resource pinning from silent clients. Without this, N candidates
-	// with per-candidate failoverTimeout could hold a goroutine for N×failoverTimeout.
-	// The ceiling is 2× the per-candidate timeout, giving a second attempt full time
-	// while capping any number of subsequent candidates to the remaining budget.
+	// The overall request deadline caps total time across all failover
+	// candidates, so a silent client cannot pin a goroutine for N candidates x
+	// failoverTimeout. The ceiling is 2x the per-candidate timeout, giving a
+	// second attempt its full time while capping any number of subsequent
+	// candidates to the remaining budget.
 	st.overallDeadline = st.startTime.Add(st.failoverTimeout * 2)
 
-	// Final re-read of accumulated settings read time. The initial read
-	// captured the rate limiter's contribution, resolve handlers added
-	// circuit breaker/failover settings, and the proxy loop added
-	// request_timeout and circuit_breaker_enabled reads. Recompute
-	// proxyOverhead with the complete total.
+	// Final re-read of the accumulated settings-read time, which now also holds
+	// this function's request_timeout and circuit_breaker_enabled reads.
 	if v := r.Context().Value(ctxkeys.SettingsReadMsKey); v != nil {
 		if p, ok := v.(*float64); ok {
 			st.timings.settingsReadMs = *p

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -15,15 +15,15 @@ import (
 
 func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, opts streamOptions) {
 
-	// Progressive stall timeout (progressiveChunkThreshold /
-	// progressiveStallMultiplier, package consts): after this many chunks the
-	// stream is clearly alive — extend the watchdog timeout to tolerate
-	// tool-call pauses and long reasoning chains.
+	// Progressive stall timeout (progressiveChunkThreshold and
+	// progressiveStallMultiplier): past that many chunks the stream is clearly
+	// alive, so the watchdog timeout extends to tolerate tool-call pauses and
+	// long reasoning chains.
 
 	defer func() {
-		// Drain remaining bytes so the Transport reuses the connection.
-		// Skip drain if the client already disconnected: the upstream body
-		// could be large and we'd block the goroutine for no benefit.
+		// Drain remaining bytes so the Transport reuses the connection, unless
+		// the client already disconnected: the upstream body may be large and
+		// draining it would block the goroutine for no benefit.
 		if r.Context().Err() == nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
 		}
@@ -33,27 +33,27 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 
 	h.initStreamResponse(w, logData, opts, resp)
 
-	// streamSink owns w/flusher and the running bytesWritten total (Phase 1
-	// of the streaming-pipeline refactor). All emit paths go through it.
+	// streamSink owns w, the flusher and the running bytesWritten total. All
+	// emit paths go through it.
 	sink := newStreamSink(w)
 
-	// streamReader owns the scanner (replaying the TTFT probe buffer), the
-	// stall watchdog, chunk counting, the empty-line limit, client-disconnect
-	// detection, BOM/CR cleanup, and SSE classification (Phase 3). It yields
-	// classified sseEvents; this orchestrator owns emits and transforms.
+	// streamReader owns the scanner (replaying the TTFT probe buffer), the stall
+	// watchdog, chunk counting, the empty-line limit, client-disconnect
+	// detection, BOM/CR cleanup, and SSE classification. It yields classified
+	// sseEvents; this orchestrator owns emits and transforms.
 	reader := newStreamReader(r.Context(), resp.Body, opts, logData, h.shutdown)
 
-	// st accumulates the per-stream metrics, carry flags, and observer state
-	// (Phase 4 §6 migration). Created before the loop and mutated in place so
-	// the transforms/observers and the finalizer share one named contract
-	// instead of a fistful of loop-locals. The stall flag and final chunkCount
-	// are filled from the reader at logUpdate.
+	// st accumulates the per-stream metrics, carry flags and observer state. It
+	// is created before the loop and mutated in place so the transforms,
+	// observers and finalizer share one named contract instead of a fistful of
+	// loop-locals. The stall flag and final chunkCount are filled from the
+	// reader at logUpdate.
 	st := &streamState{masker: opts.masker, content: logData.content}
-	// Periodic streaming progress logging (every 50 chunks) to give
-	// visibility into stream health without flooding logs.
+	// Periodic streaming progress logging, for visibility into stream health
+	// without flooding the logs.
 	const chunkLogInterval = 50
-	// Read strip_reasoning flag from context once before the scanner loop.
-	// The value is set by ProxyKeyMiddleware and never changes mid-stream.
+	// The strip_reasoning flag is read from the context once before the scanner
+	// loop: ProxyKeyMiddleware sets it and it never changes mid-stream.
 	stripReasoning := false
 	if v := r.Context().Value(ctxkeys.VirtualKeyStripReasoningKey); v != nil {
 		if sr, ok := v.(bool); ok {
@@ -65,8 +65,8 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 	for {
 		ev, ok := reader.Next()
 		if !ok {
-			// Reader stopped: disconnect (skip the stream-end error flush,
-			// matching the prior goto), empty-line abort, or normal EOF.
+			// Reader stopped: a disconnect (which skips the stream-end error
+			// flush), an empty-line abort, or a normal EOF.
 			if reader.disconnected {
 				st.clientDisconnected = true
 				goto logUpdate
@@ -78,7 +78,7 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 		}
 		chunkCount := reader.chunkCount
 
-		// Periodic streaming progress log for observability.
+		// Periodic streaming progress log.
 		if chunkCount%chunkLogInterval == 0 {
 			debuglog.Debug("proxy: streaming progress", "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten, "prompt_tokens", st.promptTokens, "completion_tokens", st.completionTokens, "thinking", st.sawThinking)
 		}
@@ -116,16 +116,16 @@ func (h *Handler) handleStreamingResponse(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	// Flush any remaining accumulated error bytes at stream end.
+	// Flush any accumulated error bytes still held at stream end.
 	st.flushAccumulatedError("proxy: accumulated SSE error (stream end)", reader.chunkCount, logData)
 
 logUpdate:
-	// Stop the watchdog before reading its stall flag, matching the prior
-	// inline ordering (close, then read the atomic).
+	// Stop the watchdog before reading its stall flag: close, then read the
+	// atomic.
 	reader.Close()
-	// st was accumulated in place by the loop; fill the reader-owned fields the
-	// loop couldn't (final chunk count and the stall flag, read after watchdog
-	// teardown), then finalize.
+	// st was accumulated in place by the loop; fill in the reader-owned fields
+	// it could not (the final chunk count and the stall flag, read after
+	// watchdog teardown), then finalize.
 	st.chunkCount = reader.chunkCount
 	st.stalled = reader.stalled()
 	st.interrupted = reader.interrupted()
@@ -143,11 +143,11 @@ func (h *Handler) initStreamResponse(w http.ResponseWriter, logData *requestLogD
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 	// 200 on the wire even when the upstream answered another 2xx, unlike the
-	// non-streaming half which passes the provider's status through. This is the
-	// gateway's own SSE stream, and EventSource treats any non-200 as a
-	// connection failure, so forwarding a 201 here would break browser clients
-	// for a status they never needed to see. The upstream's real status is
-	// recorded on the row below.
+	// non-streaming half, which passes the provider's status through. This is
+	// the gateway's own SSE stream and EventSource treats any non-200 as a
+	// connection failure, so forwarding a 201 would break browser clients for a
+	// status they never needed to see. The upstream's real status goes on the
+	// row below.
 	w.WriteHeader(http.StatusOK)
 	debuglog.Debug("proxy: streaming headers sent", "model", logData.modelID, "provider", logData.providerName)
 
@@ -164,14 +164,14 @@ func (h *Handler) initStreamResponse(w http.ResponseWriter, logData *requestLogD
 	logData.ttftMs = opts.trueTtftMs
 	logData.failoverAttempt = opts.attempt
 	logData.state = "streaming"
-	// Fire-and-forget: the interim "streaming" state update runs before
-	// the first streamed byte. Blocking on WaitForInsert (up to 5s) would
-	// delay the client. The final update (completed/failed) waits properly.
+	// Fire-and-forget: the interim "streaming" state update runs before the
+	// first streamed byte, where blocking on WaitForInsert (up to 5s) would
+	// delay the client. The final update waits properly.
 	h.updateRequestLog(logData, updateLogOption{skipWaitForInsert: true})
-	// The provider is now committed and the row carries it; tell the dashboard
-	// so a live row can swap its "Resolving" placeholder for the real
-	// provider/model while the (possibly reasoning-only) stream is still in
-	// flight, instead of waiting for the terminal request.completed event.
+	// The provider is committed and the row carries it, so the dashboard is told
+	// and a live row can swap its "Resolving" placeholder for the real provider
+	// and model while the stream is still in flight, instead of waiting for the
+	// terminal request.completed event.
 	publishRequestStreamingEvent(logData)
 }
 
@@ -180,17 +180,17 @@ func (h *Handler) initStreamResponse(w http.ResponseWriter, logData *requestLogD
 // suppressed so downstream parsers don't see a bare "\n" event. Returns
 // stop=true on a client write failure (the caller jumps to finalize).
 func (h *Handler) emitBlank(sink *streamSink, st *streamState, chunkCount int, logData *requestLogData) (stop bool) {
-	// When strip_reasoning skips a reasoning chunk, the SSE separator (empty
-	// line) that followed it must also be suppressed. Bare \n events break
-	// parsers like openai-go's ssestream (Warp's backend). Only forward the
-	// separator when the preceding data line was actually forwarded.
+	// When strip_reasoning skips a reasoning chunk, the SSE separator that
+	// followed it must be suppressed too: a bare \n event breaks parsers such as
+	// openai-go's ssestream. The separator is forwarded only when the preceding
+	// data line was.
 	if sink.swallowBlank {
 		sink.swallowBlank = false
 		return false
 	}
-	// Forward empty lines — they are SSE event separators required by the spec.
-	// Clients like eventsource-parser dispatch events on blank lines; omitting
-	// them causes all data lines to be concatenated into one invalid event.
+	// Empty lines are the SSE event separators the spec requires. Clients such
+	// as eventsource-parser dispatch events on blank lines, so omitting them
+	// concatenates every data line into one invalid event.
 	if err := sink.write([]byte("\n")); err != nil {
 		st.clientDisconnected = true
 		debuglog.Warn("proxy: client write failed during stream (blank line)", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
@@ -206,15 +206,14 @@ func (h *Handler) emitBlank(sink *streamSink, st *streamState, chunkCount int, l
 // accumulated split-error first. Returns stop=true on a client write failure.
 func (h *Handler) emitComment(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	line := ev.raw
-	// Not a data line — an SSE comment (": ..."), an event/id/retry directive,
-	// etc. Pass through without parsing.
+	// Not a data line: an SSE comment (": ..."), or an event/id/retry directive.
+	// It passes through without parsing.
 	lineStr := ev.clean
-	// P1-C: Detect Anthropic-style "event: error" lines for logging. Anthropic
-	// streams use typed events like:
+	// P1-C: Anthropic streams use typed events, as in
 	//   event: error
 	//   data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
-	// We track "event: error" so the next data line is known to be an error
-	// payload, allowing us to extract the message for logging.
+	// so "event: error" is tracked and the next data line is known to be an
+	// error payload whose message can be extracted for the log.
 	if strings.HasPrefix(lineStr, "event:") {
 		evt := strings.TrimSpace(lineStr[6:])
 		if evt == "error" {
@@ -223,8 +222,8 @@ func (h *Handler) emitComment(sink *streamSink, st *streamState, ev sseEvent, ch
 			st.lastAnthropicEvent = ""
 		}
 	}
-	// Flush any accumulated error when a non-data line arrives
-	// (the error payload has already been captured in the data line).
+	// Flush any accumulated error when a non-data line arrives: the error
+	// payload was already captured on the data line.
 	st.flushAccumulatedError("proxy: accumulated SSE error", chunkCount, logData)
 	if err := sink.write(line); err != nil {
 		st.clientDisconnected = true
@@ -240,14 +239,13 @@ func (h *Handler) emitComment(sink *streamSink, st *streamState, ev sseEvent, ch
 	return false
 }
 
-// emitDone forwards the [DONE] sentinel to the client. It sets st.sawDone before
-// the write — verbatim ordering — so a disconnect mid-[DONE] still leaves sawDone
-// set for finalizeStream's missing-[DONE] decision. Returns stop=true on a client
-// write failure; on success the caller breaks the loop into finalize.
+// emitDone forwards the [DONE] sentinel to the client. st.sawDone is set before
+// the write, so a disconnect mid-[DONE] still leaves it set for finalizeStream's
+// missing-[DONE] decision. Returns stop=true on a client write failure; on
+// success the caller breaks the loop into finalize.
 func (h *Handler) emitDone(sink *streamSink, st *streamState, ev sseEvent, chunkCount int, logData *requestLogData) (stop bool) {
 	line := ev.raw
 	st.sawDone = true
-	// Write [DONE] sentinel to the downstream client.
 	if err := sink.write(line); err != nil {
 		st.clientDisconnected = true
 		debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
@@ -277,11 +275,11 @@ func (st *streamState) emitData(sink *streamSink, payload []byte, transform stri
 	return true
 }
 
-// applyReasoningNormalize is the reasoning field normalization transform:
-// ensure reasoning_content is populated regardless of upstream format (Ollama
-// reasoning, OpenRouter/MiniMax reasoning_details, <thinking> tags in
-// content). Emits the rewritten chunk itself; wrote reports that emit and
-// stop=true a client write failure.
+// applyReasoningNormalize is the reasoning-field normalization transform: it
+// ensures reasoning_content is populated whatever the upstream format (Ollama
+// reasoning, OpenRouter/MiniMax reasoning_details, <thinking> tags in content).
+// It emits the rewritten chunk itself; wrote reports that emit, and stop=true a
+// client write failure.
 func (st *streamState) applyReasoningNormalize(sink *streamSink, chunk streamChunk, payload string, chunkCount int, logData *requestLogData) (wrote, stop bool) {
 	if len(chunk.Choices) == 0 || chunk.Choices[0].Delta == nil {
 		return false, false
@@ -299,8 +297,8 @@ func (st *streamState) applyReasoningNormalize(sink *streamSink, chunk streamChu
 }
 
 // applyEmptyContentStrip strips the noise content:"" that accompanies
-// reasoning-only deltas. Emits the rewritten chunk itself; wrote reports that
-// emit and stop=true a client write failure.
+// reasoning-only deltas. It emits the rewritten chunk itself; wrote reports that
+// emit, and stop=true a client write failure.
 func (st *streamState) applyEmptyContentStrip(sink *streamSink, chunk streamChunk, payload string, chunkCount int, logData *requestLogData) (wrote, stop bool) {
 	if len(chunk.Choices) == 0 || chunk.Choices[0].Delta == nil {
 		return false, false
@@ -333,33 +331,34 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	payload := ev.payload
 	line := ev.raw
 
-	// Capture split (P1-B) and Anthropic typed (P1-C) SSE errors into streamState.
-	// anthropicErrorCounted prevents the chunk.Error observer from double-counting.
+	// Capture truncated (P1-B) and Anthropic typed (P1-C) SSE errors into
+	// streamState. anthropicErrorCounted keeps the chunk.Error observer from
+	// double-counting.
 	anthropicErrorCounted := st.captureSSEError(payload, &st.lastAnthropicEvent, chunkCount, logData)
 
 	var written bool
 	var chunk streamChunk
 	// A shape this gateway does not model is not broken bytes. encoding/json
-	// checks the whole document for well-formedness BEFORE it decodes any of it,
-	// so an UnmarshalTypeError is proof the frame is valid JSON — and the decoder
+	// checks the whole document for well-formedness BEFORE decoding any of it,
+	// so an UnmarshalTypeError is proof the frame is valid JSON, and the decoder
 	// records that error and carries on with the siblings, so chunk holds every
 	// member that did fit.
 	//
-	// Read as "were these even JSON", one unmodelled sibling deleted the frame:
+	// Read as "were these even JSON", one unmodelled sibling deletes the frame:
 	// a relay numbering its stop reasons, or content as the array of parts the
-	// OpenAI schema now permits, and the caller lost the model's output while the
-	// observers, the masking and the error member all went unread. The frame is
+	// OpenAI schema permits, and the caller loses the model's output while the
+	// observers, the masking and the error member all go unread. The frame is
 	// the provider's answer whether or not this gateway has a struct for it.
 	//
 	// What it cannot go through are the transforms that rebuild the frame from
 	// that struct: the member that failed is missing from it, so rebuilding a
-	// content-as-parts frame would re-emit it with an empty delta, which is the
-	// same loss by another route. It is observed, masked, and forwarded verbatim,
-	// stopping short of strip_reasoning, the reasoning/empty-content transforms
-	// and finish_reason normalisation. Tool-argument normalisation is deliberately
-	// NOT skipped — it works over the payload as a map of raw members rather than
-	// the struct, so it rewrites the one member it understands and leaves the rest
-	// of the frame exactly as it arrived.
+	// content-as-parts frame would re-emit it with an empty delta, the same loss
+	// by another route. It is observed, masked and forwarded verbatim, stopping
+	// short of strip_reasoning, the reasoning and empty-content transforms and
+	// finish_reason normalisation. Tool-argument normalisation is NOT skipped: it
+	// works over the payload as a map of raw members rather than the struct, so
+	// it rewrites the one member it understands and leaves the rest of the frame
+	// as it arrived.
 	raw := []byte(payload)
 	decodeErr := json.Unmarshal(raw, &chunk)
 	typeErr := shapeError(raw, decodeErr)
@@ -367,11 +366,12 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	jsonValid := decodeErr == nil || untypeable
 	if jsonValid {
 		// Side-channel observers (usage, native_finish_reason, repeated content,
-		// chunk.Error) run for EVERY valid chunk — BEFORE the transforms, which may
-		// emit-and-return early (strip_reasoning keep-alive/forward). Running them
-		// here is what keeps usage/token metering from being silently dropped when a
-		// provider rides `usage` on the same chunk as a reasoning delta. They read
-		// the immutable typed chunk and never emit, so position doesn't affect output.
+		// chunk.Error) run for EVERY valid chunk, BEFORE the transforms, which
+		// may emit and return early (a strip_reasoning keep-alive or forward).
+		// Running them here keeps token metering from being dropped when a
+		// provider rides `usage` on the same chunk as a reasoning delta. They
+		// read the immutable typed chunk and never emit, so their position does
+		// not affect output.
 		deliveredBefore := st.deliveredBytes
 		st.observeDataChunk(chunk, anthropicErrorCounted, chunkCount, logData)
 
@@ -389,15 +389,14 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
 		// util.ErrorMemberCarries, not the member's mere presence. The regex runs
-		// over the WHOLE frame, and it can match prose — so on a frame that is
-		// not really an error it rewrites the model's answer. "error":null
-		// alongside a delta is an ordinary per-frame shape for several
-		// relays, and gating on presence redacted a key-shaped token out of
-		// the content those frames carry: an assistant explaining an AIza… or
-		// a Bearer header had its answer altered mid-stream. That is a worse
-		// failure than missing the third masking layer on a frame whose error
-		// member is empty, where the credential could only be in the content
-		// the regex must not touch anyway.
+		// over the WHOLE frame and can match prose, so on a frame that is not
+		// really an error it would rewrite the model's answer. "error":null
+		// alongside a delta is an ordinary per-frame shape for several relays,
+		// and gating on presence redacts a key-shaped token out of the content
+		// those frames carry, altering the answer of an assistant explaining an
+		// AIza… or a Bearer header mid-stream. That is worse than missing the
+		// third masking layer on a frame whose error member is empty, where the
+		// credential could only be in content the regex must not touch anyway.
 		if util.ErrorMemberCarries(chunk.Error) {
 			// An error frame is error text: every held provider key and the
 			// shape layer, not only the candidate's key the content pass
@@ -414,12 +413,9 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// Rewrite an object-form tool call into the spec's JSON string before it
 		// leaves the gateway. Accepting the object on the way IN is what stops
 		// the frame being dropped; rewriting it on the way OUT is what makes the
-		// caller's next request spec-shaped, whoever reads it.
-		//
-		// This used to be load-bearing for the gateway's own egress translators,
-		// which could not read the object form back. They can now, so what is
-		// left is conformance: the caller asked this gateway for the OpenAI
-		// shape, and an SDK or another gateway downstream is entitled to it.
+		// caller's next request spec-shaped, whoever reads it. This is
+		// conformance: the caller asked this gateway for the OpenAI shape, and
+		// an SDK or another gateway downstream is entitled to it.
 		if normalized, changed := normalizeToolArguments(payload); changed {
 			payload = normalized
 			line = append([]byte("data: "), normalized...)
@@ -432,17 +428,17 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			if stripReasoning && untypedFrameResistsStripping(untypedDelta.delta) {
 				// strip_reasoning is a promise to the caller, and forwarding a
 				// frame this gateway cannot read is no way to keep it.
-				// computeStripReasoning works over the payload and would run — but
-				// its "does this delta still carry anything" verdict reads content
-				// as a plain string, so a content-as-parts delta looks empty to it
-				// and becomes a keep-alive, taking the answer with it.
+				// computeStripReasoning would run over the payload, but its "does
+				// this delta still carry anything" verdict reads content as a
+				// plain string, so a content-as-parts delta looks empty to it and
+				// becomes a keep-alive, taking the answer with it.
 				//
 				// Only a frame that might be hiding reasoning is dropped. Gating
-				// on untypeable alone deleted the answer out of an ordinary
-				// content delta whose finish_reason happened to be a number, and
-				// gating on "content is not a plain string" deleted it out of
-				// every content-as-parts frame — which is the loss this whole
-				// change exists to stop, reinstated for one class of key.
+				// on untypeable alone deletes the answer out of an ordinary
+				// content delta whose finish_reason happens to be a number, and
+				// gating on "content is not a plain string" deletes it out of
+				// every content-as-parts frame.
+				//
 				// The observers ran before this branch and counted whatever
 				// decoded. The caller is not receiving this frame, so it is not
 				// delivery and must not be billed: roll that count back.
@@ -455,45 +451,40 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 				sink.swallowBlank = true
 				return false
 			}
-			// deliveredBytes is deliberately left exactly as the observers set
-			// it: this gateway meters what it could READ and does not guess at
-			// the rest.
-			//
-			// Every member of this frame that decoded has already been counted
-			// correctly, across every choice. What is missing is the member that
-			// did not, and four attempts at estimating it were wrong in four
-			// different directions — the raw member length billed a tool-call
-			// frame nine times over, and an empty content-as-parts opener
-			// ({"content":[{"type":"text","text":""}]}) counted as delivery,
-			// which credited the circuit breaker and suppressed the error charge
-			// so a provider failing every request could never open its circuit.
+			// deliveredBytes is left exactly as the observers set it: this
+			// gateway meters what it could READ and does not guess at the rest.
+			// Every member of this frame that decoded is already counted, across
+			// every choice; what is missing is the member that did not, and
+			// estimating it goes wrong in both directions. The raw member length
+			// bills a tool-call frame nine times over, and an empty
+			// content-as-parts opener ({"content":[{"type":"text","text":""}]})
+			// counts as delivery, crediting the circuit breaker and suppressing
+			// the error charge so a provider failing every request could never
+			// open its circuit.
 			//
 			// So an answer delivered ONLY in a shape this gateway cannot read is
-			// currently unbilled when the provider also reports no usage. That is
-			// a revenue gap, and it is the safe direction: the caller receives
-			// content master deleted outright. Reading the text out of a part
-			// array is the job of the content-as-parts work, and it is queued
-			// with it rather than guessed at here.
-			// Counted like any frame this gateway could not read: the end-of-stream
-			// verdict must not conclude the provider sent nothing on the strength
-			// of frames it could not see into (judgeStreamForBreaker reads
-			// delivery first, so a stream that plainly answered is still
-			// credited). Calling a forwarded frame delivery in its own right was
-			// worse: the terminal chunk is exactly where a relay numbers its stop
-			// reason, and that frame carries no output at all.
+			// unbilled when the provider also reports no usage. That is a revenue
+			// gap, and the safe direction: the caller receives the content rather
+			// than losing it. Reading text out of a part array belongs to the
+			// content-as-parts work.
 			//
-			// The mismatch, not the payload: which member, and what shape
-			// arrived. "choices.0.finish_reason arrived as a number" is the whole
-			// diagnosis and the part an operator can act on; the frame itself is
-			// the provider's, and the commonest reason one lands here is that the
-			// model's own output was written in a shape this gateway has no struct
-			// for — so the payload does not go in the log.
+			// The frame is counted like any this gateway could not read, so the
+			// end-of-stream verdict does not conclude the provider sent nothing
+			// on the strength of frames it could not see into
+			// (judgeStreamForBreaker reads delivery first, so a stream that
+			// plainly answered is still credited). Calling a forwarded frame
+			// delivery in its own right is worse: the terminal chunk is where a
+			// relay numbers its stop reason, and it carries no output at all.
 			//
-			// Field is bounded even though streamChunk has no member that could
-			// make it long today: encoding/json writes a MAP KEY into it
-			// verbatim, so the day a map is added to that struct is the day this
-			// line starts carrying provider text, and the bound is cheaper than
-			// remembering.
+			// The log line carries the mismatch, not the payload: which member,
+			// and what shape arrived. "choices.0.finish_reason arrived as a
+			// number" is the whole diagnosis and the part an operator can act on,
+			// while the commonest reason a frame lands here is that the model's
+			// own output was written in a shape this gateway has no struct for.
+			//
+			// Field is bounded even though no streamChunk member could make it
+			// long: encoding/json writes a MAP KEY into it verbatim, so a map
+			// added to that struct would start this line carrying provider text.
 			st.unparsedChunks++
 			debuglog.Warn("proxy: forwarding a chunk shape this gateway does not model",
 				"model", logData.modelID, "provider", logData.providerName,
@@ -507,10 +498,11 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		if stripReasoning && len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 			switch decision, newPayload := computeStripReasoning(payload, &st.lastFinishReason, logData); decision {
 			case stripPassthrough:
-				// Payload didn't parse — leave it for the later blocks.
+				// The payload did not parse: leave it for the later blocks.
 				goto stripReasoningDone
 			case stripDrop:
-				// Keep-alive marshal failed (practically unreachable) — drop.
+				// The keep-alive marshal failed, which is practically
+				// unreachable: drop the chunk.
 				return false
 			case stripKeepalive:
 				return !st.emitData(sink, newPayload, "reasoning keep-alive", chunkCount, logData)
@@ -539,7 +531,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 			sink.swallowBlank = true
 			return false
 		case finishRewrite:
-			// Only emit if an earlier transform hasn't already written.
+			// Emit only when an earlier transform has not already written.
 			if !written {
 				if !st.emitData(sink, newPayload, "stream", chunkCount, logData) {
 					return true
@@ -553,22 +545,20 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 forwardUntypeable:
 	if !written && !jsonValid {
 		// Drop what is not a frame instead of forwarding it: bytes that are not
-		// well-formed JSON, and a top-level value that is not an object at all —
-		// a bare number, a list, or the quoted sentinel "[DONE]", none of which a
-		// client can read as a chunk. A frame this gateway merely has no struct
-		// for does NOT come here; it is valid JSON and is forwarded verbatim
-		// below.
+		// well-formed JSON, and a top-level value that is not an object at all
+		// (a bare number, a list, or the quoted sentinel "[DONE]"), none of
+		// which a client can read as a chunk. A frame this gateway merely has no
+		// struct for does NOT come here; it is valid JSON and is forwarded
+		// verbatim below.
 		//
-		// The size, not the bytes. This used to log an 80-rune preview of the
-		// payload, and the commonest reason a frame fails to parse is that the
-		// stream was cut mid-delta — so the preview was the model's answer,
-		// written into the app log, the live viewer and the OTLP export. The
-		// length is what an operator can act on ("frames are arriving
-		// truncated"); the content is the provider's to keep.
+		// The log line carries the size, not the bytes. The commonest reason a
+		// frame fails to parse is a stream cut mid-delta, so a payload preview
+		// would be the model's answer written into the app log, the live viewer
+		// and the OTLP export. The length is what an operator can act on.
 		//
 		// Counted so the end-of-stream verdict knows its view of what was
 		// delivered is incomplete, and does not charge the provider for an
-		// emptiness it cannot actually vouch for.
+		// emptiness it cannot vouch for.
 		st.unparsedChunks++
 		debuglog.Warn("proxy: skipping a data line that is not a chunk",
 			"model", logData.modelID, "provider", logData.providerName,
@@ -577,8 +567,8 @@ forwardUntypeable:
 		return false
 	}
 	if !written {
-		// No transform applied — forward the original line verbatim (preserves
-		// upstream framing like LM Studio's no-space "data:").
+		// No transform applied: forward the original line verbatim, which
+		// preserves upstream framing such as LM Studio's no-space "data:".
 		if err := sink.write(line); err != nil {
 			st.clientDisconnected = true
 			debuglog.Warn("proxy: client write failed during stream", "error", err, "model", logData.modelID, "provider", logData.providerName, "chunks", chunkCount, "bytes_written", sink.bytesWritten)
@@ -596,24 +586,23 @@ forwardUntypeable:
 }
 
 // untypedFrameResistsStripping reports whether a delta this gateway could not
-// type might be hiding reasoning it cannot remove — in which case the frame is
+// type might be hiding reasoning it cannot remove, in which case the frame is
 // dropped rather than forwarded to a key that asked for reasoning to be hidden.
 //
 // Two ways it can. A reasoning member that CARRIES something, by the same rule
-// the rest of the gateway uses for an error member: gating on presence dropped
-// the answer out of every frame from a relay that stamps "reasoning":"" or
-// "reasoning_details":[] on its non-reasoning deltas, which the OpenRouter
-// family does.
+// the rest of the gateway uses for an error member: gating on presence drops the
+// answer out of every frame from a relay that stamps "reasoning":"" or
+// "reasoning_details":[] on its non-reasoning deltas, as the OpenRouter family
+// does.
 //
 // Or a content part this gateway cannot vouch for. Reasoning arrives inside a
 // part array as {"type":"thinking",…} on exactly the Anthropic-shaped relays
 // that make a frame untypeable in the first place, and computeStripReasoning
-// would not catch it either, since it only removes the three named members. But
-// a part array of plain TEXT hides nothing, and rejecting every content that is
-// not a string dropped those too — deleting the whole answer for a
-// strip_reasoning key on any content-as-parts stream, which is the loss this
-// change exists to stop. So the part types are read, and an unrecognised one is
-// what makes a frame unstrippable.
+// would not catch it either, since it removes only the three named members. A
+// part array of plain TEXT hides nothing, though, and rejecting every content
+// that is not a string would delete the whole answer for a strip_reasoning key
+// on any content-as-parts stream. So the part types are read, and an
+// unrecognised one is what makes a frame unstrippable.
 func untypedFrameResistsStripping(delta map[string]json.RawMessage) bool {
 	for _, key := range []string{"reasoning_content", "reasoning_details", "reasoning"} {
 		if util.ValueCarries(delta[key]) {
@@ -632,8 +621,8 @@ func untypedFrameResistsStripping(delta map[string]json.RawMessage) bool {
 		Type string `json:"type"`
 	}
 	if json.Unmarshal(raw, &parts) != nil {
-		// A content shape that is neither a string nor a list of parts. Nothing
-		// here can say what is in it.
+		// A content shape that is neither a string nor a list of parts, so
+		// nothing here can say what is in it.
 		return true
 	}
 	for _, part := range parts {
@@ -653,13 +642,13 @@ func untypedFrameResistsStripping(delta map[string]json.RawMessage) bool {
 // encoding/json writes a number's LITERAL into that field, but only when the
 // number lands on a NUMERIC field: {"content":8675309} into a *string reports
 // "number", while {"n":3.5} into an int reports "number 3.5". No integer field
-// under streamChunk is reachable from here — the only ones live inside Usage,
-// whose own decoder keeps what it can read rather than returning a type error —
-// so today the value is always a bare shape word.
+// under streamChunk is reachable from here, the only ones living inside Usage,
+// whose own decoder keeps what it can read rather than returning a type error,
+// so the value is always a bare shape word.
 //
-// It is kept anyway, and cheaply: the shape is the whole diagnosis, the literal
-// is provider data, and one integer field added to that struct is all it would
-// take for this line to start carrying it. TestJSONShapeName is what holds it.
+// The cut is kept anyway and is cheap: the shape is the whole diagnosis, the
+// literal is provider data, and one integer field added to that struct is all it
+// would take for this line to start carrying it.
 func jsonShapeName(v string) string {
 	shape, _, _ := strings.Cut(v, " ")
 	return shape
@@ -678,11 +667,11 @@ func jsonShapeName(v string) string {
 // forwarded as bytes: rebuilding it from streamChunk would drop every field
 // this gateway does not model.
 func normalizeToolArguments(payload string) (string, bool) {
-	// Cheap reject first. Without it every frame of every stream paid for three
+	// Cheap reject first. Without it every frame of every stream pays for three
 	// json.Unmarshal calls (~5us and ~1.8KB of garbage each) to discover it has
-	// no tool calls — several megabytes of garbage over a long stream, for
-	// nothing. This is also what makes "an ordinary frame is neither reparsed
-	// nor re-emitted" true rather than aspirational.
+	// no tool calls, which is several megabytes of garbage over a long stream.
+	// It is also what makes "an ordinary frame is neither reparsed nor
+	// re-emitted" true rather than aspirational.
 	if !strings.Contains(payload, "tool_calls") {
 		return payload, false
 	}
@@ -695,9 +684,7 @@ func normalizeToolArguments(payload string) (string, bool) {
 		return payload, false
 	}
 	// Re-marshalling below cannot fail: every value came out of a successful
-	// Unmarshal, so each RawMessage holds valid JSON. The errors are discarded
-	// rather than handled, because a branch that cannot be taken is a branch
-	// that cannot be tested.
+	// Unmarshal, so each RawMessage holds valid JSON; the errors are discarded.
 	changed := false
 	for _, choice := range choices {
 		var delta map[string]json.RawMessage

--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -163,8 +163,8 @@ var rateLimitPhrases = []rateLimitPhrase{
 	// Usage windows: time fixes these. The weekly entries must precede the
 	// session/generic ones so the longer pin is not shadowed.
 	//
-	// "limit exhausted" is the broadest phrase here and runs ahead of every
-	// saturated entry, so it also requires the body to name a reset: a spent
+	// "limit exhausted" swallows "concurrency limit exhausted" and runs ahead
+	// of every saturated entry, so it also requires the body to name a reset: a spent
 	// window says when it comes back, a busy provider says "retry shortly", and
 	// "concurrency limit exhausted" must keep reaching the saturated entries
 	// below. The Z.ai entry pins pinHintWeekly rather than the named reset

--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -17,27 +17,23 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// A 429 is two different claims wearing one number, and they need opposite
-// handling:
+// rateLimitClass says which of two claims a 429 makes:
 //
 //   - SATURATED ("busy"): a concurrency slot, RPM or TPM ceiling is full and a
 //     retry succeeds in seconds. Charging the circuit breaker for it benches a
-//     healthy provider, which is how the 2026-08-31 hotel/glm53 run turned
-//     nineteen avoidable 502s out of a provider that had free slots the whole
-//     time.
+//     healthy provider.
 //   - EXHAUSTED ("spent"): a usage window or a balance is gone and a retry
 //     cannot succeed until it resets or someone pays. Spending a second request
 //     to confirm it wastes the request and can tip a saturated sibling over.
 //
-// classifyRateLimit reads the response and says which claim it makes. Known
-// provider phrases and headers are accelerators, never prerequisites: with the
-// whole phrase table deleted the behavioural fallback in classify429Attempt (a
-// recent 2xx on the same circuit means saturated) still converges on the right
-// treatment, only more slowly. An unknown 429 keeps today's behaviour exactly.
+// classifyRateLimit reads the response and says which claim it makes. Provider
+// phrases and headers are accelerators, never prerequisites: the behavioural
+// fallback in classify429Attempt (a recent 2xx on the same circuit means
+// saturated) reaches the same verdict without them, only more slowly.
 type rateLimitClass int
 
 const (
-	// rateLimitUnknown is today's behaviour: failover-eligible, charged.
+	// rateLimitUnknown is failover-eligible and charged to the breaker.
 	rateLimitUnknown rateLimitClass = iota
 	// rateLimitSaturated: slots/RPM/TPM busy, retry in seconds.
 	rateLimitSaturated
@@ -59,16 +55,14 @@ func (c rateLimitClass) String() string {
 // rateLimitVerdict is what one 429 established, threaded from the classifier
 // to the breaker outcome, the saturation retry and the terminal response.
 type rateLimitVerdict struct {
-	// classified says the master switch was ON and the classifier actually
-	// looked, even if it found nothing (class stays unknown). It gates the
-	// 429-open escalation: with rate_limit_classify_enabled off the whole
-	// mechanism, escalation included, must restore today's behaviour bit for
-	// bit.
+	// classified says the classifier ran, even if it found nothing (class stays
+	// unknown). It gates the 429-open escalation, which is off whenever
+	// rate_limit_classify_enabled is off.
 	classified bool
 	class      rateLimitClass
 	// phrase is the phrase-table entry that decided the class, "" when the
 	// headers or the behavioural fallback did. It rides into the attempt trail
-	// so the staleness report can see which phrases still earn their keep.
+	// for the phrase staleness report.
 	phrase string
 	// detail is the sanitized body the classifier read, kept for the attempt
 	// trail (which caps and masks it); never forwarded anywhere else.
@@ -82,7 +76,7 @@ type rateLimitVerdict struct {
 	// Retry-After beyond the saturation ceiling, or the matched phrase's
 	// per-marker default. Zero means "no hint, use the ordinary cooldown". The
 	// breaker clamps it with the same floor/ceiling/jitter rules as an advisor
-	// pin, and an advisor reading always wins over it.
+	// pin, and an advisor reading wins over it.
 	pinHint time.Duration
 	// entitled marks an exhaustion a person fixes (balance, plan) rather than
 	// time; it keeps the provider_not_entitled error kind for those bodies.
@@ -108,7 +102,7 @@ func (v rateLimitVerdict) errorKind() (ErrorKind, bool) {
 const (
 	// defaultSaturationMaxWait is the Retry-After ceiling that separates "wait
 	// for a slot" from "wait for a window": a provider asking for more than a
-	// minute is telling us the window, not the slot. It also caps the
+	// minute is naming the window, not the slot. It also caps the
 	// last-candidate saturation wait. Runtime override:
 	// rate_limit_saturation_max_wait.
 	defaultSaturationMaxWait = 60 * time.Second
@@ -118,8 +112,7 @@ const (
 	// rate_limit_recent_success_window.
 	defaultRecentSuccessWindow = 60 * time.Second
 	// defaultSaturatedRetryAfter is the wait used when a saturated 429 carries
-	// no Retry-After. Two seconds is the shape of the gap the 2026-08-31 run
-	// turned into 502s.
+	// no Retry-After. Two seconds is the typical slot-freeing gap.
 	defaultSaturatedRetryAfter = 2 * time.Second
 	// pinHintWindow is the pin for a usage window whose reset the body names
 	// but does not date (Ollama's session cap, generic quota phrases).
@@ -135,11 +128,10 @@ const (
 )
 
 // rateLimitPhrase is one observed provider sentence and the claim it makes.
-// The table is data, not code: every entry names the provider it was observed
-// on and when (a test enforces both), so an entry can be deleted with its
-// provider and a phrase that stops matching has an owner to ask. Matching is a
-// lowercased substring test on the already-sanitized body, the same discipline
-// classifyUpstreamError uses; `also` narrows a phrase too generic on its own.
+// Every entry names the provider it was observed on and the date, so an entry
+// can be deleted with its provider and a phrase that stops matching has an
+// owner to ask. Matching is a lowercased substring test on the already
+// sanitized body; `also` narrows a phrase too generic on its own.
 type rateLimitPhrase struct {
 	phrase   string
 	also     string // second required substring; "" = none
@@ -151,12 +143,13 @@ type rateLimitPhrase struct {
 }
 
 // rateLimitPhrases is checked in order; first match wins. Exhausted entries
-// come first because an exhaustion body can also contain saturation vocabulary
-// ("rate limit"), and mistaking spent for busy retries into a certain 429.
+// must precede saturated ones: an exhaustion body can also contain saturation
+// vocabulary ("rate limit"), and mistaking spent for busy retries into a
+// certain 429.
 //
 // The entitled entries double as classifyUpstreamError's provider_not_entitled
-// list (entitledRateLimitPhrases below): one table, two consumers, so a phrase
-// cannot be added to one and not the other.
+// list (entitledRateLimitPhrases), so a phrase cannot be added to one and not
+// the other.
 var rateLimitPhrases = []rateLimitPhrase{
 	// Balance / plan: a person fixes these, so the pin holds as long as the
 	// ceiling allows.
@@ -170,25 +163,18 @@ var rateLimitPhrases = []rateLimitPhrase{
 	// Usage windows: time fixes these. The weekly entries must precede the
 	// session/generic ones so the longer pin is not shadowed.
 	//
-	// Z.ai's code 1310 names the reset to the second ("Your limit will reset
-	// at 2026-09-03 18:01:05"); the weekly pin, re-pinned toward that instant
-	// on each open by the advisor when the usage API agrees, is the safe
-	// reading of a body whose date format nothing here parses. Seen live on
-	// prod while the quota advisor was already pinning the same circuit; the
-	// cost of missing it was an "unrecognised" cause on every surface, a
-	// class="unknown" metric and a dependence on that advisor.
-	//
-	// "limit exhausted" alone would be the broadest phrase here, and it runs
-	// ahead of every saturated entry, so it also requires the body to name a
-	// reset: a spent window says when it comes back, a busy provider says
-	// "retry shortly", and "concurrency limit exhausted" must keep reaching
-	// the saturated entries below (a table case holds that line).
+	// "limit exhausted" is the broadest phrase here and runs ahead of every
+	// saturated entry, so it also requires the body to name a reset: a spent
+	// window says when it comes back, a busy provider says "retry shortly", and
+	// "concurrency limit exhausted" must keep reaching the saturated entries
+	// below. The Z.ai entry pins pinHintWeekly rather than the named reset
+	// instant: nothing here parses that date format.
 	{phrase: "limit exhausted", also: "reset", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
 	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "session usage limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "usage limit", also: "upgrade", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud (\"you have reached your session usage limit, upgrade for higher limits\")", observed: "2026-08-31"},
 	{phrase: "overage_limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Neuralwatt (docs; not yet observed live)", observed: "2026-08-31"},
-	// Saturation: capacity vocabulary, all observed on live providers.
+	// Saturation: capacity vocabulary.
 	{phrase: "concurrent_budget_exceeded", class: rateLimitSaturated, provider: "Neuralwatt (2026-08-31 14:52 UTC)", observed: "2026-08-31"},
 	{phrase: "rate_limit_error", also: "concurr", class: rateLimitSaturated, provider: "Neuralwatt", observed: "2026-08-31"},
 	{phrase: "too many concurrent", class: rateLimitSaturated, provider: "Z.ai Coding Plan", observed: "2026-08-31"},
@@ -212,16 +198,15 @@ var (
 	miniMaxWindowCode  = regexp.MustCompile(`"status_code"\s*:\s*"?1039\b`)
 )
 
-// The names the two MiniMax code matches report as their phrase in the attempt
-// trail, so the staleness report can count them beside the table's entries.
+// The phrase names the two MiniMax code matches report in the attempt trail,
+// so the staleness report counts them beside the table's entries.
 const (
 	miniMaxBalancePhrase = "minimax status_code 1008"
 	miniMaxWindowPhrase  = "minimax status_code 1039"
 )
 
-// entitledRateLimitPhrases is the entitled slice of the table, consumed by
-// classifyUpstreamError for provider_not_entitled. Derived, never written out
-// twice; TestRateLimitPhrases_EntitledSubsetOfExhausted pins the relationship.
+// entitledRateLimitPhrases is the entitled slice of the phrase table, consumed
+// by classifyUpstreamError for provider_not_entitled.
 func entitledRateLimitPhrases() []string {
 	var out []string
 	for _, p := range rateLimitPhrases {
@@ -238,9 +223,8 @@ func entitledRateLimitPhrases() []string {
 // the saturated retryAfter.
 //
 // Decision order, first match wins: exhausted by body, saturated by body,
-// saturated-or-exhausted by header, unknown. The caller owns the behavioural
-// fallback for unknown (classify429Attempt); this function is pure so the
-// table tests need no handler.
+// saturated-or-exhausted by header, unknown. The behavioural fallback for
+// unknown lives in classify429Attempt.
 func classifyRateLimit(status int, hdr http.Header, body string, maxWait time.Duration) rateLimitVerdict {
 	if status != http.StatusTooManyRequests {
 		return rateLimitVerdict{}
@@ -278,7 +262,7 @@ func classifyRateLimit(status int, hdr http.Header, body string, maxWait time.Du
 		return v
 	}
 
-	// No phrase matched: let the headers speak. A Retry-After at or under the
+	// No phrase matched: fall back to the headers. A Retry-After at or under the
 	// ceiling is a slot freeing; above it the provider is naming the window.
 	if wait, ok := rateLimitResetHint(hdr); ok {
 		if wait <= maxWait {
@@ -379,9 +363,8 @@ func parseResetValue(v string) (time.Duration, bool) {
 }
 
 // rebufferedBody hands back the bytes the classifier already read, then the
-// rest of the upstream stream, closing the real body. The same restore trick
-// the MiniMax envelope check uses, for the same reason: the downstream drains
-// and forwards must see the response exactly as it arrived.
+// rest of the upstream stream, closing the real body, so the downstream drains
+// and forwards see the response exactly as it arrived.
 type rebufferedBody struct {
 	io.Reader
 	io.Closer
@@ -390,19 +373,17 @@ type rebufferedBody struct {
 // classify429Attempt classifies one attempt's 429 and stamps the verdict on
 // st.rateLimit for the breaker outcome, the saturation retry and the terminal
 // response. It reads (and restores) at most failoverErrorClassifyCap of the
-// body — a 429 body is never forwarded verbatim (forwardableErrorStatus denies
+// body; a 429 body is never forwarded verbatim (forwardableErrorStatus denies
 // the status), so the peek changes nothing downstream.
 //
-// The behavioural fallback lives here, not in classifyRateLimit: an unknown
-// 429 from a (provider, model) circuit that served a 2xx inside
-// rate_limit_recent_success_window is saturated — it was fine a moment ago and
-// the load rose, and a spent window does not come back in a minute. This is
-// the rule that keeps the whole mechanism working with the phrase table
-// deleted; the phrases only make the verdict earlier. With no recent success
-// the verdict stays unknown and the 429 is charged exactly as today.
+// The behavioural fallback lives here rather than in classifyRateLimit because
+// it reads the breaker: an unknown 429 from a (provider, model) circuit that
+// served a 2xx inside rate_limit_recent_success_window is saturated, since a
+// spent window does not come back in a minute. With no recent success the
+// verdict stays unknown and the 429 is charged.
 //
-// rate_limit_classify_enabled OFF restores today's behaviour bit for bit: no
-// body peek, no verdict, every consumer sees rateLimitUnknown.
+// rate_limit_classify_enabled OFF: no body peek, no verdict, every consumer
+// sees rateLimitUnknown.
 func (h *Handler) classify429Attempt(ctx context.Context, st *requestState, candidate modelCandidate, resp *http.Response) rateLimitVerdict {
 	st.rateLimit = rateLimitVerdict{}
 	if resp.StatusCode != http.StatusTooManyRequests {
@@ -433,15 +414,13 @@ func (h *Handler) classify429Attempt(ctx context.Context, st *requestState, cand
 }
 
 // failNoAvailableProvider answers a request whose failover group resolved to
-// zero candidates. When the circuit breaker did the emptying, "502 bad
-// gateway" is not true — nothing upstream faulted on THIS request — so the
-// answer is a 429 with a Retry-After naming the earliest instant a circuit
-// comes back, capped at a minute so a long quota pin never tells a client to
-// go away for hours (a lapsed verdict frees the group far sooner than the
-// last circuit expires). The kind is exhaustion only when every skipped
-// candidate is waiting out a quota pin; a genuine upstream fault (no breaker
-// skips at all: everything disabled or missing) keeps today's 502, and so
-// does switching failover_exhaustion_status_429 off.
+// zero candidates. When the circuit breaker did the emptying nothing upstream
+// faulted on this request, so the answer is a 429 with a Retry-After naming
+// the earliest instant a circuit comes back, capped at a minute so a long
+// quota pin never tells a client to go away for hours. The kind is exhaustion
+// only when every skipped candidate is waiting out a quota pin; a genuine
+// upstream fault (no breaker skips at all: everything disabled or missing)
+// answers 502, and so does switching failover_exhaustion_status_429 off.
 func (h *Handler) failNoAvailableProvider(w http.ResponseWriter, r *http.Request, st *requestState, displayModel string, timings resolveTimings, cacheHits resolveCacheHits, skips breakerSkipSummary) {
 	msg := "no available provider for hotel/" + displayModel
 	metrics.RecordFailoverExhausted(displayModel, "no_available_provider")
@@ -466,11 +445,10 @@ func (h *Handler) failNoAvailableProvider(w http.ResponseWriter, r *http.Request
 }
 
 // rateLimitTerminalKind refines a terminal 429's classification with the
-// attempt's own verdict: the classes carry what the body-driven classifier
-// cannot see (headers, the behavioural fallback) and honour the master switch
-// (no verdict is stamped when it is off, so the old labels stand bit for
-// bit). It refines only the generic kind: a body-derived provider_not_entitled
-// names WHO fixes it and must not be blurred back into "quota".
+// attempt's own verdict, which carries what the body-driven classifier cannot
+// see (headers, the behavioural fallback). It refines only the generic kind: a
+// body-derived provider_not_entitled names WHO fixes it and must not be
+// blurred back into "quota".
 func rateLimitTerminalKind(kind ErrorKind, reason string, status int, v rateLimitVerdict) (ErrorKind, string) {
 	if status != http.StatusTooManyRequests || kind != KindProviderError {
 		return kind, reason
@@ -481,9 +459,8 @@ func rateLimitTerminalKind(kind ErrorKind, reason string, status int, v rateLimi
 	return kind, reason
 }
 
-// rateLimitClientReason words a classified 429 for the client the way
-// classifyUpstreamError words its kinds: gateway-authored static text, never
-// the provider's body.
+// rateLimitClientReason words a classified 429 for the client:
+// gateway-authored static text, never the provider's body.
 func rateLimitClientReason(class rateLimitClass) string {
 	if class == rateLimitExhausted {
 		return "the provider's usage quota is exhausted; retry after it resets"
@@ -491,8 +468,8 @@ func rateLimitClientReason(class rateLimitClass) string {
 	return "the provider is at capacity; retry shortly"
 }
 
-// rateLimitReqErr is the structured attempt error for a classified 429: it
-// keeps the terminal renderers able to tell "busy" from "spent" from "failed".
+// rateLimitReqErr is the structured attempt error for a classified 429, so the
+// terminal renderers can tell "busy" from "spent" from "failed".
 func rateLimitReqErr(v rateLimitVerdict, attempt int, providerName string) reqError {
 	kind, _ := v.errorKind()
 	detail := "HTTP 429 (" + v.class.String() + ")"
@@ -501,7 +478,7 @@ func rateLimitReqErr(v rateLimitVerdict, attempt int, providerName string) reqEr
 
 // failoverReqErr is the attempt error recorded when an eligible upstream error
 // sends the loop to the next candidate: the classified-429 shape when a
-// verdict exists, today's generic one otherwise.
+// verdict exists, the generic one otherwise.
 func failoverReqErr(rl rateLimitVerdict, attempt int, providerName string, status int) reqError {
 	if status == http.StatusTooManyRequests && rl.class != rateLimitUnknown {
 		return rateLimitReqErr(rl, attempt, providerName)
@@ -510,23 +487,21 @@ func failoverReqErr(rl rateLimitVerdict, attempt int, providerName string, statu
 }
 
 // judge429AndRecordBreaker is the one call an attempt path makes between
-// reading the status and acting on it: classify a 429 (eligible ones only —
-// with failover_on_rate_limit OFF a 429 keeps today's stay-and-forward
-// handling untouched) and record the breaker outcome with the verdict. One
-// entry point for the sequential, hedged and pass-through paths, so the three
-// cannot drift.
+// reading the status and acting on it: classify a 429 (eligible ones only, so
+// with failover_on_rate_limit OFF a 429 keeps its stay-and-forward handling)
+// and record the breaker outcome with the verdict. One entry point for the
+// sequential, hedged and pass-through paths, so the three cannot drift.
 func (h *Handler) judge429AndRecordBreaker(ctx context.Context, st *requestState, candidate modelCandidate, resp *http.Response, isFailoverEligible bool) rateLimitVerdict {
 	var rl rateLimitVerdict
 	if isFailoverEligible {
 		rl = h.classify429Attempt(ctx, st, candidate, resp)
 	}
 	// Every 429 lands here, on all three serve paths, so this is the one place
-	// to count them by class and to keep the cap ledger. Both see a 429 that
-	// failover may not act on too (failover_on_rate_limit off): that is a
-	// routing choice, and it must not blind the badge that exists for the
-	// providers nothing else reports on. Such a 429 is classified by a read
-	// that leaves the request untouched, so what the client gets is exactly
-	// what it got before.
+	// to count them by class and to keep the cap ledger. Both also see a 429
+	// failover may not act on (failover_on_rate_limit off): that is a routing
+	// choice, and it must not blind the badge that exists for the providers
+	// nothing else reports on. Such a 429 is classified by a read that leaves
+	// the request untouched, so the client sees exactly what it otherwise would.
 	if resp.StatusCode == http.StatusTooManyRequests {
 		seen := rl
 		if !isFailoverEligible {
@@ -539,15 +514,14 @@ func (h *Handler) judge429AndRecordBreaker(ctx context.Context, st *requestState
 			h.CapLedger().Note(candidate.provider.ID, provider.CapNote{Phrase: seen.phrase, Model: candidateModelID(candidate), Entitled: seen.entitled, At: time.Now()})
 		}
 	}
-	// The saturated 429 teaches the in-flight learner: the pool is provably
-	// smaller than the load that included this request, so the allowance is
-	// cut and the NEXT requests spill to the other entries before anyone has
-	// to say 429 again. Here rather than inside the breaker outcome, because
-	// the limiter is its own feature: circuit_breaker_enabled off must not
-	// stop it learning. The drawing request's own slot settles FIRST
-	// (idempotently), so cut's arithmetic sees exactly the load that fit,
-	// never a count that depends on whether the body reader beat it to the
-	// release.
+	// A saturated 429 teaches the in-flight learner: the pool is provably
+	// smaller than the load that included this request, so the allowance is cut
+	// and the NEXT requests spill to the other entries. Here rather than inside
+	// the breaker outcome, because the limiter is its own feature:
+	// circuit_breaker_enabled off must not stop it learning. The drawing
+	// request's own slot settles FIRST (idempotently), so cut's arithmetic sees
+	// exactly the load that fit, never a count that depends on whether the body
+	// reader beat it to the release.
 	if rl.class == rateLimitSaturated && st.inflightEnabled {
 		st.attemptSlot.settle(false)
 		h.inflight.cut(candidate.provider.ID, rl.retryAfter)
@@ -558,11 +532,10 @@ func (h *Handler) judge429AndRecordBreaker(ctx context.Context, st *requestState
 
 // peekRateLimitVerdict classifies a 429 that failover may not act on, for the
 // 429 counter and the cap ledger only. It rebuffers what it read for whoever
-// forwards the body and writes nothing onto the request state, so the
-// response and its log row are exactly what they were. No behavioural
-// fallback: that reads the breaker, and a verdict nothing acts on does not
-// earn the lookup. rate_limit_classify_enabled off classifies nothing, as
-// everywhere.
+// forwards the body and writes nothing onto the request state, so the response
+// and its log row are untouched. No behavioural fallback: that reads the
+// breaker, and a verdict nothing acts on does not earn the lookup.
+// rate_limit_classify_enabled off classifies nothing.
 func (h *Handler) peekRateLimitVerdict(ctx context.Context, resp *http.Response) rateLimitVerdict {
 	if !h.settingsRepo.GetBool(ctx, "rate_limit_classify_enabled", true) {
 		return rateLimitVerdict{}
@@ -577,8 +550,8 @@ func (h *Handler) peekRateLimitVerdict(ctx context.Context, resp *http.Response)
 // deferSaturatedRetry closes out an attempt whose LAST candidate answered a
 // saturated 429: the response is drained, the attempt recorded, and the loop
 // told to wait and try the same candidate once more (outcomeRetrySaturated).
-// The point is to absorb the two-second gaps that became 502s on 2026-08-31,
-// not to build a queue — st.saturationRetried caps it at one.
+// It absorbs a short slot-freeing gap rather than building a queue:
+// st.saturationRetried caps it at one.
 func (h *Handler) deferSaturatedRetry(st *requestState, candidate modelCandidate, resp *http.Response, attempt int) candidateOutcome {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()

--- a/internal/proxy/reqerror.go
+++ b/internal/proxy/reqerror.go
@@ -9,8 +9,7 @@ import (
 
 // ErrorKind classifies why a proxied request failed. It is the machine-readable
 // contract for the request log and dashboard; the human-facing message is
-// rendered FROM it and must never be parsed to recover the kind. See
-// plans/logging-and-errors-overhaul.md.
+// rendered FROM it and must never be parsed to recover the kind.
 type ErrorKind string
 
 const (
@@ -32,8 +31,8 @@ const (
 	// retrying can never succeed until someone tops up or changes plan.
 	KindProviderNotEntitled ErrorKind = "provider_not_entitled"
 	// KindProviderBadRequest means the provider understood the request and
-	// refused the payload — normally a gateway bug (wrong dialect for the
-	// upstream route), not a provider fault.
+	// refused the payload, normally a gateway bug (the wrong dialect for the
+	// upstream route) rather than a provider fault.
 	KindProviderBadRequest ErrorKind = "provider_bad_request"
 	// KindProviderSaturated means the provider is alive and refusing on
 	// capacity (concurrency slots, RPM, TPM). Retry in seconds. Distinct from
@@ -45,7 +44,7 @@ const (
 	// resets. The difference from KindProviderNotEntitled is who fixes it:
 	// time, versus a person topping up or changing plan.
 	KindProviderQuotaExhausted ErrorKind = "provider_quota_exhausted"
-	// KindProviderTimeout means the TTFT probe or stall watchdog fired — the
+	// KindProviderTimeout means the TTFT probe or stall watchdog fired: the
 	// provider accepted the connection but did not produce output in time.
 	KindProviderTimeout ErrorKind = "provider_timeout"
 	// KindFailoverTimeout means the overall failover deadline expired.
@@ -53,9 +52,9 @@ const (
 	// KindRetryTimeout means the param-strip retry's deadline expired.
 	KindRetryTimeout ErrorKind = "retry_timeout"
 	// KindHedgeSuperseded means the gateway itself abandoned this attempt because
-	// another hedged candidate won the race. It is not a failure of the provider
-	// and not a client hangup — the client is still connected and is served by
-	// the winner — so it must never be confused with KindClientDisconnect.
+	// another hedged candidate won the race. It is not a provider failure and
+	// not a client hangup, since the client is still connected and served by the
+	// winner, so it must never be confused with KindClientDisconnect.
 	KindHedgeSuperseded ErrorKind = "hedge_superseded"
 	// KindInternal is a gateway-internal failure (e.g. could not build the request).
 	KindInternal ErrorKind = "internal"
@@ -68,14 +67,14 @@ const (
 
 // reqError is the structured description of a single failed failover attempt,
 // threaded through the loop as requestState.lastReqErr. The exhaustion path
-// (failAllExhausted) renders it — possibly wrapped — into the terminal request
+// (failAllExhausted) renders it, possibly wrapped, into the terminal request
 // log message, the client response, and the HTTP status code.
 //
 // Attempt is 0-based internally and always rendered 1-based for humans.
-// Underlying preserves the real provider/transport error even when the
+// Underlying preserves the real provider or transport error even when the
 // attempt's terminal cause is a context cancellation, so the original failure
-// is never silently dropped (the motivating bug). Detail carries a short
-// structured fragment such as "HTTP 500".
+// is never silently dropped. Detail carries a short structured fragment such as
+// "HTTP 500".
 type reqError struct {
 	Kind       ErrorKind
 	Attempt    int
@@ -89,26 +88,19 @@ type reqError struct {
 	Hint string
 }
 
-// cancelOriginToKind maps an internal cancel-origin identifier (the value
-// stored under ctxkeys.CancelOriginKey, also fed to humanReadableCancelOrigin)
-// to its error kind.
 // cancelKind classifies a failure that is a context error rather than the
-// provider misbehaving, and reports whether it was one.
-//
-// It exists because a second, narrower spelling of this rule kept being
-// hand-rolled at each new site and kept dropping a case. The one that cost most:
-// checking only errors.Is(err, context.Canceled) missed context.DeadlineExceeded,
-// which is what this gateway's own request_timeout produces mid-body-read — so a
-// slow but healthy provider was charged with a breaker failure, five of them
-// taking it out of rotation for every tenant.
+// provider misbehaving, and reports whether it was one. It is the package's
+// single spelling of that rule: a narrower one checking only
+// errors.Is(err, context.Canceled) misses context.DeadlineExceeded, which is
+// what this gateway's own request_timeout produces mid-body-read, and a slow but
+// healthy provider is then charged with a breaker failure.
 //
 // Two inputs, one question: the error itself, and the attempt's context going
-// down underneath a read that reported something else. Keeping those as two
-// separate guards at each site is what let one of them ship without the other.
+// down underneath a read that reported something else.
 //
 // Whoever cancelled, it was not the provider: every kind this returns is
 // excluded by providerAtFault, so a caller that classifies with this and then
-// gates on providerAtFault needs no separate client-gone guard at all.
+// gates on providerAtFault needs no separate client-gone guard.
 func cancelKind(ctx context.Context, err error) (ErrorKind, bool) {
 	interrupted := errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 	if !interrupted && ctx.Err() == nil {
@@ -123,6 +115,9 @@ func cancelKind(ctx context.Context, err error) (ErrorKind, bool) {
 	return cancelOriginToKind(resolveCancelOrigin(ctx, err)), true
 }
 
+// cancelOriginToKind maps an internal cancel-origin identifier (the value stored
+// under ctxkeys.CancelOriginKey, also fed to humanReadableCancelOrigin) to its
+// error kind.
 func cancelOriginToKind(origin string) ErrorKind {
 	switch origin {
 	case "client_disconnect":
@@ -236,8 +231,8 @@ func (e reqError) terminalLogMessage(isFailover bool, numCandidates int) string 
 		return last
 	case KindProviderSaturated:
 		// Busy, not broken: every provider is alive and at capacity, and "all
-		// providers failed" would send the operator hunting an outage that is
-		// not happening.
+		// providers failed" sends the operator hunting an outage that is not
+		// happening.
 		if isFailover && numCandidates > 1 {
 			return fmt.Sprintf("all %d providers busy; last error: %s", numCandidates, last)
 		}
@@ -260,12 +255,12 @@ func (e reqError) terminalClientMessage(reqModel string, isFailover bool) string
 	case KindFailoverTimeout, KindRetryTimeout:
 		return fmt.Sprintf("request timed out for model %s", reqModel)
 	case KindHedgeSuperseded:
-		// Not reachable today (a superseded attempt is always replaced by the
-		// winner) but it must never render as "all providers failed".
+		// Not reachable while a superseded attempt is always replaced by the
+		// winner, but it must never render as "all providers failed".
 		return fmt.Sprintf("request superseded for model %s", reqModel)
 	case KindProviderSaturated:
 		// Alive and at capacity: telling the caller everything "failed" makes
-		// an immediate retry look pointless when it is exactly what will work.
+		// an immediate retry look pointless when it is what will work.
 		if isFailover {
 			return fmt.Sprintf("all providers busy for model %s, retry shortly", reqModel)
 		}
@@ -296,7 +291,7 @@ func errString(err error) string {
 	return string(r)
 }
 
-// statusClientClosedRequest is nginx's non-standard 499 "Client Closed Request".
-// Go's net/http has no constant for it. Used (in the request log and on the
-// wire) whenever the terminal cause is the client going away.
+// statusClientClosedRequest is nginx's non-standard 499 "Client Closed Request",
+// which Go's net/http has no constant for. It goes in the request log and on the
+// wire whenever the terminal cause is the client going away.
 const statusClientClosedRequest = 499

--- a/internal/proxy/resolve.go
+++ b/internal/proxy/resolve.go
@@ -27,11 +27,10 @@ type resolveTimings struct {
 	settingsReadMs   float64
 }
 
-// resolveCacheHits tracks whether each overhead component hit a prewarmed cache.
-// true = cache hit (fast, prewarmed); false = cache miss (had to compute/DB read).
-// Absent fields (parse, dial) are not applicable — they have no cache.
-// The canonical definition lives in internal/util.CacheHits so both proxy and
-// api packages can reference a single type.
+// resolveCacheHits tracks whether each overhead component hit a prewarmed cache:
+// true is a hit, false a miss that had to compute or read the DB. Absent fields
+// (parse, dial) have no cache. The canonical definition lives in
+// internal/util.CacheHits so the proxy and api packages share one type.
 type resolveCacheHits = util.CacheHits
 
 // proxyOverheadMs returns the total proxy overhead from accumulated timings.
@@ -41,10 +40,10 @@ func (t resolveTimings) proxyOverheadMs(parseMs float64) float64 {
 }
 
 // breakerSkipSummary aggregates the candidates the circuit breaker refused up
-// front while a group was resolving, so an empty candidate list can answer
-// with when a retry becomes worth making instead of a bare 502. allPinned
-// starts true and survives only if EVERY skip was quota-pinned: then the whole
-// group is waiting out spent windows and the honest kind is exhaustion.
+// front while a group was resolving, so an empty candidate list can say when a
+// retry becomes worth making instead of answering a bare 502. allPinned starts
+// true and survives only if EVERY skip was quota-pinned: then the whole group is
+// waiting out spent windows and the honest kind is exhaustion.
 type breakerSkipSummary struct {
 	skips         int
 	earliestRetry time.Time
@@ -85,8 +84,8 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	var ch resolveCacheHits
 	var skips breakerSkipSummary
 
-	// A — failover-group lookup + validation. Stamp ch.Failover / failoverLookupMs
-	// only after success so the early-error ledger leaves them zero.
+	// A: failover-group lookup and validation. ch.Failover and failoverLookupMs
+	// are stamped only after success, so an early error leaves them zero.
 	failoverLookupStart := time.Now()
 	fg, failoverHit, err := h.lookupFailoverGroup(ctx, displayModel)
 	if err != nil {
@@ -96,7 +95,7 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	t.failoverLookupMs = float64(time.Since(failoverLookupStart).Microseconds()) / 1000.0
 	debuglog.Debug("resolve: failover group found", "model", displayModel, "entries", len(fg.PriorityOrder), "enabled", fg.GroupEnabled)
 
-	// B — enabled-model collection + batch model lookup.
+	// B: enabled-model collection and batch model lookup.
 	modelLookupStart := time.Now()
 	enabledModelIDs := enabledEntryIDs(fg)
 	ch.Model = batchCacheHit(enabledModelIDs, model.IsCachedByUUID)
@@ -106,7 +105,7 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	}
 	t.modelLookupMs = float64(time.Since(modelLookupStart).Microseconds()) / 1000.0
 
-	// C — provider collection + batch provider lookup. providerLookupStart opens
+	// C: provider collection and batch provider lookup. providerLookupStart opens
 	// the window that physically contains the settings read (D) and every key
 	// decrypt (E); providerLookupMs is derived by subtracting those below.
 	providerLookupStart := time.Now()
@@ -119,15 +118,14 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 		return nil, t, ch, skips, err
 	}
 
-	// D — read circuit_breaker_enabled once before the loop to avoid
+	// D: read circuit_breaker_enabled once before the loop, to avoid
 	// per-candidate settings reads. The single elapsed sample is accounted for
 	// in both settingsReadMs (via the context accumulator) and
-	// settingsReadInWindow (subtracted from providerLookupMs below) — keep both
-	// adds here, off one pre-computed cbElapsed, so the dual accounting stays
-	// visible in one place. Only track settings actually read during resolve;
-	// failover_on_rate_limit is read later in shouldFailover (outside the resolve
-	// phase) so checking it here would show a false amber for requests that
-	// never trigger 429.
+	// settingsReadInWindow (subtracted from providerLookupMs below); both adds
+	// stay here, off one pre-computed cbElapsed, so the dual accounting is
+	// visible in one place. Only settings actually read during resolve are
+	// tracked: failover_on_rate_limit is read later in shouldFailover, so
+	// checking it here would show a false amber for requests that never 429.
 	cbEnabled, settingsHit, cbElapsed := h.readCircuitBreakerFlag(ctx)
 	settingsReadInWindow += cbElapsed
 	if v := ctx.Value(ctxkeys.SettingsReadMsKey); v != nil {
@@ -137,13 +135,13 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 	}
 	ch.Settings = &settingsHit
 
-	// E — candidate-build loop (no window math inside; it only returns the
-	// running key-decrypt total the caller subtracts).
+	// E: candidate-build loop. No window math inside; it returns only the
+	// running key-decrypt total the caller subtracts.
 	debuglog.Debug("resolve: building candidates from failover group", "model", displayModel, "priority_order_count", len(fg.PriorityOrder))
 	candidates, keyDecryptTotal, decryptFailures, keyHit := h.buildFailoverCandidates(fg, models, providers, cbEnabled, &skips)
 
-	// F — finalize timings + terminal error.
-	// Only record key cache hit if there were keys to decrypt.
+	// F: finalize timings and the terminal error. The key cache hit is recorded
+	// only when there were keys to decrypt.
 	if keyDecryptTotal > 0 {
 		ch.Key = &keyHit
 	}
@@ -157,9 +155,9 @@ func (h *Handler) resolveHotelModel(ctx context.Context, displayModel string) ([
 }
 
 // lookupFailoverGroup performs phase A: the failover cache probe, the repo
-// lookup, and the group-enabled / non-empty validations. It returns the group
-// and the cache-hit bool but does NOT stamp ch.Failover / failoverLookupMs —
-// the caller does that only on success, preserving the "zero on early error"
+// lookup, and the group-enabled and non-empty validations. It returns the group
+// and the cache-hit bool but does NOT stamp ch.Failover or failoverLookupMs; the
+// caller does that only on success, preserving the "zero on early error"
 // contract.
 func (h *Handler) lookupFailoverGroup(ctx context.Context, displayModel string) (*failover.FailoverGroup, bool, error) {
 	// Check failover cache before lookup (lookup populates cache on miss).
@@ -167,10 +165,9 @@ func (h *Handler) lookupFailoverGroup(ctx context.Context, displayModel string) 
 
 	fg, err := h.failoverRepo.GetByModel(ctx, displayModel)
 	if err != nil {
-		// A missing group must read as an unknown model, not a raw "no rows in
-		// result set" leaking from the DB layer (which is what a client saw when
-		// the LB routed to a member lacking a custom group). Other errors pass
-		// through unchanged.
+		// A missing group reads as an unknown model, not a raw "no rows in
+		// result set" leaking from the DB layer. Other errors pass through
+		// unchanged.
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, false, fmt.Errorf("model not found: hotel/%s", displayModel)
 		}
@@ -191,7 +188,7 @@ func (h *Handler) lookupFailoverGroup(ctx context.Context, displayModel string) 
 }
 
 // enabledEntryIDs collects the model UUIDs whose failover entry is enabled,
-// preserving PriorityOrder. Pure selector (phase B-collect).
+// preserving PriorityOrder. A pure selector, phase B-collect.
 func enabledEntryIDs(fg *failover.FailoverGroup) []uuid.UUID {
 	ids := make([]uuid.UUID, 0, len(fg.PriorityOrder))
 	for _, modelUUID := range fg.PriorityOrder {
@@ -206,8 +203,8 @@ func enabledEntryIDs(fg *failover.FailoverGroup) []uuid.UUID {
 	return ids
 }
 
-// providerIDsFor collects the unique provider IDs of the enabled+provider-enabled
-// models among ids. Pure selector (phase C-collect).
+// providerIDsFor collects the unique provider IDs of the enabled and
+// provider-enabled models among ids. A pure selector, phase C-collect.
 func providerIDsFor(ids []uuid.UUID, models map[uuid.UUID]*model.Model) []uuid.UUID {
 	providerIDSet := make(map[uuid.UUID]struct{})
 	for _, modelUUID := range ids {
@@ -223,7 +220,7 @@ func providerIDsFor(ids []uuid.UUID, models map[uuid.UUID]*model.Model) []uuid.U
 }
 
 // batchCacheHit reports whether every id is cached (all-must-hit). It returns
-// nil for an empty batch so the caller skips the cache-hit field — an empty
+// nil for an empty batch so the caller skips the cache-hit field: an empty
 // all-must-hit set would otherwise falsely read "hit".
 func batchCacheHit[T comparable](ids []T, cached func(T) bool) *bool {
 	if len(ids) == 0 {
@@ -251,8 +248,8 @@ func (h *Handler) readCircuitBreakerFlag(ctx context.Context) (enabled, hit bool
 	return enabled, hit, elapsedMs
 }
 
-// buildFailoverCandidates performs phase E: walk PriorityOrder, skip
-// disabled/missing/circuit-broken entries, decrypt keys (keyless → ""), and
+// buildFailoverCandidates performs phase E: walk PriorityOrder, skip disabled,
+// missing and circuit-broken entries, decrypt keys (keyless yields ""), and
 // build the candidate list. It owns only the per-key decrypt timing, returning
 // the running total so the caller subtracts it from providerLookupMs; it does
 // no window math itself.
@@ -296,7 +293,7 @@ func (h *Handler) buildFailoverCandidates(fg *failover.FailoverGroup, models map
 		// Circuit breaker: skip a candidate whose own model circuit is open, and
 		// every candidate of a provider the derived verdict indicts. The model id
 		// is the resolved upstream one, which is what the charge sites record
-		// against, so what failed here is what is skipped here.
+		// against, so what failed is what is skipped.
 		if cbEnabled && h.circuitBreaker.IsOpen(prov.ID, prov.Name, m.ModelID) {
 			// The skip is dated so an all-skipped group can answer with when a
 			// retry becomes worth making, and with whether it is waiting out
@@ -306,7 +303,7 @@ func (h *Handler) buildFailoverCandidates(fg *failover.FailoverGroup, models map
 			debuglog.Info("resolve: skipping candidate: circuit breaker open", "provider", prov.Name, "model", m.ModelID)
 			continue
 		}
-		// Keyless providers store nil encrypted key bytes — skip decryption.
+		// Keyless providers store nil encrypted key bytes, so skip decryption.
 		var apiKey string
 		if len(prov.EncryptedKey) == 0 {
 			apiKey = ""
@@ -375,8 +372,8 @@ func (h *Handler) resolveSpecificProvider(ctx context.Context, providerName, mod
 		return nil, t, ch, fmt.Errorf("model or provider disabled")
 	}
 
-	// Keyless providers (e.g. OpenCode Zen free models) store nil encrypted
-	// key bytes. When the key is empty, skip decryption and use empty string.
+	// Keyless providers (OpenCode Zen free models, say) store nil encrypted key
+	// bytes: skip decryption and use the empty string.
 	var apiKey string
 	if len(prov.EncryptedKey) == 0 {
 		apiKey = ""
@@ -418,8 +415,9 @@ func (h *Handler) shouldFailover(ctx context.Context, statusCode int) bool {
 	if statusCode == 402 {
 		return true
 	}
-	// 404 from a provider means the model doesn't exist there (stale DB entry,
-	// overloaded provider returning not_found, etc.) — try the next candidate.
+	// 404 from a provider means the model does not exist there (a stale DB
+	// entry, an overloaded provider returning not_found): try the next
+	// candidate.
 	if statusCode == 404 {
 		return true
 	}

--- a/internal/proxy/safe_dialer.go
+++ b/internal/proxy/safe_dialer.go
@@ -44,8 +44,8 @@ func NewSafeDialer(allowedHosts []string, knownProxies []*net.IPNet) *SafeDialer
 	}
 }
 
-// newSafeDialerWithResolver creates a SafeDialer with a custom resolver for testing.
-// This is exported for testing purposes only.
+// newSafeDialerWithResolver creates a SafeDialer with a custom resolver, for
+// tests that need to control DNS.
 func newSafeDialerWithResolver(allowedHosts []string, resolver ipResolver, knownProxies []*net.IPNet) *SafeDialer {
 	hosts := make(map[string]bool, len(allowedHosts))
 	for _, h := range allowedHosts {
@@ -69,18 +69,17 @@ func (s *SafeDialer) isKnownProxy(ip net.IP) bool {
 	return false
 }
 
-// DialContext implements the dial function signature expected by
-// http.Transport.DialContext. It resolves the target host, checks
-// every resolved IP against blocked ranges, and refuses the
-// connection if all IPs are private/reserved. To close the TOCTOU
-// gap between DNS resolution and dial, it dials by IP (picking the
-// first allowed address) so the connection target is the same IP that
-// was checked. The original hostname is preserved via TLS ServerName
-// and HTTP Host header by the transport layer.
+// DialContext implements the dial function signature http.Transport.DialContext
+// expects. It resolves the target host, checks every resolved IP against blocked
+// ranges, and refuses the connection when all IPs are private or reserved. To
+// close the TOCTOU gap between DNS resolution and dial it dials by IP, picking
+// the first allowed address, so the connection target is the IP that was
+// checked. The transport layer preserves the original hostname through the TLS
+// ServerName and the HTTP Host header.
 func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		// No port in addr — unusual but defensive.
+		// No port in addr: unusual, but handled rather than failed.
 		host = addr
 		port = ""
 	}
@@ -96,18 +95,16 @@ func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net
 	// Resolve the host to IP addresses (timed).
 	dnsStart := time.Now()
 	ips, err := s.resolver.LookupIPAddr(ctx, host)
-	// Record the per-request dial timing if the caller provided a slot (see
+	// Record the per-request dial timing when the caller provided a slot (see
 	// dialTiming for why it is not a plain pointer). This captures DNS
-	// resolution only when the dial fails before TCP; successful dials
-	// overwrite it with the full DNS+TCP time below.
+	// resolution alone when the dial fails before TCP; a successful dial
+	// overwrites it with the full DNS+TCP time below.
 	recordDialMs(ctx, dnsStart)
 	if err != nil {
-		// Resolution failure: return the DNS error directly rather than
-		// falling through to an unchecked dial. A host that can't be
-		// resolved can't be safely dialed — the fallback dial would bypass
-		// the IP blocklist, violating the invariant that every dial is
-		// IP-checked. The caller still sees a connection error, just a
-		// more specific one.
+		// Resolution failure returns the DNS error directly rather than falling
+		// through to an unchecked dial: a fallback dial would bypass the IP
+		// blocklist and break the invariant that every dial is IP-checked. The
+		// caller still sees a connection error, just a more specific one.
 		debuglog.Warn("proxy: SafeDialer DNS resolution failed, rejecting dial", "host", host, "error", err)
 		return nil, fmt.Errorf("safeDialer: DNS resolution failed for %s: %w", host, err)
 	}
@@ -126,9 +123,9 @@ func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net
 		return nil, fmt.Errorf("proxy: refused connection to private/reserved IP %s for host %s", ips[0].IP, host)
 	}
 
-	// Dial by the first allowed IP to close the TOCTOU gap: the IP we
-	// checked is the one we connect to, preventing DNS rebinding between
-	// resolution and dial.
+	// Dial by the first allowed IP to close the TOCTOU gap: the IP that was
+	// checked is the one connected to, so DNS cannot rebind between resolution
+	// and dial.
 	for _, ip := range ips {
 		if isBlockedIP(ip.IP) && !s.isKnownProxy(ip.IP) {
 			debuglog.Debug("proxy: SafeDialer blocked IP skipped", "host", host, "ip", ip.IP)
@@ -146,8 +143,7 @@ func (s *SafeDialer) DialContext(ctx context.Context, network, addr string) (net
 		return conn, nil
 	}
 
-	// Should not be reachable (fell through without a non-blocked IP),
-	// but handle gracefully.
+	// Reached only when the loop fell through without a non-blocked IP.
 	return nil, fmt.Errorf("proxy: no allowed IP found for host %s", host)
 }
 
@@ -162,9 +158,9 @@ func (s *SafeDialer) CheckRedirect(req *http.Request, via []*http.Request) error
 	// provider's credentials with it. Go's http.Client strips the standard
 	// Authorization header across hosts, but forwards custom auth headers
 	// (x-api-key, x-goog-api-key) verbatim, which would leak the key to the
-	// redirect target. Strip all provider auth headers on any cross-host hop,
-	// before the allowlist/IP checks below, so it applies regardless of whether
-	// the target is allowed.
+	// redirect target. Every provider auth header is stripped on a cross-host
+	// hop, ahead of the allowlist and IP checks below, so it applies whether or
+	// not the target is allowed.
 	if len(via) > 0 && !strings.EqualFold(host, via[0].URL.Hostname()) {
 		util.StripProviderAuthHeaders(req)
 	}
@@ -172,15 +168,15 @@ func (s *SafeDialer) CheckRedirect(req *http.Request, via []*http.Request) error
 	if s.hosts[strings.ToLower(host)] {
 		return nil
 	}
-	// Resolve host and check IPs. Derive the timeout from the request
-	// context so that cancelled requests don't leave DNS goroutines running.
+	// Resolve the host and check its IPs. The timeout derives from the request
+	// context so a cancelled request leaves no DNS goroutine running.
 	resolveCtx, cancel := context.WithTimeout(req.Context(), 5*time.Second)
 	defer cancel()
 	ips, err := s.resolver.LookupIPAddr(resolveCtx, host)
 	if err != nil {
-		// Resolution failure on a redirect: reject the redirect since we
-		// cannot validate its target. The original response is still available
-		// to the caller via the last successful request.
+		// A redirect whose target cannot be resolved cannot be validated, so it
+		// is rejected. The last successful request's response is still
+		// available to the caller.
 		return fmt.Errorf("proxy: redirect to host %s rejected: DNS resolution failed: %w", host, err)
 	}
 	hasAllowedIP := false
@@ -196,10 +192,10 @@ func (s *SafeDialer) CheckRedirect(req *http.Request, via []*http.Request) error
 	return nil
 }
 
-// isBlockedIP checks whether an IP falls into a range that should never be
-// dialled by the proxy: loopback, private, link-local, carrier-grade NAT, or
-// cloud metadata. It delegates to util.IsBlockedIP so provider-URL validation
-// (config.ValidateProviderURL) enforces the exact same ranges.
+// isBlockedIP reports whether an IP falls into a range the proxy must never
+// dial: loopback, private, link-local, carrier-grade NAT, or cloud metadata. It
+// delegates to util.IsBlockedIP so provider-URL validation
+// (config.ValidateProviderURL) enforces the same ranges.
 func isBlockedIP(ip net.IP) bool {
 	return util.IsBlockedIP(ip)
 }

--- a/internal/proxy/stream_finalize.go
+++ b/internal/proxy/stream_finalize.go
@@ -16,8 +16,7 @@ import (
 
 // Progressive stall timeout knobs, shared by the scanner loop (which pings the
 // watchdog) and finalizeStream (which reconstructs the effective stall window
-// for diagnostics). Lifted to package scope from handleStreamingResponse in
-// Phase 2 of the streaming-pipeline refactor so both can reference one source.
+// for diagnostics).
 const (
 	progressiveChunkThreshold  = 50
 	progressiveStallMultiplier = 3
@@ -25,9 +24,7 @@ const (
 
 // streamState accumulates the per-stream metrics and carry flags that the
 // scanner loop in handleStreamingResponse produces and finalizeStream consumes.
-// Introduced in Phase 2 of the streaming-pipeline refactor as the explicit
-// hand-off between the loop and the finalizer; later phases migrate more of the
-// loop-local accumulators here.
+// It is the explicit hand-off between the loop and the finalizer.
 type streamState struct {
 	// content fences echoes of the request's own text out of the error
 	// messages this stream logs (errLogAttr). Copied from the log entry; nil
@@ -46,11 +43,11 @@ type streamState struct {
 	errorChunkCount       int
 	// unparsedChunks counts data frames this gateway could not read: bytes that
 	// are not well-formed JSON (dropped), a shape its types do not cover
-	// (forwarded verbatim), and the frames dropped because strip_reasoning could
-	// not be applied to one. Whether the provider actually answered in them is
-	// unknowable from here, so they are neither evidence of emptiness nor
-	// evidence against it — see judgeStreamForBreaker, which reads delivery
-	// FIRST and falls back to this only when nothing typed reached the caller.
+	// (forwarded verbatim), and frames dropped because strip_reasoning could not
+	// be applied to one. Whether the provider answered in them is unknowable
+	// from here, so they are neither evidence of emptiness nor evidence against
+	// it: judgeStreamForBreaker reads delivery FIRST and falls back to this only
+	// when nothing typed reached the caller.
 	unparsedChunks int
 	lastErrMsg     string
 	sawDone        bool
@@ -61,9 +58,9 @@ type streamState struct {
 	// some providers, and the TTFT probe can be turned off.
 	sawContent bool
 	// sawImage records a generated image delta: the whole answer of an image
-	// model, and the streaming twin of the non-streaming breaker bar's
-	// `images` member (choiceCarriesSomething). The retirement verdict does
-	// not read it, as it does not read that member either.
+	// model, and the streaming twin of the non-streaming breaker bar's `images`
+	// member (choiceCarriesSomething). The retirement verdict does not read it,
+	// as it does not read that member either.
 	sawImage bool
 	// deliveredBytes counts the bytes of content, reasoning and tool-call
 	// arguments the model produced as it streamed (before any strip_reasoning
@@ -83,9 +80,9 @@ type streamState struct {
 	// gateway-authored on every other failure path.
 	clientErrMsg string
 
-	// Observer state carried across chunks (Phase 4). Not consumed by the
-	// finalizer, but co-located here so the data-chunk observers operate on one
-	// named accumulator instead of a fistful of loop-locals.
+	// Observer state carried across chunks. Not consumed by the finalizer, but
+	// co-located here so the data-chunk observers operate on one named
+	// accumulator instead of a fistful of loop-locals.
 	lastNativeFinishReason string // P2-7
 	sawThinking            bool   // first-occurrence reasoning log
 	lastContent            string // P2-5 repeated-content detection
@@ -118,26 +115,25 @@ func providerAtFault(kind ErrorKind) bool {
 // streamDeliveredOutput reports whether the caller actually received model
 // output, from the signals that answer that question and only those:
 //
-//   - st.sawContent — a non-empty content or reasoning delta reached the client.
-//   - st.deliveredBytes — the bytes of content, reasoning, reasoning_details and
+//   - st.sawContent: a non-empty content or reasoning delta reached the client.
+//   - st.deliveredBytes: the bytes of content, reasoning, reasoning_details and
 //     tool-call arguments the model produced. Counted on BOTH the translated and
 //     the native Anthropic path, so it is the one signal that catches a native
 //     stream which really did deliver.
-//   - st.completionTokens — the provider reported usage even if this gateway
+//   - st.completionTokens: the provider reported usage even if this gateway
 //     never parsed content out of the deltas.
 //
 // Deliberately NOT logData.deliveredContent, and deliberately NOT
 // st.sawMessageStop. deliveredContent is derived as sawContent||sawMessageStop
-// for the RETIREMENT verdict, where a terminal message_stop is allowed to stand
-// in for "the model answered". Here it cannot: message_stop is a TERMINATION
-// signal, present on every native stream that ends cleanly, including one that
-// ended having produced nothing. Reading it as delivery is what let a completely
-// empty /v1/messages response escape the charge entirely.
+// for the RETIREMENT verdict, where a terminal message_stop may stand in for
+// "the model answered". Here it cannot: message_stop is a TERMINATION signal,
+// present on every native stream that ends cleanly, including one that produced
+// nothing.
 //
-// A tool call is output. So is reasoning, and so is a generated image. The
-// cost of missing one of these is a charge against a provider that answered
-// correctly, which after five requests takes it out of rotation for every
-// tenant — so this errs toward "delivered".
+// A tool call is output, and so are reasoning and a generated image. The cost of
+// missing one is a charge against a provider that answered correctly, which
+// after five requests takes it out of rotation for every tenant, so this errs
+// toward "delivered".
 func streamDeliveredOutput(st *streamState) bool {
 	return st.sawContent || st.sawImage || st.deliveredBytes > 0 || st.completionTokens > 0
 }
@@ -145,22 +141,18 @@ func streamDeliveredOutput(st *streamState) bool {
 // judgeStreamForBreaker decides what a finished stream tells the circuit
 // breaker. It is the whole policy for a streaming 200, in one place.
 //
-// Why the verdict lives HERE rather than at the TTFT probe: recordBreakerOutcome
-// deliberately says nothing for a streaming 200, so the probe was the only voice
-// these requests had — and it spoke too early. A first token is not a served
-// stream. Recording success there zeroed consecutiveFails on every single
-// request, so a provider that failed AFTER the first token oscillated 0→1 against
-// a threshold of 5 and could never open its circuit. Both charges below were
-// therefore inert in production. Move a success back to the probe and they go
-// inert again.
+// The verdict lives here rather than at the TTFT probe because a first token is
+// not a served stream: recording success at the probe zeroes consecutiveFails on
+// every request, so a provider that fails AFTER the first token oscillates 0->1
+// against a threshold of 5 and can never open its circuit, leaving both charges
+// below inert. Move a success back to the probe and they go inert again.
 //
 // Failure has three shapes. A stall is the provider going silent; an error is
 // the provider saying it failed; an empty finish is the provider completing
-// having said nothing at all. The stall charge is unconditional (as it has
-// always been); the other two are charged only when the caller received
-// nothing, because a stream that delivered real output before dying did part of
-// its job and charging it would break the circuit on every
-// truncated-but-useful response.
+// having said nothing at all. The stall charge is unconditional; the other two
+// are charged only when the caller received nothing, since a stream that
+// delivered real output before dying did part of its job and charging it would
+// break the circuit on every truncated-but-useful response.
 //
 // The error charge matters because the probe has already committed to this
 // provider by the time a later frame turns out to be an error, and the hedged
@@ -172,22 +164,20 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		return streamBreakerVerdict{}
 	}
 	if errMsg == "" {
-		// A clean finish still has to have finished something. A stream that
-		// got past the probe, completed without error and handed the caller
-		// nothing is a completely empty response, and counts against the
-		// provider rather than clearing its failures — which is what recording
-		// a success here used to do.
+		// A clean finish still has to have finished something. A stream that got
+		// past the probe, completed without error and handed the caller nothing
+		// is a completely empty response, and counts against the provider rather
+		// than clearing its failures.
 		//
 		// The probe catches the stream that never produced a chunk; this is its
 		// sibling, the one that produced frames carrying no output and was
 		// already committed to by the time that became clear.
 		//
-		// Delivery is read FIRST, and unparsedChunks only decides what to do
-		// when nothing typed arrived. Read the other way round, one frame this
-		// gateway could not parse withheld the CREDIT from a stream that plainly
-		// answered — so a provider whose shapes it does not model never cleared
-		// its consecutive-failure count, and old failures accumulated until an
-		// unrelated one opened the circuit.
+		// Delivery is read FIRST, and unparsedChunks only decides what to do when
+		// nothing typed arrived. Read the other way round, one unparseable frame
+		// withholds the CREDIT from a stream that plainly answered, so a provider
+		// whose shapes this gateway does not model never clears its
+		// consecutive-failure count.
 		if streamDeliveredOutput(st) {
 			// Includes the stream whose absent [DONE] was injected above: the
 			// sentinel was missing, the answer was not.
@@ -195,22 +185,22 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 		}
 		// Nothing typed reached the caller, and frames went unread. Those were
 		// unreadable to THIS gateway's parser, not left out by the provider, so
-		// emptiness cannot be pinned on the upstream. Recording nothing is the
-		// honest verdict — neither a charge nor a credit. Calling them delivery
-		// instead was worse than either: a relay that numbers its stop reasons
-		// emits one untypeable frame per stream, on the terminal chunk, which
-		// carries no output at all — so every empty response it gave would have
-		// cleared its failure streak, and its circuit could never open.
+		// emptiness cannot be pinned on the upstream: recording nothing is the
+		// honest verdict, neither a charge nor a credit. Counting them as
+		// delivery is worse, since a relay that numbers its stop reasons emits
+		// one untypeable frame per stream on the terminal chunk, which carries no
+		// output at all, and every empty response it gave would clear its failure
+		// streak.
 		if st.unparsedChunks > 0 {
 			return streamBreakerVerdict{}
 		}
 		return streamBreakerVerdict{failureReason: "stream completed without delivering content"}
 	}
 	// Reached only with a non-empty errMsg, so errorKind is always set:
-	// deriveStreamError writes the two together. The clean-finish charge above
-	// sits ABOVE this gate deliberately — it has no errMsg and therefore no
-	// kind, and the two non-provider causes that could reach it (interrupted,
-	// clientDisconnected) are already short-circuited at the top.
+	// deriveStreamError writes the two together. The clean-finish charge sits
+	// above this gate deliberately, having no errMsg and therefore no kind; the
+	// two non-provider causes that could reach it (interrupted,
+	// clientDisconnected) are short-circuited at the top.
 	if !providerAtFault(logData.errorKind) {
 		return streamBreakerVerdict{}
 	}
@@ -226,22 +216,21 @@ func judgeStreamForBreaker(st *streamState, logData *requestLogData, errMsg stri
 	return streamBreakerVerdict{}
 }
 
-// finalizeStream performs the end-of-stream bookkeeping that used to live under
-// the handleStreamingResponse `logUpdate:` label: TPS computation, scanner-error
-// and stall classification, missing-[DONE] injection vs "truncated", the final
-// updateRequestLog, circuit-breaker failure on stall, and token-usage recording.
+// finalizeStream performs the end-of-stream bookkeeping: TPS computation,
+// scanner-error and stall classification, missing-[DONE] injection vs
+// "truncated", the final updateRequestLog, the circuit-breaker verdict, and
+// token-usage recording.
 //
-// Extracted in Phase 2 of the streaming-pipeline refactor; behavior is
-// unchanged. The watchdog teardown stays in the orchestrator (it owns the
-// watchdog goroutine), so st.stalled is read from the atomic before this runs.
-// statusCode is the upstream response status (resp.StatusCode); scanErr is the
-// reader's terminal scanner error (reader.err()).
+// The watchdog teardown stays in the orchestrator, which owns the watchdog
+// goroutine, so st.stalled is read from the atomic before this runs. statusCode
+// is the upstream response status; scanErr is the reader's terminal scanner
+// error.
 func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr error, logData *requestLogData, opts streamOptions, statusCode int, startTime time.Time) {
 	totalDuration := float64(time.Since(startTime).Microseconds()) / 1000.0
 	var tps float64
-	// Use total output tokens (text + reasoning) for TPS numerator,
-	// and generation time as denominator. Prefer true TTFT (first token)
-	// when the probe measured it; fall back to response header time.
+	// Total output tokens (text + reasoning) over generation time. True TTFT
+	// (first token) is preferred when the probe measured it, response header
+	// time otherwise.
 	totalOutputTokens := st.completionTokens + st.reasoningTokens
 	ttftForTPS := opts.responseHeaderMs
 	if opts.trueTtftMs > 0 {
@@ -260,11 +249,11 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	errMsg := deriveStreamError(st, scanErr, opts, logData)
 	if errMsg == "" && !st.sawDone && opts.rawPassthrough {
 		// Native Anthropic passthrough: the Messages stream ends with a
-		// message_stop event + EOF and never sends a [DONE] sentinel. A clean EOF
-		// *with* message_stop is a real completion; a clean EOF *without* it means
-		// the upstream dropped mid-stream, which must log as truncated (and must
-		// NOT bill the partial output as a complete response). We never inject
-		// [DONE] here — Anthropic clients don't expect it.
+		// message_stop event plus EOF and never sends a [DONE] sentinel. A clean
+		// EOF with message_stop is a real completion; a clean EOF without it
+		// means the upstream dropped mid-stream, which logs as truncated and must
+		// NOT bill the partial output as a complete response. No [DONE] is
+		// injected here: Anthropic clients do not expect one.
 		if st.sawMessageStop {
 			debuglog.Debug("proxy: native anthropic stream completed (message_stop seen)", "model", logData.modelID, "provider", logData.providerName, "chunks", st.chunkCount)
 		} else {
@@ -273,9 +262,9 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 			debuglog.Warn("proxy: native anthropic stream ended without message_stop", "model", logData.modelID, "provider", logData.providerName, "chunks", st.chunkCount)
 		}
 	} else if errMsg == "" && !st.sawDone {
-		// Upstream closed without [DONE] sentinel. If we received content and
-		// the scanner didn't error, inject the sentinel for the downstream
-		// client so the frontend knows the stream completed normally.
+		// Upstream closed without a [DONE] sentinel. When content arrived and the
+		// scanner did not error, inject the sentinel downstream so the client
+		// knows the stream completed normally.
 		if !st.clientDisconnected && scanErr == nil && st.chunkCount > 0 {
 			debuglog.Info("proxy: upstream omitted [DONE] sentinel; injecting for downstream", "model", logData.modelID, "provider", logData.providerName, "chunks", st.chunkCount)
 			if err := sink.write([]byte("data: [DONE]\n\n")); err != nil {
@@ -286,7 +275,7 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 			// Stream was complete; the missing sentinel is benign.
 			debuglog.Info("proxy: stream completed (upstream omitted [DONE])", "model", logData.modelID, "provider", logData.providerName, "chunks", st.chunkCount)
 		} else {
-			// No content received or scanner error - genuinely truncated.
+			// No content received, or a scanner error: genuinely truncated.
 			errMsg = "stream truncated: upstream closed connection without [DONE] sentinel"
 			logData.errorKind = KindProviderError
 			debuglog.Warn("proxy: stream ended without [DONE] sentinel", "model", logData.modelID, "provider", logData.providerName, "chunks", st.chunkCount)
@@ -316,11 +305,10 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	// deliveredBytes, not sawContent alone: sawContent watches content and
 	// reasoning on choices[0], so a stream whose whole answer is a tool call, or
 	// one delivered in a shape this gateway forwarded without being able to
-	// type, read as having produced nothing — and the streak a real answer
-	// should have cleared stayed on the model. It is the same bar the breaker
-	// uses (streamDeliveredOutput), and it can only ever turn an inconclusive
+	// type, would read as having produced nothing. It is the same bar the
+	// breaker uses (streamDeliveredOutput), and can only turn an inconclusive
 	// verdict into a served one: verdictForStream decides gone from the error
-	// kind, before it looks at this at all.
+	// kind before it looks at this at all.
 	logData.deliveredContent = st.sawContent || st.sawMessageStop || st.deliveredBytes > 0
 	if errMsg != "" {
 		h.writeTerminalError(sink, st, opts, logData, errMsg)
@@ -335,10 +323,9 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	}
 
 	// The breaker verdict comes BEFORE the terminal write: the write closes the
-	// attempt's trail record, and that record carries what the breaker was
-	// told. deriveStreamError already warns about the stall or the error
-	// itself; the line below records that the breaker was CHARGED for it,
-	// which those do not say and which is otherwise invisible above Debug.
+	// attempt's trail record, and that record carries what the breaker was told.
+	// deriveStreamError already warns about the stall or the error itself; the
+	// line below records that the breaker was CHARGED for it.
 	if verdict := judgeStreamForBreaker(st, logData, errMsg, opts.circuitBreakerOn); verdict.failureReason != "" {
 		debuglog.Warn("proxy: recording circuit breaker failure", "reason", verdict.failureReason, "provider", opts.providerName, "provider_id", opts.providerID, "attempt", opts.attempt, "chunks", st.chunkCount, "error_chunks", st.errorChunkCount, "duration_ms", totalDuration, "model", opts.model)
 		logData.noteBreaker(breakerCharge)
@@ -351,9 +338,8 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 
 	debuglog.Info("proxy: streaming finished", "model", logData.modelID, "provider", logData.providerName, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "true_ttft_ms", opts.trueTtftMs, "duration_ms", totalDuration, "chunks", st.chunkCount, "bytes_written", sink.bytesWritten, "prompt_tokens", st.promptTokens, "completion_tokens", st.completionTokens, "error_chunks", st.errorChunkCount, "has_error", errMsg != "")
 	if errMsg != "" {
-		// errLogAttr, not errMsg: the row above it is masked, the client frame
-		// beside it is masked, and this line was the one place the provider's
-		// raw text — a relayed credential included — reached the app log.
+		// errLogAttr, not errMsg: the row and the client frame are both masked,
+		// and provider text is where a relayed credential turns up.
 		debuglog.Warn("proxy: streaming error", "model", logData.modelID, "provider", logData.providerName, "error", st.errLogAttr(errMsg), "upstream_status", statusCode, "attempt", opts.attempt, "duration_ms", totalDuration)
 	} else {
 		debuglog.Debug("proxy: streaming completed successfully", "model", logData.modelID, "provider", logData.providerName, "attempt", opts.attempt, "response_header_ms", opts.responseHeaderMs, "duration_ms", totalDuration)
@@ -370,7 +356,7 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 	}
 	// The estimate applies on failed streams too (an SSE error after some
 	// output, a truncation): the provider billed whatever was produced before
-	// the failure. The non-streaming path only meters a decoded 2xx, which is
+	// the failure. The non-streaming path meters only a decoded 2xx, which is
 	// the same rule, since nothing was produced for the client otherwise.
 	promptTokens, completionTokens, reasoningTokens := estimateMissingUsage(st.promptTokens, st.completionTokens, st.reasoningTokens, logData, st.deliveredBytes)
 	h.recordTokenUsage(opts.vkHash, logData, promptTokens, completionTokens, reasoningTokens)
@@ -383,22 +369,20 @@ func (h *Handler) finalizeStream(st *streamState, sink *streamSink, scanErr erro
 // client disconnect on st), then a client disconnect overrides whatever message
 // was derived so far, and finally a stall overrides the raw IO error produced
 // by the watchdog's body.Close(). The missing-[DONE] diagnosis is NOT handled
-// here — it may write to the client, so it stays in finalizeStream.
+// here: it may write to the client, so it stays in finalizeStream.
 func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logData *requestLogData) string {
 	errMsg := st.lastErrMsg
 	if errMsg != "" {
-		// An in-stream SSE error body from the provider. Unlike the non-streaming
-		// path (forwardUpstreamError) this text never went through
-		// SanitizeLogBody, so it reached request_logs uncapped and with UUIDs
-		// intact — a provider is free to echo the request back inside an error,
-		// and an unbounded provider string must not land in the log either way.
+		// An in-stream SSE error body from the provider. It is sanitized here for
+		// the same reason forwardUpstreamError sanitizes on the non-streaming
+		// path: a provider may echo the request back inside an error, and an
+		// unbounded provider string must not land in the log.
 		errMsg = util.SanitizeLogBody(errMsg, 10000)
 		logData.errorKind, _ = classifyUpstreamError(logData.statusCode, errMsg, upstreamModelID(logData))
 		// Kept separately as well, because everything below can overwrite
 		// errorKind with a later cause. A client that receives this error chunk
-		// and hangs up — which is exactly what a client does on seeing an error
-		// — would otherwise replace the provider's "this model is gone" with
-		// client_disconnect, and the retirement would lose the very strike the
+		// and hangs up would otherwise replace the provider's "this model is
+		// gone" with client_disconnect, costing the retirement the strike the
 		// provider just handed it. What the provider said about the model does
 		// not depend on what the client did next.
 		logData.upstreamKind = logData.errorKind
@@ -407,12 +391,12 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 		switch {
 		case errors.Is(scanErr, context.Canceled):
 			// The scanner caught the cancellation before the select between
-			// iterations could. This is always a client disconnect — the
+			// iterations could. This is always a client disconnect: the
 			// parent request context was cancelled.
 			st.clientDisconnected = true
 		case errors.Is(scanErr, context.DeadlineExceeded):
 			// A derived context's deadline expired (failover or retry timeout).
-			// Use cancelOrigin to produce a human-readable message.
+			// cancelOrigin names which, for a human-readable message.
 			switch opts.cancelOrigin {
 			case "retry_timeout":
 				errMsg = "stream interrupted: param-strip retry timed out"
@@ -421,7 +405,7 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 				errMsg = "stream interrupted: upstream request timed out"
 				logData.errorKind = KindFailoverTimeout
 			default:
-				// Unknown origin — preserve the value rather than guessing.
+				// Unknown origin: preserve the value rather than guessing.
 				errMsg = fmt.Sprintf("stream interrupted: %s", humanReadableCancelOrigin(opts.cancelOrigin))
 				logData.errorKind = cancelOriginToKind(opts.cancelOrigin)
 			}
@@ -436,16 +420,17 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 	if st.clientDisconnected {
 		errMsg = "client disconnected"
 		logData.errorKind = KindClientDisconnect
-		// A client hangup is normal client behavior, not a gateway/provider
-		// fault — log at Info (see the level semantics in doc/logging.md).
+		// A client hangup is normal client behavior, not a gateway or provider
+		// fault, so it logs at Info.
 		debuglog.Info("proxy: client disconnected during streaming", "model", logData.modelID)
 	}
-	// Stall detection takes precedence over the raw IO error produced by
-	// the watchdog's body.Close(). Replace it with a descriptive message.
-	// Only flag a stall when we did NOT see [DONE] — if the stream completed
-	// normally, a late timer fire is a false positive. Also skip when the
-	// client disconnected, which is a more meaningful diagnosis.
-	// A process shutdown closed the upstream body. It is judged before the
+	// Stall detection takes precedence over the raw IO error the watchdog's
+	// body.Close() produces, and replaces it with a descriptive message. A stall
+	// is only flagged when no [DONE] was seen, since a late timer fire on a
+	// normally completed stream is a false positive, and not when the client
+	// disconnected, which is the more meaningful diagnosis.
+	//
+	// A process shutdown also closes the upstream body, and is judged before the
 	// stall so a restart never reads as a provider fault.
 	if st.interrupted && !st.sawDone && !st.sawMessageStop && !st.clientDisconnected {
 		errMsg = "stream interrupted: gateway restarting"
@@ -468,12 +453,10 @@ func deriveStreamError(st *streamState, scanErr error, opts streamOptions, logDa
 //
 // modelID is the client's spelling: for a failover request it is the literal
 // "hotel/<group>", and resolvedModelID is where the committed candidate's real
-// id lands (beginAttempt sets it only on that path, which is why the fallback is
-// not a convenience). Handing the alias to classifyUpstreamError meant its
-// gone-phrase test looked for "claude" — modelGoneAbout trims to the last path
-// segment — inside "Model claude-sonnet-4 is no longer available", and did not
-// find it, so a model retired inside a failover group recorded no strike and was
-// never probed.
+// id lands (beginAttempt sets it only on that path, so the fallback is not a
+// convenience). Handing the alias to classifyUpstreamError makes its gone-phrase
+// test look for "claude", since modelGoneAbout trims to the last path segment,
+// and a model retired inside a failover group then records no strike.
 //
 // Every other classification site passes candidate.model.ModelID directly. This
 // one runs at stream teardown with no candidate in hand, so it reads the same
@@ -488,16 +471,15 @@ func upstreamModelID(logData *requestLogData) string {
 // writeTerminalError ends a stream that failed after commit with a
 // well-formed error frame so the client receives an API error it can act on
 // rather than a cut connection (an "incomplete chunked read" in most SDKs).
-// A stream that stalled, was truncated by the upstream, or was cut by a
-// gateway restart cannot fail over once bytes have gone out, so the frame is
-// the graceful end. Nothing is written when the client is gone, when the
-// upstream already sent an error the client saw (errorChunkCount>0; note a
-// provider that split its error object across data lines has that counter set
-// even though the fragments were dropped, so that rare stream still ends
-// without a frame), or when [DONE] / a native message_stop went out: the
-// terminal frame must be the one error the client sees. The translated path speaks OpenAI (error object, then
-// [DONE]); the native Anthropic passthrough speaks Messages (an error event,
-// no sentinel).
+// A stream that stalled, was truncated by the upstream, or was cut by a gateway
+// restart cannot fail over once bytes have gone out, so the frame is the
+// graceful end. Nothing is written when the client is gone, when the upstream
+// already sent an error the client saw (errorChunkCount>0, which is also set for
+// a provider that split its error object across data lines, so that rare stream
+// ends without a frame), or when [DONE] or a native message_stop went out: the
+// terminal frame must be the one error the client sees. The translated path
+// speaks OpenAI (error object, then [DONE]); the native Anthropic passthrough
+// speaks Messages (an error event, no sentinel).
 func (h *Handler) writeTerminalError(sink *streamSink, st *streamState, opts streamOptions, logData *requestLogData, errMsg string) {
 	if st.clientDisconnected || st.sawDone || st.sawMessageStop || st.errorChunkCount > 0 {
 		return

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -13,26 +13,25 @@ import (
 // a line arrives that is not one, then parsed) and P1-C Anthropic typed error
 // events (a data line following an "event: error" line).
 //
-// P1-B is named for split errors, and its comments long claimed to reassemble
-// one, but it cannot: a CONTINUATION line does not start with {"error", so it
-// takes the flush branch rather than the append. What the buffer actually holds
-// is the last {"error"-prefixed line that would not parse — a truncated frame,
-// which is the case worth salvaging and the only one it ever sees. Any extracted message is recorded into streamState; it
-// returns whether it counted an Anthropic error for this line so the later
-// chunk.Error observer does not double-count it. lastAnthropicEvent is the carry
-// from the preceding "event:" line and is consumed (reset) here. No client output.
+// P1-B holds only the last {"error"-prefixed line that would not parse, a
+// truncated frame. It cannot reassemble a split error despite the name: a
+// continuation line does not start with {"error", so it takes the flush branch
+// rather than the append.
+//
+// Any extracted message is recorded into streamState. The return says whether an
+// Anthropic error was counted for this line, so the later chunk.Error observer
+// does not double-count it. lastAnthropicEvent is the carry from the preceding
+// "event:" line and is consumed here. Nothing is written to the client.
 func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *string, chunkCount int, logData *requestLogData) bool {
 	// P1-B: hold a truncated error line; flush on any other line.
 	//
-	// Only a FRAGMENT is held. A payload that parses is a whole frame,
-	// whatever it starts with, and the observer reads its error member properly;
-	// handing it to the accumulator instead put it in front of
-	// parseAccumulatedError, whose last resort is to return the entire payload
-	// as the error message. A frame like
-	// {"error":"","choices":[{"delta":{"content":…}}]} — an empty error member
-	// riding alongside a real delta — therefore wrote the model's output into
-	// request_logs.error_message, and marked the request failed for an error no
-	// reader of that member agrees is there.
+	// Only a FRAGMENT is held. A payload that parses is a whole frame, whatever
+	// it starts with, and the observer reads its error member properly. Handing
+	// one to the accumulator instead puts it in front of parseAccumulatedError,
+	// whose last resort is to return the entire payload as the error message, so
+	// a frame like {"error":"","choices":[{"delta":{"content":…}}]} would write
+	// the model's output into request_logs.error_message and mark the request
+	// failed for an error that is not there.
 	if strings.HasPrefix(payload, `{"error"`) && !json.Valid([]byte(payload)) {
 		st.errAccum = append(st.errAccum, []byte(payload)...)
 	} else {
@@ -43,17 +42,15 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 	// wrapped as {"type":"error","error":{...}} even when it doesn't start with
 	// {"error". Extract the message regardless.
 	//
-	// The member is read with the rule the rest of the gateway shares, not with a
-	// private object type one struct away from it. Typed as an object, any other
-	// shape failed the whole decode and this branch fell silent — the observer
-	// below still caught the member, but the event's own type went unlogged.
+	// The member is read with the rule the rest of the gateway shares rather than
+	// a private object type: typed as an object, any other shape fails the whole
+	// decode and this branch falls silent, leaving the event's own type unlogged.
 	//
-	// Emptiness matters more here than anywhere else it is read. errorChunkCount
-	// is what tells writeTerminalError the client has already seen the provider's
-	// error, and counting a member that carries nothing spent that on nothing: it
-	// left lastErrMsg blank, so no error was derived from it, and it suppressed
-	// the terminal frame for whatever really did end the stream afterwards. The
-	// caller got a cut connection in place of a reason.
+	// Emptiness matters more here than anywhere else the member is read.
+	// errorChunkCount is what tells writeTerminalError the client has already
+	// seen the provider's error, so counting a member that carries nothing
+	// leaves lastErrMsg blank and suppresses the terminal frame for whatever
+	// really ended the stream, handing the caller a cut connection.
 	anthropicErrorCounted := false
 	if *lastAnthropicEvent == "error" {
 		*lastAnthropicEvent = ""
@@ -81,12 +78,11 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 }
 
 // flushAccumulatedError parses and records any P1-B held error bytes (a
-// truncated {"error":…} line), then clears the buffer. A
-// no-op when nothing is accumulated. Every flush site goes through here — the
-// comment-line handler, captureSSEError's non-error data-line branch, and the
-// stream-end sweep — so they cannot drift; `what` is the only thing that differs
-// between them, and a copy of this body is how the stream-end sweep came to log
-// the provider's error text unmasked while the other two did not.
+// truncated {"error":…} line), then clears the buffer. It is a no-op when
+// nothing is accumulated. Every flush site goes through here (the comment-line
+// handler, captureSSEError's non-error data-line branch, and the stream-end
+// sweep) so they cannot drift; `what` is the only thing that differs between
+// them.
 func (st *streamState) flushAccumulatedError(what string, chunkCount int, logData *requestLogData) {
 	if len(st.errAccum) == 0 {
 		return
@@ -102,34 +98,32 @@ func (st *streamState) flushAccumulatedError(what string, chunkCount int, logDat
 // errLogAttr prepares provider error text for an application-log attribute:
 // masked, then bounded.
 //
-// The request log gets both of those at finalize, but the app log had neither.
-// It is a different audience and a different store — the live log viewer, the
-// app-logs API, the OTLP export — and provider error text is exactly where a
-// relay quotes a credential ("invalid key sk-…") or runs to whatever length it
-// likes. The observers also run BEFORE the stream's masking block, so the text
-// they hold has been scrubbed by nothing at all.
+// The app log is a different audience and a different store from the request log
+// (the live log viewer, the app-logs API, the OTLP export), and provider error
+// text is exactly where a relay quotes a credential ("invalid key sk-…") or runs
+// to whatever length it likes. The observers also run BEFORE the stream's
+// masking block, so the text they hold is otherwise unscrubbed.
 //
-// 500 bytes — SanitizeLogBody's limit is a byte count, so CJK error text from
-// MiniMax or Z.ai is cut at roughly a third of that in characters. It matches
-// the probe's own error sanitizer rather than the request log's 10000: a log
-// attribute is for recognising the failure, and the full text is already on the
-// row. SanitizeLogBody also redacts UUIDs, so a provider echoing a request id
-// back inside its error does not put one in the app log.
+// 500 bytes, matching the probe's error sanitizer rather than the request log's
+// 10000: a log attribute is for recognising the failure, and the full text is
+// already on the row. SanitizeLogBody's limit is a byte count, so CJK error text
+// from MiniMax or Z.ai is cut at roughly a third of that in characters. It also
+// redacts UUIDs, so a provider echoing a request id back inside its error does
+// not put one in the app log.
 //
-// A zero-value masker (a keyless local provider) masks by shape only, which is
-// what every other site on those paths does too.
+// A zero-value masker (a keyless local provider) masks by shape only, as every
+// other site on those paths does.
 func (st *streamState) errLogAttr(msg string) string {
 	return st.content.maskOne(util.SanitizeLogBody(string(st.masker.mask([]byte(msg))), 500))
 }
 
 // repeatedContentLimit is the consecutive-identical-content threshold (P2-5) at
-// which we log a warning. Lifted to package scope from handleStreamingResponse
-// in Phase 4 so observeDataChunk can reference it.
+// which observeDataChunk logs a warning.
 const repeatedContentLimit = 10
 
 // streamChunk is the typed view of a streaming "data:" JSON chunk that the
-// transforms and observers inspect (Phase 4). Only the fields the proxy acts on
-// are modelled; everything else is ignored on unmarshal.
+// transforms and observers inspect. Only the fields the proxy acts on are
+// modelled; everything else is ignored on unmarshal.
 type streamChunk struct {
 	Choices []struct {
 		Delta *struct {
@@ -138,10 +132,9 @@ type streamChunk struct {
 			// The two other spellings of the same thing. Ollama and OpenRouter
 			// send "reasoning"; OpenRouter and MiniMax send "reasoning_details".
 			// normalizeReasoningChunk rewrites both into reasoning_content for
-			// the client, but it runs AFTER the observers — so without these the
+			// the client, but runs AFTER the observers, so without these the
 			// caller receives a full answer while the delivery accounting sees
-			// nothing, and the provider is charged for an empty response it did
-			// not give.
+			// nothing and the provider is charged for an empty response.
 			Reasoning        *string         `json:"reasoning"`
 			ReasoningDetails json.RawMessage `json:"reasoning_details"`
 			ToolCalls        []struct {
@@ -149,8 +142,8 @@ type streamChunk struct {
 					Name string `json:"name"`
 					// util.ToolArguments, not string: several providers send the
 					// argument OBJECT where the spec says a JSON string, and a
-					// plain string field failed the WHOLE chunk unmarshal, so
-					// the frame was dropped as though the bytes were corrupt.
+					// plain string field fails the WHOLE chunk unmarshal, so
+					// the frame is dropped as though the bytes were corrupt.
 					Arguments util.ToolArguments `json:"arguments"`
 				} `json:"function"`
 			} `json:"tool_calls"`
@@ -164,25 +157,23 @@ type streamChunk struct {
 	} `json:"choices"`
 	Usage *Usage `json:"usage"`
 	// json.RawMessage, not a typed object: providers put an error of any shape
-	// here — Ollama's bare string, a list, a number — and a typed field failed
-	// the WHOLE chunk unmarshal, so the frame was dropped as corrupt bytes
-	// instead of forwarded, and the error it reported was recorded only when
-	// the payload happened to START with {"error" (the P1-B prefix). What the
-	// member means is util.ErrorMemberCarries/ErrorMemberMessage's answer, shared
-	// with the probe so the two readings cannot drift.
+	// here (Ollama's bare string, a list, a number), and a typed field fails the
+	// WHOLE chunk unmarshal, so the frame is dropped as corrupt bytes instead of
+	// forwarded. What the member means is
+	// util.ErrorMemberCarries/ErrorMemberMessage's answer, shared with the probe
+	// so the two readings cannot drift.
 	Error json.RawMessage `json:"error"`
 }
 
 // observeUsage records the counts a usage block reports.
 //
-// Each count is guarded on its own, the way the cache split already was. Two
-// providers make that necessary: one that rides a usage block on EVERY chunk,
-// and one whose usage block this gateway could only partly read —
-// encoding/json allocates the pointer before it calls the custom unmarshaler, so
-// a usage member in an unmodelled shape leaves a valid pointer to an all-zero
-// Usage, and a bare assignment then wrote zeros over counts an earlier chunk had
-// already reported. A usage chunk saying zero says nothing; only a count carries
-// a reading.
+// Each count is guarded on its own, as the cache split is. Two providers make
+// that necessary: one that rides a usage block on EVERY chunk, and one whose
+// usage block this gateway can only partly read. encoding/json allocates the
+// pointer before calling the custom unmarshaler, so a usage member in an
+// unmodelled shape leaves a valid pointer to an all-zero Usage, and a bare
+// assignment would write zeros over counts an earlier chunk reported. A usage
+// chunk saying zero says nothing; only a count carries a reading.
 //
 // The guard is a range, not a sign: a count is a reading only inside
 // (0, maxSaneTokenCount]. A member outside it neither replaces an earlier good
@@ -207,11 +198,10 @@ func (st *streamState) observeUsage(usage *Usage) {
 }
 
 // observeDataChunk applies the four non-emitting, side-channel observers over a
-// parsed data chunk, updating streamState in place (Phase 4 — the first pipeline
-// stage extracted from handleStreamingResponse). It never writes to the client
-// and never affects the emit decision; it only records metrics and detection
-// state. anthropicErrorCounted reports whether the P1-C Anthropic path already
-// counted an error for this line (so chunk.Error doesn't double-count it).
+// parsed data chunk, updating streamState in place. It never writes to the
+// client and never affects the emit decision; it records metrics and detection
+// state only. anthropicErrorCounted reports whether the P1-C Anthropic path
+// already counted an error for this line, so chunk.Error does not double-count.
 //
 // Observers, in order:
 //   - usage/token extraction (last usage chunk wins; cache hit/miss only when set)
@@ -220,23 +210,23 @@ func (st *streamState) observeUsage(usage *Usage) {
 //   - chunk.Error capture (clears errAccum so P1-B won't re-count)
 func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted bool, chunkCount int, logData *requestLogData) {
 	st.observeUsage(chunk.Usage)
-	// P2-7: Log native_finish_reason from OpenRouter for debugging.
-	// OpenRouter includes this field alongside the normalized finish_reason,
-	// preserving the original provider's value (e.g. "STOP" instead of "stop").
+	// P2-7: log OpenRouter's native_finish_reason, which rides alongside the
+	// normalized finish_reason and preserves the original provider's value
+	// ("STOP" rather than "stop").
 	if len(chunk.Choices) > 0 && chunk.Choices[0].NativeFinishReason != nil {
 		if *chunk.Choices[0].NativeFinishReason != st.lastNativeFinishReason {
 			st.lastNativeFinishReason = *chunk.Choices[0].NativeFinishReason
 			debuglog.Debug("proxy: native_finish_reason", "native_finish_reason", st.lastNativeFinishReason, "model", logData.modelID, "provider", logData.providerName)
 		}
 	}
-	// P2-5: Detect repeated identical content. Some models (notably
-	// xAI Grok reasoning) send the same reasoning text in consecutive
-	// deltas, causing "Thinking... Thinking... Thinking..." loops.
-	// We track consecutive identical content and log a warning when
-	// the threshold is exceeded.
-	// Every choice is delivered output, so the byte count covers all of them
-	// (an n>1 stream is billed for every choice), unlike the observers below,
-	// which only watch choices[0].
+	// P2-5: detect repeated identical content. Some models (notably xAI Grok
+	// reasoning) send the same reasoning text in consecutive deltas, causing
+	// "Thinking... Thinking... Thinking..." loops, so consecutive identical
+	// content is counted and a warning logged past the threshold.
+	//
+	// Every choice is delivered output, so the byte count covers all of them (an
+	// n>1 stream is billed for every choice), unlike the observers below, which
+	// watch choices[0] only.
 	for _, choice := range chunk.Choices {
 		if choice.Delta == nil {
 			continue
@@ -279,11 +269,10 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 			}
 		}
 		if currentContent != "" {
-			// The model produced something. Recorded here, at the only place
-			// that sees content itself, because the retirement verdict needs to
-			// know a stream really answered and cannot learn it from usage
-			// (providers omit the usage chunk) or from TTFT (the probe can be
-			// switched off).
+			// The model produced something. Recorded here, the only place that
+			// sees content itself, because the retirement verdict needs to know
+			// a stream really answered and cannot learn it from usage (providers
+			// omit the usage chunk) or from TTFT (the probe can be switched off).
 			st.sawContent = true
 		}
 		if currentContent == st.lastContent && currentContent != "" {
@@ -297,14 +286,14 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		st.lastContent = currentContent
 	}
 	if !anthropicErrorCounted && util.ErrorMemberCarries(chunk.Error) {
-		// Only count if P1-C didn't already handle this as an
-		// Anthropic error event (which shares the same data line).
+		// Counted only when P1-C did not already handle this as an Anthropic
+		// error event, which shares the same data line.
 		msg := util.ErrorMemberMessage(chunk.Error)
 		st.lastErrMsg = msg
 		st.errorChunkCount++
 		debuglog.Warn("proxy: SSE error chunk", "model", logData.modelID, "provider", logData.providerName, "error_message", st.errLogAttr(msg), "chunk_number", chunkCount)
-		// Clear st.errAccum: chunk.Error already captured this error,
-		// so P1-B's next flush must not re-count it.
+		// chunk.Error captured this error, so P1-B's next flush must not
+		// re-count it.
 		st.errAccum = nil
 	}
 }

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -14,9 +14,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// ModelRepository defines the interface for model operations.
-// Used to enable mocking in tests while allowing the real *model.Repository
-// to be used in production.
+// ModelRepository is the set of model-store operations the proxy needs.
 type ModelRepository interface {
 	ListEnabled(ctx context.Context) ([]*model.Model, error)
 	Upsert(ctx context.Context, model *model.Model) error
@@ -28,16 +26,14 @@ type ModelRepository interface {
 	SetEnabled(ctx context.Context, id uuid.UUID, enabled bool) (*model.Model, error)
 	// AutoRetireIfConfirmed disables a model the provider has reported retired,
 	// staging the write so a model that answers while it is in flight never has
-	// a disabled state other sessions can act on (see noteModelGone).
+	// a disabled state other sessions can act on.
 	AutoRetireIfConfirmed(ctx context.Context, id uuid.UUID, confirm func() bool) (bool, error)
 	// RevertAutoRetire undoes such a retirement, but only while the row is still
 	// as the retirement left it, so it cannot overwrite an operator's disable.
 	RevertAutoRetire(ctx context.Context, id uuid.UUID) (bool, error)
 }
 
-// VirtualKeyRepository defines the interface for virtual key operations.
-// Used to enable mocking in tests while allowing the real *virtualkey.Repository
-// to be used in production.
+// VirtualKeyRepository is the set of virtual-key operations the proxy needs.
 type VirtualKeyRepository interface {
 	AddTokens(ctx context.Context, keyHash string, tokens int) error
 	TouchLastUsed(ctx context.Context, keyHash string) error
@@ -82,14 +78,13 @@ type contextKey string
 const virtualKeyNameKey contextKey = "virtual_key_name"
 const virtualKeyIDKey contextKey = "virtual_key_id"
 
-// VirtualKeyHashKey re-exports the shared context key from ctxkeys so
-// existing code in this package can reference it without a package prefix.
-// The canonical definition lives in internal/ctxkeys to avoid import cycles.
+// VirtualKeyHashKey re-exports the shared context key so this package can use
+// it without a package prefix. The canonical definition lives in
+// internal/ctxkeys to avoid import cycles.
 const VirtualKeyHashKey = ctxkeys.VirtualKeyHashKey
 
-// Endpoint families recorded in request_logs.endpoint_type. The proxy serves
-// chat completions plus the multimodal OpenAI-compatible endpoints; every
-// request log row is tagged with the family it came through.
+// Endpoint families recorded in request_logs.endpoint_type: every request log
+// row is tagged with the family it came through.
 const (
 	endpointTypeChat       = "chat"
 	endpointTypeMessages   = "messages"
@@ -106,8 +101,8 @@ type requestLogData struct {
 	// the provider identity for each attempt; zero value masks by shape only.
 	masker credentialMasker
 	// content fences echoes of the request's own text out of the upstream
-	// error fragments this row stores (content_fence.go). Nil when the
-	// request carried nothing to fence.
+	// error fragments this row stores. Nil when the request carried nothing to
+	// fence.
 	content                   *contentFence
 	id                        string
 	providerID                uuid.UUID
@@ -144,51 +139,47 @@ type requestLogData struct {
 	clientIP string
 	// ownerUserID is the owning dashboard user's UUID; "" for unowned keys
 	// (admin-only visibility). Persisted to request_logs.owner_user_id only when
-	// there is no virtual key (migration 067); keyed rows resolve their owner
-	// through the key instead.
+	// there is no virtual key; keyed rows resolve their owner through the key
+	// instead.
 	ownerUserID  string
 	errorMessage string
 	errorKind    ErrorKind // machine-readable classification; "" = unclassified (NULL in DB)
-	// upstreamKind is what the PROVIDER said, kept apart from errorKind because
+	// upstreamKind is what the provider said, kept apart from errorKind because
 	// errorKind records how the request ended and later causes overwrite earlier
-	// ones. A client that hangs up on receiving an in-stream error turns the
-	// recorded kind into client_disconnect, which would otherwise erase the
-	// provider's own statement that the model is gone — the evidence destroyed
-	// by the client reacting to it. Not persisted; it exists so the retirement
-	// verdict can be drawn from the provider alone.
+	// ones: a client that hangs up on an in-stream error turns the recorded kind
+	// into client_disconnect, erasing the provider's statement that the model is
+	// gone. Not persisted; it lets the retirement verdict read what the provider
+	// said rather than how the request ended.
 	upstreamKind ErrorKind
 	// deliveredContent records that the stream actually produced content. Not
-	// persisted; it exists because the two signals that used to stand in for it
-	// are both optional — a provider can omit the usage chunk and the TTFT probe
-	// can be switched off — and a real success that reports neither would
-	// otherwise look indistinguishable from a stream that emitted nothing.
+	// persisted. Both weaker signals are optional (a provider can omit the usage
+	// chunk, the TTFT probe can be switched off), so without this a real success
+	// reporting neither looks like a stream that emitted nothing.
 	deliveredContent bool
-	// emptyCompletion records that the upstream answered with nothing at all --
-	// no choices and no completion tokens -- which is the only shape the circuit
-	// breaker charges a 200 for.
+	// emptyCompletion records that the upstream answered with nothing at all:
+	// no choices and no completion tokens, the only shape the circuit breaker
+	// charges a 200 for.
 	//
-	// A different question from !deliveredContent, not a narrower one. That flag
-	// backs the RETIREMENT verdict and stays strict, because `refusal` is the
-	// likeliest field for an aggregator to write "this model is gone" into
-	// behind a 200 and it must not clear a gone-strike streak. This one asks
-	// only whether ANYTHING came back, so a safety refusal, an audio answer, an
-	// Azure content_filter block or a legacy function_call all count as the
-	// provider answering. See answerCarriesSomething.
+	// A different question from !deliveredContent, not a narrower one: that flag
+	// backs the retirement verdict and stays strict, while this one asks only
+	// whether anything came back, so a safety refusal, an audio answer, an Azure
+	// content_filter block or a legacy function_call all count as the provider
+	// answering.
 	emptyCompletion bool
 	// promptTextBytes is the size of the prompt text in the client's request
 	// (message text and tool definitions, never inline media), recorded at
 	// ingest so every response path can estimate the prompt when the provider
-	// reports no usage (see estimateMissingUsage). Not persisted.
+	// reports no usage. Not persisted.
 	promptTextBytes int
 	failoverAttempt int
 	state           string
 	resolvedModelID string
 	endpointType    string         // endpoint family: chat, embeddings, rerank, image, tts, stt
 	insertWg        sync.WaitGroup // signals when the async INSERT has completed
-	// The per-attempt trail (see attempt_trail.go): attempts holds the closed
-	// records in order, openAttempt the one in flight, attemptStarted when it
-	// began and attemptBreaker what the breaker was told about it. Persisted
-	// as request_logs.attempts by the terminal write.
+	// The per-attempt trail: attempts holds the closed records in order,
+	// openAttempt the one in flight, attemptStarted when it began and
+	// attemptBreaker what the breaker was told about it. Persisted as
+	// request_logs.attempts by the terminal write.
 	attempts       []attemptRecord
 	openAttempt    *attemptRecord
 	attemptStarted time.Time
@@ -202,11 +193,10 @@ type requestLogData struct {
 	attemptStatus int
 	attemptPhrase string
 	// judgeAnswer is the deferred breaker verdict for a non-streaming attempt
-	// (recordAnswerOutcome bound to its candidate). The handler that decodes
-	// the answer also writes the terminal row, and the verdict must land before
-	// that write for the trail's terminal record to carry it, so
-	// updateRequestLog runs it first; the attempt path runs it afterwards only
-	// if no terminal write did. Exactly one of the two fires.
+	// (recordAnswerOutcome bound to its candidate). It must land before the
+	// terminal row is written for the trail's terminal record to carry it, so
+	// updateRequestLog runs it first and the attempt path runs it only if no
+	// terminal write did. Exactly one of the two fires.
 	judgeAnswer func()
 }
 
@@ -217,10 +207,10 @@ type modelCandidate struct {
 }
 
 // requestState is the per-request scratch threaded through the ChatCompletions
-// phases (ingest → resolve → config → failover loop), replacing the ~20 closure
-// locals the handler previously carried. It is built by ingestRequest and
-// augmented by later phases. Helpers mutate the shared pointer instance — never
-// a copy — so timing/overhead accumulation is visible to subsequent phases.
+// phases (ingest, resolve, config, failover loop). It is built by ingestRequest
+// and augmented by later phases. Helpers mutate the shared pointer instance,
+// never a copy, so timing and overhead accumulation is visible to subsequent
+// phases.
 type requestState struct {
 	startTime   time.Time
 	reqModel    string
@@ -271,13 +261,13 @@ type requestState struct {
 	// shape the pipeline and client expect.
 	geminiAttempt bool
 	// speechFormat is set by buildGeminiSpeechRequest for a /v1/audio/speech
-	// attempt served through generateContent (gemini_speech.go): the wav or
-	// pcm the answer's audio part is delivered as. Empty on every other
-	// attempt, which is how the pass-through dispatch tells the two apart.
+	// attempt served through generateContent: the wav or pcm the answer's audio
+	// part is delivered as. Empty on every other attempt, which is how the
+	// pass-through dispatch tells the two apart.
 	speechFormat string
 	// passthroughUsage is the usage a translating adapter read off the
-	// provider's answer before re-shaping it into a body that carries none;
-	// the binary pass-through path meters from it in place of the estimate.
+	// provider's answer before re-shaping it into a body that carries none.
+	// The binary pass-through path meters from it in place of the estimate.
 	passthroughUsage *passthroughUsage
 
 	// Anthropic egress adapter (zero value = plain chat-completions).
@@ -290,10 +280,9 @@ type requestState struct {
 	// the pipeline and client expect.
 	anthropicEgressAttempt bool
 	// messagesRetried marks that this candidate's request has already been
-	// re-issued once by the Messages-route self-heal (see
-	// anthropic_thinking_retry.go). A 400 after that is about something the
-	// self-heal cannot fix, so the attempt ends rather than asking a third time.
-	// Reset per candidate with the dialect flags above.
+	// re-issued once by the Messages-route self-heal. A 400 after that is about
+	// something the self-heal cannot fix, so the attempt ends rather than asking
+	// a third time. Reset per candidate with the dialect flags above.
 	messagesRetried bool
 	// lastMessagesBody is the Messages body of the current egress attempt, kept
 	// so the self-heal can tell whether a rebuild actually changed anything.
@@ -324,13 +313,12 @@ type requestState struct {
 	lastErr    string
 	lastReqErr reqError
 
-	// rateLimit is the current attempt's 429 verdict (see classify429Attempt),
-	// reset at attempt start by beginAttempt. The terminal paths read it for
-	// the Retry-After they hand the client; only a terminal whose own status is
-	// a classified 429 does, so a stale verdict from an earlier attempt can
-	// never label a later failure. saturationRetried marks that this request
-	// has already spent its one wait-and-retry on a saturated last candidate —
-	// one retry, not a loop.
+	// rateLimit is the current attempt's 429 verdict, reset at attempt start by
+	// beginAttempt. The terminal paths read it for the Retry-After they hand the
+	// client, and only a terminal whose own status is a classified 429 does, so
+	// a stale verdict from an earlier attempt can never label a later failure.
+	// saturationRetried marks that this request has already spent its one
+	// wait-and-retry on a saturated last candidate.
 	rateLimit         rateLimitVerdict
 	saturationRetried bool
 
@@ -344,31 +332,27 @@ type requestState struct {
 }
 
 // setReqErr records the structured cause of the most recent failed attempt and
-// keeps the rendered lastErr string in sync. Every failover-loop site that used
-// to assign st.lastErr a fmt.Sprintf string now goes through here so the
-// exhaustion path always has a structured error to render and classify.
+// keeps the rendered lastErr string in sync. Every failover-loop failure goes
+// through here, so the exhaustion path always has a structured error to render
+// and classify.
 func (st *requestState) setReqErr(e reqError) {
 	st.lastReqErr = e
 	st.lastErr = e.render()
 }
 
 // sentChatCompletionsBody reports whether the current attempt POSTed an OpenAI
-// chat-completions body to a chat-completions route — that is, no dialect flag
+// chat-completions body to a chat-completions route, that is, no dialect flag
 // is set for it.
 //
 // Everything that interprets a 400 as OpenAI gates on this: the param
 // self-heal's rebuild-and-re-POST, and learning a rejected param or a
 // /v1/responses requirement from the error text. On a dialect attempt both are
-// wrong — another dialect's error names another dialect's fields, so a strip
-// learned there poisons the compat path for that model, and a rebuilt chat body
-// re-POSTed to a native endpoint would be malformed. The sequential and hedged
-// 400 paths share this predicate, so a dialect added later is covered at both
-// sites by extending it here. The Responses dialect is the one exception,
-// handled by name at both sites: its body is a closed struct sharing only
-// the sampling names with chat-completions, OpenAI names a rejected one
-// exactly as it does there, the one shared name that means something else
-// is dropped by responsesRejectedParams, and the retry rebuilds in that
-// dialect (rebuildForParamRetry).
+// wrong: another dialect's error names another dialect's fields, and a rebuilt
+// chat body re-POSTed to a native endpoint would be malformed. A dialect added
+// later is covered at both the sequential and hedged 400 sites by extending
+// this predicate. The Responses dialect is the one exception, handled by name
+// at both sites, since it shares the sampling parameter names and rebuilds in
+// its own dialect.
 //
 // It reads the attempt's own state: the hedged path holds a private snapshot
 // whose flags its own buildCandidateRequest set, so there is no shared-state
@@ -378,19 +362,17 @@ func (st *requestState) sentChatCompletionsBody() bool {
 }
 
 // retryBudgetLeft reports whether a self-heal round may still be issued: at
-// least retryMinRound before the overall deadline. Past that, the refusal
-// in hand is handed on as the provider gave it, to fail over or reach the
-// client, rather than a round that would time out on issue and turn the
-// provider's own answer into a timeout of this gateway's making. What the
-// refusal taught is learned either way. A state that never set the deadline
-// (the unit tests' bare state) always has budget.
+// least retryMinRound before the overall deadline. Past that the refusal in
+// hand is handed on as the provider gave it, rather than a round that would
+// time out on issue. What the refusal taught is learned either way. A state
+// that never set the deadline always has budget.
 func (st *requestState) retryBudgetLeft() bool {
 	return st.overallDeadline.IsZero() || time.Until(st.overallDeadline) > retryMinRound
 }
 
-// candidateOutcome is the result of a single failover attempt
-// (attemptCandidate): whether the caller should try the next candidate, has
-// already served the client, or has written a terminal error.
+// candidateOutcome is the result of a single failover attempt: whether the
+// caller should try the next candidate, has already served the client, or has
+// written a terminal error.
 type candidateOutcome int
 
 const (
@@ -400,25 +382,24 @@ const (
 	outcomeServed
 	// outcomeFatal: a terminal error response was written; return.
 	outcomeFatal
-	// outcomeRetrySaturated: the LAST candidate answered a saturated 429 —
-	// alive, at capacity, a slot frees in seconds — and nothing was written.
-	// The loop waits the provider's Retry-After (bounded) and retries the same
-	// candidate once; st.saturationRetried guards the "once".
+	// outcomeRetrySaturated: the last candidate answered a saturated 429 (alive,
+	// at capacity, a slot frees in seconds) and nothing was written. The loop
+	// waits the provider's Retry-After (bounded) and retries the same candidate
+	// once; st.saturationRetried guards the "once".
 	outcomeRetrySaturated
 	// outcomeBusy: the candidate's provider is at its learned in-flight limit,
-	// so the attempt was skipped WITHOUT a request — the way a breaker-open
-	// candidate is. The loop moves on, remembers the candidate, and when every
-	// live entry ends busy it waits for the first slot to free on any of them.
+	// so the attempt was skipped without a request. The loop moves on, remembers
+	// the candidate, and when every live entry ends busy it waits for the first
+	// slot to free on any of them.
 	outcomeBusy
-	// outcomeSkipped: the candidate cannot serve this request as asked (a
-	// Gemini TTS candidate and a response format it does not produce), so
-	// the attempt was skipped WITHOUT a request. The loop moves on; unlike
-	// a busy skip nothing frees up later, so it is not retried.
+	// outcomeSkipped: the candidate cannot serve this request as asked (a Gemini
+	// TTS candidate and a response format it does not produce), so the attempt
+	// was skipped without a request. The loop moves on; unlike a busy skip
+	// nothing frees up later, so it is not retried.
 	outcomeSkipped
 )
 
-// streamOptions consolidates the parameters for handleStreamingResponse into
-// a single struct, replacing 17 positional parameters with named fields.
+// streamOptions carries the parameters for handleStreamingResponse.
 type streamOptions struct {
 	preReadBuf         *bytes.Buffer // nil = no TTFT probe (immediate commit)
 	trueTtftMs         float64       // measured during TTFT probe; a probe that finds no token fails rather than reporting 0
@@ -428,8 +409,8 @@ type streamOptions struct {
 	providerName       string
 	// model is the candidate's resolved upstream model id, the key
 	// finalizeStream charges and credits the breaker under. It rides here rather
-	// than being read off logData, whose modelID is what the CLIENT asked for
-	// (a hotel/ alias on a failover group) and so is not a circuit key at all.
+	// than being read off logData, whose modelID is what the client asked for (a
+	// hotel/ alias on a failover group) and so is not a circuit key.
 	model            string
 	circuitBreakerOn bool
 	// timing fields
@@ -470,18 +451,17 @@ type ChatCompletionResponse struct {
 	Usage   Usage    `json:"usage"`
 	// Extra carries the top-level fields this struct does not model
 	// (system_fingerprint, OpenRouter's provider, service_tier, ...) so they
-	// survive the non-streaming decode + re-encode. See jsonextras.go.
+	// survive the non-streaming decode + re-encode.
 	Extra jsonExtras `json:"-"`
 }
 
 // Choice represents a single completion choice in the response.
 //
-// Delta is a pointer so the two response shapes stay distinct. A struct is
-// never empty to encoding/json, so a value field emitted "delta":{"role":"",
-// "content":null} on every non-streaming completion, a key the OpenAI
-// non-streaming schema does not have. Nil omits it; a streaming chunk that
-// carries a delta still round-trips one, even a delta holding nothing but the
-// role.
+// Delta is a pointer so the two response shapes stay distinct: a struct is
+// never empty to encoding/json, so a value field would emit
+// "delta":{"role":"","content":null} on every non-streaming completion, a key
+// the OpenAI non-streaming schema does not have. Nil omits it, while a
+// streaming chunk that carries a delta still round-trips one.
 type Choice struct {
 	Index        int      `json:"index"`
 	Message      Message  `json:"message"`
@@ -489,7 +469,7 @@ type Choice struct {
 	FinishReason *string  `json:"finish_reason,omitempty"`
 	// Extra carries the per-choice fields this struct does not model (logprobs,
 	// OpenRouter's native_finish_reason, ...) so they survive the non-streaming
-	// decode + re-encode. See jsonextras.go.
+	// decode + re-encode.
 	Extra jsonExtras `json:"-"`
 }
 
@@ -498,8 +478,8 @@ type Message struct {
 	Role    string `json:"role"`
 	Content any    `json:"content"`
 	// ToolCalls/ToolCallID must round-trip through the non-streaming decode +
-	// re-encode in handleNonStreamingResponse, or function calls are silently
-	// dropped (finish_reason:"tool_calls" with no tool_calls array) for every
+	// re-encode, or function calls are silently dropped
+	// (finish_reason:"tool_calls" with no tool_calls array) for every
 	// non-streaming client. omitempty keeps plain text responses unchanged.
 	ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`
 	ToolCallID       string            `json:"tool_call_id,omitempty"`
@@ -507,7 +487,7 @@ type Message struct {
 	Reasoning        string            `json:"reasoning,omitempty"`         // Ollama, OpenRouter
 	ReasoningDetails []ReasoningDetail `json:"reasoning_details,omitempty"` // OpenRouter, MiniMax
 	// Extra carries the response fields this struct does not model, so they
-	// survive the non-streaming decode + re-encode. See jsonextras.go.
+	// survive the non-streaming decode + re-encode.
 	Extra jsonExtras `json:"-"`
 }
 
@@ -520,17 +500,16 @@ type ToolCall struct {
 	Function ToolCallFunc `json:"function"`
 	// Extra carries provider fields this struct does not model. Gemini 3 puts
 	// extra_content.google.thought_signature here and rejects the follow-up
-	// turn without it, so dropping it breaks tool use outright. See
-	// jsonextras.go.
+	// turn without it, so dropping it breaks tool use outright.
 	Extra jsonExtras `json:"-"`
 }
 
 // ToolCallFunc is the function name + raw JSON arguments of a tool call.
 type ToolCallFunc struct {
 	Name string `json:"name"`
-	// See util.ToolArguments. A plain string here made the whole
-	// ChatCompletionResponse fail to decode when a provider sent the argument
-	// object, and the caller got an error envelope instead of its tool call.
+	// util.ToolArguments accepts both shapes providers send. A plain string
+	// here fails the whole ChatCompletionResponse decode when a provider sends
+	// the arguments as an object.
 	Arguments util.ToolArguments `json:"arguments"`
 }
 
@@ -562,6 +541,6 @@ type Usage struct {
 	CompletionTokensDetails  *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	// Extra carries the usage fields this struct does not model (OpenRouter's
 	// cost and is_byok, provider-specific token breakdowns, ...) so they survive
-	// the non-streaming decode + re-encode. See jsonextras.go.
+	// the non-streaming decode + re-encode.
 	Extra jsonExtras `json:"-"`
 }

--- a/internal/proxy/upstream_classify.go
+++ b/internal/proxy/upstream_classify.go
@@ -9,13 +9,10 @@ import (
 )
 
 // modelScopedErrorCodes name the model in the field itself, so a body carrying
-// one is talking about the model the request asked for by construction.
+// one is talking about the model the request asked for.
 //
-// A deliberately small allowlist rather than a "model_*" pattern. A provider is
-// free to invent "model_overloaded" or "model_rate_limited", and those are
-// transient faults about a model that very much still exists — matching them by
-// prefix would retire it. The list grows from payloads observed in /api/logs,
-// which is the rule this whole change came from.
+// An allowlist rather than a "model_*" prefix match: "model_overloaded" and
+// "model_rate_limited" are transient faults about a model that still exists.
 var modelScopedErrorCodes = map[string]bool{
 	"model_not_found":     true,
 	"model_not_supported": true,
@@ -24,29 +21,22 @@ var modelScopedErrorCodes = map[string]bool{
 // genericNotFoundTypes say something is missing without saying what, so they
 // only count as a retirement alongside the requested model's own id.
 //
-// not_found_error is Anthropic's, forwarded verbatim by aggregators. It is used
-// for any absent entity — a conversation, a file, a batch — so on its own it is
-// far too weak to disable a model on.
+// not_found_error is Anthropic's, forwarded verbatim by aggregators, and covers
+// any absent entity (a conversation, a file, a batch), so on its own it is far
+// too weak to disable a model on.
 var genericNotFoundTypes = map[string]bool{
 	"not_found_error": true,
 }
 
-// structuredError is what a provider said about WHY it refused, in fields rather
-// than prose.
+// structuredError is what a provider said about why it refused, in fields
+// rather than prose.
 //
-// The three fields must come from ONE object. That is the invariant this type
-// exists to carry, and it has been broken three separate ways while this was
-// being written: a message read from anywhere in the body, then from a different
-// level of the same document, then from a sibling object of the right one. Each
-// is the same mistake — a code or type is a claim about whatever its own object
-// is describing, and pairing it with a message from elsewhere invents a
-// statement no provider made. The identity check that bounds a generic
-// not-found type then reads the wrong text and retires a model nobody said
-// anything about.
-//
-// Both extractors enforce it and neither may relax it: the parse takes the error
-// object whole or the top level whole, and the scan works inside one delimited
-// region.
+// The three fields must come from ONE object: a code or type is a claim about
+// whatever its own object describes, and pairing it with a message from
+// elsewhere invents a statement no provider made, so the identity check that
+// bounds a generic not-found type reads the wrong text. Both extractors enforce
+// this and neither may relax it: the parse takes the error object whole or the
+// top level whole, and the scan works inside one delimited region.
 type structuredError struct {
 	code    string
 	typ     string
@@ -56,12 +46,11 @@ type structuredError struct {
 // The scan fallback's patterns: a quoted string field by name, anchored on the
 // key so a value that merely looks like one cannot be picked up.
 //
-// The value may contain escaped quotes, which is not a nicety: providers quote
-// the model name inside the message they are already sending as JSON, so
-// `"message":"model \"gpt-4\" not found"` is an ordinary shape, and a pattern
-// that stopped at the first quote captured `model \` and lost the id. The escape
-// handling matches jsonObjectBody's, so the region walker and the field readers
-// agree about where a string ends.
+// The value may contain escaped quotes: providers quote the model name inside a
+// message they are already sending as JSON, so `"message":"model \"gpt-4\" not
+// found"` is an ordinary shape and a pattern stopping at the first quote loses
+// the id. The escape handling matches jsonObjectBody's, so the region walker
+// and the field readers agree about where a string ends.
 var (
 	scanCode    = regexp.MustCompile(`"code"\s*:\s*"((?:[^"\\]|\\.)*)"`)
 	scanType    = regexp.MustCompile(`"type"\s*:\s*"((?:[^"\\]|\\.)*)"`)
@@ -75,16 +64,15 @@ var (
 // start, up to its matching close brace, or to the end of the input when the
 // object never closes.
 //
-// The unclosed case is not an error path, it is the point: this only runs on a
-// body no parser would accept, which usually means SanitizeLogBody cut it
-// mid-object. A truncated object has no siblings after it, so running to the end
-// is exactly right there — and where the object DOES close, stopping at the brace
-// is what keeps a sibling's message from being read as this error's.
+// The unclosed case is normal rather than an error path: this only runs on a
+// body no parser would accept, usually one SanitizeLogBody cut mid-object, and
+// a truncated object has no siblings after it. Where the object does close,
+// stopping at the brace keeps a sibling's message from being read as this
+// error's.
 //
-// Braces inside strings are skipped, because a provider message is free to
-// contain one ("expected { at position 4"), and a quote is only a delimiter when
-// it is not escaped. Anything more than that — numbers, nesting rules, escape
-// semantics beyond \" — belongs to the parser this function is the fallback for.
+// Braces inside strings are skipped, since a provider message may contain one
+// ("expected { at position 4"), and a quote delimits only when unescaped.
+// Anything beyond that belongs to the parser this function backs up.
 func jsonObjectBody(body string, start int) string {
 	depth := 1
 	inString, escaped := false, false
@@ -114,23 +102,19 @@ func jsonObjectBody(body string, start int) string {
 // scanStructuredError extracts the three fields from a body no parser would
 // accept, scoped to the error object when one can be found.
 //
-// The scoping is the whole point rather than tidiness. The payload this change
-// exists for opens `{"type":"error","error":{"type":"not_found_error",…}}`, so a
-// scan of the whole document finds the ENVELOPE's type first and reads "error" —
-// which is not a retirement signal, and shadows the one that is. A truncated
-// body is the normal case for a large error, so the fallback has to handle the
-// real shape rather than a tidier one.
+// The scoping matters: a payload opening
+// `{"type":"error","error":{"type":"not_found_error",…}}` yields the ENVELOPE's
+// type first on a whole-document scan, which is not a retirement signal and
+// shadows the one that is.
 //
-// Falling back to the whole document when no error object is found keeps a
-// provider that reports its fields at the top level working; it is looser, and
-// what the callers do with the result is what bounds it.
+// With no error object the whole document is scanned, so a provider reporting
+// its fields at the top level still works; the callers bound how loose that is.
 func scanStructuredError(body string) structuredError {
-	// One region for all three fields, never a field-by-field fallback. Reading
-	// the type from inside the error object and the message from outside it
-	// pairs a real signal with an unrelated sentence, and the identity check
-	// that is meant to bound the type then answers about the wrong text: a body
-	// whose top-level message merely mentions the model would retire it. Fields
-	// that do not travel together are not evidence about each other.
+	// One region for all three fields, never a field-by-field fallback: a type
+	// from inside the error object paired with a message from outside it is two
+	// unrelated statements, and the identity check meant to bound the type then
+	// reads the wrong text. Fields that do not travel together are not evidence
+	// about each other.
 	region := body
 	if at := errorObjectStart.FindStringIndex(body); at != nil {
 		region = jsonObjectBody(body, at[1])
@@ -148,16 +132,15 @@ func scanStructuredError(body string) structuredError {
 // and never fails: an absent field means no signal, which every caller treats as
 // "nothing established".
 //
-// Two passes, because the input cannot be trusted to be a document. The body
-// reaching the classifier has been through util.SanitizeLogBody, which truncates
-// at 10 000 bytes and will happily cut JSON mid-structure, and plenty of
-// providers answer with HTML or plain text. So the parse is tried first, for its
-// precision — it reads error.code and error.type from the error OBJECT, not from
-// anywhere the strings happen to appear — and a key scan is the fallback.
+// Two passes, because the input cannot be trusted to be a document: the body
+// has been through util.SanitizeLogBody, which truncates at 10 000 bytes and
+// can cut JSON mid-structure, and plenty of providers answer with HTML or plain
+// text. The parse runs first for its precision, reading error.code and
+// error.type from the error OBJECT rather than from anywhere the strings
+// appear; the key scan is the fallback.
 //
-// The fallback is the looser of the two and is scoped by what the callers do
-// with it rather than by the scan itself: a code only counts if it is in a small
-// allowlist, and a type only counts alongside the model's own id. A stray
+// The callers bound the looser scan: a code counts only if it is in a small
+// allowlist, and a type only alongside the model's own id, so a stray
 // "type":"function" in an echoed tool definition matches neither.
 func parseStructuredError(body string) structuredError {
 	var envelope struct {
@@ -183,11 +166,9 @@ func parseStructuredError(body string) structuredError {
 			message: envelope.Error.Message,
 		}
 		// One level or the other, never a mixture, for the reason
-		// scanStructuredError gives: a type from the error object paired with a
-		// message from outside it is two unrelated statements, and the identity
-		// check that bounds the type would then be reading the wrong text. The
-		// error object wins whenever it said anything at all; a provider that
-		// reports at the top level still works because then it said nothing.
+		// scanStructuredError gives. The error object wins whenever it says
+		// anything at all; a provider reporting at the top level still works,
+		// because then the error object said nothing.
 		if nested != (structuredError{}) {
 			return nested
 		}
@@ -213,31 +194,27 @@ func normalizeModelID(modelID string) string {
 	return id
 }
 
-// structuredModelGone reports whether the body's ERROR FIELDS say the requested
+// structuredModelGone reports whether the body's error FIELDS say the requested
 // model is gone, for the providers that answer with a code rather than a
 // sentence.
 //
-// It exists because prose matching cannot reach these payloads at all. Zen
-// forwards Anthropic's error verbatim, and the only retirement signal in it is
-// error.type; the model id lives in error.message. modelGoneAbout requires the
-// two to be adjacent with no clause break between them — a rule that is right
-// for prose and structurally impossible to satisfy across two JSON fields, which
-// are separated by the comma isClauseBreak treats as a boundary by design.
+// Prose matching cannot reach these payloads: OpenCode Zen forwards Anthropic's
+// error verbatim, where the only retirement signal is error.type while the
+// model id lives in error.message, and modelGoneAbout requires the two adjacent
+// with no clause break between them.
 //
-// Two tiers, and the difference between them is whether the field already names
-// its subject:
+// Two tiers, differing in whether the field already names its subject:
 //
-//   - A model-scoped code is about the model by construction. There is no prose
-//     to anchor to and none is wanted.
+//   - A model-scoped code is about the model by construction, so no prose
+//     anchor is wanted.
 //   - A generic not-found type could as easily be a missing conversation, so it
 //     needs the requested model named in the error's own message. Not merely
 //     somewhere in the body: a provider echoing the request back would name the
-//     model in it, and a not_found_error about something else entirely would
-//     then read as this model's retirement.
+//     model in it, and a not_found_error about something else would then read
+//     as this model's retirement.
 //
-// An empty model id claims nothing, for the same reason modelGoneAbout claims
-// nothing: a retirement that cannot be attributed is not one this gateway will
-// assert.
+// An empty model id claims nothing: a retirement that cannot be attributed is
+// not asserted.
 func structuredModelGone(body, modelID string) bool {
 	id := normalizeModelID(modelID)
 	if id == "" || body == "" {
@@ -251,19 +228,16 @@ func structuredModelGone(body, modelID string) bool {
 }
 
 // modelGoneAbout reports whether the body is the provider asserting that THIS
-// model — the one the request asked for — is gone.
+// model, the one the request asked for, is gone.
 //
-// Requiring the model's own id next to the phrase is the constraint that makes
-// this safe, and it replaces four rounds of trying to get the wording alone
-// right. Matching prose without it meant any body that merely mentioned a
-// different missing model, or echoed request content containing "unknown
-// model", was read as proof the requested model had been retired — and three
-// such responses disable it. No amount of phrase-tuning fixes that, because the
-// text being matched was never required to be about the model in question.
+// The model's own id must sit next to the gone-phrase. Without that, a body
+// merely mentioning some other missing model, or echoing request content
+// containing "unknown model", counts as proof the requested model is retired,
+// and three such responses disable it.
 //
-// modelID is the upstream model id for the attempt. When it is empty nothing can
-// be verified, so nothing is claimed: the caller gets the generic provider
-// error rather than a retirement it cannot substantiate.
+// modelID is the upstream model id for the attempt. An empty one verifies
+// nothing, so nothing is claimed and the caller gets the generic provider
+// error.
 func modelGoneAbout(body, modelID string) bool {
 	id := normalizeModelID(modelID)
 	if id == "" || body == "" {
@@ -292,86 +266,68 @@ func modelGoneAbout(body, modelID string) bool {
 }
 
 // classifyUpstreamError turns an upstream non-2xx response into a stable
-// ErrorKind plus a short, gateway-authored reason for the client.
+// ErrorKind plus a short, gateway-authored reason for the client. It keeps
+// apart the three failures that need different operator responses: a model the
+// provider has retired, a model the account is not entitled to, and a transient
+// upstream fault.
 //
-// Why this exists: every upstream failure used to be recorded as
-// KindProviderError and reported to the caller as the bare "upstream provider
-// returned HTTP 400". Three failures that need completely different operator
-// responses were indistinguishable from each other on the wire and in metrics:
+// For ROUTING this is observability only. Failover eligibility is purely
+// status-code driven (isFailoverEligible, plus the MiniMax 1008 -> 429 remap
+// that funnels balance errors into the rate-limit path so failover moves on),
+// and a new kind here must never change where a request is routed.
 //
-//   - a model the provider has retired (fix the catalog / stop routing to it)
-//   - a model the account is not entitled to (top up, or change plan)
-//   - a transient upstream fault (do nothing, it will pass)
-//
-// A catalog audit had to reconstruct that distinction by hand out of
-// request_logs.error_message. Classifying it here makes it a queryable
-// error_kind and a Prometheus label instead.
-//
-// IMPORTANT: for ROUTING this is observability only — failover eligibility
-// stays purely status-code driven (see isFailoverEligible and the MiniMax
-// 1008 -> 429 remap, which deliberately funnels balance errors into the
-// rate-limit path so failover moves on), and returning a new kind here must
-// never change where a request is routed.
-//
-// The CIRCUIT BREAKER is deliberately no longer on that list. For every
-// status but 429 it still decides from the status alone (breakerRecordAction),
-// but a 429's charge now follows the classified claim — saturated is a no-op,
-// exhausted opens at once — through classifyRateLimit and
-// recordBreakerOutcome, which share the phrase table with this function (one
-// table, two consumers: rateLimitPhrases). Per-model circuit keying (#827)
-// still covers the per-model entitlement refusal without reading a sentence;
-// the classes cover the claim keying cannot separate, a provider that is
-// merely busy.
+// The circuit breaker decides from the status alone for every status but 429
+// (breakerRecordAction); a 429's charge follows the classified claim, saturated
+// being a no-op and exhausted opening at once, through classifyRateLimit and
+// recordBreakerOutcome, which share the rateLimitPhrases table with this
+// function.
 //
 // The returned reason is always gateway-authored static text. The upstream body
-// is never echoed to the caller: it can quote the request back at us, and the
-// no-request-content-in-logs rule extends to what we hand to clients.
+// is never echoed to the caller: it can quote the request back, and the
+// no-request-content-in-logs rule extends to what clients are handed.
 //
 // modelID is the upstream model id this attempt asked for. It is required for
 // the retirement verdict: the body has to be the provider talking about THAT
 // model, not merely text that reads like a retirement.
 //
-// body must already be sanitized (util.SanitizeLogBody); matching is done on a
-// lowercased copy and every phrase below was observed on a real provider
+// body must already be sanitized (util.SanitizeLogBody); matching runs on a
+// lowercased copy, and every phrase below was observed on a real provider
 // response.
 func classifyUpstreamError(status int, body, modelID string) (ErrorKind, string) {
 	b := strings.ToLower(body)
 
 	// Model retired or never served by this provider, said in fields rather than
 	// in a sentence. Ahead of the prose path because it is the more specific
-	// claim: a provider that names a model-scoped code has already told us what
-	// its message can only imply.
+	// claim.
 	//
-	// The capability veto deliberately does not apply here. It exists to stop
-	// "is not supported for this endpoint" reading as a retirement, which is a
-	// property of prose; a structured model_not_supported is the provider
-	// answering the question directly, and there is no qualifying clause to
+	// The capability veto does not apply here: it exists to stop "is not
+	// supported for this endpoint" reading as a retirement, which is a property
+	// of prose, and a structured model_not_supported has no qualifying clause to
 	// misread.
 	if structuredModelGone(b, modelID) {
 		return KindProviderModelGone, "the provider no longer serves this model"
 	}
 
-	// Model retired or never served by this provider. modelGoneAbout requires
-	// the requested model's own id beside the phrase AND that the phrase is not
-	// merely refusing one capability — both checks are per phrase, so an
-	// unrelated sentence elsewhere in the body can neither create the verdict
-	// nor suppress it.
+	// Model retired or never served by this provider, said in prose.
+	// modelGoneAbout requires the requested model's own id beside the phrase and
+	// that the phrase is not merely refusing one capability. Both checks are per
+	// phrase, so an unrelated sentence elsewhere in the body can neither create
+	// the verdict nor suppress it.
 	if modelGoneAbout(b, modelID) {
 		return KindProviderModelGone, "the provider no longer serves this model"
 	}
 
-	// Account cannot pay for this model: Z.ai's coding-plan endpoint answers
+	// The account cannot pay for this model: Z.ai's coding-plan endpoint answers
 	// 429 code 1113 "Insufficient balance or no resource package. Please
-	// recharge." for models outside the subscription. Without this it is
-	// indistinguishable from ordinary rate limiting, so it looks retryable
-	// when it will never succeed until someone pays.
+	// recharge." for models outside the subscription, which is otherwise
+	// indistinguishable from ordinary rate limiting and looks retryable when it
+	// can only succeed once someone pays.
 	//
-	// 402 is the unambiguous signal and needs no body match at all. The phrases
-	// are each a full sentence fragment from a real provider; a bare "billing"
-	// was deliberately removed after review, because a transient fault naming a
-	// billing subsystem ("billing_engine_timeout" on a 500) would have been
-	// recorded as a permanent entitlement failure and sent an operator chasing a
-	// provider_not_entitled spike that was really a provider outage.
+	// 402 is unambiguous and needs no body match at all. The phrases are each a
+	// full sentence fragment from a real provider, never a bare word like
+	// "billing": a transient fault naming a billing subsystem
+	// ("billing_engine_timeout" on a 500) must not read as a permanent
+	// entitlement failure.
 	if status == http.StatusPaymentRequired {
 		return KindProviderNotEntitled, "the provider rejected this request for billing or plan reasons"
 	}
@@ -384,11 +340,11 @@ func classifyUpstreamError(status int, body, modelID string) (ErrorKind, string)
 		}
 	}
 
-	// A 429's remaining claims (saturated vs quota-exhausted) are deliberately
-	// NOT classified here: this function cannot read settings, and the
-	// rate_limit_classify_enabled master switch has to restore today's labels
-	// bit for bit when it is off. The terminal forward refines the kind from
-	// the attempt's verdict instead — see rateLimitTerminalKind.
+	// A 429's remaining claims (saturated vs quota-exhausted) are not classified
+	// here: this function cannot read settings, and the
+	// rate_limit_classify_enabled master switch has to restore the unclassified
+	// labels bit for bit when it is off. rateLimitTerminalKind refines the kind
+	// from the attempt's verdict at the terminal forward instead.
 
 	// The provider understood us and refused the payload. Seen when a request
 	// is sent in the wrong dialect: OpenCode Zen routes its Gemini models to

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -15,13 +15,11 @@ import (
 
 // forwardableErrorStatus reports whether a status is in the payload class a
 // client may see the provider's body for: a 4xx that judged the caller's own
-// request. Deliberately static where shouldFailover is dynamic: its 429
-// verdict follows the failover_on_rate_limit setting, but a quota body is the
-// operator's account state whichever way that toggle points, and what can
-// reach a client must not be a side effect of a routing knob. The denied 4xx
-// are the auth, billing, quota and routing classes whose bodies can carry
-// operator account detail; 1xx/3xx are not payload errors and 5xx bodies are
-// the provider talking about itself, so none of those forward either.
+// request. Static where shouldFailover is dynamic, so what can reach a client
+// is never a side effect of a routing setting. The denied 4xx are the auth,
+// billing, quota and routing classes whose bodies can carry operator account
+// detail; 1xx/3xx are not payload errors and 5xx bodies are the provider
+// talking about itself, so none of those forward either.
 func forwardableErrorStatus(status int) bool {
 	if status < 400 || status >= 500 {
 		return false
@@ -42,41 +40,36 @@ func forwardableErrorStatus(status int) bool {
 // answered with the synthesised envelope instead.
 const forwardableErrorBodyCap = 1 << 20
 
-// forwardUpstreamError handles a FAILED upstream response that is NOT being
-// failed over (phase G): log + meter the failure via failRequest, then answer the
-// client.
+// forwardUpstreamError handles a failed upstream response that is not being
+// failed over (phase G): log and meter the failure via failRequest, then answer
+// the client.
 //
-// Callers must only ever hand it a non-2xx. It answers by writing an error, and
+// Callers must only ever hand it a non-2xx: it answers by writing an error, so
 // a success routed here would be served to the client while failRequest wrote
-// the row as a failure and metered nothing — the quota bypass that made the
-// caller-side status test a RANGE rather than an equality. Both call sites now
-// route on that range. isFailoverEligible carries the caller's shouldFailover verdict; what
-// the client may see is decided by it together with the static
+// the row as a failure and metered nothing.
+//
+// isFailoverEligible carries the caller's shouldFailover verdict; what the
+// client may see is decided by it together with the static
 // forwardableErrorStatus class. A payload-class refusal (a plain 400 and its
 // kin) judged this caller's own request, so the upstream's error object is
-// forwarded with the provider's credential masked (credentialMasker: exact
-// key, then key-shaped tokens). Everything else - auth, billing,
-// rate limit, not-found, server faults, whether classed by eligibility or by
-// status - gets a synthesised envelope with the classified reason, because
-// those bodies can quote the operator's provider credentials or account
-// details; the body stays in the request log either way, with only this
-// gateway's own key redacted. Drains/closes
+// forwarded with the provider's credential masked (exact key, then key-shaped
+// tokens). Everything else, whether classed by eligibility or by status, gets a
+// synthesised envelope with the classified reason, because auth, billing,
+// rate-limit, not-found and server-fault bodies can quote the operator's
+// provider credentials or account details. The body stays in the request log
+// either way, with only this gateway's own key redacted. Drains and closes
 // resp.Body exactly once and always returns outcomeFatal.
 func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, isFailoverEligible bool, responseHeaderMs float64) candidateOutcome {
 	logData := st.logData
 	masker := logData.masker
 	mayForwardError := !isFailoverEligible && forwardableErrorStatus(resp.StatusCode)
 	// How much of the body is worth holding depends on what happens to it
-	// below. A forwardable error is read under its own cap, and one that
-	// overflows it is demoted to the envelope rather than forwarded truncated,
-	// so a client never receives invalid JSON where the provider sent something
-	// complete. A discarded body is read under the same cap as the two drain
-	// sites, since all that is left to take from it is a classification and the
-	// first 10 000 bytes of request log.
-	//
-	// Every branch is bounded. The unbounded read that used to sit here was for
-	// the 2xx case, on the reasoning that truncating a success corrupts it —
-	// true, and the reason a success does not belong in this function at all.
+	// below, and every branch is bounded. A forwardable error is read under its
+	// own cap, and one that overflows it is demoted to the envelope rather than
+	// forwarded truncated, so a client never receives invalid JSON where the
+	// provider sent something complete. A discarded body is read under the same
+	// cap as the two drain sites, since all that is left to take from it is a
+	// classification and the first 10 000 bytes of request log.
 	var body []byte
 	oversized := false
 	switch {
@@ -93,7 +86,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	}
 	_ = resp.Body.Close()
 	errMsg := util.SanitizeLogBody(string(body), 10000)
-	// Classify for the request log and metrics only — routing is unaffected,
+	// Classify for the request log and metrics only: routing is unaffected,
 	// the caller already decided it from the status code.
 	kind, reason := classifyUpstreamError(resp.StatusCode, errMsg, candidate.model.ModelID)
 	kind, reason = rateLimitTerminalKind(kind, reason, resp.StatusCode, st.rateLimit)
@@ -114,14 +107,14 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	h.failRequest(logData, resp.StatusCode, kind, string(masker.mask([]byte(errMsg))), attempt, st.startTime, st.parseMs, st.timings, st.cacheHits, st.proxyOverhead)
 
 	if !mayForwardError {
-		// Auth, billing, rate-limit, not-found and server-fault classes -
+		// Auth, billing, rate-limit, not-found and server-fault classes,
 		// whether ruled out by the caller's eligibility verdict or by the
 		// static status class. Their bodies are the ones that can quote the
 		// operator's provider credentials ("Incorrect API key provided:
 		// sk-...") or account details a virtual-key holder must not see, so the
-		// body (own key redacted) stays in the DB request log via failRequest and the caller gets
-		// the classified reason: enough to tell "this model is gone" from "top
-		// up your account" from "try again shortly".
+		// body (own key redacted) stays in the request log via failRequest and
+		// the caller gets the classified reason: enough to tell "this model is
+		// gone" from "top up your account" from "try again shortly".
 		writeOpenAIError(w, upstreamClientMessage(candidate.provider.Name, resp.StatusCode, reason), resp.StatusCode)
 		return outcomeFatal
 	}
@@ -133,8 +126,8 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 	case carriesErrorObject(body) && !oversized:
 		// Forward the upstream response so clients can react to semantic errors
 		// (e.g. context_length_exceeded). The upstream's own error object
-		// carries detail this gateway cannot reconstruct — code, type, param,
-		// provider-specific fields — so it is passed through byte for byte
+		// carries detail this gateway cannot reconstruct (code, type, param,
+		// provider-specific fields), so it is passed through byte for byte
 		// apart from masking key-shaped tokens, since even a payload error is
 		// provider-authored free text.
 		w.Header().Set("Content-Type", "application/json")
@@ -155,40 +148,37 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// OpenAI-compatible envelope so JSON-parsing clients don't crash.
 		//
 		// The sanitized body rides inside the message here, where the case above
-		// hands back only the classified reason. The asymmetry is deliberate: the
-		// full body reaches the request log either way via failRequest, and how
-		// much of a provider's response this gateway echoes to callers is one
-		// decision for all three cases rather than something to widen here.
+		// hands back only the classified reason. The full body reaches the
+		// request log either way via failRequest.
 		writeOpenAIError(w, string(masker.mask([]byte(errMsg))), resp.StatusCode)
 	}
 	return outcomeFatal
 }
 
-// credentialMinLen is the shared threshold, not a second opinion on it: two
-// copies of one rule is how the scrub itself came to differ between packages.
+// credentialMinLen is util's threshold, aliased rather than restated so the
+// rule has one definition.
 const credentialMinLen = util.CredentialMinLen
 
-// credentialMasker scrubs the operator's credentials out of client-bound
-// text. The exact layer is the primary control: an exact byte match covers
-// every key shape, including custom or self-hosted gateways whose format the
-// prefix regex can never anticipate, but not a JSON-escaped rendering of a
+// credentialMasker scrubs the operator's credentials out of client-bound text.
+//
+// The exact layer is the primary control: a byte match covers every key shape,
+// including custom or self-hosted gateways whose format the prefix regex cannot
+// anticipate, but not a JSON-escaped rendering of a
 // key (an encoder turning "&" into "\u0026" or "/" into "\/" defeats it;
 // real keys rarely carry such bytes). Over error text (mask) it replaces the
 // attempted candidate's key and every provider key the gateway holds
-// (util.HeldSecrets): a relay in front of the operator's other vendor
-// accounts echoes the rejection it received upstream, and that rejection
-// quotes the key of a different provider row, which the single-key masker
-// this used to be had no way to know. maskKeyShapedTokens runs after it as
-// the third layer, behind the status-class gate, for credentials a relay
-// quotes that are not ours at all. Build one per candidate with
-// newCredentialMasker and pass it to every client-facing emit of provider
-// error text: the buffered paths in forwardUpstreamError and the in-stream
-// error frames on the translated (handleDataChunk), native Anthropic
-// (emitRawData) and pass-through (sseErrorMaskWriter) streaming paths, each
-// of which applies mask to the frames it recognises as errors and maskExact
-// to the rest. The zero value masks the held set and by shape. The exact layer alone
-// (maskExact) runs on every other provider body a client receives, and there
-// it keeps to the candidate's own key (see util's held_secrets.go for why);
+// (util.HeldSecrets), because a relay in front of the operator's other vendor
+// accounts can echo a rejection quoting the key of a different provider row.
+// maskKeyShapedTokens is the third layer, behind the status-class gate, for
+// credentials a relay quotes that are not ours at all.
+//
+// Build one per candidate with newCredentialMasker and pass it to every
+// client-facing emit of provider error text: the buffered paths in
+// forwardUpstreamError and the in-stream error frames on the translated,
+// native Anthropic and pass-through streaming paths, each of which applies
+// mask to the frames it recognises as errors and maskExact to the rest. The
+// zero value masks the held set and by shape. maskExact alone runs on every
+// other provider body a client receives, keeping to the candidate's own key;
 // the request log's error message gets both layers, since it is error text
 // readable by non-admin users with the logs grant. Content bodies never meet
 // the regex.
@@ -207,7 +197,7 @@ func newCredentialMasker(apiKey string) credentialMasker {
 // held provider key, then any key-shaped token, replaced by "[redacted]". The
 // exact passes run first so the regex cannot split a key and leave a
 // recognisable remainder. For error frames and bodies only: the regex layer
-// can match prose, and the held set is for error text (held_secrets.go).
+// can match prose, and the held set is for error text.
 func (m credentialMasker) mask(body []byte) []byte {
 	return maskKeyShapedTokens(m.maskAll(body))
 }
@@ -297,8 +287,7 @@ func (e *exactMaskWriter) Flush() error {
 //
 // The rule itself lives in internal/util, shared with the dashboard's model
 // test and provider discovery, which decrypt the same credential and write the
-// same bodies to the same tables. Two copies is how one of them came to have
-// only a UUID scrub.
+// same bodies to the same tables.
 func maskKeyShapedTokens(body []byte) []byte {
 	return util.MaskKeyShapedTokens(body)
 }

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -101,7 +101,7 @@ func Assess(providerType string, s Snapshot) Assessment {
 // so Remaining can be *int64: that payload is passed through to the dashboard
 // as-is and must not change shape, but a bare int64 cannot tell "field absent"
 // apart from an explicit 0, and treating an absent remaining as a spent window
-// would pin a healthy provider shut. Same reasoning as minimaxModelRemain below.
+// would pin a healthy provider shut. Same reasoning as minimaxModelRemain.
 type zaiCodingQuotaLimit struct {
 	Type          string   `json:"type"`
 	Unit          int      `json:"unit"`
@@ -131,12 +131,12 @@ func assessZaiCoding(payload json.RawMessage) Assessment {
 		// Z.ai's remaining cannot be trusted on its own: the live API sends an
 		// explicit remaining: 0 on windows that are only partially used, while
 		// percentage (percent of the window consumed) tracks the account page
-		// exactly. A sane percentage — within [0, 100], the same definition
-		// addMiniMaxWindow uses — therefore decides; anything outside that
-		// range is nonsense, not a signal, and falls back to the remaining
-		// rule (where Z.ai's ever-present remaining: 0 still reads a genuine
-		// overage as exhausted). A missing field decodes to nil, never to 0,
-		// so absence is never read as exhausted.
+		// exactly. A sane percentage decides (within [0, 100], the same
+		// definition addMiniMaxWindow uses); anything outside that range is
+		// nonsense, not a signal, and falls back to the remaining rule, where
+		// Z.ai's ever-present remaining: 0 still reads a genuine overage as
+		// exhausted. A missing field decodes to nil, never to 0, so absence is
+		// never read as exhausted.
 		exhausted := false
 		switch {
 		case l.Percentage != nil && *l.Percentage >= 0 && *l.Percentage <= 100:
@@ -169,51 +169,46 @@ type neuralwattQuotaPayload struct {
 		// claim KwhRemaining <= 0 makes numerically. A bare bool rather than a
 		// pointer because the snapshot path stores a re-marshal of the provider
 		// struct, where the field is a bare bool too: absent upstream arrives
-		// here as false, which is the safe direction — it can only ever add
-		// exhaustion when NeuralWatt affirmatively says so.
+		// here as false, the safe direction, since it can only add exhaustion
+		// when NeuralWatt affirmatively says so.
 		InOverage        bool   `json:"in_overage"`
 		CurrentPeriodEnd string `json:"current_period_end"`
 	} `json:"subscription"`
 }
 
 // creditsSpentFloorUSD is the balance below which NeuralWatt credits count as
-// spent. It is not zero because NeuralWatt does not wait for zero:
-// observed on prod 2026-09-01, the account began answering 402
-// payment_required ("Subscription access is currently blocked because a usage
-// or billing limit was previously reached") with credits_remaining_usd still
-// at 0.0035, and it stayed there — the residue never drains, so an exact
-// <= 0 test never becomes true and the provider is never pinned.
+// spent. It is not zero because NeuralWatt does not wait for zero: the account
+// answers 402 payment_required ("Subscription access is currently blocked
+// because a usage or billing limit was previously reached") with
+// credits_remaining_usd still around 0.0035, and that residue never drains, so
+// an exact <= 0 test never becomes true and the provider is never pinned.
 //
-// What a cent is worth depends entirely on the request: the run that triggered
-// this burned $9.1061 over 1007 large-context requests (~$0.009 each, so a cent
-// is about one), while a 2026-08-24 probe of 49 tiny requests drew ~$0.006
-// (~$0.0001 each, so a cent is nearer eighty). The floor therefore forfeits
-// somewhere between one and a few dozen requests of genuine headroom, and only
-// for an account already in overage with its included energy gone. Being wrong
-// in the other direction leaves a provider that answers nothing but 402 sitting
-// live in its failover group, which is the state this rule exists to end.
+// What a cent buys depends on the request: large-context requests run about
+// $0.009 each (a cent is one), tiny ones about $0.0001 (a cent is nearer
+// eighty). The floor therefore forfeits between one and a few dozen requests of
+// genuine headroom, and only for an account already in overage with its
+// included energy gone. Being wrong in the other direction leaves a provider
+// that answers nothing but 402 sitting live in its failover group.
 const creditsSpentFloorUSD = 0.01
 
 // assessNeuralwatt handles NeuralWatt's balance model, which differs from the
 // window models above: spending the included monthly energy does not make the
-// provider refuse requests — it keeps serving in overage, debiting the credit
+// provider refuse requests, it keeps serving in overage, debiting the credit
 // balance. Requests only start failing once BOTH the included energy is gone
-// and the credit balance has fallen below creditsSpentFloorUSD — not to zero,
-// which NeuralWatt never reports; see that constant. The only scheduled
+// and the credit balance has fallen below creditsSpentFloorUSD (not to zero,
+// which NeuralWatt never reports; see that constant). The only scheduled
 // recovery from that state is the billing period end, so that is the reset the
-// pin targets (the
-// breaker's 24h pin ceiling re-pins toward it on each open, and an
-// off-schedule recovery — a top-up, a plan change — lifts the pin on the next
-// poll via the recovered path in buildQuotaAdvice).
+// pin targets: the breaker's 24h pin ceiling re-pins toward it on each open,
+// and an off-schedule recovery (a top-up, a plan change) lifts the pin on the
+// next poll via the recovered path in buildQuotaAdvice.
 //
 // That recovery path needs a datable reset to work: an account reporting no
-// usable current_period_end assesses OK=false below, which reaches neither
-// advice nor recovered, so nothing releases its pin early and it runs the full
-// ceiling. That is the intended trade. The alternative — reporting a spent
-// account healthy because it did not say when it recovers — puts it in
-// recovered, where ReleaseQuotaPins drops the pin and clears the 429-open
-// escalation of every circuit it owns, on every poll pass, for an account
-// answering nothing but 402.
+// usable current_period_end assesses OK=false, which reaches neither advice nor
+// recovered, so nothing releases its pin early and it runs the full ceiling.
+// That is the intended trade. Reporting a spent account healthy because it did
+// not say when it recovers would put it in recovered, where ReleaseQuotaPins
+// drops the pin and clears the 429-open escalation of every circuit it owns, on
+// every poll pass, for an account answering nothing but 402.
 func assessNeuralwatt(payload json.RawMessage) Assessment {
 	var res neuralwattQuotaPayload
 	if err := json.Unmarshal(payload, &res); err != nil {
@@ -221,8 +216,8 @@ func assessNeuralwatt(payload json.RawMessage) Assessment {
 	}
 	// Either signal settles the energy side: the number when NeuralWatt reports
 	// one, and the flag it sets on entering overage. Reading both means a
-	// kwh_remaining that freezes at a residue instead of a clean zero — the same
-	// shape the credits balance has — cannot short-circuit the conjunction and
+	// kwh_remaining that freezes at a residue instead of a clean zero (the same
+	// shape the credits balance has) cannot short-circuit the conjunction and
 	// leave the credits floor unreachable.
 	energySpent := (res.Subscription.KwhRemaining != nil && *res.Subscription.KwhRemaining <= 0) ||
 		res.Subscription.InOverage
@@ -237,7 +232,7 @@ func assessNeuralwatt(payload json.RawMessage) Assessment {
 			// through to e.result here would report "not exhausted", and
 			// buildQuotaAdvice reads that as affirmative health: the provider
 			// joins `recovered`, and ReleaseQuotaPins then clears the 429-open
-			// escalation of every circuit it owns on every poll pass — for an
+			// escalation of every circuit it owns on every poll pass, for an
 			// account answering nothing but 402. OK=false is the honest answer;
 			// it lands the provider in neither advice nor recovered.
 			return Assessment{}
@@ -337,16 +332,15 @@ func assessMiniMax(payload json.RawMessage) Assessment {
 
 // addMiniMaxWindow records one window if it is spent. Only a window the plan
 // actually covers is considered at all: status 1 means active, 3 means the
-// model class is not in the plan and its percent reads misleadingly as 100
-// (per plans/already-implemented/2026-07-19-minimax-provider-research.md).
+// model class is not in the plan and its percent reads misleadingly as 100.
 // A missing status decodes to 0 and is skipped the same way, so an
 // unrecognized shape fails open rather than guesses.
 //
 // Counts win when present: total > 0 means the count fields are meaningful,
 // and used >= total is exhausted, matching the other providers' rule. Some
 // Token Plan tiers report all-zero counts even on an active window, in which
-// case (total <= 0) the remaining-percentage field is the only real signal —
-// but only when it was actually present in the payload; a missing percent
+// case (total <= 0) the remaining-percentage field is the only real signal,
+// and only when it is actually present in the payload; a missing percent
 // decodes to nil, never to 0, so it can never be misread as "0% remaining".
 // The percent is REMAINING, not consumed, despite the neighbouring
 // *_usage_count field names, and a value outside [0, 100] is skipped as

--- a/internal/util/credential.go
+++ b/internal/util/credential.go
@@ -12,18 +12,16 @@ import (
 // Replicate, Groq and xAI), Google API keys (AIza...), AWS access key ids
 // (AKIA...), bare JWTs (the MiniMax API key format), and bearer tokens. The
 // minimum tail lengths keep prose like "sk-abc" out of scope, and the digit
-// rule below spares prose for the ambiguous half. A prefix list
-// necessarily trails the provider roster, so it is never the only layer:
-// MaskCredential runs an exact match of the gateway's own key in front of it,
-// and the proxy gates it behind a status class.
+// rule below spares prose for the ambiguous half. A prefix list necessarily
+// trails the provider roster, so it is never the only layer: MaskCredential
+// runs an exact match of the gateway's own key in front of it, and the proxy
+// gates it behind a status class.
 //
 // It lives here rather than in internal/proxy because the proxy is not the
-// only thing that handles upstream error text. The dashboard's model test and
+// only thing that handles upstream error text: the dashboard's model test and
 // provider discovery decrypt the same credential and write the same bodies to
-// the same tables, and when this rule lived in the proxy alone those paths had
-// only a UUID scrub, so an upstream quoting the key back ("Incorrect API key
-// provided: sk-...") put it in request_logs and app_logs in cleartext.
-// The two halves are split by whether a match needs the digit veto below.
+// the same tables. The two halves are split by whether a match needs the digit
+// veto below.
 //
 // ambiguousKeyShape carries prefixes that also start ordinary identifiers and
 // prose, so a match with no digit in it is kept: "sk_business_unit_identifier"
@@ -37,11 +35,10 @@ var ambiguousKeyShape = regexp.MustCompile(`\b(?:sk|gsk|xai|hf|fw|r8)[-_][A-Za-z
 // characters, and about one in thirty-six of them contains no digit at all.
 //
 // The JWT signature is optional so that header.payload alone still matches.
-// Every other pattern here matches its own truncated prefix, but a JWT needed
-// BOTH dots, so one cut short — by a truncating caller, or by the scan window
-// in SanitizeLogBody — matched nothing and left its head in the output. The
-// header and payload are the parts that carry claims; requiring the signature
-// to redact them had it backwards.
+// Every other pattern here matches its own truncated prefix; requiring BOTH
+// dots would leave the head of a JWT cut short (by a truncating caller, or by
+// the scan window in SanitizeLogBody) in the output, and the header and
+// payload are the parts that carry claims.
 var unambiguousKeyShape = regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{30,}|\bAKIA[A-Z0-9]{16}\b|\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_-]{5,})?`)
 
 // CredentialMinLen is the shortest provider key the exact-value mask will
@@ -63,13 +60,13 @@ const CredentialMinLen = 8
 // Keeping this off model ids matters, because the proxy classifies a
 // retirement by finding the requested model's own id beside a phrase in a
 // sanitized body, and a scrub that ate an id could change routing. Two things
-// hold that line: no model id in the bundled catalogs matches (a test pins
-// it), and a replacement cannot CREATE a verdict either, since the brackets in
+// hold that line: no model id in the bundled catalogs matches, and a
+// replacement cannot CREATE a verdict either, since the brackets in
 // "[redacted]" break the phrase-binding gap the classifier requires.
 func MaskKeyShapedTokens(body []byte) []byte {
 	// The ambiguous pass runs FIRST because its alternatives are the outer
-	// ones. "Bearer <jwt>" is matched whole by the bearer alternative, but if
-	// the JWT is consumed first the bearer alternative no longer has sixteen
+	// ones. "Bearer <jwt>" is matched whole by the bearer alternative; with
+	// the JWT consumed first, that alternative no longer has sixteen
 	// characters left to match and up to fifteen characters of the token's
 	// head survive.
 	body = ambiguousKeyShape.ReplaceAllFunc(body, func(m []byte) []byte {
@@ -91,10 +88,8 @@ func MaskKeyShapedTokens(body []byte) []byte {
 // encoder turning "&" into "\u0026" defeats it; real keys rarely carry such
 // bytes), which is what the shape layer behind it is for.
 //
-// This is the same two-layer rule internal/proxy applies to the bodies it logs
-// and forwards. Callers outside that package hold a decrypted key only while
-// they are talking to an upstream, and this is the function to run over
-// anything that upstream says back.
+// Callers hold a decrypted key only while they are talking to an upstream, and
+// this is the function to run over anything that upstream says back.
 func MaskCredential(secret, body string) string {
 	return MaskCredentials([]string{secret}, body)
 }
@@ -106,8 +101,8 @@ func MaskCredential(secret, body string) string {
 // the request they are about to send, and so mask with everything that request
 // carries (each bearer, each query value) rather than with one named key.
 // Entries shorter than CredentialMinLen are skipped for the reason given there.
-// Every exact pass also masks the held set (held_secrets.go): the secrets the
-// caller names are the ones it knows about, and a relay can quote any other.
+// Every exact pass also masks the held set (held_secrets.go): the caller names
+// only the secrets it knows about, and a relay can quote any other.
 func MaskCredentials(secrets []string, body string) string {
 	return string(MaskKeyShapedTokens([]byte(maskExact(secrets, body))))
 }
@@ -165,7 +160,7 @@ func MaskCredentialsBounded(secrets []string, body string, maxLen int) string {
 // MaskCredentialBounded is MaskCredentialsBounded for a caller that holds one
 // key. It is the form every vendor path that logs or returns an upstream body
 // uses; MaskCredential over an already-sanitized body is the inverted order
-// and must not be written.
+// and unsafe.
 func MaskCredentialBounded(secret, body string, maxLen int) string {
 	return MaskCredentialsBounded([]string{secret}, body, maxLen)
 }

--- a/internal/util/held_secrets.go
+++ b/internal/util/held_secrets.go
@@ -8,21 +8,18 @@ import (
 // Held secrets: every provider key the gateway holds, kept for the exact
 // layer of the credential mask over error text and log lines.
 //
-// The exact layer used to know one secret at a time, the key of the provider
-// whose response was being masked. That is the wrong scope for the threat it
-// exists for. A relay or aggregator in front of the operator's other vendor
-// accounts echoes the rejection it received upstream, and that rejection can
-// quote the key of a different provider row, in a custom format the shape
-// layer cannot recognise; the masker then had exactly the one credential it
-// did not need. The gateway holds every one of those keys, so the exact layer
-// over error text masks all of them: the set is seeded from the provider
-// table at startup and after every import (provider.HoldKeys), the create and
-// update handlers add the plaintext they have in hand, and every exact pass
-// over error or log text unions the secrets its caller names with this set.
+// A relay or aggregator in front of the operator's other vendor accounts
+// echoes the rejection it received upstream, and that rejection can quote the
+// key of a different provider row, in a custom format the shape layer cannot
+// recognise. The gateway holds every one of those keys, so the exact layer
+// over error text masks all of them: the set is seeded from the provider table
+// at startup and after every import (provider.HoldKeys), the create and update
+// handlers add the plaintext they hold, and every exact pass over error or log
+// text unions the secrets its caller names with this set.
 //
-// Only error and log text. The exact pass a client's content goes through
-// (a streamed answer, a success body) keeps to the attempted provider's own
-// key: no provider quotes another provider's key inside an answer, and a
+// Only error and log text. The exact pass a client's content goes through (a
+// streamed answer, a success body) keeps to the attempted provider's own key:
+// no provider quotes another provider's key inside an answer, and a
 // placeholder key an operator typed for a keyless local server ("not-needed")
 // is a plain word that must not be rewritten out of every answer the gateway
 // serves. The length floor here is the only filter, for the same reason: a
@@ -30,10 +27,9 @@ import (
 //
 // Registration is by value and never expires within a process: a rotated key
 // stays held until the next restart, after which the set is seeded from the
-// table again and the old key is gone with the row that held it. The set is
-// bounded by the number of distinct keys, a
-// few dozen on a large deployment, and a pass costs one substring search per
-// held key over an error body that is already bounded.
+// table again. The set is bounded by the number of distinct keys (a few dozen
+// on a large deployment), and a pass costs one substring search per held key
+// over an already bounded error body.
 
 var (
 	heldMu   sync.RWMutex

--- a/web/src/api/types/failover.ts
+++ b/web/src/api/types/failover.ts
@@ -7,8 +7,8 @@ export interface FailoverEntry {
 	enabled: boolean;
 	model_enabled: boolean;
 	provider_enabled: boolean;
-	/** True when a user disabled the model; false when discovery auto-disabled it
-	 * (model no longer offered by the provider). Drives the N/A reason tooltip. */
+	/** True when a user disabled the model, false when discovery auto-disabled it
+	 * (the provider does not offer it). Drives the N/A reason tooltip. */
 	disabled_manually: boolean;
 	context_length: number | null;
 	owned_by: string;
@@ -57,46 +57,39 @@ export interface CircuitBreakerProviderStatus {
 	opened_at?: string;
 	cooldown_ms?: number;
 	next_retry_at?: string;
-	// True when the cooldown currently governing this circuit was pinned to the
-	// provider's quota reset deadline rather than the ordinary retry backoff. It
-	// describes the override in force, not a claim that traffic is blocked right
-	// now; when set, next_retry_at is that reset deadline.
+	// True when the cooldown governing this circuit is pinned to the provider's
+	// quota reset deadline rather than the ordinary retry backoff. Describes the
+	// override in force, not whether traffic is blocked; next_retry_at is then
+	// that reset deadline.
 	quota_pinned?: boolean;
-	// True when a probe backoff is in force on this circuit: the ordinary
-	// cooldown doubled once per half-open probe that failed since the circuit
-	// last closed, up to circuit_breaker_backoff_max. Like quota_pinned it
-	// describes an override in force, not whether traffic is blocked right now.
-	// Both can be set at once; cooldown_ms and next_retry_at are then whichever
-	// reaches further, which is nearly always the pin (a pin is floored at the
-	// backoff when it is stamped). Omitted when false.
+	// True when a probe backoff is in force: the cooldown doubled once per
+	// half-open probe that failed since the circuit last closed, up to
+	// circuit_breaker_backoff_max. Can be set alongside quota_pinned, in which
+	// case cooldown_ms and next_retry_at are whichever reaches further, nearly
+	// always the pin (a pin is floored at the backoff when it is stamped).
+	// Omitted when false.
 	backed_off?: boolean;
 	// How many half-open probes have failed since the circuit last closed. Sent
-	// whenever it is non-zero, even with backoff switched off: it is what
-	// happened, where backed_off is what governs.
+	// whenever non-zero, even with backoff switched off.
 	failed_probes?: number;
 	// The derived provider-wide verdict: whether the breaker is skipping this
 	// provider for every model. Circuits are keyed (provider, resolved upstream
-	// model), so `state` above describes the provider's most degraded circuit and
-	// the two legitimately disagree: one open model at the default span of 2
-	// gives state "open" with provider_open false, a provider still serving
-	// everything else. Always sent, false included, so a consumer never has to
-	// re-derive it from open_models and a span setting it cannot see.
+	// model), so `state` above is the provider's most degraded circuit and the
+	// two legitimately disagree: one open model at the default span of 2 gives
+	// state "open" with provider_open false. Always sent, false included.
 	provider_open: boolean;
 	// The resolved upstream model ids the breaker is currently blocking, sorted.
-	// Omitted when empty, so absent means none. Exactly the set provider_open is
-	// counted from; circuits owed a probe are not in it, because they block
-	// nothing.
+	// Omitted when empty. Exactly the set provider_open is counted from;
+	// circuits owed a probe are not in it, because they block nothing.
 	open_models?: string[];
 	// Every circuit the row above is built from, sorted by model, each with its
-	// own state, wait and last verdict. Additive: open_models stays what
-	// entryCircuitStatus keys on, and a member from before this field simply
-	// omits it, so a consumer must fall back to open_models when it is absent.
+	// own state, wait and last verdict. Absent when the member does not send it,
+	// so a consumer falls back to open_models.
 	circuits?: CircuitStatus[];
 }
 // One (provider, resolved upstream model) circuit as the detail endpoint
-// reports it. The row-level fields above describe the provider's most
-// degraded circuit; these are the same fields at the level the breaker keeps
-// them, plus the verdict that last landed on the circuit.
+// reports it: the row-level fields at the level the breaker keeps them, plus
+// the verdict that last landed on the circuit.
 export interface CircuitStatus {
 	model: string;
 	state: "closed" | "open" | "half-open";
@@ -105,7 +98,7 @@ export interface CircuitStatus {
 	cooldown_ms?: number;
 	next_retry_at?: string;
 	// The overrides governing THIS circuit's cooldown, unlike the row's
-	// quota_pinned, which is the verdict's "any blocking circuit is pinned" arm.
+	// quota_pinned, which means "any blocking circuit is pinned".
 	quota_pinned?: boolean;
 	pin_source?: "advisor" | "response";
 	backed_off?: boolean;
@@ -119,16 +112,15 @@ export interface CircuitStatus {
 	last_at?: string;
 }
 // Outcome of an operator forcing one provider's circuit back closed.
-// previous_state is what the breaker reported a moment before the reset, and
-// reset is false when there was nothing to clear (an already-closed or
-// never-tracked provider), so the UI can report a no-op honestly instead of
-// claiming a recovery that did not happen.
+// previous_state is what the breaker reported just before the reset; reset is
+// false when there was nothing to clear (an already-closed or never-tracked
+// provider), so the UI can report a no-op rather than claim a recovery.
 export interface CircuitBreakerResetResult {
 	provider_id: string;
 	previous_state: "closed" | "open" | "half-open";
 	reset: boolean;
-	// The upstream model id when the reset was scoped with ?model=. API-only
-	// today: the dashboard's per-entry reset button clears the whole provider.
+	// The upstream model id when the reset was scoped with ?model=. API only:
+	// the dashboard's per-entry reset button clears the whole provider.
 	model?: string;
 }
 export interface DeletedGroupInfo {

--- a/web/src/api/types/logs.ts
+++ b/web/src/api/types/logs.ts
@@ -36,23 +36,23 @@ export interface LogEntry {
 	virtual_key_name: string;
 	virtual_key_deleted?: boolean;
 	virtual_key_id?: string;
-	/** Trusted-proxy-aware client address; "" or absent for rows predating it. */
+	/** Trusted-proxy-aware client address; "" or absent when unknown. */
 	client_ip?: string;
 	error_message: string;
-	/** Machine-readable failure classification; "" or absent for legacy rows. */
+	/** Machine-readable failure classification; "" or absent when unclassified. */
 	error_kind?: string;
 	failover_attempt: number;
 	created_at: string;
 	resolved_model_id: string;
 	endpoint_type: string;
 	/** Per-attempt trail: one element per failover attempt, hedged probes and
-	 * breaker skips included, in order. Absent for rows without one (legacy
-	 * rows, rows an older member wrote, requests that never reached a
-	 * candidate). The terminal attempt's values also live in the flat columns. */
+	 * breaker skips included, in order. Absent for rows without one, such as a
+	 * request that never reached a candidate. The terminal attempt's values also
+	 * live in the flat columns. */
 	attempts?: AttemptRecord[];
 }
 export interface AttemptRecord {
-	/** The loop's index (same numbering as failover_attempt); -1 marks a
+	/** The loop's index (same numbering as failover_attempt). -1 marks a
 	 * candidate the circuit breaker refused before any request was made. */
 	attempt: number;
 	provider_id: string;
@@ -80,8 +80,8 @@ export interface AppLogEntry {
 	source: string;
 	message: string;
 	/** True when the message's attribute values use the backend's flattened
-	 * encoding (spaces as \x20); gates display-side decoding. Absent/false on
-	 * legacy rows and raw io.Writer lines, which render verbatim. */
+	 * encoding (spaces as \x20); gates display-side decoding. Absent or false
+	 * for rows that render verbatim, such as raw io.Writer lines. */
 	escaped?: boolean;
 	/** Byte offset where the encoded attribute suffix begins; decoding applies
 	 * only from here, so raw message text is never altered. */

--- a/web/src/api/types/providers.ts
+++ b/web/src/api/types/providers.ts
@@ -16,9 +16,9 @@ export interface Provider {
 	updated_at: string;
 	model_count: number;
 	total_tokens: number;
-	/** The last exhausted 429 this provider answered since the gateway started:
-	 *  the only quota reading a provider with no usage API ever gives. Absent
-	 *  when there has been none. */
+	/** The last exhausted 429 this provider answered since the gateway started,
+	 *  the only quota reading a provider with no usage API gives. Absent when
+	 *  there has been none. */
 	last_cap?: CapNote;
 }
 export interface CapNote {
@@ -26,7 +26,7 @@ export interface CapNote {
 	 *  decided. Never the response body. */
 	phrase?: string;
 	model: string;
-	/** A spent balance or plan (a person fixes it) rather than a window. */
+	/** True when a spent balance or plan rather than a time window. */
 	entitled?: boolean;
 	at: string;
 }

--- a/web/src/components/AttemptTrail.tsx
+++ b/web/src/components/AttemptTrail.tsx
@@ -6,9 +6,8 @@ import { DetailSectionHeader } from "./DetailSectionHeader";
 import { InfoHint } from "./InfoHint";
 import { StatusBadge } from "./LogDetailStatusBadge";
 
-// breakerVerdictKey maps an attempt's breaker verdict to its label key. Unknown
-// verdicts (a newer member's vocabulary) fall back to the generic key, which
-// interpolates the raw word, so the row never renders an empty span.
+// Label key per breaker verdict. An unknown verdict falls back to the generic
+// key, which interpolates the raw word, so the row never renders an empty span.
 const BREAKER_VERDICT_KEYS: Record<string, string> = {
 	charge: "components.requestLogDetail.attemptBreakerCharge",
 	noop: "components.requestLogDetail.attemptBreakerNoop",
@@ -18,14 +17,12 @@ const BREAKER_VERDICT_KEYS: Record<string, string> = {
 	disabled: "components.requestLogDetail.attemptBreakerDisabled",
 };
 
-// AttemptTrail renders the per-attempt trail of one request log row: every
-// provider the request was routed to, in order, with what each one answered,
-// so a "Neuralwatt 429 → Ollama 200" reads as the chain it was. Rendered by
-// RequestLogDetail whenever the row carries a trail.
+// AttemptTrail renders one request log row's attempt trail: every provider the
+// request was routed to, in order, with what each one answered.
 export function AttemptTrail({ attempts }: { attempts: AttemptRecord[] }) {
 	const { t } = useTranslation();
-	// Skips first, then by attempt index: a hedged race reports its losers in
-	// arrival order, so the winner (attempt 0) can arrive after a loser
+	// Skips (attempt -1) first, then by attempt index: a hedged race reports its
+	// losers in arrival order, so the winner (attempt 0) can arrive after a loser
 	// (attempt 1) and would otherwise read backwards. Stable, so equal indices
 	// keep their arrival order.
 	const ordered = [...attempts].sort((x, y) => x.attempt - y.attempt);
@@ -56,9 +53,8 @@ export function AttemptTrail({ attempts }: { attempts: AttemptRecord[] }) {
 								{t("components.requestLogDetail.attemptSkipped")}
 							</span>
 						) : a.error_kind === "hedge_superseded" ? (
-							// Abandoned by the gateway because another candidate won:
-							// not a failure, the client was served. Neutral, like the
-							// rest of the UI treats an interruption.
+							// Abandoned because another candidate won: not a failure,
+							// the client was served, so the badge is neutral.
 							<span
 								className="ui-badge ui-badge-neutral text-xs"
 								data-testid="attempt-superseded"

--- a/web/src/components/CapNoteBadge.tsx
+++ b/web/src/components/CapNoteBadge.tsx
@@ -2,13 +2,10 @@ import { useTranslation } from "react-i18next";
 import type { CapNote } from "../api/types";
 import { formatTime, formatTimestamp } from "../utils/format";
 
-// What the gateway cannot know, made explicit. A provider with no usage API
-// (a plain OpenAI-compatible endpoint, or Ollama Cloud, whose account API says
-// the plan but never the usage) has no quota badge to show; the one reading
-// the gateway ever gets from it is the 429 whose body says the window or
-// balance is spent. This badge shows the last of those, so an operator who
-// saw a "90% used" email knows that was the last real reading and that the
-// cap has been hit since, without guessing which window.
+// Shows the last exhausted 429 a provider answered. A provider with no usage
+// API (a plain OpenAI-compatible endpoint, or Ollama Cloud, whose account API
+// names the plan but never the usage) has no quota badge, so that 429 is the
+// only cap reading the gateway gets from it.
 export function CapNoteBadge({ note }: { note: CapNote }) {
 	const { t } = useTranslation();
 	const valid = !Number.isNaN(new Date(note.at).getTime());

--- a/web/src/components/layout/FailoverNavBadge.tsx
+++ b/web/src/components/layout/FailoverNavBadge.tsx
@@ -10,20 +10,17 @@ function count(n: number | undefined): number {
 }
 
 /**
- * The two provider counts beside the Failover item, with a tooltip that always
- * explains what they mean (they track providers, not groups, a common mix-up)
- * and names the unhealthy providers, split by what the breaker is actually
- * doing with each: skipping it entirely, waiting on its quota reset, or keeping
- * it in rotation with only some models blocked.
+ * The two provider counts beside the Failover item, with a tooltip that says
+ * what they mean (they track providers, not groups) and names the unhealthy
+ * providers split by what the breaker does with each: skipping it entirely,
+ * waiting on its quota reset, or keeping it in rotation with only some models
+ * blocked.
  *
- * The red number is the providers the breaker is skipping, which is the derived
- * verdict and not the endpoint's `open` tally. That tally counts providers whose
- * most degraded model circuit is open, and since circuits are keyed per model
- * that includes providers still serving every other model: at the default span
- * of 2 the first model to go dark leaves the provider in rotation. Those
- * providers stay visible in the amber count, which is therefore "unhealthy but
- * still routing" rather than only "recovering". The two derived numbers add up
- * to the endpoint's half_open + open, so nothing is dropped, only reclassified.
+ * The red number is the derived provider_open verdict, not the endpoint's
+ * `open` tally: that tally counts providers whose most degraded model circuit
+ * is open, which includes providers still serving every other model. Those sit
+ * in the amber count, which is therefore "unhealthy but still routing" rather
+ * than only "recovering". The two numbers add up to half_open + open.
  */
 export function FailoverNavBadge({
 	cbStatus,
@@ -36,10 +33,9 @@ export function FailoverNavBadge({
 	const unhealthy = cbStatus.providers?.filter(
 		(p) => p.state === "open" || p.state === "half-open",
 	);
-	// Without the detail rows there is no verdict to read, only the endpoint's
-	// own tally. Reporting it unchanged is the truthful fallback: it is the whole
-	// of what that response says. The nav badge always asks for detail, so this
-	// is the shape of the plain list endpoint rather than a state it reaches.
+	// Without the detail rows there is no verdict to read, so the endpoint's own
+	// tally is reported unchanged. The nav badge always asks for detail, so this
+	// is the shape of the plain list endpoint.
 	const skippedCount = unhealthy
 		? unhealthy.filter((p) => p.provider_open).length
 		: count(cbStatus.open);
@@ -55,30 +51,27 @@ export function FailoverNavBadge({
 	let title = explain;
 	if (unhealthy && unhealthy.length > 0) {
 		// Quota-pinned circuits wait until the provider's quota window resets,
-		// which can be days. Listing them beside ordinary sixty-second cooldowns
-		// reads as "back shortly", so they get their own line.
+		// which can be days, so they get their own line rather than reading as
+		// "back shortly" beside ordinary sixty-second cooldowns.
 		//
 		// The state check is load-bearing: quota_pinned stays set for the whole
 		// life of the circuit, and a pinned circuit whose deadline has passed is
 		// reported as half-open (ready to probe) with no next_retry_at. Bucketing
 		// on the flag alone would keep claiming a provider is waiting on a quota
-		// window that has already reset. This mirrors the per-entry rule, where
-		// cooldown-over wins over the quota tooltip.
+		// window that has already reset.
 		const stillPinned = (p: (typeof unhealthy)[number]) =>
 			Boolean(p.quota_pinned) && p.state === "open";
-		// Circuits are keyed per model, so a provider with an open circuit is not
-		// necessarily a provider that is down: at the default span of 2 the first
-		// model to go dark leaves every other model of that provider serving. Only
-		// the derived verdict says the breaker is skipping the provider outright,
-		// and the two buckets get separate lines so a partial outage is never read
-		// as a dead provider. Each name carries the models it is blocking, since
-		// that is what tells an operator which of the two this is.
-		// A quota-pinned provider the breaker is skipping outright lists no
-		// models: its quota window is spent for every model it serves, so naming
-		// each disabled model only makes the tooltip long without saying
-		// anything the provider's name does not. Pins land per circuit, though,
-		// so a pinned provider still routing the rest of its models is a partial
-		// outage and keeps naming the models that are dark.
+		// Names one bucket's providers, each with the models it is blocking.
+		// Circuits are keyed per model, so an open circuit is not necessarily a
+		// dead provider: at the default span of 2 the first model to go dark
+		// leaves every other model of that provider serving. Only the derived
+		// verdict says the breaker skips the provider outright, so the buckets get
+		// separate lines and a partial outage is never read as a dead provider.
+		//
+		// A quota-pinned provider the breaker skips outright lists no models: its
+		// quota window is spent for every model it serves. Pins land per circuit,
+		// so a pinned provider still routing the rest is a partial outage and
+		// keeps naming the models that are dark.
 		const names = (
 			list: typeof unhealthy,
 			withModels: (p: CircuitBreakerProviderStatus) => boolean = () => true,

--- a/web/src/hooks/useQuotaRefresh.ts
+++ b/web/src/hooks/useQuotaRefresh.ts
@@ -4,10 +4,9 @@ import { useTranslation } from "react-i18next";
 import { api } from "../api/client";
 import { useToast } from "../context/ToastContext";
 
-// quotaRefreshCooldownMs matches the quota panel's refresh cooldown: the
-// refresh forwards to every quota-bearing provider and each call lands in the
-// audit trail, so a second click inside the window is answered with a toast,
-// not a second sweep.
+// quotaRefreshCooldownMs is the click cooldown on a quota refresh: the sweep
+// forwards to every quota-bearing provider and each call lands in the audit
+// trail, so a second click inside the window is answered with a toast.
 export const quotaRefreshCooldownMs = 10_000;
 
 // useQuotaRefresh is the Providers page's "refresh quotas" action: the

--- a/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
+++ b/web/src/pages/FailoverGroups/FailoverGroupCard.tsx
@@ -30,9 +30,9 @@ import {
 } from "./entryCircuit";
 import { SortableEntry } from "./SortableEntry";
 
-// Derive a stable key from entries so the card resets local state
-// when the server data changes (after mutation/refetch).
-// Includes enabled state so toggles are detected, not just UUID order.
+// A stable key over the entries, so the card resets its local state when the
+// server data changes. Includes the enabled flag, so a toggle is detected and
+// not just a change of UUID order.
 function entriesKey(entries: FailoverGroup["entries"]): string {
 	return entries.map((e) => `${e.model_uuid}:${e.enabled}`).join(",");
 }
@@ -60,15 +60,14 @@ export function FailoverGroupCard({
 	onDelete: () => void;
 	onEdit?: () => void;
 	// When true this group's config is managed by the fleet primary. Every write
-	// here (edit, delete, reorder/priority_order, the group on/off flag, and the
-	// per-entry enabled flags) is synced config that the next config sync
-	// overwrites, so all of them are hidden or locked. These are not local
-	// runtime overrides; selection/bulk affordances are gated upstream too.
+	// here (edit, delete, reorder/priority_order, the group on/off flag and the
+	// per-entry enabled flags) is synced config the next config sync overwrites,
+	// so all of them are hidden or locked.
 	managed?: boolean;
 	cbProviderMap: Map<string, CircuitBreakerProviderStatus>;
 	// Passed straight to the entries. Unlike every other write on this card it
 	// survives `managed`: clearing a circuit is local runtime recovery, not a
-	// config edit the primary would overwrite.
+	// config edit the primary overwrites.
 	onResetCircuit?: (providerId: string, providerName: string) => void;
 	resetPendingProviderId?: string;
 }) {
@@ -76,14 +75,13 @@ export function FailoverGroupCard({
 	const { toast } = useToast();
 	const { copy } = useCopyToClipboard({ trackCopied: false });
 
-	// Optimistic local state: reorders immediately on dragEnd so the DOM
-	// order matches the visual drag position. key-based reset ensures
-	// local state re-syncs when the server data changes after mutation.
+	// Optimistic local state: reorders on dragEnd so the DOM order matches the
+	// visual drag position.
 	const [localEntries, setLocalEntries] = useState(group.entries);
 	const key = useMemo(() => entriesKey(group.entries), [group.entries]);
 
-	// When server data changes, reset local state. Using key as a dep
-	// avoids the lint error from setState-in-effect while still syncing.
+	// Resets the local state when the server data changes. Comparing the key
+	// during render avoids the setState-in-effect lint error while still syncing.
 	const [prevKey, setPrevKey] = useState(key);
 	if (prevKey !== key) {
 		setPrevKey(key);
@@ -91,12 +89,10 @@ export function FailoverGroupCard({
 	}
 
 	// The breaker's view of each entry the router will actually use: the entry
-	// toggle on AND the underlying model and provider enabled (matches
-	// SortableEntry's effective-state display). One map feeds the count, each
-	// entry's chip and the header ("2 of 3 entries live", or "all entries dark"
-	// with the earliest retry), so the three cannot drift apart. The parent
-	// rebuilds cbProviderMap on every poll, which is also what keeps the busy
-	// window current: memoise that map upstream and this needs its own tick.
+	// toggle on AND the underlying model and provider enabled. One map feeds the
+	// count, each entry's chip and the header, so the three cannot drift apart.
+	// The parent rebuilds cbProviderMap on every poll, which is what keeps the
+	// busy window current: memoise that map upstream and this needs its own tick.
 	const circuitViews = useMemo(() => {
 		const views = new Map<string, EntryCircuitView>();
 		for (const e of localEntries) {

--- a/web/src/pages/FailoverGroups/SortableEntry.tsx
+++ b/web/src/pages/FailoverGroups/SortableEntry.tsx
@@ -23,20 +23,19 @@ export interface SortableEntryProps {
 		next_retry_at?: string;
 		opened_at?: string;
 		consecutive_fails: number;
-		// Set when a quota pin is in force: the cooldown was pinned to the
+		// Set when a quota pin is in force: the cooldown is pinned to the
 		// provider's quota reset deadline. next_retry_at is then that deadline
 		// unless a longer backoff is also in force, which is rare (a pin is
 		// floored at the backoff when it is stamped).
 		quota_pinned?: boolean;
 		// Set when a probe backoff is in force: the cooldown doubled once per
-		// failed half-open probe. Says why the wait is longer than the setting,
-		// the way quota_pinned does; next_retry_at is the longer of the two.
+		// failed half-open probe. Says why the wait is longer than the setting;
+		// next_retry_at is the longer of it and any pin.
 		backed_off?: boolean;
 		// The derived verdict that the breaker is skipping this provider for
-		// every model, and the model ids it is blocking. Which entries get a
-		// status at all is entryCircuitStatus's decision; these two are here so
-		// the tooltip can say whether the whole provider is out and name the
-		// models the verdict rests on.
+		// every model, and the model ids it is blocking. Here so the tooltip can
+		// say whether the whole provider is out and name the models the verdict
+		// rests on.
 		provider_open?: boolean;
 		open_models?: string[];
 	};
@@ -47,8 +46,8 @@ export interface SortableEntryProps {
 	onResetCircuit?: (providerId: string, providerName: string) => void;
 	resetPending?: boolean;
 	// The entry's own circuit as the chip and tooltip read it (entryCircuitView):
-	// live / busy / open / probe / pinned, with the last cause when the member
-	// reports circuits[]. Optional so older callers and tests render as before.
+	// live / busy / open / probe / pinned, with the last cause when the row
+	// carries circuits[]. Without it no chip is rendered.
 	circuitView?: EntryCircuitView;
 }
 
@@ -68,10 +67,9 @@ const CHIP_CLASS: Record<EntryCircuitView["chip"], string> = {
 const FUSE_ANIMATION_MAX_MS = 15 * 60 * 1000;
 
 // How often a still-too-long countdown re-checks whether it has come inside the
-// window above. Coarse on purpose: the threshold is a rough "is this worth
-// animating" judgement, so arriving up to half a minute late costs nothing,
-// while a per-second clock would re-render every open entry in every group for
-// the entire cooldown.
+// window above. Coarse on purpose: arriving up to half a minute late costs
+// nothing, while a per-second clock would re-render every open entry in every
+// group for the entire cooldown.
 const FUSE_THRESHOLD_TICK_MS = 30 * 1000;
 
 export function SortableEntry({
@@ -85,9 +83,8 @@ export function SortableEntry({
 	circuitView,
 }: SortableEntryProps) {
 	const { t } = useTranslation();
-	// The cause line the tooltip appends when the member reports the circuit's
-	// last verdict: what the breaker saw, the upstream status behind it and
-	// when. Absent on an older member, where only the row is known.
+	// The cause line the tooltip appends when the circuit reports its last
+	// verdict: what the breaker saw, the upstream status behind it and when.
 	// Some verdicts carry no upstream status (a pin retarget, a transport
 	// failure), and those read without the status clause.
 	const causeWhen = circuitView?.lastAt
@@ -136,9 +133,9 @@ export function SortableEntry({
 	const naReason = naReasonKey(entry);
 	const naReasonText = naReason ? t(naReason) : undefined;
 
-	// Determine if fuse should show (circuit breaker open/half-open).
-	// We trust the circuit breaker's own state — the backend already enforces
-	// the configured threshold before transitioning to open/half-open.
+	// The fuse shows while the circuit is open or half-open. The backend enforces
+	// the configured threshold before it transitions, so the reported state is
+	// taken as given.
 	const showFuse =
 		cbStatus &&
 		entry.enabled &&
@@ -152,31 +149,29 @@ export function SortableEntry({
 	// This says why the wait is long, not that the provider is unreachable now.
 	const quotaPinned = Boolean(showFuse && cbStatus.quota_pinned);
 
-	// The cooldown in force has been doubled by failed probes. Ranked below a
-	// provider-wide skip in the tooltip: that a whole provider is out matters
-	// more than why this one model's wait is long, and a backoff never implies
-	// the provider verdict the way a quota pin does. Ranked below the quota pin
-	// too, because a pin names the cause and is nearly always the longer of
-	// the two when both are set; the status has no field for which one governs.
+	// The cooldown in force has been doubled by failed probes. Ranked below both
+	// the provider-wide skip and the quota pin in the tooltip: a whole provider
+	// being out matters more than why one model's wait is long, and a pin names
+	// the cause and is nearly always the longer of the two when both are set;
+	// the status has no field for which one governs.
 	const backedOff = Boolean(showFuse && cbStatus.backed_off);
 
 	const nextRetryAt = cbStatus?.next_retry_at;
 
-	// The instant the countdown was last measured against. It advances only on
-	// the coarse tick below, never on an ordinary re-render, which is what keeps
-	// remainingMs stable: without that, intermediate re-renders (drag, toggle,
-	// parent refetch) would shorten it each time and the fuse would snap ahead of
-	// the cooldown it visualises.
+	// The instant the countdown is measured against. It advances only on the
+	// coarse tick below, never on an ordinary re-render, which keeps remainingMs
+	// stable: otherwise re-renders (drag, toggle, parent refetch) would shorten
+	// it each time and the fuse would snap ahead of the cooldown it visualises.
 	const [measuredAt, setMeasuredAt] = useState(() => Date.now());
 
 	// Which deadline that anchor belongs to. An entry that never unmounts can be
-	// handed a *new* next_retry_at — the circuit re-opened, or a quota pin
-	// replaced an ordinary cooldown — and measuring that against the anchor of
-	// the deadline it replaced folds all the time that passed before it arrived
-	// into the new duration: the fuse burns too slowly, or sits static for a
-	// cooldown that belongs inside the animation window. So the anchor is taken
-	// again whenever the deadline changes, and only then — re-taking it on every
-	// render is the very thing measuredAt exists to prevent.
+	// handed a *new* next_retry_at (the circuit re-opened, or a quota pin
+	// replaced an ordinary cooldown), and measuring that against the previous
+	// deadline's anchor folds the time that passed before it arrived into the new
+	// duration: the fuse burns too slowly, or sits static for a cooldown that
+	// belongs inside the animation window. So the anchor is taken again whenever
+	// the deadline changes, and only then: re-taking it on every render is the
+	// very thing measuredAt exists to prevent.
 	//
 	// Layout effect, not a plain one: the fuse restarts its CSS timeline every
 	// time durationMs changes, so a frame painted from the stale anchor would
@@ -188,11 +183,11 @@ export function SortableEntry({
 		setMeasuredAt(Date.now());
 	}, [nextRetryAt]);
 
-	// A countdown too long to animate has to keep watching the clock, because the
+	// A countdown too long to animate keeps watching the clock, because the
 	// animate-vs-static decision is a function of *now* while next_retry_at never
 	// changes for as long as the circuit stays open. Settled once at mount, an
-	// entry that appeared at 16 minutes remaining stayed static for the rest of
-	// its cooldown and never began burning as it crossed the threshold.
+	// entry that appears at 16 minutes remaining would stay static for the rest
+	// of its cooldown and never begin burning as it crossed the threshold.
 	//
 	// The watch stops itself at the crossing rather than running for the whole
 	// cooldown. Time only moves one way, so the decision cannot reverse, and
@@ -212,8 +207,8 @@ export function SortableEntry({
 		return () => clearInterval(id);
 	}, [showFuse, isHalfOpen, nextRetryAt]);
 
-	// Elapsed cooldown: circuit is open but the deadline has passed — the breaker
-	// has not reported half-open yet (clock drift or polling delay).
+	// Elapsed cooldown: the circuit is open but the deadline has passed and the
+	// breaker has not reported half-open yet (clock drift or polling delay).
 	const { remainingMs, elapsedCooldown } = useMemo(() => {
 		if (!showFuse || isHalfOpen || !nextRetryAt) {
 			return { remainingMs: 0, elapsedCooldown: false };
@@ -237,8 +232,8 @@ export function SortableEntry({
 		remainingMs <= FUSE_ANIMATION_MAX_MS;
 
 	// The provider itself is skipped, so this entry is turned away whatever its
-	// own model is doing. Naming the models the verdict rests on is the only way
-	// an operator can tell a provider outage from two unrelated models failing.
+	// own model is doing. The tooltip names the models the verdict rests on, so
+	// a provider outage reads apart from two unrelated models failing.
 	const openModels = cbStatus?.open_models;
 	const providerSkipped = Boolean(
 		showFuse && cbStatus.provider_open && openModels && openModels.length > 0,
@@ -262,11 +257,9 @@ export function SortableEntry({
 								resetTime: new Date(cbStatus.next_retry_at).toLocaleString(),
 							})
 						: t("failoverGroups.entry.circuitBreakerOpen");
-	// The chip's tooltip: the fuse text (or, for a busy entry, which has no fuse
-	// because its circuit is closed, why it is busy) plus the cause line. The
-	// row keeps only the fuse text: its inner text div carries its own title,
-	// so a row title is reachable only from the strip beside it, while the chip
-	// is the surface an operator actually hovers.
+	// The chip's tooltip: the fuse text, or for a busy entry (which has no fuse,
+	// its circuit being closed) why it is busy, plus the cause line. The row
+	// keeps only the fuse text, since its inner text div carries its own title.
 	const chipTitle =
 		circuitView?.chip === "busy"
 			? t("failoverGroups.entry.chipBusyTip")
@@ -339,10 +332,9 @@ export function SortableEntry({
 					</span>
 				)}
 			</div>
-			{/* Offered exactly where the fuse burns, i.e. an enabled member whose
-			    circuit is open or half-open. A closed circuit has nothing to reset,
-			    and a member the operator has switched off shows no breaker state at
-			    all, so a lone reset button there would have no context to act on. */}
+			{/* Offered exactly where the fuse burns: an enabled member whose circuit
+			    is open or half-open. A closed circuit has nothing to reset, and a
+			    member switched off shows no breaker state to act on. */}
 			{showFuse && onResetCircuit && (
 				<button
 					type="button"
@@ -358,10 +350,9 @@ export function SortableEntry({
 			)}
 			<Toggle
 				size="sm"
-				// Reflect effective state: an entry whose model/provider is disabled
-				// is not routable, so show the toggle off and lock it. Flipping the
-				// per-entry flag would do nothing while the underlying model is dead,
-				// which is the confusing "toggle says on but it's disabled" case.
+				// Effective state: an entry whose model or provider is disabled is not
+				// routable, so the toggle reads off and is locked. Flipping the
+				// per-entry flag does nothing while the underlying model is dead.
 				checked={entry.enabled && !effectivelyDisabled}
 				disabled={!groupEnabled || effectivelyDisabled || locked}
 				onChange={(v) => onToggle(entry.model_uuid, v)}

--- a/web/src/pages/FailoverGroups/entryCircuit.ts
+++ b/web/src/pages/FailoverGroups/entryCircuit.ts
@@ -8,18 +8,17 @@ import type {
  * breaker is not turning that entry away.
  *
  * Circuits are keyed (provider, resolved upstream model) and the status endpoint
- * reports one row per provider, built from its most degraded circuit. So a row
+ * reports one row per provider, built from its most degraded circuit, so a row
  * saying "open" means *some* model of that provider is dark, not necessarily
- * this one, and painting every entry of the provider from it is exactly the
- * provider-wide darkening the per-model keying exists to end.
+ * this one.
  *
  * An entry is turned away when the derived provider verdict is open (the breaker
  * skips the provider for every model, whether from a quota pin or from enough
- * models corroborating) or when its own circuit is open or owed a probe. On a
- * member that reports circuits[] the entry's own circuit is the whole answer:
- * an entry with none has never been routed, and a sibling model's probe says
- * nothing about it. On an older member only the row and open_models are known:
- * a row owed a probe ("half-open") names no model at all, since open_models
+ * models corroborating) or when its own circuit is open or owed a probe. When
+ * the row carries circuits[] the entry's own circuit is the whole answer: an
+ * entry with none has never been routed, and a sibling model's probe says
+ * nothing about it. Without circuits[] only the row and open_models are known,
+ * and a row owed a probe ("half-open") names no model at all, since open_models
  * carries only circuits that are still blocking, so it stays on every entry of
  * the provider, where it reads as recovering rather than as down.
  */
@@ -32,9 +31,10 @@ export function entryCircuitStatus(
 	if (row.circuits) {
 		const own = row.circuits.find((c) => c.model === modelId);
 		if (!own || own.state === "closed") return undefined;
-		// The fuse reads state, the pin and backoff flags and the retry instant
-		// off the row it is given. The row's are the provider's most degraded
-		// circuit's, which may be a sibling's; this entry's fuse burns on its own.
+		// The fuse reads state, the pin and backoff flags and the retry instant off
+		// the row it is given, so this entry's own circuit values replace the row's,
+		// which belong to the provider's most degraded circuit and may be a
+		// sibling's.
 		return {
 			...row,
 			state: own.state,
@@ -53,16 +53,15 @@ export type EntryChip = "live" | "busy" | "open" | "probe" | "pinned";
 /**
  * How recently a saturated 429 must have landed on a closed circuit for the
  * entry to read as busy rather than live. Matches the breaker's behavioural
- * window (rate_limit_recent_success_window default): a provider that said
- * "busy" a minute ago is a routing fact, one that said it an hour ago is not.
+ * window (the rate_limit_recent_success_window default).
  */
 export const BUSY_WINDOW_MS = 60_000;
 
 /** What the chip and tooltip need about one entry's own circuit. */
 export interface EntryCircuitView {
 	chip: EntryChip;
-	// The entry's own circuit when the member reports circuits[]; undefined on
-	// a member from before that field, where only the row is known.
+	// The entry's own circuit when the row carries circuits[]; undefined when
+	// only the row is known.
 	circuit?: CircuitStatus;
 	// Why (and how recently) the breaker last judged this circuit, when known.
 	lastCause?: string;
@@ -74,8 +73,8 @@ export interface EntryCircuitView {
 
 /**
  * Derives the entry's chip from the provider row, preferring the entry's own
- * circuit when the member reports circuits[] (the per-model truth) and falling
- * back to the row's open_models on an older member, so a mixed-version fleet
+ * circuit when the row carries circuits[] (the per-model truth) and falling
+ * back to the row's open_models when it does not, so a mixed-version fleet
  * renders every entry either way.
  *
  * Rules, in order: the provider verdict open turns every entry of the provider
@@ -127,9 +126,9 @@ export function entryCircuitView(
 		return base;
 	}
 
-	// Older member: only the row and open_models are known. A current member
-	// that reports circuits[] without one for this model has simply never
-	// routed it, and a sibling model's probe or outage says nothing about it.
+	// No circuits[]: only the row and open_models are known. A row that carries
+	// circuits[] without one for this model has never routed it, and a sibling
+	// model's probe or outage says nothing about it.
 	if (!row.circuits) {
 		if (row.state === "half-open") return { ...base, chip: "probe" };
 		if (row.state === "open" && row.open_models?.includes(modelId)) {
@@ -147,8 +146,8 @@ export function entryCircuitView(
  * The group header's summary: how many entries are live out of those enabled,
  * and, when none are, the earliest instant one of them is eligible to probe
  * again. Busy counts as live (it still serves), and so does an entry owed a
- * probe: it gets exactly one request, which overstates it, but a group whose
- * every entry is recovering is not dark, and "all entries dark" is the alarm.
+ * probe, which gets exactly one request: a group whose every entry is
+ * recovering is not dark, and "all entries dark" is the alarm.
  */
 export function groupCircuitSummary(views: EntryCircuitView[]): {
 	live: number;

--- a/web/src/pages/Providers/EditProviderModal.tsx
+++ b/web/src/pages/Providers/EditProviderModal.tsx
@@ -45,8 +45,7 @@ export function EditProviderModal({
 }) {
 	const queryClient = useQueryClient();
 	// Claims are read per enabled provider, so switching one off takes every
-	// claim it owns out of the Models nav badge (and back on restores them).
-	// See useRefreshDiscoveryBadge.
+	// claim it owns out of the Models nav badge, and back on restores them.
 	const refreshBadge = useRefreshDiscoveryBadge();
 	const { t } = useTranslation();
 	const [formData, setFormData] = useState({
@@ -333,7 +332,7 @@ export function EditProviderModal({
 								checked={formData.enabled}
 								onChange={(v) => {
 									// Switching off hides the schedule row and disables its
-									// trigger, so an open picker goes with it. The keyboard
+									// trigger, so an open picker closes with it. The keyboard
 									// path fires no mousedown and so never reaches the
 									// popover's own click-outside handler.
 									if (!v) setPickerOpen(false);

--- a/web/src/pages/Providers/ProviderCard.tsx
+++ b/web/src/pages/Providers/ProviderCard.tsx
@@ -57,11 +57,11 @@ export function ProviderCard({
 	const { t } = useTranslation();
 
 	// Disabled cards render their informational content grayscale and dimmed,
-	// while the controls that keep working (Edit/Delete) and the Disabled
-	// badge stay at full color. CSS filters apply to the whole subtree with
-	// no child opt-out, so the split is per-element rather than one class on
-	// the card. The models-count and quota badges are hidden entirely: they
-	// would only show stale pre-disable values.
+	// while the controls that keep working (Edit/Delete) and the Disabled badge
+	// stay at full color. A CSS filter applies to the whole subtree with no child
+	// opt-out, so the split is per-element rather than one class on the card. The
+	// models-count and quota badges are hidden entirely, since they would only
+	// show stale values.
 	const dim = provider.enabled ? "" : "grayscale opacity-50";
 
 	return (
@@ -246,10 +246,10 @@ export function ProviderCard({
 	);
 }
 
-// capNoteApplies says whether the provider's quota badge is the one place a
-// cap message can appear: a provider with no usage API at all, or Ollama
-// Cloud, whose account API names the plan and never the usage. A provider
-// with a usage badge shows its real reading instead.
+// capNoteApplies says whether a cap note is the only quota reading available:
+// a provider with no usage API at all, or Ollama Cloud, whose account API names
+// the plan and never the usage. A provider with a usage badge shows its real
+// reading instead.
 function capNoteApplies(baseUrl: string): boolean {
 	const type = detectQuotaProviderType(baseUrl);
 	return type === null || type === "ollama-cloud";

--- a/web/src/pages/Settings/CircuitBreakerSettings.tsx
+++ b/web/src/pages/Settings/CircuitBreakerSettings.tsx
@@ -17,37 +17,36 @@ import { InflightLimiterGroup } from "./InflightLimiterGroup";
 import { useSettingsMutations } from "./useSettingsMutations";
 
 // Bounds of the quota-pin ceiling slider, in hours. The floor keeps the
-// operator off the zero that does not mean what it looks like; the ceiling is
-// one week, the longest reset window internal/quota/normalize.go recognises.
-// Shared by the clamp and the slider props so the two cannot drift apart.
+// operator off zero, which the breaker reads as unset and replaces with its
+// default; the ceiling is one week, the longest reset window
+// internal/quota/normalize.go recognises. Shared by the clamp and the slider
+// props so the two cannot drift apart.
 const QUOTA_PIN_MAX_MIN_HOURS = 1;
 const QUOTA_PIN_MAX_MAX_HOURS = 168;
 
 // Bounds of the probe-backoff ceiling slider, in minutes. Minutes rather than
 // hours because the backoff starts from a cooldown measured in seconds and
 // doubles: 1, 2, 4, 8 minutes at the default cooldown before the default
-// 15-minute limit holds it, and an operator choosing where that stops wants
-// finer steps than an hour. The floor keeps the operator off the zero that
-// restores the default rather than disabling anything; the ceiling is four
-// hours, which keeps the track draggable (a day at one-minute steps is not)
-// while leaving room well past anything a probe cadence should be. A limit at
-// or below the cooldown period leaves the backoff nothing to add, which the
-// description says.
+// 15-minute limit holds it. The floor keeps the operator off the zero that
+// restores the default rather than disabling anything; the ceiling of four
+// hours keeps the track draggable (a day at one-minute steps is not) while
+// leaving room well past any probe cadence. A limit at or below the cooldown
+// period leaves the backoff nothing to add, which the description says.
 const BACKOFF_MAX_MIN_MINUTES = 1;
 const BACKOFF_MAX_MAX_MINUTES = 240;
 
 // Bounds of the model-span slider: how many of a provider's models must hold an
-// open circuit before the provider itself is skipped. The floor of 1 is the
-// escape hatch the breaker enforces too (internal/failover/model_circuits.go:
-// effectiveSpan), and it reproduces the old provider-wide behaviour. The ceiling
-// is far above any provider's catalog, so it only ever bites on a typo.
+// open circuit before the provider itself is skipped. The floor of 1, which the
+// breaker enforces too (internal/failover/model_circuits.go: effectiveSpan),
+// skips the provider on its first open model. The ceiling is far above any
+// provider's catalog, so it only ever bites on a typo.
 const SPAN_MODELS_MIN = 1;
 const SPAN_MODELS_MAX = 100;
 
 // Bounds of the two 429-classification sliders, in seconds. The saturation
 // wait limit separates "busy, a slot frees in seconds" from "the window is
 // spent": the floor keeps it a wait rather than a disable, the ceiling of two
-// minutes is already past any slot wait worth blocking a request for. The
+// minutes is past any slot wait worth blocking a request for. The
 // recent-success window bounds the fallback that reads an unrecognised 429
 // from a just-working model as busy; five minutes is the most a "moment ago"
 // can honestly stretch to.
@@ -64,9 +63,8 @@ interface CircuitBreakerSettingsProps {
 }
 
 // The 429 handling group: how a rate-limited response is classified (busy vs
-// spent) and what the breaker and the client get told about it. A sibling of
-// the main component rather than inline in it, so each stays well under the
-// function-size ceiling.
+// spent) and what the breaker and the client are told about it. Its own
+// component so each stays under the function-size ceiling.
 function RateLimit429Group() {
 	const { t } = useTranslation();
 	const { settings, updateMutation, resetSettingMutation, isResetting } =
@@ -74,8 +72,7 @@ function RateLimit429Group() {
 
 	// Fallbacks mirror the Go defaults (internal/proxy/rate_limit_classify.go:
 	// classification on, 60s for both durations, exhaustion opens at once, the
-	// 429 exhaustion status on), fallback before clamp, clamp for display only,
-	// exactly as the quota-pin and backoff pairs above.
+	// 429 exhaustion status on). Fallback before clamp, clamp for display only.
 	const classifyEnabled = settings?.rate_limit_classify_enabled !== "false";
 	const saturationWaitSeconds = Math.min(
 		SATURATION_WAIT_MAX_SECONDS,
@@ -279,10 +276,9 @@ export function CircuitBreakerSettings({
 	);
 	// Both quota-pin fallbacks mirror the Go defaults the breaker applies when
 	// the key is absent (internal/failover/circuitbreaker.go: quotaPinEnabled
-	// defaults true, quotaPinMax falls back to 24h). The `|| 24` on the hours is
-	// the same fallback for a stored non-positive duration, which the breaker
-	// also reads as unset, so the slider shows the ceiling actually in force
-	// rather than a number nothing obeys.
+	// defaults true, quotaPinMax falls back to 24h). The `|| 24` on the hours
+	// covers a stored non-positive duration too, which the breaker also reads as
+	// unset, so the slider shows the ceiling actually in force.
 	//
 	// The clamp must come after that fallback, never merged into it: clamping
 	// first would turn a stored 0 into the floor of 1, which is truthy, and the
@@ -291,10 +287,9 @@ export function CircuitBreakerSettings({
 	// PUT /api/settings accepts any duration, so a stored value can also sit
 	// below the floor or above the ceiling. Both are clamped for display, since
 	// the browser sanitizes the range track against min/max but leaves the
-	// number box alone, and one control showing two different numbers is worse
-	// than either number. Display only: SettingsSlider seeds its local state
-	// from this prop and fires onChange on interaction, never on mount, so
-	// nothing is written back until the operator actually moves the control.
+	// number box alone. Display only: SettingsSlider seeds its local state from
+	// this prop and fires onChange on interaction, never on mount, so nothing is
+	// written back until the operator moves the control.
 	const quotaPinEnabled =
 		settings?.circuit_breaker_quota_pin_enabled !== "false";
 	const quotaPinMaxHours = Math.min(
@@ -304,10 +299,10 @@ export function CircuitBreakerSettings({
 			goDurationToHours(settings?.circuit_breaker_quota_pin_max || "24h") || 24,
 		),
 	);
-	// Same shape as the quota-pin pair, for the same reasons: the fallbacks
-	// mirror the Go defaults (backoffEnabled defaults true, backoffMax falls back
-	// to 15m, and a stored non-positive duration reads as unset), the fallback
-	// comes before the clamp, and the clamp is display only.
+	// Same shape as the quota-pin pair: the fallbacks mirror the Go defaults
+	// (backoffEnabled defaults true, backoffMax falls back to 15m, and a stored
+	// non-positive duration reads as unset), the fallback comes before the clamp,
+	// and the clamp is display only.
 	const backoffEnabled = settings?.circuit_breaker_backoff_enabled !== "false";
 	const backoffMaxMinutes = Math.min(
 		BACKOFF_MAX_MAX_MINUTES,

--- a/web/src/pages/Settings/DatabaseBackupSettings.tsx
+++ b/web/src/pages/Settings/DatabaseBackupSettings.tsx
@@ -67,17 +67,17 @@ export function DatabaseBackupSettings({
 	});
 
 	// GFS bucket per backup, so each row can carry a Grandfather/Father/Son tag.
-	// Sourced from the prune-preview classifier (it groups every backup by age
-	// against the configured retention), so the labels track the same rotation
-	// the sliders above configure.
-	// Its own key, outside the "backups" prefix: the preview is a POST the
-	// server treats as a read, and re-running it on every backups invalidation
-	// (create, delete, prune, restore) re-classified an unchanged list. It
-	// re-runs when the classification can differ: the set of backups on disk
-	// or the retention the classifier applies changes, both carried in the key.
-	// It waits for the settings so a late settings answer does not cost a
-	// second read (isPending, not undefined, so a settings error still lets
-	// the buckets load).
+	// Sourced from the prune-preview classifier, which groups every backup by age
+	// against the configured retention, so the labels track the same rotation the
+	// sliders above configure.
+	//
+	// Its own key, outside the "backups" prefix: the preview is a POST the server
+	// treats as a read, and running it on every backups invalidation (create,
+	// delete, prune, restore) would re-classify an unchanged list. The key
+	// carries what can change the classification: the set of backups on disk and
+	// the retention the classifier applies. It waits for the settings so a late
+	// settings answer does not cost a second read (isPending, not undefined, so
+	// a settings error still lets the buckets load).
 	const backupNames = useMemo(
 		() => (backups ?? []).map((b) => b.filename).sort(),
 		[backups],
@@ -211,10 +211,10 @@ export function DatabaseBackupSettings({
 		trackCopied: false,
 	});
 
-	// Puts the backup's signature sidecar on the clipboard for the restore
-	// form. The download hands over the dump alone, and without shell access to
-	// the backup directory this is the only way an operator can get the value
-	// that lets a restore be verified rather than taken on trust.
+	// Puts the backup's signature sidecar on the clipboard for the restore form.
+	// The download hands over the dump alone, so without shell access to the
+	// backup directory this is the only way to get the value a verified restore
+	// needs.
 	const copySignature = async (filename: string) => {
 		try {
 			const { signature } = await api.backups.signature(filename);

--- a/web/src/pages/Settings/InflightLimiterGroup.tsx
+++ b/web/src/pages/Settings/InflightLimiterGroup.tsx
@@ -11,8 +11,8 @@ import { useSettingsMutations } from "./useSettingsMutations";
 // keeps a single lucky burst from widening the window, the ceiling of 100 is
 // already glacial. The forget horizon is in minutes: a capped window returns
 // to uncapped after this long without a cut, so the floor of 1 minute keeps it
-// a horizon rather than a disable, and an hour is far past any transient
-// congestion worth remembering.
+// a horizon rather than a disable, and the ceiling of an hour is past any
+// transient congestion worth remembering.
 const GROW_AFTER_MIN = 5;
 const GROW_AFTER_MAX = 100;
 const FORGET_MIN_MINUTES = 1;
@@ -20,17 +20,17 @@ const FORGET_MAX_MINUTES = 60;
 
 // The adaptive concurrency group: the in-flight learner that cuts a provider's
 // allowance on a saturated 429 and grows it back on clean completions, so the
-// router spills to the next entry before anyone has to say 429 again. Rendered
-// inside the Circuit Breaker & Failover section beside the 429-handling group
-// it acts on; its own file keeps every component under the size ceilings.
+// router spills to the next entry sooner. Rendered inside the Circuit Breaker
+// & Failover section beside the 429-handling group it acts on; its own file
+// keeps every component under the size ceilings.
 export function InflightLimiterGroup() {
 	const { t } = useTranslation();
 	const { settings, updateMutation, resetSettingMutation, isResetting } =
 		useSettingsMutations();
 
 	// Fallbacks mirror the Go defaults (internal/proxy/inflight.go: enabled,
-	// grow after 20, forget after 10m); fallback before clamp, clamp for
-	// display only, as everywhere else in this section.
+	// grow after 20, forget after 10m). Fallback before clamp, clamp for
+	// display only.
 	const limiterEnabled = settings?.inflight_limiter_enabled !== "false";
 	const growAfter = Math.min(
 		GROW_AFTER_MAX,

--- a/web/src/pages/Settings/defaults.ts
+++ b/web/src/pages/Settings/defaults.ts
@@ -1,12 +1,12 @@
 /**
  * Default values for all settings. When a setting is deleted from the
- * database, the server falls through to its Go-side default — these
+ * database, the server falls through to its Go-side default, so these
  * frontend defaults MUST match the Go defaults in:
  *   - internal/settings/settings.go (GetBool/GetInt/GetWithDefault fallbacks)
  *   - internal/api/settings.go (allowedSettings map)
  *
- * There is no automated cross-language sync test. When changing a Go
- * default, update the corresponding entry here (and in en.json labels).
+ * There is no automated cross-language sync test: when changing a Go default,
+ * update the corresponding entry here (and in en.json labels).
  */
 export const SETTING_DEFAULTS: Record<SettingKey, string> = {
 	// Discovery
@@ -64,7 +64,7 @@ export const SETTING_DEFAULTS: Record<SettingKey, string> = {
 	stale_request_timeout: "30m0s",
 
 	// Alerting (Apprise). alert_events MUST match Go's alert.DefaultEnabledCSV()
-	// (internal/alert/catalog.go) — the comma-joined default-on event types.
+	// (internal/alert/catalog.go): the comma-joined default-on event types.
 	alert_enabled: "false",
 	alert_apprise_api_url: "",
 	alert_apprise_targets: "",
@@ -74,12 +74,12 @@ export const SETTING_DEFAULTS: Record<SettingKey, string> = {
 	// discovery.claims_outstanding fires. Matches DefaultClaimAlertDays in
 	// internal/api/discovery_claim_alert.go. The ceiling is NOT here: it is
 	// derived from ClaimWindow and served as the read-only
-	// discovery_claim_window_days key, so the two cannot drift.
+	// discovery_claim_window_days key.
 	discovery_claim_alert_days: "7",
 
 	// Authentication. Dashboard auto-logout after inactivity, in minutes; 0
-	// disables it. Consumed entirely on the frontend (see useIdleLogout); the
-	// backend only validates/stores the value.
+	// disables it. Consumed entirely on the frontend (useIdleLogout); the
+	// backend only validates and stores the value.
 	session_idle_timeout_minutes: "60",
 
 	// Reject new account passwords found in a known breach (Have I Been Pwned


### PR DESCRIPTION
## Summary

Comment-only cleanup of every production file touched since #841 (115 files, net -890 lines). Comments described how the code got here (dates, incident runs, PR and Strix ids, "used to" / "moved here" notes, test names, line references) rather than what it does. Each comment now describes only the code it sits on, in the present tense.

Kept: invariants, ordering rules, magic-constant rationale, security and privacy constraints, concurrency notes, and third-party quirk references (e.g. google-gemini/cookbook#1028).

Also fixed six doc comments that sat on the wrong declaration (`mapKeys`, `classifyProbeFailure`, `cancelOriginToKind`, `streamingAwareTimeout`, `interruptedMessage`, Front Desk client `fleetCircuitReset`), and two older package notes reviewers flagged (`internal/anthropic/events.go`, `internal/openairesponses/stream.go`).

No code changes: the diff was mechanically checked to contain only comment lines. SQL and Prometheus `Help:` string literals were left alone.

## Verification

- `go build`, `go vet`, `golangci-lint run` (0 issues), size gate
- `tsc -b` on both frontends, ESLint, Biome
- Go tests: 4696 passed in the 13 touched non-DB packages
- Three independent review passes over the diff; 3 HIGH (inverted setting polarity, two misstatements), 7 MED (lost gotchas) and ~20 LOW findings all fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ymnr4LJFJhUfdMTDTCpM7
