### PR TITLE
refactor: fold the Opus-era duplicates into one helper each

### DIFF
--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -92,7 +92,7 @@ func TestInspectStreamEvent_MessageStartCountSpellings(t *testing.T) {
 	}
 }
 
-// An explicit null is not a usage block. The *antUsage this replaced was nil for
+// An explicit null is not a usage block. The *Usage this replaced was nil for
 // absent AND null alike; a json.RawMessage for null is four non-empty bytes, and
 // emitRawData assigns OutputTokens unguarded — so a null usage on a later event
 // would wipe the count message_start reported.
@@ -234,5 +234,27 @@ func TestBuildMessageResponse_BrokenBytesStillFail(t *testing.T) {
 				t.Error("want an error: these bytes are broken, not a count in another spelling")
 			}
 		})
+	}
+}
+
+// An unreadable member costs only the figures it feeds: the prompt addends fall
+// together, output_tokens is read straight off its own member.
+func TestReadUsage_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
+	t.Parallel()
+	u, ok := ReadUsage([]byte(`{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`))
+	if !ok {
+		t.Fatal("the whole block was rejected for one unreadable member")
+	}
+	if u.InputTokens != 0 || u.CacheReadInputTokens != 0 {
+		t.Errorf("prompt addends = %d/%d, want both dropped together", u.InputTokens, u.CacheReadInputTokens)
+	}
+	if u.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want 5", u.OutputTokens)
+	}
+	if _, ok := ReadUsage([]byte(`null`)); ok {
+		t.Error("null is not a usage block")
+	}
+	if _, ok := ReadUsage(nil); ok {
+		t.Error("an absent member is not a usage block")
 	}
 }

--- a/internal/anthropic/count_spelling_test.go
+++ b/internal/anthropic/count_spelling_test.go
@@ -92,8 +92,8 @@ func TestInspectStreamEvent_MessageStartCountSpellings(t *testing.T) {
 	}
 }
 
-// An explicit null is not a usage block. The *Usage this replaced was nil for
-// absent AND null alike; a json.RawMessage for null is four non-empty bytes, and
+// An explicit null is not a usage block: a json.RawMessage for null is four
+// non-empty bytes, and
 // emitRawData assigns OutputTokens unguarded — so a null usage on a later event
 // would wipe the count message_start reported.
 func TestInspectStreamEvent_ANullUsageIsNotAReading(t *testing.T) {

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -60,10 +60,12 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	return u.summary()
 }
 
