### PR TITLE
fix(web): group the quota modal toggle and refresh buttons, gap before close

### DIFF
--- a/web/src/components/modals/shared.tsx
+++ b/web/src/components/modals/shared.tsx
@@ -117,11 +117,11 @@ export function QuotaModalHeaderActions({
 	const { uiStyle } = useTheme();
 
 	return (
-		<div className="flex items-center gap-2">
+		<div className="absolute top-4 right-16 flex items-center gap-1">
 			<button
 				type="button"
 				onClick={() => onToggleBarMode()}
-				className="ui-icon-btn absolute top-4 right-20 p-1.5"
+				className="ui-icon-btn p-1.5"
 				aria-label={toggleAriaLabel}
 				title={toggleTitle}
 			>
@@ -131,7 +131,7 @@ export function QuotaModalHeaderActions({
 				type="button"
 				onClick={onRefresh}
 				disabled={isRefreshing}
-				className="ui-icon-btn absolute top-4 right-10 p-1.5"
+				className="ui-icon-btn p-1.5"
 				aria-label={refreshAriaLabel}
 				title={refreshTitle}
 			>


### PR DESCRIPTION
## What

Regroups the icons in the top-right of every provider quota modal (OpenRouter, NanoGPT, NeuralWatt, MiniMax, Kimi Code, Z.ai Coding).

Before: `[toggle]  ····  [refresh][close]`
After: `[toggle][refresh]  ····  [close]`

## How

The toggle and refresh buttons in the shared `QuotaModalHeaderActions` were each absolutely positioned at their own fixed offset (`right-20` / `right-10`), which put the toggle far from refresh and refresh nearly on top of the close button. The wrapper is now positioned once (`absolute top-4 right-16`) and the two buttons sit in a normal flex row with `gap-1`, leaving the larger gap before the modal's close button.

## Testing

- `pnpm lint`, Biome, and the modals + Providers vitest suites pass (349 tests).
- Rebuilt the dev stack and screenshotted the OpenRouter quota modal header to confirm the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaXFmvpikfDbrh45zC7gtv
