### PR TITLE
fix(proxy): turn an image request size into the aspect ratio xAI accepts

### DIFF
--- a/internal/paramrewrite/image.go
+++ b/internal/paramrewrite/image.go
@@ -9,40 +9,46 @@ import (
 )
 
 // RewriteImageRequest adapts an OpenAI-shaped /v1/images/generations body to
-// what the provider's image endpoint accepts. Today that is xAI only: its
-// image API has no "size" and answers 400 "Argument not supported: size" to
-// any request carrying one, which the OpenAI SDKs and open-webui send by
-// default. The dimensions are kept as the aspect_ratio xAI does accept when
-// they reduce to one of its ratios, and dropped otherwise (xAI then picks its
-// own default, which is still an image rather than a refusal). A body that
-// does not parse is forwarded as it came, like every other rewriter here.
-func RewriteImageRequest(body []byte, providerType string) []byte {
+// what a provider TYPE's image API accepts; like the other type-keyed rewrites
+// here it cannot tell a relay behind that type apart from the real endpoint.
+// Today that is xAI only: its image API has no "size" and answers 400
+// "Argument not supported: size" to any request carrying one, which the OpenAI
+// SDKs and open-webui send by default. The dimensions are kept as the
+// aspect_ratio the grok-imagine family accepts when they reduce to one of its
+// ratios, and dropped otherwise (xAI then picks its own default, which is
+// still an image rather than a refusal). The older grok-2-image models take
+// neither member, so for them the size is only dropped. A body that does not
+// parse is forwarded as it came, like every other rewriter here. It reports
+// the aspect_ratio it chose, empty when none was set, for the caller's log.
+func RewriteImageRequest(body []byte, providerType, modelID string) ([]byte, string) {
 	if providerType != "xai" {
-		return body
+		return body, ""
 	}
 	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	var raw map[string]any
 	if dec.Decode(&raw) != nil {
-		return body
+		return body, ""
 	}
 	size, present := raw["size"]
 	if !present {
-		return body
+		return body, ""
 	}
 	delete(raw, "size")
-	if s, ok := size.(string); ok {
+	chosen := ""
+	if s, ok := size.(string); ok && strings.Contains(modelID, "imagine") {
 		if _, has := raw["aspect_ratio"]; !has {
 			if ratio, ok := xaiAspectRatio(s); ok {
 				raw["aspect_ratio"] = ratio
+				chosen = ratio
 			}
 		}
 	}
 	out, err := json.Marshal(raw)
 	if err != nil {
-		return body
+		return body, ""
 	}
-	return out
+	return out, chosen
 }
 
 // xaiAspectRatios are the aspect_ratio values xAI's image API documents.

--- a/internal/paramrewrite/image.go
+++ b/internal/paramrewrite/image.go
@@ -1,0 +1,84 @@
+package paramrewrite
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// RewriteImageRequest adapts an OpenAI-shaped /v1/images/generations body to
+// what the provider's image endpoint accepts. Today that is xAI only: its
+// image API has no "size" and answers 400 "Argument not supported: size" to
+// any request carrying one, which the OpenAI SDKs and open-webui send by
+// default. The dimensions are kept as the aspect_ratio xAI does accept when
+// they reduce to one of its ratios, and dropped otherwise (xAI then picks its
+// own default, which is still an image rather than a refusal). A body that
+// does not parse is forwarded as it came, like every other rewriter here.
+func RewriteImageRequest(body []byte, providerType string) []byte {
+	if providerType != "xai" {
+		return body
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var raw map[string]any
+	if dec.Decode(&raw) != nil {
+		return body
+	}
+	size, present := raw["size"]
+	if !present {
+		return body
+	}
+	delete(raw, "size")
+	if s, ok := size.(string); ok {
+		if _, has := raw["aspect_ratio"]; !has {
+			if ratio, ok := xaiAspectRatio(s); ok {
+				raw["aspect_ratio"] = ratio
+			}
+		}
+	}
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// xaiAspectRatios are the aspect_ratio values xAI's image API documents.
+var xaiAspectRatios = []string{"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "2:1", "1:2", "19.5:9", "9:19.5", "20:9", "9:20", "21:9", "5:2"}
+
+// xaiAspectRatioTolerance is how far a WxH size may sit from a documented
+// ratio and still be read as it. DALL-E's 1792x1024 is 1.75 against 16:9's
+// 1.78, so the OpenAI sizes need a few percent of slack; anything further off
+// is a size this table cannot honestly stand in for.
+const xaiAspectRatioTolerance = 0.03
+
+// xaiAspectRatio maps an OpenAI "WxH" size to the nearest documented xAI
+// aspect_ratio, reporting false for "auto", a malformed size, or one that no
+// documented ratio approximates.
+func xaiAspectRatio(size string) (string, bool) {
+	w, h, ok := strings.Cut(strings.ToLower(strings.TrimSpace(size)), "x")
+	if !ok {
+		return "", false
+	}
+	wf, errW := strconv.ParseFloat(w, 64)
+	hf, errH := strconv.ParseFloat(h, 64)
+	if errW != nil || errH != nil || wf <= 0 || hf <= 0 {
+		return "", false
+	}
+	want := wf / hf
+	best, bestDiff := "", math.Inf(1)
+	for _, r := range xaiAspectRatios {
+		a, b, _ := strings.Cut(r, ":")
+		af, _ := strconv.ParseFloat(a, 64)
+		bf, _ := strconv.ParseFloat(b, 64)
+		if diff := math.Abs(want-af/bf) / (af / bf); diff < bestDiff {
+			best, bestDiff = r, diff
+		}
+	}
+	if bestDiff > xaiAspectRatioTolerance {
+		return "", false
+	}
+	return best, true
+}

--- a/internal/paramrewrite/image.go
+++ b/internal/paramrewrite/image.go
@@ -3,6 +3,7 @@ package paramrewrite
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -17,38 +18,44 @@ import (
 // aspect_ratio the grok-imagine family accepts when they reduce to one of its
 // ratios, and dropped otherwise (xAI then picks its own default, which is
 // still an image rather than a refusal). The older grok-2-image models take
-// neither member, so for them the size is only dropped. A body that does not
-// parse is forwarded as it came, like every other rewriter here. It reports
-// the aspect_ratio it chose, empty when none was set, for the caller's log.
-func RewriteImageRequest(body []byte, providerType, modelID string) ([]byte, string) {
+// neither member, so for them both are dropped. A body that does not parse is
+// forwarded as it came, like every other rewriter here. It reports the size it
+// dropped and the aspect_ratio it chose, each empty when nothing happened, so
+// the caller can log every body it changed.
+func RewriteImageRequest(body []byte, providerType, modelID string) (out []byte, droppedSize, chosenRatio string) {
 	if providerType != "xai" {
-		return body, ""
+		return body, "", ""
 	}
 	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	var raw map[string]any
 	if dec.Decode(&raw) != nil {
-		return body, ""
+		return body, "", ""
 	}
-	size, present := raw["size"]
-	if !present {
-		return body, ""
+	imagine := strings.Contains(strings.ToLower(modelID), "imagine")
+	size, hasSize := raw["size"]
+	_, hasRatio := raw["aspect_ratio"]
+	if !hasSize && (imagine || !hasRatio) {
+		return body, "", ""
 	}
-	delete(raw, "size")
-	chosen := ""
-	if s, ok := size.(string); ok && strings.Contains(modelID, "imagine") {
-		if _, has := raw["aspect_ratio"]; !has {
+	if hasSize {
+		delete(raw, "size")
+		droppedSize = fmt.Sprint(size)
+		if s, ok := size.(string); ok && imagine && !hasRatio {
 			if ratio, ok := xaiAspectRatio(s); ok {
 				raw["aspect_ratio"] = ratio
-				chosen = ratio
+				chosenRatio = ratio
 			}
 		}
 	}
+	if !imagine {
+		delete(raw, "aspect_ratio")
+	}
 	out, err := json.Marshal(raw)
 	if err != nil {
-		return body, ""
+		return body, "", ""
 	}
-	return out, chosen
+	return out, droppedSize, chosenRatio
 }
 
 // xaiAspectRatios are the aspect_ratio values xAI's image API documents.

--- a/internal/paramrewrite/image_test.go
+++ b/internal/paramrewrite/image_test.go
@@ -1,0 +1,83 @@
+package paramrewrite
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// xAI's image API rejects "size" outright, so a request carrying one is
+// rewritten into the aspect_ratio it does accept, or has the size dropped
+// when no documented ratio stands in for it.
+func TestRewriteImageRequest_XAISizeBecomesAspectRatio(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		body      string
+		wantRatio string // "" means no aspect_ratio member
+	}{
+		{"square", `{"model":"grok-imagine-image","prompt":"p","size":"1024x1024"}`, "1:1"},
+		{"dall-e landscape", `{"model":"m","prompt":"p","size":"1792x1024"}`, "16:9"},
+		{"dall-e portrait", `{"model":"m","prompt":"p","size":"1024x1792"}`, "9:16"},
+		{"gpt-image landscape", `{"model":"m","prompt":"p","size":"1536x1024"}`, "3:2"},
+		{"gpt-image portrait", `{"model":"m","prompt":"p","size":"1024x1536"}`, "2:3"},
+		{"auto", `{"model":"m","prompt":"p","size":"auto"}`, ""},
+		{"garbage", `{"model":"m","prompt":"p","size":"large"}`, ""},
+		{"zero height", `{"model":"m","prompt":"p","size":"1024x0"}`, ""},
+		{"ratio nothing documented approximates", `{"model":"m","prompt":"p","size":"1000x1150"}`, ""},
+		{"not a string", `{"model":"m","prompt":"p","size":1024}`, ""},
+		{"caller already chose a ratio", `{"model":"m","prompt":"p","size":"1024x1024","aspect_ratio":"16:9"}`, "16:9"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := RewriteImageRequest([]byte(tc.body), "xai")
+			var got map[string]any
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("rewritten body is not JSON: %v: %s", err, out)
+			}
+			if _, has := got["size"]; has {
+				t.Errorf("size survived the rewrite: %s", out)
+			}
+			ratio, _ := got["aspect_ratio"].(string)
+			if ratio != tc.wantRatio {
+				t.Errorf("aspect_ratio = %q, want %q (body %s)", ratio, tc.wantRatio, out)
+			}
+			if got["prompt"] != "p" || got["model"] == nil {
+				t.Errorf("unrelated members disturbed: %s", out)
+			}
+		})
+	}
+}
+
+// Nothing else is touched: another provider's body, a body with no size, and
+// bytes that do not parse all come back exactly as they went in.
+func TestRewriteImageRequest_LeavesEverythingElseAlone(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, body, providerType string
+	}{
+		{"openai keeps size", `{"model":"dall-e-3","prompt":"p","size":"1024x1024"}`, "openai"},
+		{"xai without size", `{"model":"m","prompt":"p","n":2}`, "xai"},
+		{"xai unparseable", `{"model":"m","prompt":"p","size":"1024x1024"`, "xai"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(RewriteImageRequest([]byte(tc.body), tc.providerType)); got != tc.body {
+				t.Errorf("body changed:\ngot  %s\nwant %s", got, tc.body)
+			}
+		})
+	}
+}
+
+// Numbers ride through with the literal the caller wrote, the way the model
+// rewriter keeps them: a rewritten body must not turn n:1 into 1.0 or lose
+// precision on a seed.
+func TestRewriteImageRequest_KeepsNumberLiterals(t *testing.T) {
+	t.Parallel()
+	out := RewriteImageRequest([]byte(`{"model":"m","prompt":"p","size":"1024x1024","n":1,"seed":9007199254740993}`), "xai")
+	for _, want := range []string{`"n":1`, `"seed":9007199254740993`} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("rewritten body lost %s: %s", want, out)
+		}
+	}
+}

--- a/internal/paramrewrite/image_test.go
+++ b/internal/paramrewrite/image_test.go
@@ -12,25 +12,27 @@ import (
 func TestRewriteImageRequest_XAISizeBecomesAspectRatio(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name      string
-		body      string
-		wantRatio string // "" means no aspect_ratio member
+		name        string
+		body        string
+		wantRatio   string // "" means no aspect_ratio member
+		wantChosen  string // what the rewrite reports it SET
+		wantDropped string
 	}{
-		{"square", `{"model":"grok-imagine-image","prompt":"p","size":"1024x1024"}`, "1:1"},
-		{"dall-e landscape", `{"model":"m","prompt":"p","size":"1792x1024"}`, "16:9"},
-		{"dall-e portrait", `{"model":"m","prompt":"p","size":"1024x1792"}`, "9:16"},
-		{"gpt-image landscape", `{"model":"m","prompt":"p","size":"1536x1024"}`, "3:2"},
-		{"gpt-image portrait", `{"model":"m","prompt":"p","size":"1024x1536"}`, "2:3"},
-		{"auto", `{"model":"m","prompt":"p","size":"auto"}`, ""},
-		{"garbage", `{"model":"m","prompt":"p","size":"large"}`, ""},
-		{"zero height", `{"model":"m","prompt":"p","size":"1024x0"}`, ""},
-		{"ratio nothing documented approximates", `{"model":"m","prompt":"p","size":"1000x1150"}`, ""},
-		{"not a string", `{"model":"m","prompt":"p","size":1024}`, ""},
-		{"caller already chose a ratio", `{"model":"m","prompt":"p","size":"1024x1024","aspect_ratio":"16:9"}`, "16:9"},
+		{"square", `{"model":"grok-imagine-image","prompt":"p","size":"1024x1024"}`, "1:1", "1:1", "1024x1024"},
+		{"dall-e landscape", `{"model":"m","prompt":"p","size":"1792x1024"}`, "16:9", "16:9", "1792x1024"},
+		{"dall-e portrait", `{"model":"m","prompt":"p","size":"1024x1792"}`, "9:16", "9:16", "1024x1792"},
+		{"gpt-image landscape", `{"model":"m","prompt":"p","size":"1536x1024"}`, "3:2", "3:2", "1536x1024"},
+		{"gpt-image portrait", `{"model":"m","prompt":"p","size":"1024x1536"}`, "2:3", "2:3", "1024x1536"},
+		{"auto", `{"model":"m","prompt":"p","size":"auto"}`, "", "", "auto"},
+		{"garbage", `{"model":"m","prompt":"p","size":"large"}`, "", "", "large"},
+		{"zero height", `{"model":"m","prompt":"p","size":"1024x0"}`, "", "", "1024x0"},
+		{"ratio nothing documented approximates", `{"model":"m","prompt":"p","size":"1000x1150"}`, "", "", "1000x1150"},
+		{"not a string", `{"model":"m","prompt":"p","size":1024}`, "", "", "1024"},
+		{"caller already chose a ratio", `{"model":"m","prompt":"p","size":"1024x1024","aspect_ratio":"16:9"}`, "16:9", "", "1024x1024"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			out, chosen := RewriteImageRequest([]byte(tc.body), "xai", "grok-imagine-image")
+			out, dropped, chosen := RewriteImageRequest([]byte(tc.body), "xai", "Grok-Imagine-Image")
 			var got map[string]any
 			if err := json.Unmarshal(out, &got); err != nil {
 				t.Fatalf("rewritten body is not JSON: %v: %s", err, out)
@@ -42,14 +44,8 @@ func TestRewriteImageRequest_XAISizeBecomesAspectRatio(t *testing.T) {
 			if ratio != tc.wantRatio {
 				t.Errorf("aspect_ratio = %q, want %q (body %s)", ratio, tc.wantRatio, out)
 			}
-			// The reported choice is what the rewrite SET, so a ratio the
-			// caller sent themselves is not reported as chosen.
-			wantChosen := tc.wantRatio
-			if strings.Contains(tc.body, "aspect_ratio") {
-				wantChosen = ""
-			}
-			if chosen != wantChosen {
-				t.Errorf("chosen = %q, want %q", chosen, wantChosen)
+			if chosen != tc.wantChosen || dropped != tc.wantDropped {
+				t.Errorf("reported chosen %q dropped %q, want %q %q", chosen, dropped, tc.wantChosen, tc.wantDropped)
 			}
 			if got["prompt"] != "p" || got["model"] == nil {
 				t.Errorf("unrelated members disturbed: %s", out)
@@ -71,9 +67,9 @@ func TestRewriteImageRequest_LeavesEverythingElseAlone(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			out, chosen := RewriteImageRequest([]byte(tc.body), tc.providerType, "grok-imagine-image")
-			if got := string(out); got != tc.body || chosen != "" {
-				t.Errorf("body changed (chosen %q):\ngot  %s\nwant %s", chosen, got, tc.body)
+			out, dropped, chosen := RewriteImageRequest([]byte(tc.body), tc.providerType, "grok-imagine-image")
+			if got := string(out); got != tc.body || chosen != "" || dropped != "" {
+				t.Errorf("body changed (dropped %q chosen %q):\ngot  %s\nwant %s", dropped, chosen, got, tc.body)
 			}
 		})
 	}
@@ -84,7 +80,7 @@ func TestRewriteImageRequest_LeavesEverythingElseAlone(t *testing.T) {
 // precision on a seed.
 func TestRewriteImageRequest_KeepsNumberLiterals(t *testing.T) {
 	t.Parallel()
-	out, _ := RewriteImageRequest([]byte(`{"model":"m","prompt":"p","size":"1024x1024","n":1,"seed":9007199254740993}`), "xai", "grok-imagine-image")
+	out, _, _ := RewriteImageRequest([]byte(`{"model":"m","prompt":"p","size":"1024x1024","n":1,"seed":9007199254740993}`), "xai", "grok-imagine-image")
 	for _, want := range []string{`"n":1`, `"seed":9007199254740993`} {
 		if !strings.Contains(string(out), want) {
 			t.Errorf("rewritten body lost %s: %s", want, out)
@@ -93,12 +89,23 @@ func TestRewriteImageRequest_KeepsNumberLiterals(t *testing.T) {
 }
 
 // The older grok-2-image models take neither size nor aspect_ratio, so for
-// them the size is dropped and nothing is put in its place: injecting the
-// ratio would only trade one "Argument not supported" for another.
-func TestRewriteImageRequest_Grok2ImageOnlyDropsSize(t *testing.T) {
+// them both are dropped and nothing is put in their place: injecting the ratio
+// would only trade one "Argument not supported" for another, and a ratio the
+// caller sent would draw the same refusal.
+func TestRewriteImageRequest_Grok2ImageDropsBothMembers(t *testing.T) {
 	t.Parallel()
-	out, chosen := RewriteImageRequest([]byte(`{"model":"grok-2-image-1212","prompt":"p","size":"1792x1024"}`), "xai", "grok-2-image-1212")
-	if strings.Contains(string(out), "size") || strings.Contains(string(out), "aspect_ratio") || chosen != "" {
-		t.Errorf("want size dropped and no aspect_ratio, got %s (chosen %q)", out, chosen)
+	for _, body := range []string{
+		`{"model":"grok-2-image-1212","prompt":"p","size":"1792x1024"}`,
+		`{"model":"grok-2-image-1212","prompt":"p","aspect_ratio":"16:9"}`,
+		`{"model":"grok-2-image-1212","prompt":"p","size":"1792x1024","aspect_ratio":"16:9"}`,
+	} {
+		out, _, chosen := RewriteImageRequest([]byte(body), "xai", "grok-2-image-1212")
+		if strings.Contains(string(out), "size") || strings.Contains(string(out), "aspect_ratio") || chosen != "" {
+			t.Errorf("want size and aspect_ratio dropped, got %s (chosen %q)", out, chosen)
+		}
+	}
+	out, dropped, _ := RewriteImageRequest([]byte(`{"model":"grok-2-image-1212","prompt":"p","n":1}`), "xai", "grok-2-image-1212")
+	if string(out) != `{"model":"grok-2-image-1212","prompt":"p","n":1}` || dropped != "" {
+		t.Errorf("a body with neither member must pass untouched, got %s", out)
 	}
 }

--- a/internal/paramrewrite/image_test.go
+++ b/internal/paramrewrite/image_test.go
@@ -30,7 +30,7 @@ func TestRewriteImageRequest_XAISizeBecomesAspectRatio(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			out := RewriteImageRequest([]byte(tc.body), "xai")
+			out, chosen := RewriteImageRequest([]byte(tc.body), "xai", "grok-imagine-image")
 			var got map[string]any
 			if err := json.Unmarshal(out, &got); err != nil {
 				t.Fatalf("rewritten body is not JSON: %v: %s", err, out)
@@ -41,6 +41,15 @@ func TestRewriteImageRequest_XAISizeBecomesAspectRatio(t *testing.T) {
 			ratio, _ := got["aspect_ratio"].(string)
 			if ratio != tc.wantRatio {
 				t.Errorf("aspect_ratio = %q, want %q (body %s)", ratio, tc.wantRatio, out)
+			}
+			// The reported choice is what the rewrite SET, so a ratio the
+			// caller sent themselves is not reported as chosen.
+			wantChosen := tc.wantRatio
+			if strings.Contains(tc.body, "aspect_ratio") {
+				wantChosen = ""
+			}
+			if chosen != wantChosen {
+				t.Errorf("chosen = %q, want %q", chosen, wantChosen)
 			}
 			if got["prompt"] != "p" || got["model"] == nil {
 				t.Errorf("unrelated members disturbed: %s", out)
@@ -62,8 +71,9 @@ func TestRewriteImageRequest_LeavesEverythingElseAlone(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := string(RewriteImageRequest([]byte(tc.body), tc.providerType)); got != tc.body {
-				t.Errorf("body changed:\ngot  %s\nwant %s", got, tc.body)
+			out, chosen := RewriteImageRequest([]byte(tc.body), tc.providerType, "grok-imagine-image")
+			if got := string(out); got != tc.body || chosen != "" {
+				t.Errorf("body changed (chosen %q):\ngot  %s\nwant %s", chosen, got, tc.body)
 			}
 		})
 	}
@@ -74,10 +84,21 @@ func TestRewriteImageRequest_LeavesEverythingElseAlone(t *testing.T) {
 // precision on a seed.
 func TestRewriteImageRequest_KeepsNumberLiterals(t *testing.T) {
 	t.Parallel()
-	out := RewriteImageRequest([]byte(`{"model":"m","prompt":"p","size":"1024x1024","n":1,"seed":9007199254740993}`), "xai")
+	out, _ := RewriteImageRequest([]byte(`{"model":"m","prompt":"p","size":"1024x1024","n":1,"seed":9007199254740993}`), "xai", "grok-imagine-image")
 	for _, want := range []string{`"n":1`, `"seed":9007199254740993`} {
 		if !strings.Contains(string(out), want) {
 			t.Errorf("rewritten body lost %s: %s", want, out)
 		}
+	}
+}
+
+// The older grok-2-image models take neither size nor aspect_ratio, so for
+// them the size is dropped and nothing is put in its place: injecting the
+// ratio would only trade one "Argument not supported" for another.
+func TestRewriteImageRequest_Grok2ImageOnlyDropsSize(t *testing.T) {
+	t.Parallel()
+	out, chosen := RewriteImageRequest([]byte(`{"model":"grok-2-image-1212","prompt":"p","size":"1792x1024"}`), "xai", "grok-2-image-1212")
+	if strings.Contains(string(out), "size") || strings.Contains(string(out), "aspect_ratio") || chosen != "" {
+		t.Errorf("want size dropped and no aspect_ratio, got %s (chosen %q)", out, chosen)
 	}
 }

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -1717,3 +1717,46 @@ func TestImageGenerations_SSEPassthroughMasksSplitErrorFrame(t *testing.T) {
 		t.Errorf("masked stream mismatch:\ngot  %q\nwant %q", got, want)
 	}
 }
+
+// xAI's image API has no "size" and refuses a request carrying one, which the
+// OpenAI SDKs and open-webui send by default. On an xai-typed provider the
+// pass-through hands upstream the aspect_ratio xAI accepts instead; on every
+// other provider the size goes through untouched.
+func TestImageGenerations_XAISizeBecomesAspectRatio(t *testing.T) {
+	var gotBody atomic.Value
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"created":1,"data":[{"url":"https://x/img.png"}]}`)
+	})
+	for _, tc := range []struct {
+		providerType string
+		wantSize     bool
+		wantRatio    string
+	}{
+		{"xai", false, "16:9"},
+		{"openai", true, ""},
+	} {
+		t.Run(tc.providerType, func(t *testing.T) {
+			env := newMultimodalEnvTyped(t, upstream, `["image"]`, tc.providerType, "")
+			body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat","size":"1792x1024"}`, env.providerName, env.modelName)
+			req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			env.handler.ImageGenerations(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+			}
+			sent, _ := gotBody.Load().(string)
+			if strings.Contains(sent, `"size"`) != tc.wantSize {
+				t.Errorf("upstream body size present = %v, want %v: %s", !tc.wantSize, tc.wantSize, sent)
+			}
+			if tc.wantRatio != "" && !strings.Contains(sent, `"aspect_ratio":"`+tc.wantRatio+`"`) {
+				t.Errorf("upstream body lacks aspect_ratio %s: %s", tc.wantRatio, sent)
+			}
+			if tc.wantRatio == "" && strings.Contains(sent, "aspect_ratio") {
+				t.Errorf("aspect_ratio invented for %s: %s", tc.providerType, sent)
+			}
+		})
+	}
+}

--- a/internal/proxy/multimodal_passthrough_test.go
+++ b/internal/proxy/multimodal_passthrough_test.go
@@ -1740,7 +1740,17 @@ func TestImageGenerations_XAISizeBecomesAspectRatio(t *testing.T) {
 	} {
 		t.Run(tc.providerType, func(t *testing.T) {
 			env := newMultimodalEnvTyped(t, upstream, `["image"]`, tc.providerType, "")
-			body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat","size":"1792x1024"}`, env.providerName, env.modelName)
+			// The ratio is put on the grok-imagine family only, so the model
+			// under test carries that name on both providers.
+			const modelID = "grok-imagine-image"
+			if err := model.NewRepository(testDB.Pool()).Upsert(context.Background(), &model.Model{
+				ID: uuid.New(), ProviderID: env.providerID, ModelID: modelID, Name: modelID,
+				Capabilities: "{}", Params: "{}", InputModalities: "[]", OutputModalities: `["image"]`,
+				Enabled: true, ProviderName: env.providerName, ProviderEnabled: true,
+			}); err != nil {
+				t.Fatalf("create model: %v", err)
+			}
+			body := fmt.Sprintf(`{"model":"%s/%s","prompt":"a cat","size":"1792x1024"}`, env.providerName, modelID)
 			req := env.request("/v1/images/generations", "application/json", strings.NewReader(body))
 			w := httptest.NewRecorder()
 			env.handler.ImageGenerations(w, req)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -581,10 +581,10 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 		// 400 to the "size" the OpenAI SDKs send by default. Adapted here, the
 		// one place both are known.
 		if logData.endpointType == endpointTypeImage && contentType == "application/json" {
-			var ratio string
-			upstreamBody, ratio = paramrewrite.RewriteImageRequest(upstreamBody, providerType, candidate.model.ModelID)
-			if ratio != "" {
-				debuglog.Debug("proxy: image size rewritten to aspect ratio", "provider_type", providerType, "model", candidate.model.ModelID, "aspect_ratio", ratio)
+			var droppedSize, ratio string
+			upstreamBody, droppedSize, ratio = paramrewrite.RewriteImageRequest(upstreamBody, providerType, candidate.model.ModelID)
+			if droppedSize != "" {
+				debuglog.Debug("proxy: image size rewritten for the provider", "provider_type", providerType, "resolved_model", candidate.model.ModelID, "dropped_size", droppedSize, "aspect_ratio", ratio)
 			}
 		}
 	} else {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -576,6 +576,14 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 		if err != nil {
 			return nil, providerType, targetURL, err
 		}
+		// The body builder knows the model but not the provider, and an image
+		// request carries parameters not every image API accepts: xAI answers
+		// 400 to the "size" the OpenAI SDKs send by default. Adapted here, the
+		// one place both are known, for every image attempt (the retirement
+		// probe's included).
+		if logData.endpointType == endpointTypeImage && contentType == "application/json" {
+			upstreamBody = paramrewrite.RewriteImageRequest(upstreamBody, providerType)
+		}
 	} else {
 		needsRewrite := st.reqModel != candidate.model.ModelID || isAnthropicFamily(providerType) || paramrewrite.NeedsProviderInjection(providerType) || st.isStreaming
 		debuglog.Debug("proxy: request rewrite check", "needs_rewrite", needsRewrite, "request_model", logData.modelID, "provider", logData.providerName, "resolved_model", candidate.model.ModelID, "provider_type", providerType)

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -579,10 +579,13 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 		// The body builder knows the model but not the provider, and an image
 		// request carries parameters not every image API accepts: xAI answers
 		// 400 to the "size" the OpenAI SDKs send by default. Adapted here, the
-		// one place both are known, for every image attempt (the retirement
-		// probe's included).
+		// one place both are known.
 		if logData.endpointType == endpointTypeImage && contentType == "application/json" {
-			upstreamBody = paramrewrite.RewriteImageRequest(upstreamBody, providerType)
+			var ratio string
+			upstreamBody, ratio = paramrewrite.RewriteImageRequest(upstreamBody, providerType, candidate.model.ModelID)
+			if ratio != "" {
+				debuglog.Debug("proxy: image size rewritten to aspect ratio", "provider_type", providerType, "model", candidate.model.ModelID, "aspect_ratio", ratio)
+			}
 		}
 	} else {
 		needsRewrite := st.reqModel != candidate.model.ModelID || isAnthropicFamily(providerType) || paramrewrite.NeedsProviderInjection(providerType) || st.isStreaming


### PR DESCRIPTION
## Summary

xAI's image API has no `size` parameter and answers `400 Argument not supported: size` to any request carrying one. The OpenAI SDKs and open-webui send `size` by default, so through the gateway every such request to `grok-imagine-image` failed with the provider's 400 forwarded as-is. The image pass-through has no parameter self-heal (the chat path's learn-and-strip is wired into `attemptCandidate` only), and the chat path's param reader would not recognise the field anyway. Found by the 2026-09-02 fleet sweep, which only passes because the sweep tool itself retries without `size`.

Prior art: [open-webui #23611](https://github.com/open-webui/open-webui/issues/23611); xAI's [image generation docs](https://docs.x.ai/developers/model-capabilities/images/generation) list `aspect_ratio` (1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 2:1, 1:2, 19.5:9, 9:19.5, 20:9, 9:20, 21:9, 5:2) and no `size`.

## Change

- `paramrewrite.RewriteImageRequest(body, providerType, modelID)`: on an `xai`-typed provider, drops `size`; for the grok-imagine family sets `aspect_ratio` to the nearest documented ratio within 3% of the requested WxH (1792x1024 to 16:9, 1024x1792 to 9:16, 1536x1024 to 3:2, 1024x1536 to 2:3, 1024x1024 to 1:1) unless the caller already sent one; a size no ratio approximates is dropped so xAI picks its own default. The older grok-2-image models take neither member, so both are dropped there. Number literals are preserved (UseNumber). Every other provider type is untouched.
- Applied at the one upstream-body build site that knows both the endpoint family and the provider type (`proxy_failover.go`), gated on the image family and a JSON content type (multipart edits never reach it), with a debug line naming the dropped size and chosen ratio whenever the body changed.

Not in this PR, queued: a general learned param self-heal for the pass-through families (xAI also rejects `style`, `background`, `moderation`, `output_format`; every image provider has its own list). That is a design item in its own right, not a one-provider fix.

## Verification

- Unit table for the rewrite (mappings, `auto`, garbage, zero height, non-string, caller-chosen ratio, grok-2 both members, untouched bodies, number literals) and a DB-backed pass-through test asserting the upstream request body for `xai` vs `openai`.
- `go build`, `go vet`, `golangci-lint`, `make size-check` clean; all changed production lines covered except the unreachable marshal-error return.
- Two adversarial review rounds; their findings are the two follow-up commits and the test fix.
- Live on the rebuilt dev stack against real xAI: `size` 1024x1024, 1792x1024 and 1024x1792 all 200 (they were 400 before); the landscape request came back 1280x720 and the portrait 720x1280, so the mapped ratio is honoured upstream, not merely accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuxqVM8WBVagaLF18cXqrQ