-// Usage is an Anthropic usage block. The cache fields are absent from
-// responses that use no cache, which decodes to zero. Shared with the egress
-// translator, which reads the same block off an Anthropic-Messages upstream.
-type Usage struct {
+// UsageBlock is the usage block an Anthropic-Messages upstream reports, as
+// this gateway reads it. The cache fields are absent from responses that use
+// no cache, which decodes to zero. Shared with the egress translator, which
+// reads the same block. Distinct from the unexported usage in events.go, which
+// is the block this gateway WRITES when it emits Anthropic events.
+type UsageBlock struct {
 	InputTokens              int `json:"input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
@@ -81,7 +83,7 @@ type Usage struct {
 // reports NO cache counts rather than "miss = the whole prompt". Creation
 // tokens still count inside PromptTokens, which is what the request is metered
 // and priced on.
-func (u Usage) summary() ResponseUsage {
+func (u UsageBlock) summary() ResponseUsage {
 	out := ResponseUsage{
 		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
 		CompletionTokens: u.OutputTokens,
@@ -251,13 +253,13 @@ var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_c
 // it FEEDS. output_tokens stands or falls alone; the prompt figure needs all
 // three of its addends, since a cache-read count of 20000 lost to an
 // unreadable sibling would bill 4, and no estimate replaces a non-zero figure.
-func ReadUsage(raw json.RawMessage) (Usage, bool) {
+func ReadUsage(raw json.RawMessage) (UsageBlock, bool) {
 	if !util.JSONMemberSet(raw) {
-		return Usage{}, false
+		return UsageBlock{}, false
 	}
-	var u Usage
+	var u UsageBlock
 	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
-		return Usage{}, false
+		return UsageBlock{}, false
 	}
 	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
 		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -50,15 +50,20 @@ func ParseResponseUsage(body []byte) ResponseUsage {
 	var resp struct {
 		Usage json.RawMessage `json:"usage"`
 	}
-	if json.Unmarshal(body, &resp) != nil || !util.JSONMemberSet(resp.Usage) {
+	if json.Unmarshal(body, &resp) != nil {
 		return ResponseUsage{}
 	}
-	return readUsage(resp.Usage)
+	u, ok := ReadUsage(resp.Usage)
+	if !ok {
+		return ResponseUsage{}
+	}
+	return u.summary()
 }
 
-// antUsage is an Anthropic usage block. The cache fields are absent from
-// responses that use no cache, which decodes to zero.
-type antUsage struct {
+// Usage is an Anthropic usage block. The cache fields are absent from
+// responses that use no cache, which decodes to zero. Shared with the egress
+// translator, which reads the same block off an Anthropic-Messages upstream.
+type Usage struct {
 	InputTokens              int `json:"input_tokens"`
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
@@ -76,7 +81,7 @@ type antUsage struct {
 // reports NO cache counts rather than "miss = the whole prompt". Creation
 // tokens still count inside PromptTokens, which is what the request is metered
 // and priced on.
-func (u antUsage) summary() ResponseUsage {
+func (u Usage) summary() ResponseUsage {
 	out := ResponseUsage{
 		PromptTokens:     u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens,
 		CompletionTokens: u.OutputTokens,
@@ -174,7 +179,7 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 		// json.RawMessage, not a typed object: a relay is free to send a bare
 		// string here, and a typed field fails the WHOLE event unmarshal, which
 		// costs the event its type, leaves the error uncounted and forwards the
-		// frame with no key-shape masking. util.ErrorMemberCarries is the same
+		// frame with no key-shape masking. util.ValueCarries is the same
 		// rule the OpenAI-compatible path reads this member with.
 		Error json.RawMessage `json:"error"`
 		Delta *struct {
@@ -189,17 +194,17 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	if json.Unmarshal(payload, &ev) != nil {
 		return StreamEvent{}
 	}
-	info := StreamEvent{Type: ev.Type, CarriesError: util.ErrorMemberCarries(ev.Error)}
+	info := StreamEvent{Type: ev.Type, CarriesError: util.ValueCarries(ev.Error)}
 	switch ev.Type {
 	case "message_start":
 		var raw json.RawMessage
 		if ev.Message != nil {
 			raw = ev.Message.Usage
 		}
-		if usage, ok := readEventUsage(raw); ok {
+		if usage, ok := ReadUsage(raw); ok {
 			u := usage.summary()
 			// HasInput means there is a READING, so it follows the figure rather
-			// than the event: readEventUsage drops a prompt figure whose addend
+			// than the event: ReadUsage drops a prompt figure whose addend
 			// it could not read, and claiming a reading of zero for that would
 			// have the caller overwrite a good count with nothing.
 			info.InputTokens, info.HasInput = u.PromptTokens, u.PromptTokens > 0
@@ -209,7 +214,7 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			}
 		}
 	case "message_delta":
-		if usage, ok := readEventUsage(ev.Usage); ok {
+		if usage, ok := ReadUsage(ev.Usage); ok {
 			// An output figure that is not positive is not a reading: assigned
 			// verbatim, a negative output_tokens reaches the completion
 			// metering and draws the key's usage down.
@@ -218,7 +223,7 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 			}
 		}
 	case "error":
-		if util.ErrorMemberCarries(ev.Error) {
+		if util.ValueCarries(ev.Error) {
 			info.ErrorMessage = util.ErrorMemberMessage(ev.Error)
 		}
 	case "content_block_delta":
@@ -233,20 +238,27 @@ func InspectStreamEvent(payload []byte) StreamEvent {
 	return info
 }
 
-// readEventUsage decodes a stream event's usage member on its own, reporting
-// whether there was one to read. A count spelled differently must not cost the
-// event its type, and a member that cannot be read at all must not cost the
-// counts beside it.
-func readEventUsage(raw json.RawMessage) (antUsage, bool) {
+// promptAddends are the members Anthropic's prompt figure is SUMMED from.
+var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}
+
+// ReadUsage decodes an Anthropic usage block on its own, reporting whether
+// there was one to read: an absent or null member is not a reading. Decoded
+// separately from the event or response around it so a count spelled
+// differently (quoted, or with a fraction on it) costs the counts and never
+// the event's type or the answer beside it.
+//
+// Per FIGURE, not per block: a member that could not be read costs the figures
+// it FEEDS. output_tokens stands or falls alone; the prompt figure needs all
+// three of its addends, since a cache-read count of 20000 lost to an
+// unreadable sibling would bill 4, and no estimate replaces a non-zero figure.
+func ReadUsage(raw json.RawMessage) (Usage, bool) {
 	if !util.JSONMemberSet(raw) {
-		return antUsage{}, false
+		return Usage{}, false
 	}
-	var u antUsage
+	var u Usage
 	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
-		return antUsage{}, false
+		return Usage{}, false
 	}
-	// A member that could not be read costs the figures it FEEDS, not the whole
-	// block.
 	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
 		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
 	}
@@ -254,29 +266,4 @@ func readEventUsage(raw json.RawMessage) (antUsage, bool) {
 		u.OutputTokens = 0
 	}
 	return u, true
-}
-
-// promptAddends are the members Anthropic's prompt figure is SUMMED from.
-var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}
-
-// readUsage decodes an Anthropic usage block per FIGURE, not per block: a
-// member that could not be read costs the figures it FEEDS. output_tokens
-// stands or falls alone; the prompt figure needs all three of its addends,
-// since a cache-read count of 20000 lost to an unreadable sibling would bill 4
-// and no estimate would replace a non-zero figure.
-func readUsage(raw json.RawMessage) ResponseUsage {
-	if !util.JSONMemberSet(raw) {
-		return ResponseUsage{}
-	}
-	var u antUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
-		return ResponseUsage{}
-	}
-	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
-		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
-	}
-	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
-		u.OutputTokens = 0
-	}
-	return u.summary()
 }

--- a/internal/anthropicegress/count_spelling_test.go
+++ b/internal/anthropicegress/count_spelling_test.go
@@ -148,18 +148,3 @@ func TestBuildChatCompletion_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T
 		t.Errorf("the completion count was read straight off its own member and was thrown away: %s", out)
 	}
 }
-
-// The streaming reader keeps the same rule.
-func TestReadEventUsage_AnUnreadableMemberCostsOnlyWhatItFeeds(t *testing.T) {
-	t.Parallel()
-	u, ok := readEventUsage([]byte(`{"input_tokens":4,"output_tokens":5,"cache_read_input_tokens":[]}`))
-	if !ok {
-		t.Fatal("the whole block was rejected for one unreadable member")
-	}
-	if u.InputTokens != 0 {
-		t.Errorf("InputTokens = %d, want the prompt addends dropped together", u.InputTokens)
-	}
-	if u.OutputTokens != 5 {
-		t.Errorf("OutputTokens = %d, want 5: it is read straight off its own member", u.OutputTokens)
-	}
-}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropic"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
-	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming Anthropic Messages response shape ---
@@ -41,16 +41,6 @@ type antRespBlock struct {
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
-}
-
-// antRespUsage carries Anthropic token accounting, including the two cache
-// fields Anthropic reports at the top level of usage (unlike OpenAI, which
-// nests its cached-read count under prompt_tokens_details).
-type antRespUsage struct {
-	InputTokens              int `json:"input_tokens"`
-	OutputTokens             int `json:"output_tokens"`
-	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
-	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }
 
 // antRespError is the body of an Anthropic {"type":"error"} envelope. Only
@@ -233,31 +223,19 @@ func mapFinishReason(stopReason string) string {
 // internal/proxy/helpers.go's extractCacheTokens, which computes
 // missTokens = promptTokens - cacheReadTokens).
 func translateUsage(raw json.RawMessage) *completionUsage {
-	if !util.JSONMemberSet(raw) {
+	// anthropic.ReadUsage holds the per-figure rule: a member that could not be
+	// read costs only the figures it feeds, and a completion count is what tells
+	// the breaker the provider answered at all.
+	u, ok := anthropic.ReadUsage(raw)
+	if !ok {
 		return nil
-	}
-	// Per FIGURE, not per block. A figure read straight off one member is right
-	// or absent; a SUMMED one is only as good as its addends, and a lost addend
-	// leaves a number that is wrong AND non-zero, which reads as authoritative
-	// and stops estimateMissingUsage replacing it. Dropping the whole block
-	// instead threw away counts that were never in doubt — and a completion
-	// count is what tells the breaker the provider answered at all.
-	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
-		return nil
-	}
-	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
-		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
-	}
-	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
-		u.OutputTokens = 0
 	}
 	return buildUsage(u)
 }
 
 // buildUsage renders counts this package already holds. The streaming translator
 // accumulates its own across events and has no raw bytes to read.
-func buildUsage(u antRespUsage) *completionUsage {
+func buildUsage(u anthropic.Usage) *completionUsage {
 	prompt := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 	out := &completionUsage{
 		PromptTokens:     prompt,
@@ -273,6 +251,3 @@ func buildUsage(u antRespUsage) *completionUsage {
 	}
 	return out
 }
-
-// promptAddends are the members the prompt figure is SUMMED from.
-var promptAddends = []string{"input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"}

--- a/internal/anthropicegress/response.go
+++ b/internal/anthropicegress/response.go
@@ -235,7 +235,7 @@ func translateUsage(raw json.RawMessage) *completionUsage {
 
 // buildUsage renders counts this package already holds. The streaming translator
 // accumulates its own across events and has no raw bytes to read.
-func buildUsage(u anthropic.Usage) *completionUsage {
+func buildUsage(u anthropic.UsageBlock) *completionUsage {
 	prompt := u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
 	out := &completionUsage{
 		PromptTokens:     prompt,

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hugalafutro/model-hotel/internal/anthropic"
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
-	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // --- Incoming Anthropic SSE event shapes ---
@@ -114,7 +114,7 @@ type StreamTranslator struct {
 	// runs them through translateUsage's arithmetic. A usage object carrying
 	// nothing but zeros leaves this zero-valued, and the terminal chunk then
 	// omits usage rather than reporting a fabricated 0/0/0.
-	usage antRespUsage
+	usage anthropic.Usage
 
 	// Anthropic's content-block indices count every block; OpenAI's
 	// tool_calls[].index counts only tool calls. This maps one to the other so
@@ -179,7 +179,7 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 	switch ev.Type {
 	case "message_start":
 		if ev.Message != nil {
-			if u, ok := readEventUsage(ev.Message.Usage); ok {
+			if u, ok := anthropic.ReadUsage(ev.Message.Usage); ok {
 				t.usage.InputTokens = u.InputTokens
 				t.usage.CacheCreationInputTokens = u.CacheCreationInputTokens
 				t.usage.CacheReadInputTokens = u.CacheReadInputTokens
@@ -200,7 +200,7 @@ func (t *StreamTranslator) Translate(payload []byte) ([]byte, error) {
 		if ev.Delta != nil && ev.Delta.StopReason != "" {
 			t.stopReason = ev.Delta.StopReason
 		}
-		if u, ok := readEventUsage(ev.Usage); ok {
+		if u, ok := anthropic.ReadUsage(ev.Usage); ok {
 			t.usage.OutputTokens = u.OutputTokens
 		}
 	case "message_stop":
@@ -305,7 +305,7 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 	var buf bytes.Buffer
 	reason := mapFinishReason(t.stopReason)
 	var usage *completionUsage
-	if t.usage != (antRespUsage{}) {
+	if t.usage != (anthropic.Usage{}) {
 		usage = buildUsage(t.usage)
 	}
 	if err := t.writeChunk(&buf, chunkDelta{}, &reason, usage); err != nil {
@@ -313,29 +313,4 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 	}
 	buf.WriteString("data: [DONE]\n\n")
 	return buf.Bytes(), nil
-}
-
-// readEventUsage decodes a stream event's usage member on its own, reporting
-// whether there was one to read.
-//
-// Separate from the event decode because an error there kills the STREAM: the
-// event loses its type along with its counts, so message_stop and the error
-// events stop being recognised for that frame. A count the provider spelled
-// differently — quoted, or with a fraction on it — is not a reason to do that.
-func readEventUsage(raw json.RawMessage) (antRespUsage, bool) {
-	if !util.JSONMemberSet(raw) {
-		return antRespUsage{}, false
-	}
-	// Per figure, as in translateUsage.
-	var u antRespUsage
-	if err := util.DecodeCounts(raw, &u); err != nil && util.ShapeError(raw, err) == nil {
-		return antRespUsage{}, false
-	}
-	if len(util.UnreadableCounts(raw, promptAddends...)) > 0 {
-		u.InputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens = 0, 0, 0
-	}
-	if len(util.UnreadableCounts(raw, "output_tokens")) > 0 {
-		u.OutputTokens = 0
-	}
-	return u, true
 }

--- a/internal/anthropicegress/stream.go
+++ b/internal/anthropicegress/stream.go
@@ -114,7 +114,7 @@ type StreamTranslator struct {
 	// runs them through translateUsage's arithmetic. A usage object carrying
 	// nothing but zeros leaves this zero-valued, and the terminal chunk then
 	// omits usage rather than reporting a fabricated 0/0/0.
-	usage anthropic.Usage
+	usage anthropic.UsageBlock
 
 	// Anthropic's content-block indices count every block; OpenAI's
 	// tool_calls[].index counts only tool calls. This maps one to the other so
@@ -305,7 +305,7 @@ func (t *StreamTranslator) Finish() ([]byte, error) {
 	var buf bytes.Buffer
 	reason := mapFinishReason(t.stopReason)
 	var usage *completionUsage
-	if t.usage != (anthropic.Usage{}) {
+	if t.usage != (anthropic.UsageBlock{}) {
 		usage = buildUsage(t.usage)
 	}
 	if err := t.writeChunk(&buf, chunkDelta{}, &reason, usage); err != nil {

--- a/internal/api/quota_drift.go
+++ b/internal/api/quota_drift.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
 	"github.com/hugalafutro/model-hotel/internal/quota"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // The quota schema-drift watch alerts when a provider changes the *shape* of
@@ -93,10 +94,11 @@ func driftEligible(s quota.Snapshot, maxAge time.Duration, now time.Time) bool {
 	if maxAge <= 0 || s.HTTPStatus != http.StatusOK || len(s.Payload) == 0 {
 		return false
 	}
-	// Negative age (a future stamp) is untrustworthy, not eligible: see
-	// snapshotWithinAge. This is the same field and the same repository feed as
-	// the two staleness checks in quota_snapshot.go.
-	return snapshotWithinAge(now, s.FetchedAt, maxAge)
+	// A future stamp is untrustworthy, not eligible (util.TrustedAge). Same
+	// field and same repository feed as the two staleness checks in
+	// quota_snapshot.go; a snapshot at exactly maxAge is still eligible.
+	age, ok := util.TrustedAge(now, s.FetchedAt)
+	return ok && age <= maxAge
 }
 
 // driftDecision is the whole per-provider decision, kept pure so the debounce

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -12,33 +12,8 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
-
-// snapshotFresherThan and snapshotWithinAge exist so a future-dated snapshot can
-// never read as fresh.
-//
-// Both questions used to be asked with a bare time.Since/Sub comparison, which
-// returns a NEGATIVE duration when the stamp is in the future. Negative
-// satisfies every "< interval" and fails every "> maxAge", so a single
-// future-dated row silently made a provider permanently fresh: its upstream poll
-// was skipped forever, and its stale quota kept counting as evidence. The
-// repository now clamps on write, so these guards are defence in depth for rows
-// that predate the clamp or arrive by another path (a direct database write, a
-// restored backup).
-//
-// Same class of bug, and the same repair, as the fleet rate-limit divisor's
-// staleness check: treat a negative age as untrustworthy rather than as fresh.
-func snapshotFresherThan(now, fetchedAt time.Time, within time.Duration) bool {
-	age := now.Sub(fetchedAt)
-	return age >= 0 && age < within
-}
-
-// snapshotWithinAge reports whether a snapshot is recent enough to be trusted as
-// evidence. A future stamp is not.
-func snapshotWithinAge(now, fetchedAt time.Time, maxAge time.Duration) bool {
-	age := now.Sub(fetchedAt)
-	return age >= 0 && age <= maxAge
-}
 
 // quotaKindFor maps a provider type to the snapshot kind it produces, or
 // ok=false when the type exposes no quota/usage/balance/account endpoint.
@@ -170,8 +145,14 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 		// never worse than standalone.
 		interval := time.Duration(h.settingsRepo.GetInt(ctx, "quota_refresh_interval_min", 5)) * time.Minute
 		if interval > 0 {
-			if snap, _ := h.quotaRepo.Get(ctx, prov.ID, kind); snap != nil && snap.Source == "fleet" && snapshotFresherThan(time.Now(), snap.FetchedAt, interval) {
-				continue
+			// util.TrustedAge: a future-dated row must never read as fresh, or
+			// this member's own poll is skipped forever. The repository clamps
+			// on write; this is defence in depth for a row that predates the
+			// clamp or arrived by another path (a restored backup).
+			if snap, _ := h.quotaRepo.Get(ctx, prov.ID, kind); snap != nil && snap.Source == "fleet" {
+				if age, ok := util.TrustedAge(time.Now(), snap.FetchedAt); ok && age < interval {
+					continue
+				}
 			}
 		}
 
@@ -467,7 +448,9 @@ func buildQuotaAdvice(
 		return advice, recovered
 	}
 	for _, s := range snaps {
-		if !snapshotWithinAge(now, s.FetchedAt, maxAge) {
+		// A snapshot at exactly maxAge is still evidence; a future-dated one
+		// never is (util.TrustedAge).
+		if age, ok := util.TrustedAge(now, s.FetchedAt); !ok || age > maxAge {
 			continue
 		}
 		a := quota.Assess(typeByID[s.ProviderID], s)

--- a/internal/api/quota_staleness_test.go
+++ b/internal/api/quota_staleness_test.go
@@ -1,12 +1,74 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/quota"
 )
+
+// TestPollQuotasOnce_FutureFleetStampDoesNotSuppress pins the negative-age guard
+// at the fleet-skip site. A fleet snapshot dated in the future has a NEGATIVE age,
+// which a raw comparison reads as fresher than any interval, so the member's own
+// poll would be skipped for as long as the stamp stood. The repository clamps a
+// future stamp on write, so the row is aged past the clamp directly, the way a
+// restored backup or a row predating the clamp would arrive.
+func TestPollQuotasOnce_FutureFleetStampDoesNotSuppress(t *testing.T) {
+	h := newTestHandler(t)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-fleet-future", "https://api.nano-gpt.com/v1", true)
+
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{
+		ProviderID: id, Kind: "usage", Payload: json.RawMessage(`{"used":1}`), HTTPStatus: 200, Source: "fleet",
+	}); err != nil {
+		t.Fatalf("seed fleet snapshot: %v", err)
+	}
+	if _, err := h.dbPool.Pool().Exec(context.Background(),
+		`UPDATE provider_quota_snapshots SET fetched_at = $1 WHERE provider_id = $2`, time.Now().Add(48*time.Hour), id); err != nil {
+		t.Fatalf("age the row into the future: %v", err)
+	}
+
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(2) }
+
+	h.PollQuotasOnce(context.Background())
+
+	snap, _ := h.quotaRepo.Get(context.Background(), id, "usage")
+	if snap == nil || snap.Source != "poll" {
+		t.Fatalf("a future-dated fleet snapshot must not suppress the self-poll, got %+v", snap)
+	}
+}
+
+// TestBuildQuotaAdvice_FutureStampIsNotEvidence pins the same guard at the
+// advice site: a future stamp fails every "> maxAge" test and would count as
+// evidence forever.
+func TestBuildQuotaAdvice_FutureStampIsNotEvidence(t *testing.T) {
+	now := time.Now()
+	payload, err := json.Marshal(map[string]any{
+		"data": map[string]any{"limits": []map[string]any{
+			{"type": "TOKENS_LIMIT", "unit": 3, "remaining": 0, "nextResetTime": now.Add(time.Hour).UnixMilli()},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	id := uuid.New()
+
+	got, _ := buildQuotaAdvice(
+		[]quota.Snapshot{{ProviderID: id, Kind: "usage", Payload: payload, FetchedAt: now.Add(48 * time.Hour)}},
+		map[uuid.UUID]string{id: "zai-coding"},
+		15*time.Minute,
+		now,
+	)
+
+	if _, ok := got[id]; ok {
+		t.Error("a future-dated snapshot must not count as evidence; the negative-age guard is missing at this site")
+	}
+}
 
 // TestDriftEligible_FutureStampIsNotEligible pins the negative-age guard at its
 // call site: time.Sub returns a NEGATIVE duration for a future timestamp, which

--- a/internal/api/quota_staleness_test.go
+++ b/internal/api/quota_staleness_test.go
@@ -8,60 +8,10 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
-// TestSnapshotFreshness_FutureStampIsNeverFresh is the bug these guards exist
-// for. time.Since and Sub return a NEGATIVE duration for a future timestamp,
-// which satisfies every "< interval" test and fails every "> maxAge" test, so a
-// single future-dated snapshot made a provider permanently fresh: its upstream
-// poll was skipped forever and its stale quota kept counting as evidence.
-//
-// The same mistake was found and fixed once already in the fleet rate-limit
-// divisor. These cases pin the repair at the two remaining sites.
-func TestSnapshotFreshness_FutureStampIsNeverFresh(t *testing.T) {
-	now := time.Now()
-
-	for _, tc := range []struct {
-		name       string
-		fetchedAt  time.Time
-		wantFresh  bool
-		wantWithin bool
-	}{
-		{"just fetched", now, true, true},
-		{"comfortably recent", now.Add(-1 * time.Minute), true, true},
-		{"older than the window", now.Add(-30 * time.Minute), false, false},
-		{"one second in the future", now.Add(1 * time.Second), false, false},
-		{"far in the future", now.Add(48 * time.Hour), false, false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := snapshotFresherThan(now, tc.fetchedAt, 5*time.Minute); got != tc.wantFresh {
-				t.Errorf("snapshotFresherThan = %v, want %v", got, tc.wantFresh)
-			}
-			if got := snapshotWithinAge(now, tc.fetchedAt, 5*time.Minute); got != tc.wantWithin {
-				t.Errorf("snapshotWithinAge = %v, want %v", got, tc.wantWithin)
-			}
-		})
-	}
-}
-
-// TestSnapshotFreshness_BoundariesUnchanged keeps the guards from quietly
-// shifting the windows they replaced: the dedup check was strictly-less-than and
-// the evidence check kept a snapshot at exactly maxAge.
-func TestSnapshotFreshness_BoundariesUnchanged(t *testing.T) {
-	now := time.Now()
-	const window = 5 * time.Minute
-	atWindow := now.Add(-window)
-
-	if snapshotFresherThan(now, atWindow, window) {
-		t.Error("snapshotFresherThan at exactly the window = true, want false (was <, not <=)")
-	}
-	if !snapshotWithinAge(now, atWindow, window) {
-		t.Error("snapshotWithinAge at exactly maxAge = false, want true (was >, so equal was kept)")
-	}
-}
-
-// TestDriftEligible_FutureStampIsNotEligible pins the guard at its call site
-// rather than only on the helper. driftEligible was the third site with this
-// bug and was missed by the first pass at the fix, so a helper-only test would
-// have gone on passing while the site itself stayed broken.
+// TestDriftEligible_FutureStampIsNotEligible pins the negative-age guard at its
+// call site: time.Sub returns a NEGATIVE duration for a future timestamp, which
+// fails every "> maxAge" test, so a single future-dated snapshot would count as
+// evidence forever. A snapshot at exactly maxAge is kept, as it always was.
 func TestDriftEligible_FutureStampIsNotEligible(t *testing.T) {
 	now := time.Now()
 	const maxAge = 15 * time.Minute
@@ -83,5 +33,11 @@ func TestDriftEligible_FutureStampIsNotEligible(t *testing.T) {
 	future.FetchedAt = now.Add(48 * time.Hour)
 	if driftEligible(future, maxAge, now) {
 		t.Error("a future-dated snapshot is drift-eligible forever; the negative-age guard is missing at this site")
+	}
+
+	atMaxAge := ok
+	atMaxAge.FetchedAt = now.Add(-maxAge)
+	if !driftEligible(atMaxAge, maxAge, now) {
+		t.Error("a snapshot at exactly maxAge should still be eligible (the bound is <=, not <)")
 	}
 }

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -182,7 +182,7 @@ func (a *anthropicResponseWriter) handleStreamLine(line []byte) {
 	// Anthropic translator, so a count the provider spelled differently reaches
 	// it verbatim, and keeping the frame while losing the count told the client
 	// the model produced zero output tokens for a real answer.
-	if err := util.DecodeCounts(payload, &chunk); err != nil && shapeError(payload, err) == nil {
+	if err := util.DecodeCounts(payload, &chunk); err != nil && util.ShapeError(payload, err) == nil {
 		debuglog.Debug("anthropic: skip unparseable upstream chunk", "error", err)
 		return
 	}

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -208,7 +208,7 @@ func parseAccumulatedError(data []byte) string {
 		return ""
 	}
 	if complete {
-		if !util.ErrorMemberCarries(member) {
+		if !util.ValueCarries(member) {
 			return ""
 		}
 		return util.ErrorMemberMessage(member)

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -8,14 +8,6 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-// shapeError is util.ShapeError, kept as a name this package reads well with.
-// The rule moved to util when the egress translators needed it too: four
-// packages deciding separately what "a member I have no struct for" means is
-// how they come to disagree.
-func shapeError(data []byte, decodeErr error) *json.UnmarshalTypeError {
-	return util.ShapeError(data, decodeErr)
-}
-
 // Provider-specific fields that this package does not model must survive the
 // decode/re-encode in handleNonStreamingResponse, because some of them are
 // required on the NEXT request rather than merely informative.
@@ -219,7 +211,7 @@ func (u *Usage) UnmarshalJSON(data []byte) error {
 	type alias Usage
 	var a alias
 	if err := util.DecodeCounts(data, &a); err != nil {
-		if shapeError(data, err) == nil {
+		if util.ShapeError(data, err) == nil {
 			return err
 		}
 		// encoding/json allocates a breakdown's pointer before it reaches the

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -237,7 +237,7 @@ func keepIfObject[T any](data []byte, member string, ptr *T) *T {
 		return nil
 	}
 	// A non-nil pointer means the decoder reached this member, in a document
-	// shapeError has already found to be valid JSON — so data is an object and
+	// util.ShapeError has already found to be valid JSON — so data is an object and
 	// the member is in it. A failure here would leave members nil, and an absent
 	// member reads as a non-object, which is the safe answer anyway.
 	var members map[string]json.RawMessage

--- a/internal/proxy/jsonextras.go
+++ b/internal/proxy/jsonextras.go
@@ -237,9 +237,9 @@ func keepIfObject[T any](data []byte, member string, ptr *T) *T {
 		return nil
 	}
 	// A non-nil pointer means the decoder reached this member, in a document
-	// util.ShapeError has already found to be valid JSON — so data is an object and
-	// the member is in it. A failure here would leave members nil, and an absent
-	// member reads as a non-object, which is the safe answer anyway.
+	// util.ShapeError has already found to be valid JSON — so data is an object
+	// and the member is in it. A failure here would leave members nil, and an
+	// absent member reads as a non-object, which is the safe answer anyway.
 	var members map[string]json.RawMessage
 	_ = json.Unmarshal(data, &members)
 	if trimmed := bytes.TrimSpace(members[member]); len(trimmed) > 0 && trimmed[0] == '{' {

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -275,7 +275,9 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	switch {
 	case r.Context().Err() != nil:
 		// The request was interrupted; nothing here is the provider's doing.
-	case answered:
+	case answered || !servedSuccessStatus(resp.StatusCode):
+		// The provider answered: with content, or with a definitive non-2xx,
+		// which says it is plainly alive.
 		if st.circuitBreakerEnabled {
 			logData.noteBreaker(breakerSuccess)
 			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
@@ -292,12 +294,12 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		// have each chat charge erased by the next embeddings call, and the
 		// circuit would never open. Same argument as the 404 no-op in
 		// breakerRecordAction: recording a success erases real failure history.
-	case !servedSuccessStatus(resp.StatusCode):
-		// A definitive non-2xx: the provider is plainly alive and answered.
-		if st.circuitBreakerEnabled {
-			logData.noteBreaker(breakerSuccess)
-			h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
-		}
+		//
+		// A no-op here and a CHARGE on the chat path (handleNonStreamingResponse)
+		// is deliberate, not drift: an embeddings or image family has no rule
+		// that a success must carry a body, so a 204 proves nothing, while a
+		// chat completion that answers 204 has by definition produced no
+		// completion.
 	default:
 		h.chargeBreaker(st, candidate, resp.StatusCode, "response completed without delivering content")
 	}
@@ -616,7 +618,7 @@ func extractPassthroughUsage(body []byte) (promptTokens, completionTokens int) {
 	// fraction is still a count, and one unreadable member must not cost the
 	// request every count beside it. Metering a served request as zero is quota
 	// the caller never spends.
-	if err := util.DecodeCounts(envelope.Usage, &usage); err != nil && shapeError(envelope.Usage, err) == nil {
+	if err := util.DecodeCounts(envelope.Usage, &usage); err != nil && util.ShapeError(envelope.Usage, err) == nil {
 		return 0, 0
 	}
 	// The fallback stops at the first member the provider SENT, readable or not.

--- a/internal/proxy/multimodal_multipart.go
+++ b/internal/proxy/multimodal_multipart.go
@@ -128,17 +128,18 @@ func newMultipartBodyBuilder(parts []multipartPart) func(string) ([]byte, string
 	}
 }
 
-// multipartPromptFields are the form fields that carry prompt TEXT on the
-// multipart endpoints. "prompt" is the only one: an image edit's prompt is the
-// same string /v1/images/generations sends as JSON, and a transcription's
-// prompt is the context hint the model conditions on.
+// multipartPromptField is the one form field that carries prompt TEXT on the
+// multipart endpoints: an image edit's prompt is the same string
+// /v1/images/generations sends as JSON, and a transcription's prompt is the
+// context hint the model conditions on.
 //
-// An allowlist rather than a denylist, because everything else on these forms is
-// configuration (language, temperature, response_format, size, n, voice,
-// timestamp_granularities) and charging for it would bill the caller for their
-// own options. A denylist gets that wrong by default every time a provider adds
-// a parameter, which is the wrong direction for a billing decision to fail in.
-var multipartPromptFields = map[string]bool{"prompt": true}
+// Named rather than matched by exclusion, because everything else on these
+// forms is configuration (language, temperature, response_format, size, n,
+// voice, timestamp_granularities) and charging for it would bill the caller for
+// their own options. A denylist gets that wrong by default every time a
+// provider adds a parameter, which is the wrong direction for a billing
+// decision to fail in.
+const multipartPromptField = "prompt"
 
 // multipartTextFields returns the text a multipart request carries in its
 // non-file fields, for the content fence: the prompt of an image request and
@@ -165,7 +166,7 @@ func multipartTextFields(parts []multipartPart) []string {
 func multipartPromptTextBytes(parts []multipartPart) int {
 	n := 0
 	for _, p := range parts {
-		if p.fileName != "" || !multipartPromptFields[p.fieldName] {
+		if p.fileName != "" || p.fieldName != multipartPromptField {
 			continue
 		}
 		n += len(p.data)

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -259,6 +259,12 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		// each time, its circuit could never open, and the group would route to
 		// a black hole for ever.
 		//
+		// This CHARGES where the pass-through families make a 204 a breaker
+		// no-op (serveBufferedJSONPassthrough), and the split is deliberate: a
+		// chat completion that answers 204 has by definition produced no
+		// completion, while an embeddings or image family has no rule that a
+		// success must carry a body.
+		//
 		// deliveredContent is not set alongside it: it is already false, and
 		// every site that sets it sits on a terminal path that cannot precede
 		// this branch.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -300,7 +300,7 @@ func (e *emptyStreamError) Error() string {
 // is an error envelope instead of a token, and ok == false for every ordinary
 // frame.
 //
-// Whether the frame is an error is util.ErrorMemberCarries' decision alone (a
+// Whether the frame is an error is util.ValueCarries' decision alone (a
 // populated error member of any shape, including Ollama's bare string; not
 // null/{}/""/[]/false/0, which leave a caller nothing to read). Deciding it a
 // second time here is how the two drift, and either direction is a bug: a miss
@@ -315,7 +315,7 @@ func errorEnvelopeMessage(content string) (msg string, ok bool) {
 		return "", false
 	}
 	raw := envelope["error"]
-	if !util.ErrorMemberCarries(raw) {
+	if !util.ValueCarries(raw) {
 		return "", false
 	}
 	// A bare string, a list, a number, or an object without a "message": render

--- a/internal/proxy/proxy_stream_response.go
+++ b/internal/proxy/proxy_stream_response.go
@@ -361,7 +361,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 	// as it arrived.
 	raw := []byte(payload)
 	decodeErr := json.Unmarshal(raw, &chunk)
-	typeErr := shapeError(raw, decodeErr)
+	typeErr := util.ShapeError(raw, decodeErr)
 	untypeable := typeErr != nil
 	jsonValid := decodeErr == nil || untypeable
 	if jsonValid {
@@ -388,7 +388,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// normalization rebuilds the delta from it, not from payload; a stale
 		// chunk would hand the transform the original text to re-emit.
 		masked := st.masker.maskExact([]byte(payload))
-		// util.ErrorMemberCarries, not the member's mere presence. The regex runs
+		// util.ValueCarries, not the member's mere presence. The regex runs
 		// over the WHOLE frame and can match prose, so on a frame that is not
 		// really an error it would rewrite the model's answer. "error":null
 		// alongside a delta is an ordinary per-frame shape for several relays,
@@ -397,7 +397,7 @@ func (h *Handler) handleDataChunk(sink *streamSink, st *streamState, ev sseEvent
 		// AIza… or a Bearer header mid-stream. That is worse than missing the
 		// third masking layer on a frame whose error member is empty, where the
 		// credential could only be in content the regex must not touch anyway.
-		if util.ErrorMemberCarries(chunk.Error) {
+		if util.ValueCarries(chunk.Error) {
 			// An error frame is error text: every held provider key and the
 			// shape layer, not only the candidate's key the content pass
 			// applied above (a relay's rejection quotes another row's key).

--- a/internal/proxy/stream_observers.go
+++ b/internal/proxy/stream_observers.go
@@ -59,7 +59,7 @@ func (st *streamState) captureSSEError(payload string, lastAnthropicEvent *strin
 		var anthErr struct {
 			Error json.RawMessage `json:"error"`
 		}
-		if json.Unmarshal([]byte(payload), &anthErr) == nil && util.ErrorMemberCarries(anthErr.Error) {
+		if json.Unmarshal([]byte(payload), &anthErr) == nil && util.ValueCarries(anthErr.Error) {
 			msg := util.ErrorMemberMessage(anthErr.Error)
 			st.lastErrMsg = msg
 			anthropicErrorCounted = true
@@ -160,7 +160,7 @@ type streamChunk struct {
 	// here (Ollama's bare string, a list, a number), and a typed field fails the
 	// WHOLE chunk unmarshal, so the frame is dropped as corrupt bytes instead of
 	// forwarded. What the member means is
-	// util.ErrorMemberCarries/ErrorMemberMessage's answer, shared with the probe
+	// util.ValueCarries/ErrorMemberMessage's answer, shared with the probe
 	// so the two readings cannot drift.
 	Error json.RawMessage `json:"error"`
 }
@@ -285,7 +285,7 @@ func (st *streamState) observeDataChunk(chunk streamChunk, anthropicErrorCounted
 		}
 		st.lastContent = currentContent
 	}
-	if !anthropicErrorCounted && util.ErrorMemberCarries(chunk.Error) {
+	if !anthropicErrorCounted && util.ValueCarries(chunk.Error) {
 		// Counted only when P1-C did not already handle this as an Anthropic
 		// error event, which shares the same data line.
 		msg := util.ErrorMemberMessage(chunk.Error)

--- a/internal/proxy/untypeable_frame_test.go
+++ b/internal/proxy/untypeable_frame_test.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -479,32 +478,6 @@ func TestHandleStreamingResponse_StripReasoningDropsUntypeableFrames(t *testing.
 	}
 }
 
-// The inference the forward path rests on — a type error proves the bytes are
-// well-formed — is a property of json.Unmarshal, which validates the whole
-// document before decoding any of it. json.Decoder does not promise it, and
-// GOEXPERIMENT=jsonv2 decodes streaming and so can report a type error on an
-// early member before reaching a syntax error later on.
-//
-// The predicate therefore checks rather than infers. If that guarantee ever goes
-// away this branch keeps dropping truncated bytes instead of forwarding them to
-// callers, which is the whole point of the drop branch existing.
-func TestShapeError_ChecksValidityRatherThanInferringIt(t *testing.T) {
-	t.Parallel()
-	typeErr := &json.UnmarshalTypeError{Value: "number", Field: "choices.0.finish_reason"}
-	if shapeError([]byte(`{"choices":[{"finish_reason":0}]}`), typeErr) == nil {
-		t.Error("a type error on well-formed JSON is an untypeable frame")
-	}
-	if got := shapeError([]byte(`{"choices":[{"finish_reason":0`), typeErr); got != nil {
-		t.Errorf("a type error on truncated bytes must not be forwarded, got %v", got)
-	}
-	if got := shapeError([]byte(`{"choices":[]}`), nil); got != nil {
-		t.Errorf("a clean decode is not an untypeable frame, got %v", got)
-	}
-	if got := shapeError([]byte(`{"choices":[`), &json.SyntaxError{}); got != nil {
-		t.Errorf("a syntax error is not an untypeable frame, got %v", got)
-	}
-}
-
 // A frame whose usage member could not be read leaves chunk.Usage a valid
 // pointer to an all-zero Usage: encoding/json allocates it before it calls the
 // custom unmarshaler. The observer gated on the pointer alone, so such a frame
@@ -839,38 +812,6 @@ func TestHandleStreamingResponse_UnreadableUsageDoesNotCostTheFrame(t *testing.T
 
 			if !strings.Contains(w.Body.String(), "CONTENTMARKER") {
 				t.Errorf("a usage member the gateway could not read cost the caller the answer: %q", w.Body.String())
-			}
-		})
-	}
-}
-
-// The object rule, read directly. A nested custom UnmarshalJSON returns its
-// error with an empty Field, so "does the type error name a member" could not
-// tell a chat frame with an unreadable usage member from a bare number.
-func TestShapeError_RequiresAJSONObject(t *testing.T) {
-	t.Parallel()
-	typeErr := &json.UnmarshalTypeError{Value: "number", Field: "choices.0.finish_reason"}
-	fieldless := &json.UnmarshalTypeError{Value: "array"}
-	for _, tc := range []struct {
-		data string
-		err  error
-		want bool
-	}{
-		{`{"choices":[{"finish_reason":0}]}`, typeErr, true},
-		// An object whose type error names nothing: a nested unmarshaler's.
-		{`{"choices":[{"delta":{"content":"hi"}}],"usage":[]}`, fieldless, true},
-		// Not the document at all.
-		{`[1,2,3]`, fieldless, false},
-		{`"[DONE]"`, fieldless, false},
-		{`42`, fieldless, false},
-		{`null`, fieldless, false},
-		// An object, but not sound bytes.
-		{`{"choices":[`, typeErr, false},
-	} {
-		t.Run(tc.data, func(t *testing.T) {
-			t.Parallel()
-			if got := shapeError([]byte(tc.data), tc.err) != nil; got != tc.want {
-				t.Errorf("shapeError(%s) non-nil = %v, want %v", tc.data, got, tc.want)
 			}
 		})
 	}

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -296,7 +296,7 @@ func maskKeyShapedTokens(body []byte) []byte {
 // "error" member that actually carries something, which is what decides between
 // forwarding that body verbatim and synthesising an envelope over it.
 //
-// util.ErrorMemberCarries holds the rule and documents it: emptiness, not shape,
+// util.ValueCarries holds the rule and documents it: emptiness, not shape,
 // applied at every depth, with `false` and `0` counting as empty like every
 // other zero value. A body that is not a JSON object (an array, a bare string,
 // HTML) can carry no member and reports false.
@@ -305,5 +305,5 @@ func carriesErrorObject(body []byte) bool {
 	if err := json.Unmarshal(body, &envelope); err != nil {
 		return false
 	}
-	return util.ErrorMemberCarries(envelope["error"])
+	return util.ValueCarries(envelope["error"])
 }

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -101,15 +101,25 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 	if dec.Decode(&root) != nil {
 		return nil, false
 	}
-	holder, key, ok := locate(root, path)
+	parent, key, ok := locate(root, path)
 	if !ok {
 		return nil, false
 	}
-	n, ok := asCount(holder.get(key))
-	if !ok {
-		return nil, false
+	switch c := parent.(type) {
+	case map[string]any:
+		n, ok := asCount(c[key])
+		if !ok {
+			return nil, false
+		}
+		c[key] = n
+	case []any:
+		i, _ := strconv.Atoi(key) // locate already validated the index
+		n, ok := asCount(c[i])
+		if !ok {
+			return nil, false
+		}
+		c[i] = n
 	}
-	holder.set(key, n)
 	out, err := json.Marshal(root)
 	if err != nil {
 		return nil, false
@@ -118,19 +128,19 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 }
 
 // locate walks the dotted member path encoding/json reports and returns the
-// container holding the leaf, addressed by a key or an index.
+// object or array holding the leaf, with the key or index that addresses it.
 //
 // The path steps through arrays as well as objects: the decoder writes the index
 // into it, so a count inside a list reads as rows.1.count. A key containing a
 // dot is matched whole before the path is split, which covers it at the level it
 // appears on. A path that does not resolve simply yields no rewrite, and the
 // caller returns the decoder's original error.
-func locate(v any, path string) (container, string, bool) {
+func locate(v any, path string) (any, string, bool) {
 	head, rest, nested := strings.Cut(path, ".")
 	switch v := v.(type) {
 	case map[string]any:
 		if _, exists := v[path]; exists {
-			return objectContainer(v), path, true
+			return v, path, true
 		}
 		if !nested {
 			return nil, "", false
@@ -142,39 +152,11 @@ func locate(v any, path string) (container, string, bool) {
 			return nil, "", false
 		}
 		if !nested {
-			return sliceContainer(v), head, true
+			return v, head, true
 		}
 		return locate(v[i], rest)
 	default:
 		return nil, "", false
-	}
-}
-
-// container is the object or array a located member sits in, read and written
-// by the key or index the path named.
-type container interface {
-	get(key string) any
-	set(key string, v json.Number)
-}
-
-type objectContainer map[string]any
-
-func (c objectContainer) get(key string) any            { return c[key] }
-func (c objectContainer) set(key string, v json.Number) { c[key] = v }
-
-type sliceContainer []any
-
-func (c sliceContainer) get(key string) any {
-	i, err := strconv.Atoi(key)
-	if err != nil || i < 0 || i >= len(c) {
-		return nil
-	}
-	return c[i]
-}
-
-func (c sliceContainer) set(key string, v json.Number) {
-	if i, err := strconv.Atoi(key); err == nil && i >= 0 && i < len(c) {
-		c[i] = v
 	}
 }
 

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -119,6 +119,8 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 			return nil, false
 		}
 		c[i] = n
+	default:
+		return nil, false
 	}
 	out, err := json.Marshal(root)
 	if err != nil {

--- a/internal/util/counts.go
+++ b/internal/util/counts.go
@@ -113,13 +113,18 @@ func coerceCount(data []byte, path string) ([]byte, bool) {
 		}
 		c[key] = n
 	case []any:
-		i, _ := strconv.Atoi(key) // locate already validated the index
+		i, err := strconv.Atoi(key)
+		if err != nil || i < 0 || i >= len(c) {
+			return nil, false
+		}
 		n, ok := asCount(c[i])
 		if !ok {
 			return nil, false
 		}
 		c[i] = n
 	default:
+		// locate yields only the two cases above; anything else is refused
+		// rather than reported as a rewrite.
 		return nil, false
 	}
 	out, err := json.Marshal(root)

--- a/internal/util/errormember.go
+++ b/internal/util/errormember.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 )
 
-// ErrorMemberCarries reports whether the "error" member of a provider payload
-// leaves a client something to read.
+// ValueCarries reports whether a JSON value leaves a reader anything at all.
+// Its first job is the "error" member of a provider payload: does it leave a
+// client something to read.
 //
 // The test is emptiness, not shape. What a provider puts inside its error is
 // not a gateway's to judge, so any populated value counts: an object with
@@ -33,21 +34,14 @@ import (
 // forwarder, and the native Anthropic passthrough. They read the same bytes, so
 // a second opinion is only ever a way for them to disagree, and the disagreement
 // costs a hedged race to a provider whose failure is then never recorded.
-func ErrorMemberCarries(raw json.RawMessage) bool {
-	return ValueCarries(raw)
-}
-
-// ValueCarries is the emptiness rule above, without the error-member framing:
-// does this JSON value leave a reader anything at all?
 //
-// The streaming path asks it of a delta's members too. A reasoning marker a
-// relay stamps on every non-reasoning frame ("reasoning":"" or
+// The streaming path asks the same question of a delta's members. A reasoning
+// marker a relay stamps on every non-reasoning frame ("reasoning":"" or
 // "reasoning_details":[]) is present without carrying anything, and a rule that
 // read presence dropped the answer beside it on every frame; and a member that
-// carries nothing is not output, so it must not be metered as delivery.
-//
-// Same rule, deliberately: a second reading of "is there anything here" is only
-// ever a way for two callers to disagree.
+// carries nothing is not output, so it must not be metered as delivery. One
+// rule, deliberately: a second reading of "is there anything here" is only ever
+// a way for two callers to disagree.
 func ValueCarries(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false

--- a/internal/util/errormember_test.go
+++ b/internal/util/errormember_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
-func TestErrorMemberCarries(t *testing.T) {
+func TestValueCarries(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		member string
@@ -45,8 +45,8 @@ func TestErrorMemberCarries(t *testing.T) {
 	} {
 		t.Run(tc.member, func(t *testing.T) {
 			t.Parallel()
-			if got := util.ErrorMemberCarries(json.RawMessage(tc.member)); got != tc.want {
-				t.Errorf("ErrorMemberCarries(%s) = %v, want %v", tc.member, got, tc.want)
+			if got := util.ValueCarries(json.RawMessage(tc.member)); got != tc.want {
+				t.Errorf("ValueCarries(%s) = %v, want %v", tc.member, got, tc.want)
 			}
 		})
 	}
@@ -73,15 +73,15 @@ func TestErrorMemberMessage(t *testing.T) {
 
 // encoding/json caps nesting while decoding, so the recursion is bounded before
 // it is ever entered. This is the depth that cap allows.
-func TestErrorMemberCarries_DeepNesting(t *testing.T) {
+func TestValueCarries_DeepNesting(t *testing.T) {
 	t.Parallel()
 	const depth = 9000
 	deep := strings.Repeat(`[`, depth) + `"boom"` + strings.Repeat(`]`, depth)
-	if !util.ErrorMemberCarries(json.RawMessage(deep)) {
+	if !util.ValueCarries(json.RawMessage(deep)) {
 		t.Error("a value nested to the decoder's limit must still be read")
 	}
 	empty := strings.Repeat(`[`, depth) + strings.Repeat(`]`, depth)
-	if util.ErrorMemberCarries(json.RawMessage(empty)) {
+	if util.ValueCarries(json.RawMessage(empty)) {
 		t.Error("nesting alone is not something to read")
 	}
 }


### PR DESCRIPTION
## Summary

A behaviour-preserving cleanup of duplication found while reviewing the 2026-08-27 to 08-30 batch (#798 to #830). No functional change intended; net -197 lines.

- **One Anthropic usage reader.** `internal/anthropic` and `internal/anthropicegress` each carried two copies of the same twelve-line per-figure usage decode, plus their own usage struct and `promptAddends`. Now one exported `anthropic.ReadUsage` and `anthropic.Usage`; anthropicegress imports anthropic (no cycle: anthropic depends only on util/egress/jsonfault).
- **Quota staleness uses `util.TrustedAge`.** The two hand-rolled negative-age guards in `internal/api/quota_snapshot.go` predate the util helper from #800 and were never migrated. The three call sites now call `util.TrustedAge` inline with the exact same bounds (`< interval` for the fleet-skip check, `<= maxAge` for the evidence checks).
- **Aliases removed.** `util.ErrorMemberCarries` was a one-line alias of `util.ValueCarries`; `proxy.shapeError` was a one-line alias of `util.ShapeError`. Callers use the one name. Two proxy tests that duplicated util's `TestShapeError` table go with the alias.
- **`util.DecodeCounts`**: the `container` interface with two implementations becomes a type switch in `coerceCount`.
- **`multipartPromptFields`** one-entry map becomes a named constant.
- **Pass-through breaker switch**: two arms with identical bodies merged into one (`answered || !servedSuccessStatus`); ordering preserved, a 204 cannot reach the merged arm.

### 204/205 breaker policy

The chat path charges the breaker on a bodiless success (a chat completion that answers 204 has produced no completion); the pass-through families make it a no-op (an embeddings or image family has no rule that a success must carry a body). Both behaviours are kept exactly as they were. The two comments used to read as if one side had drifted; they now state the split and why, cross-referencing each other.

## Verification

- `go build ./...`, `go vet`, `golangci-lint run` clean; `make size-check` passes.
- `go test`: util + anthropic + anthropicegress (875), proxy (2275), api quota scope against the 5433 test DB (117), all green.
- Every changed production line is covered (checked via `-coverprofile` on the touched packages).
- Two adversarial review rounds; their findings are the three follow-up commits (call-site future-stamp tests, `UsageBlock` naming, coerced-index bounds check).
- Rebuilt dev stack and exercised the touched paths live: Anthropic-dialect chat (streaming + non-streaming) with usage metered, `/v1/messages` ingress, an embeddings pass-through, and a quota poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuxqVM8WBVagaLF18cXqrQ
