### PR TITLE
fix(discovery): send the Google API key in a header, not the URL

### DIFF
--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -79,9 +79,9 @@ const maxDiscoveryRetries = 3
 var credentialHeaders = []string{"Authorization", "X-Api-Key", "Api-Key", "X-Goog-Api-Key"}
 
 // credentialQueryParams are the query parameter names a key may travel in
-// (a custom gateway may authenticate by ?key=). Only these are treated as secrets: a
-// sweep of every query value would redact Azure's ?api-version=... out of the
-// one diagnostic an operator needs when a version is refused.
+// (a custom gateway may authenticate by ?key=). Only these are treated as
+// secrets: a sweep of every query value would redact Azure's ?api-version=...
+// out of the one diagnostic an operator needs when a version is refused.
 var credentialQueryParams = map[string]bool{
 	"key": true, "api_key": true, "apikey": true, "api-key": true,
 	"token": true, "access_token": true, "secret": true, "password": true,
@@ -189,10 +189,9 @@ func (d *DiscoveryService) doDiscoveryRequest(ctx context.Context, newReq func()
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
 			if isTransientNetworkError(err) {
-				// A transport error quotes the request URL, and one provider
-				// family authenticates by query parameter, so the key IS in
-				// scope here: it is in the request that just failed. Masked
-				// exactly off that request, then by shape, before it reaches
+				// A transport error quotes the request URL, and a custom
+				// gateway may authenticate by query parameter. Masked exactly
+				// off the failed request, then by shape, before it reaches
 				// the log or the caller.
 				lastErr = maskedRequestError(req, err)
 				debuglog.Info("discovery: transient fetch error, will retry",
@@ -229,8 +228,9 @@ func (e *maskedError) Error() string { return e.text }
 func (e *maskedError) Unwrap() error { return e.cause }
 
 // maskedRequestError wraps err so its text is scrubbed of everything req
-// carried (a url.Error quotes the request URL, and one family authenticates
-// by query parameter) and of anything key-shaped, bounded to 500 runes.
+// carried (a url.Error quotes the request URL, and a custom gateway may
+// authenticate by query parameter) and of anything key-shaped, bounded to 500
+// runes.
 func maskedRequestError(req *http.Request, err error) error {
 	if err == nil {
 		return nil

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -79,7 +79,7 @@ const maxDiscoveryRetries = 3
 var credentialHeaders = []string{"Authorization", "X-Api-Key", "Api-Key", "X-Goog-Api-Key"}
 
 // credentialQueryParams are the query parameter names a key may travel in
-// (one family authenticates by ?key=). Only these are treated as secrets: a
+// (a custom gateway may authenticate by ?key=). Only these are treated as secrets: a
 // sweep of every query value would redact Azure's ?api-version=... out of the
 // one diagnostic an operator needs when a version is refused.
 var credentialQueryParams = map[string]bool{

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	neturl "net/url"
 	"slices"
 	"strings"
 
@@ -20,31 +19,25 @@ import (
 func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider *Provider, apiKey string) ([]*model.Model, error) {
 	baseURL := util.SanitizeBaseURL(provider.BaseURL)
 
-	// Determine the native API base URL from the proxy base URL.
-	// The proxy uses /v1beta/openai/ but discovery uses /v1beta/models?key=KEY
+	// The proxy uses /v1beta/openai/; discovery uses the native /v1beta/models.
 	nativeBaseURL := GoogleNativeBaseURL(baseURL)
 
-	// Use ?key= auth for native API.
-	//
-	// The credential is therefore IN THE URL, and a transport failure returns a
-	// *url.Error whose Error() quotes the whole URL back: Go redacts only
-	// userinfo passwords, not query parameters. The transport error below is
-	// scrubbed for exactly that reason; moving to the x-goog-api-key
-	// header would remove the class instead of masking it.
-	url := fmt.Sprintf("%s/models?key=%s", nativeBaseURL, neturl.QueryEscape(apiKey))
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	// The key goes in the x-goog-api-key header, never the URL: a transport
+	// failure quotes the whole URL back through *url.Error, and Go redacts only
+	// userinfo passwords, not query parameters.
+	req, err := http.NewRequestWithContext(ctx, "GET", nativeBaseURL+"/models", http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("google: failed to create request for provider %s: %w", provider.Name, err)
 	}
+	req.Header.Set("x-goog-api-key", apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
-		scrubbed := util.MaskCredential(apiKey, err.Error())
+		// Scrubbed anyway: the header value is what the shared masker reads.
+		scrubbed := maskRequestSecrets(req, err.Error(), 500)
 		debuglog.Error("discovery: google http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", scrubbed)
-		// %s, not %w: the wrapped error's own text is the leak, and nothing
-		// unwraps a transport failure from here.
+		// %s, not %w: the wrapped error's own text is what would leak.
 		return nil, fmt.Errorf("google: failed to fetch models for provider %s: %s", provider.Name, scrubbed)
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -30,15 +30,13 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 		return nil, fmt.Errorf("google: failed to create request for provider %s: %w", provider.Name, err)
 	}
 	req.Header.Set("x-goog-api-key", apiKey)
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := d.doDiscoveryRequestPrebuilt(ctx, req)
 	if err != nil {
-		// Scrubbed anyway: the header value is what the shared masker reads.
-		scrubbed := maskRequestSecrets(req, err.Error(), 500)
-		debuglog.Error("discovery: google http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", scrubbed)
-		// %s, not %w: the wrapped error's own text is what would leak.
-		return nil, fmt.Errorf("google: failed to fetch models for provider %s: %s", provider.Name, scrubbed)
+		// err is already masked by the shared retry path. %s, not %w: callers
+		// must not unwrap to the raw transport error.
+		debuglog.Error("discovery: google http request failed", "provider", provider.Name, "provider_id", provider.ID, "error", err.Error())
+		return nil, fmt.Errorf("google: failed to fetch models for provider %s: %s", provider.Name, err.Error())
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -48,7 +46,7 @@ func (d *DiscoveryService) discoverGoogleAIStudio(ctx context.Context, provider 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		debuglog.Error("discovery: google non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", util.MaskCredentialBounded(apiKey, string(bodyBytes), 2000))
+		debuglog.Error("discovery: google non-200 status", "status", resp.StatusCode, "provider", provider.Name, "provider_id", provider.ID, "body", maskRequestSecrets(req, string(bodyBytes), 2000))
 		return nil, fmt.Errorf("google: unexpected status code %d for provider %s", resp.StatusCode, provider.Name)
 	}
 

--- a/internal/provider/discovery_google_http_test.go
+++ b/internal/provider/discovery_google_http_test.go
@@ -23,9 +23,11 @@ func TestDiscoverGoogleAIStudio(t *testing.T) {
 			return
 		}
 
-		// Check key parameter
-		key := r.URL.Query().Get("key")
-		if key != "test-api-key" {
+		if r.URL.Query().Has("key") {
+			http.Error(w, "key must not travel in the URL", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("x-goog-api-key") != "test-api-key" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/internal/provider/discovery_google_leak_test.go
+++ b/internal/provider/discovery_google_leak_test.go
@@ -2,21 +2,23 @@ package provider
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
 // Go's *url.Error renders the whole request URL in Error(), redacting only
-// userinfo passwords, so a key in the query string would reach the app log,
-// the discovery HTTP response and the discovery.provider_failed SSE event on
-// any transport failure. The key travels in a header; this pins that.
+// userinfo passwords. Pins the class end to end: the key travels in a header,
+// and the shared retry path masks whatever the transport error quotes.
 //
 // A shapeless key, so the shape layer cannot hide a regression.
-func TestDiscoverGoogle_TransportErrorDoesNotCarryTheKeyFromTheURL(t *testing.T) {
+func TestDiscoverGoogle_TransportErrorDoesNotCarryTheKey(t *testing.T) {
 	const key = "selfhosted-gateway-secret"
 
 	// A closed listener: the request is guaranteed to fail at the transport
@@ -35,18 +37,24 @@ func TestDiscoverGoogle_TransportErrorDoesNotCarryTheKeyFromTheURL(t *testing.T)
 	}
 }
 
-// The same body-echo shape as the other providers, on the non-200 path.
+// The non-200 path logs the upstream body; the echoed key must be redacted in
+// that log line.
 func TestDiscoverGoogle_ErrorBodyDoesNotCarryTheKey(t *testing.T) {
-	const key = "selfhosted-gateway-secret"
+	var logged strings.Builder
+	prev := slog.Default()
+	debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	defer slog.SetDefault(prev)
+
 	srv := httptest.NewServer(echoKeyHandler(http.StatusUnauthorized))
 	defer srv.Close()
 
 	svc := &DiscoveryService{httpClient: srv.Client()}
-	_, err := svc.discoverGoogleAIStudio(context.Background(), &Provider{ID: uuid.New(), Name: "google-leak", BaseURL: srv.URL}, key)
+	_, err := svc.discoverGoogleAIStudio(context.Background(), &Provider{ID: uuid.New(), Name: "google-leak", BaseURL: srv.URL}, leakedKey)
 	if err == nil {
 		t.Fatal("expected an error from the 401")
 	}
-	if strings.Contains(err.Error(), key) {
+	if strings.Contains(err.Error(), leakedKey) {
 		t.Errorf("the API key survived into the error: %q", err.Error())
 	}
+	assertScrubbed(t, logged.String())
 }

--- a/internal/provider/discovery_google_leak_test.go
+++ b/internal/provider/discovery_google_leak_test.go
@@ -10,16 +10,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// Google discovery authenticates by query parameter, so the credential is in
-// the request URL. Go's *url.Error renders the whole URL in Error() — it
-// redacts userinfo passwords, nothing else — so any transport failure (DNS,
-// TLS, timeout, a SafeDialer refusal) produced an error string carrying the
-// key, and that string reached the app log, the discovery HTTP response and
-// the discovery.provider_failed SSE event.
+// Go's *url.Error renders the whole request URL in Error(), redacting only
+// userinfo passwords, so a key in the query string would reach the app log,
+// the discovery HTTP response and the discovery.provider_failed SSE event on
+// any transport failure. The key travels in a header; this pins that.
 //
-// A real Google key is AIza-prefixed, which the shape layer catches on its
-// own; this uses a shapeless key so the assertion pins the exact-match layer
-// at the call site rather than the shared scrub.
+// A shapeless key, so the shape layer cannot hide a regression.
 func TestDiscoverGoogle_TransportErrorDoesNotCarryTheKeyFromTheURL(t *testing.T) {
 	const key = "selfhosted-gateway-secret"
 
@@ -35,10 +31,7 @@ func TestDiscoverGoogle_TransportErrorDoesNotCarryTheKeyFromTheURL(t *testing.T)
 		t.Fatal("expected a transport error against a closed listener")
 	}
 	if strings.Contains(err.Error(), key) {
-		t.Errorf("the API key survived from the URL into the error: %q", err.Error())
-	}
-	if !strings.Contains(err.Error(), "[redacted]") {
-		t.Errorf("the URL-borne credential was not scrubbed at all: %q", err.Error())
+		t.Errorf("the API key reached the error text: %q", err.Error())
 	}
 }
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -671,7 +671,7 @@ The live result is then merged with the catalog. The catalog **backfills** the f
 
 **Source files:** `discovery_google.go`, `google_catalog.go`, `google_types.go`
 
-**Method:** Uses Google's native Gemini API (`GET /v1beta/models?key=KEY`) for discovery, which provides rich metadata including context windows, max output tokens, supported generation methods, and thinking support. The base URL is configured for the OpenAI-compatible proxy endpoint (`/v1beta/openai`), but discovery internally converts to the native API URL.
+**Method:** Uses Google's native Gemini API (`GET /v1beta/models`, key in the `x-goog-api-key` header) for discovery, which provides rich metadata including context windows, max output tokens, supported generation methods, and thinking support. The base URL is configured for the OpenAI-compatible proxy endpoint (`/v1beta/openai`), but discovery internally converts to the native API URL.
 
 Model IDs from the native API have a `models/` prefix (e.g., `models/gemini-2.5-flash`) which is stripped for internal use.
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -708,7 +708,7 @@ Model IDs from the native API have a `models/` prefix (e.g., `models/gemini-2.5-
 
 **Model filtering:** Only models supporting `generateContent` or `embedContent` are included. AQA-only models are excluded.
 
-**Auth:** Discovery uses `?key=API_KEY` query parameter (native API). Proxy uses `Authorization: Bearer API_KEY` (OpenAI-compatible endpoint). Google API keys are simple alphanumeric strings starting with `AIzaSy...`.
+**Auth:** Discovery sends the key in the `x-goog-api-key` header (native API). Proxy uses `Authorization: Bearer API_KEY` (OpenAI-compatible endpoint). Google API keys are simple alphanumeric strings starting with `AIzaSy...`.
 
 ### Cohere
 


### PR DESCRIPTION
## Summary

Google AI Studio discovery authenticated with `?key=` in the query string, so every transport error quoted the key back through `*url.Error` and each error path had to scrub it; the request-build error path did not. The key now travels in the `x-goog-api-key` header, the same as Vertex Express discovery, the proxy egress and the quota reads, so no discovery URL carries a credential.

- Transport errors are masked once, by the shared retry path; the redundant second pass is gone.
- The non-200 body log reads the key back off the request header through the shared masker like every other family.
- The mock server answers 400 to any request carrying `?key=`, so a reintroduction fails the suite; the leak test captures the non-200 log line, which is where an echoed key would land.
- Stale "one family authenticates by query parameter" wording in the shared helpers and two wiki lines updated.

Behaviour note: a key pasted with a stray control byte used to be percent-escaped into the URL and get a 401 from Google; it now fails at the transport with `invalid header field value for "X-Goog-Api-Key"`. The value is not in that error text.

Closes #886

## Verification

- `go test ./internal/provider/` 1043 passed, golangci-lint 0 issues
- Dev stack rebuilt; live AI Studio discovery through the header returned 43 models. Vertex Express path is untouched (its dev key has been dead since 2026-08-22, unrelated).
- One opus review round: 0 HIGH, 5 MED, 6 LOW, all addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ymnr4LJFJhUfdMTDTCpM7
