### PR TITLE
fix(virtualkeys,web): widen the key preview tail, show the full audit entity id

### DIFF
--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -339,8 +339,11 @@ func TestCreateVirtualKey_Success(t *testing.T) {
 	if resp.Key == "" {
 		t.Error("expected key to be returned on creation")
 	}
-	if resp.KeyPreview == "" {
-		t.Error("expected key_preview to be set")
+	// The preview is the "sk-" prefix plus the key's last four characters,
+	// the same tail width the provider card shows; checked against the
+	// returned key so a wrong slice offset cannot pass on shape alone.
+	if want := "sk-..." + resp.Key[len(resp.Key)-4:]; resp.KeyPreview != want {
+		t.Errorf("key_preview = %q, want %q", resp.KeyPreview, want)
 	}
 }
 

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -381,7 +381,11 @@ func (h *Handler) CreateVirtualKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyHash := virtualkey.Hash(rawKey)
-	keyPreview := rawKey[:3] + "..." + rawKey[len(rawKey)-2:]
+	// The "sk-" prefix and the last four characters: the same four-character
+	// tail the provider card shows (provider.MaskAPIKey), since two characters
+	// left too many keys reading alike to tell apart. The key is stored hashed,
+	// so a key issued before the tail widened keeps its old preview.
+	keyPreview := rawKey[:3] + "..." + rawKey[len(rawKey)-4:]
 
 	vk, err := h.virtualKeyRepo.Create(r.Context(), req.Name, keyHash, keyPreview, req.RateLimitRPS, req.RateLimitBurst, req.RateLimitTPM, req.AllowedProviders, req.StripReasoning, owner)
 	if err != nil {

--- a/web/src/pages/Audit/__tests__/Audit.test.tsx
+++ b/web/src/pages/Audit/__tests__/Audit.test.tsx
@@ -97,11 +97,15 @@ describe("Audit page", () => {
 		expect(screen.getByText("DELETE")).toBeInTheDocument();
 		expect(screen.getByText("204")).toBeInTheDocument();
 		expect(screen.getByText("192.168.7.9:4242")).toBeInTheDocument();
-		// Unresolved entity falls back to the truncated UUID; a resolved one
-		// shows its current display name instead.
-		expect(screen.getByText("11111111…")).toBeInTheDocument();
+		// Unresolved entity falls back to its full UUID (the cell clips it, the
+		// markup does not); a resolved one shows its current display name instead.
+		expect(
+			screen.getByText("11111111-2222-4333-8444-555555555555"),
+		).toBeInTheDocument();
 		expect(screen.getByText("gpt-nice-name")).toBeInTheDocument();
-		expect(screen.queryByText("22222222…")).not.toBeInTheDocument();
+		expect(
+			screen.queryByText("22222222-2222-4333-8444-555555555555"),
+		).not.toBeInTheDocument();
 	});
 
 	it("opens the detail modal on row click", async () => {
@@ -131,7 +135,8 @@ describe("Audit page", () => {
 		await user.click(await screen.findByText("/api/models/{id}"));
 		const dialog = await screen.findByRole("dialog");
 		expect(dialog).toHaveTextContent("Audit Entry");
-		// Full path and UUID appear in the modal (the table truncates both).
+		// Full path and UUID appear in the modal; the table shows the route and
+		// the resolved name.
 		expect(dialog).toHaveTextContent(
 			"/api/models/33333333-2222-4333-8444-555555555555",
 		);

--- a/web/src/pages/Audit/index.tsx
+++ b/web/src/pages/Audit/index.tsx
@@ -247,14 +247,15 @@ export function Audit() {
 										>
 											{e.route}
 										</td>
-										{/* Resolved name when the entity still exists; its UUID
-										   (truncated) as the fallback trace when it does not. */}
+										{/* Resolved name when the entity still exists; its full UUID
+										   as the fallback trace when it does not. The cell clips
+										   with an ellipsis only once the column runs out of room. */}
 										<td className="px-4 py-3 text-sm text-gray-400 truncate">
 											{e.entity_name ? (
 												<span title={e.entity_id}>{e.entity_name}</span>
 											) : e.entity_id ? (
 												<span className="font-mono" title={e.entity_id}>
-													{e.entity_id.slice(0, 8)}…
+													{e.entity_id}
 												</span>
 											) : (
 												"—"

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -823,7 +823,7 @@ This endpoint is **deliberately API only: there is no UI control for it, by deci
   {
     "id": "uuid",
     "name": "Production Key",
-    "key_preview": "sk-...ab",
+    "key_preview": "sk-...c5d6",
     "tokens_used": 123456,
     "last_used_at": "2024-01-01T00:00:00Z",
     "created_at": "2024-01-01T00:00:00Z",
@@ -867,7 +867,7 @@ This endpoint is **deliberately API only: there is no UI control for it, by deci
   "id": "uuid",
   "name": "Production Key",
   "key": "sk-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
-  "key_preview": "sk-...d6",
+  "key_preview": "sk-...c5d6",
   "tokens_used": 0,
   "last_used_at": null,
   "created_at": "2024-01-01T00:00:00Z",

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -55,7 +55,7 @@ Virtual keys use the `sk-` prefix (e.g., `sk-a1b2c3d4e5f6a7b8`) and are stored a
 - The raw key is shown **once** on creation, then discarded - it is never stored in plaintext
 - Only the SHA-256 hash is persisted in the `virtual_keys` table
 - Lookup compares SHA-256 of the provided Bearer token against the stored hash
-- A key preview (`sk-...01`) is stored for display purposes in the UI
+- A key preview (`sk-...ef01`) is stored for display purposes in the UI
 
 ### Admin Token
 

--- a/wiki/Virtual-Keys.md
+++ b/wiki/Virtual-Keys.md
@@ -58,8 +58,8 @@ func Generate() (string, error) {
 
 The `key_preview` field stores a human-readable identifier for the key:
 
-- **Format**: First 3 characters (including `sk-` prefix) + `...` + last 2 characters
-- **Example**: `sk-a1b2c3d4e5f6789012345678abcdef01` → `sk-...01`
+- **Format**: First 3 characters (including `sk-` prefix) + `...` + last 4 characters
+- **Example**: `sk-a1b2c3d4e5f6789012345678abcdef01` → `sk-...ef01`
 - **Purpose**: UI identification without exposing the full key
 - **Storage**: Stored in plaintext alongside the hash in the `virtual_keys` table
 
@@ -188,7 +188,7 @@ CREATE INDEX IF NOT EXISTS idx_virtual_keys_key_hash ON virtual_keys(key_hash);
 | `id` | `UUID` | PRIMARY KEY, DEFAULT `gen_random_uuid()` | Unique identifier |
 | `name` | `TEXT` | NOT NULL | Human-readable name (1-100 chars, printable) |
 | `key_hash` | `TEXT` | NOT NULL, UNIQUE | SHA-256 hash (64 hex characters) |
-| `key_preview` | `TEXT` | NOT NULL | First 3 + last 2 chars (e.g., `sk-...01`) |
+| `key_preview` | `TEXT` | NOT NULL | First 3 + last 4 chars (e.g., `sk-...ef01`) |
 | `tokens_used` | `BIGINT` | NOT NULL, DEFAULT 0 | Cumulative token count (prompt + completion) |
 | `last_used_at` | `TIMESTAMPTZ` | NULLABLE | Last authentication timestamp |
 | `created_at` | `TIMESTAMPTZ` | DEFAULT `now()` | Creation timestamp |
@@ -253,7 +253,7 @@ These are reserved because they conflict with built-in URL paths.
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "name": "production-app",
   "key": "sk-a1b2c3d4e5f6789012345678abcdef01",
-  "key_preview": "sk-...01",
+  "key_preview": "sk-...ef01",
   "tokens_used": 0,
   "last_used_at": null,
   "created_at": "2025-01-15T10:30:00Z",
@@ -278,7 +278,7 @@ These are reserved because they conflict with built-in URL paths.
     "id": "550e8400-e29b-41d4-a716-446655440000",
     "name": "production-app",
     "key": "",
-    "key_preview": "sk-...01",
+    "key_preview": "sk-...ef01",
     "tokens_used": 125000,
     "last_used_at": "2025-01-15T14:22:00Z",
     "created_at": "2025-01-15T10:30:00Z",
@@ -290,7 +290,7 @@ These are reserved because they conflict with built-in URL paths.
     "id": "660e8400-e29b-41d4-a716-446655440001",
     "name": "dev-testing",
     "key": "",
-    "key_preview": "sk-...ab",
+    "key_preview": "sk-...9fab",
     "tokens_used": 4500,
     "last_used_at": null,
     "created_at": "2025-01-14T08:15:00Z",
@@ -313,7 +313,7 @@ Note: `key` is always empty string in list/get responses. `rate_limit_*` fields 
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "name": "production-app",
   "key": "",
-  "key_preview": "sk-...01",
+  "key_preview": "sk-...ef01",
   "tokens_used": 125000,
   "last_used_at": "2025-01-15T14:22:00Z",
   "created_at": "2025-01-15T10:30:00Z",
@@ -343,7 +343,7 @@ Note: `key` is always empty string in list/get responses. `rate_limit_*` fields 
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "name": "production-app-v2",
   "key": "",
-  "key_preview": "sk-...01",
+  "key_preview": "sk-...ef01",
   "tokens_used": 125000,
   "last_used_at": "2025-01-15T14:22:00Z",
   "created_at": "2025-01-15T10:30:00Z",
@@ -564,7 +564,7 @@ console.log(response.choices[0].message.content);
 |----------|---------------|
 | **Storage** | SHA-256 hash only - raw key never persisted |
 | **Key format** | `sk-` + 32 hex chars (128 bits entropy) |
-| **Key preview** | First 3 + last 2 chars stored as `key_preview` (e.g., `sk-...01`) |
+| **Key preview** | First 3 + last 4 chars stored as `key_preview` (e.g., `sk-...ef01`) |
 | **Deletion** | Permanent - `DELETE` removes key entirely |
 | **Per-key tracking** | Token usage logged per virtual key |
 | **Rate limiting** | Independent token bucket per key |


### PR DESCRIPTION
## What

- **Virtual key preview** now stores `sk-` plus the last four characters of the key, the same tail width the provider card shows since #891. Two characters left too many keys reading alike. Keys are stored hashed, so a key issued before this keeps its old preview until it is reissued; no backfill is possible.
- **Audit table entity column** renders the full entity id instead of cutting it to eight characters. The cell already truncates with an ellipsis in a fixed-layout table, so the id is clipped only when the column actually runs out of room.
- Wiki examples updated to the wider tail.

## Not changed

`POST /api/discovery/dismiss` stays in the audit trail. It stamps `discovery_dismissed_at` on models, a real state change; the bursts of rows come from "Dismiss everything" fanning out one request per provider.

## Verification

- Go: the create-key test now checks the preview tail against the returned key.
- Vitest: Audit page test expects the full id.
- Dev stack rebuilt from this branch; a fresh key shows `sk-...3129` beside the older two-character previews, and the audit column shows full ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCs6zxZ2UmdoeDFh8mj9bx
