### PR TITLE
fix(discovery,audit): name the provider on a dismiss or unpin audit row

### DIFF
--- a/internal/api/configsync_apply_models.go
+++ b/internal/api/configsync_apply_models.go
@@ -190,7 +190,7 @@ func (h *ConfigSyncHandler) applyDisabledModels(ctx context.Context, refs []Expo
 // reset with the pin because a pin held past the disable threshold leaves a mature
 // streak behind, and clearing the stamp alone would disable the model on its very
 // next scan instead of giving it the same grace an unpinned model gets (the same
-// rule POST /discovery/unpin follows).
+// rule POST /discovery/{provider_id}/unpin follows).
 //
 // Both directions re-zero missing_scans on every import, which is why a member's
 // own discrepancy modal rarely lists its pinned rows: listClaimRows reports a pin

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -81,8 +81,11 @@ func (h *Handler) RegisterProviderDiscovery(r chi.Router) {
 		r.Post("/ack", h.AckDiscoveryChanges)
 	})
 	r.Get("/discovery/status", h.GetDiscoveryStatus)
-	r.Post("/discovery/dismiss", h.DismissDiscoveryClaims)
-	r.Post("/discovery/unpin", h.UnpinDiscoveryClaims)
+	// The provider rides in the path, not the body, so the audit trail can
+	// name it: a modal-wide verdict fans out one call per provider, and rows
+	// without an entity read as identical.
+	r.Post("/discovery/{provider_id}/dismiss", h.DismissDiscoveryClaims)
+	r.Post("/discovery/{provider_id}/unpin", h.UnpinDiscoveryClaims)
 }
 
 // settingKeyDiscoveryLastReviewed marks when the operator last opened the

--- a/internal/api/discovery_dismiss.go
+++ b/internal/api/discovery_dismiss.go
@@ -3,10 +3,12 @@ package api
 import (
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
-// DismissDiscoveryClaimsRequest carries the models to dismiss on one provider.
+// DismissDiscoveryClaimsRequest carries the models to dismiss on the provider
+// named in the path.
 //
 // Dismiss-only, deliberately: there is no un-dismiss direction. A dismissal
 // self-heals, because models.Upsert clears discovery_dismissed_at on any
@@ -24,8 +26,7 @@ import (
 // preserve-the-dismissal rule around a stamp nothing could clear. Still no
 // endpoint needed.
 type DismissDiscoveryClaimsRequest struct {
-	ProviderID string   `json:"provider_id"`
-	ModelIDs   []string `json:"model_ids"`
+	ModelIDs []string `json:"model_ids"`
 }
 
 // DismissDiscoveryClaims stamps the operator dismissal for models on one
@@ -38,13 +39,13 @@ type DismissDiscoveryClaimsRequest struct {
 // ack it sits beside, this suppresses a real discrepancy from every operator's
 // view, which is a genuine state change.
 func (h *Handler) DismissDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
-	var req DismissDiscoveryClaimsRequest
-	if !decodeJSON(w, r, &req) {
-		return
-	}
-	providerID, err := uuid.Parse(req.ProviderID)
+	providerID, err := uuid.Parse(chi.URLParam(r, "provider_id"))
 	if err != nil {
 		http.Error(w, "invalid provider ID", http.StatusBadRequest)
+		return
+	}
+	var req DismissDiscoveryClaimsRequest
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if len(req.ModelIDs) == 0 {
@@ -68,9 +69,10 @@ func (h *Handler) DismissDiscoveryClaims(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, map[string]any{"dismissed": dismissed, "updated": len(dismissed)})
 }
 
-// UnpinDiscoveryClaimsRequest carries the models to unpin on one provider. It is
-// shaped exactly like DismissDiscoveryClaimsRequest because it is the same kind
-// of operation from the modal's side: a bulk verdict on a provider's rows.
+// UnpinDiscoveryClaimsRequest carries the models to unpin on the provider named
+// in the path. It is shaped exactly like DismissDiscoveryClaimsRequest because
+// it is the same kind of operation from the modal's side: a bulk verdict on a
+// provider's rows.
 //
 // Unpin-only, like dismiss, and for a matching reason: the pin direction is not
 // an endpoint. A pin is armed by the operator enabling the model
@@ -80,8 +82,7 @@ func (h *Handler) DismissDiscoveryClaims(w http.ResponseWriter, r *http.Request)
 // the operator changing their mind about a model the provider still does not
 // list, where there is nothing to enable and no sighting coming.
 type UnpinDiscoveryClaimsRequest struct {
-	ProviderID string   `json:"provider_id"`
-	ModelIDs   []string `json:"model_ids"`
+	ModelIDs []string `json:"model_ids"`
 }
 
 // UnpinDiscoveryClaims drops the operator pin from models on one provider,
@@ -99,13 +100,13 @@ type UnpinDiscoveryClaimsRequest struct {
 // Deliberately NOT added to httpx.IsReadOnlyExemptPost: it hands a model back to
 // automatic management, which is a genuine state change.
 func (h *Handler) UnpinDiscoveryClaims(w http.ResponseWriter, r *http.Request) {
-	var req UnpinDiscoveryClaimsRequest
-	if !decodeJSON(w, r, &req) {
-		return
-	}
-	providerID, err := uuid.Parse(req.ProviderID)
+	providerID, err := uuid.Parse(chi.URLParam(r, "provider_id"))
 	if err != nil {
 		http.Error(w, "invalid provider ID", http.StatusBadRequest)
+		return
+	}
+	var req UnpinDiscoveryClaimsRequest
+	if !decodeJSON(w, r, &req) {
 		return
 	}
 	if len(req.ModelIDs) == 0 {

--- a/internal/api/discovery_failure_test.go
+++ b/internal/api/discovery_failure_test.go
@@ -186,8 +186,8 @@ func TestDismissDiscoveryClaims_RejectsMalformedRequests(t *testing.T) {
 	providerID := seedClaimProvider(t, pool, "dismiss-malformed", true)
 	seedClaimModel(t, pool, providerID, "gone-model", false, false, 0, nil)
 
-	post := func(body string) int {
-		req := httptest.NewRequest(http.MethodPost, "/discovery/dismiss", strings.NewReader(body))
+	post := func(provider, body string) int {
+		req := httptest.NewRequest(http.MethodPost, "/discovery/"+provider+"/dismiss", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -195,24 +195,24 @@ func TestDismissDiscoveryClaims_RejectsMalformedRequests(t *testing.T) {
 		return rec.Code
 	}
 
-	if code := post(`{"provider_id": not json at all`); code != http.StatusBadRequest {
+	if code := post(providerID.String(), `{"model_ids": not json at all`); code != http.StatusBadRequest {
 		t.Errorf("undecodable body = %d, want 400", code)
 	}
-	if code := post(`{"provider_id":"nanogpt","model_ids":["gone-model"]}`); code != http.StatusBadRequest {
+	if code := post("nanogpt", `{"model_ids":["gone-model"]}`); code != http.StatusBadRequest {
 		t.Errorf("non-UUID provider_id = %d, want 400 (not 404: the request was never understood)", code)
 	}
 
 	// Anchor: an otherwise identical, well-formed request succeeds against the
 	// same fixture, so the 400s above are the validation firing rather than the
 	// endpoint rejecting everything.
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["gone-model"]}`, providerID)); code != http.StatusOK {
+	if code := post(providerID.String(), `{"model_ids":["gone-model"]}`); code != http.StatusOK {
 		t.Fatalf("well-formed dismiss = %d, want 200", code)
 	}
 }
 
 // TestUnpinDiscoveryClaims_RejectsMalformedRequests mirrors
 // TestDismissDiscoveryClaims_RejectsMalformedRequests for the unpin endpoint's
-// twin validation: an undecodable body and a non-UUID provider_id are both 400,
+// twin validation: an undecodable body and a non-UUID provider path are both 400,
 // and neither reaches the database, for the same 400-vs-404 reason as dismiss.
 func TestUnpinDiscoveryClaims_RejectsMalformedRequests(t *testing.T) {
 	h, r := newTestHandlerWithRouter(t)
@@ -221,8 +221,8 @@ func TestUnpinDiscoveryClaims_RejectsMalformedRequests(t *testing.T) {
 	seedClaimModel(t, pool, providerID, "held-model", true, false, 1, nil)
 	pinClaimModel(t, pool, providerID, "held-model")
 
-	post := func(body string) int {
-		req := httptest.NewRequest(http.MethodPost, "/discovery/unpin", strings.NewReader(body))
+	post := func(provider, body string) int {
+		req := httptest.NewRequest(http.MethodPost, "/discovery/"+provider+"/unpin", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -230,17 +230,17 @@ func TestUnpinDiscoveryClaims_RejectsMalformedRequests(t *testing.T) {
 		return rec.Code
 	}
 
-	if code := post(`{"provider_id": not json at all`); code != http.StatusBadRequest {
+	if code := post(providerID.String(), `{"model_ids": not json at all`); code != http.StatusBadRequest {
 		t.Errorf("undecodable body = %d, want 400", code)
 	}
-	if code := post(`{"provider_id":"nanogpt","model_ids":["held-model"]}`); code != http.StatusBadRequest {
+	if code := post("nanogpt", `{"model_ids":["held-model"]}`); code != http.StatusBadRequest {
 		t.Errorf("non-UUID provider_id = %d, want 400 (not 404: the request was never understood)", code)
 	}
 
 	// Anchor: an otherwise identical, well-formed request succeeds against the
 	// same fixture, so the 400s above are the validation firing rather than the
 	// endpoint rejecting everything.
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["held-model"]}`, providerID)); code != http.StatusOK {
+	if code := post(providerID.String(), `{"model_ids":["held-model"]}`); code != http.StatusOK {
 		t.Fatalf("well-formed unpin = %d, want 200", code)
 	}
 }
@@ -261,8 +261,8 @@ func TestDismissDiscoveryClaims_DatabaseFailureIs500(t *testing.T) {
 
 	h.dbPool = closedAPIPool(t)
 
-	body := fmt.Sprintf(`{"provider_id":%q,"model_ids":["gone-model"]}`, providerID)
-	req := httptest.NewRequest(http.MethodPost, "/discovery/dismiss", strings.NewReader(body))
+	body := `{"model_ids":["gone-model"]}`
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/dismiss", providerID), strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/internal/api/discovery_status_test.go
+++ b/internal/api/discovery_status_test.go
@@ -324,8 +324,8 @@ func TestDismissDiscoveryClaims_RemovesClaim(t *testing.T) {
 		t.Fatalf("before dismiss, claims = %v, want [doomed]", ids)
 	}
 
-	body := fmt.Sprintf(`{"provider_id":%q,"model_ids":["doomed"]}`, providerID)
-	req := httptest.NewRequest(http.MethodPost, "/discovery/dismiss", strings.NewReader(body))
+	body := `{"model_ids":["doomed"]}`
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/dismiss", providerID), strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -345,7 +345,7 @@ func TestDismissDiscoveryClaims_UnknownModel(t *testing.T) {
 	providerID := seedClaimProvider(t, h.dbPool.Pool(), "dismiss-unknown", true)
 
 	post := func(body string) int {
-		req := httptest.NewRequest(http.MethodPost, "/discovery/dismiss", strings.NewReader(body))
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/dismiss", providerID), strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -360,11 +360,11 @@ func TestDismissDiscoveryClaims_UnknownModel(t *testing.T) {
 	// the route is live before the 404 below is trusted to mean "no matching
 	// model" rather than "no matching route". This does not touch the store
 	// layer at all, so it does not duplicate TestSetModelsDismissed.
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":[]}`, providerID)); code != http.StatusBadRequest {
+	if code := post(`{"model_ids":[]}`); code != http.StatusBadRequest {
 		t.Fatalf("empty model_ids = %d, want 400 (anchor: proves the route is mounted)", code)
 	}
 
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["not-a-model"]}`, providerID)); code != http.StatusNotFound {
+	if code := post(`{"model_ids":["not-a-model"]}`); code != http.StatusNotFound {
 		t.Errorf("unknown model = %d, want 404", code)
 	}
 }
@@ -386,16 +386,16 @@ func TestDismissDiscoveryClaims_SuspectModelNotDismissible(t *testing.T) {
 	seedClaimModel(t, pool, providerID, "wobbling", true, false, 1, nil)
 
 	// Anchor 1: proves the seeded row is genuinely in suspect state, via
-	// GET /discovery/status. This does NOT prove POST /discovery/dismiss is
-	// mounted — that route and the status route are independently registered
-	// (discovery.go:73-74), so a status-route-only check cannot catch a
-	// missing dismiss route.
+	// GET /discovery/status. This does NOT prove POST
+	// /discovery/{provider_id}/dismiss is mounted — that route and the status
+	// route are independently registered, so a status-route-only check cannot
+	// catch a missing dismiss route.
 	if claim := findClaim(t, getStatus(t, r, "/discovery/status"), "wobbling"); claim.State != ClaimStateSuspect {
 		t.Fatalf("wobbling state = %q, want %q before the dismiss attempt", claim.State, ClaimStateSuspect)
 	}
 
 	post := func(body string) int {
-		req := httptest.NewRequest(http.MethodPost, "/discovery/dismiss", strings.NewReader(body))
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/dismiss", providerID), strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -406,14 +406,14 @@ func TestDismissDiscoveryClaims_SuspectModelNotDismissible(t *testing.T) {
 	// Anchor 2: mirrors TestDismissDiscoveryClaims_UnknownModel's pattern. An
 	// empty model_ids list only yields 400 once the request reaches the
 	// handler's own validation; an unmounted route 404s before that code
-	// runs. This proves POST /discovery/dismiss is live before the 404 below
+	// runs. This proves POST /discovery/{provider_id}/dismiss is live before the 404 below
 	// is trusted to mean "suspect model correctly rejected" rather than
 	// "route not mounted".
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":[]}`, providerID)); code != http.StatusBadRequest {
+	if code := post(`{"model_ids":[]}`); code != http.StatusBadRequest {
 		t.Fatalf("empty model_ids = %d, want 400 (anchor: proves the route is mounted)", code)
 	}
 
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["wobbling"]}`, providerID)); code != http.StatusNotFound {
+	if code := post(`{"model_ids":["wobbling"]}`); code != http.StatusNotFound {
 		t.Errorf("dismiss suspect model = %d, want 404", code)
 	}
 
@@ -450,8 +450,8 @@ func TestUnpinDiscoveryClaims_ClearsPin(t *testing.T) {
 		t.Fatalf("held state = %q, want %q before the unpin", claim.State, ClaimStatePinned)
 	}
 
-	body := fmt.Sprintf(`{"provider_id":%q,"model_ids":["held"]}`, providerID)
-	req := httptest.NewRequest(http.MethodPost, "/discovery/unpin", strings.NewReader(body))
+	body := `{"model_ids":["held"]}`
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/unpin", providerID), strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -506,7 +506,7 @@ func TestUnpinDiscoveryClaims_UnknownModel(t *testing.T) {
 	seedClaimModel(t, pool, providerID, "never-pinned", true, false, 1, nil)
 
 	post := func(body string) int {
-		req := httptest.NewRequest(http.MethodPost, "/discovery/unpin", strings.NewReader(body))
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/discovery/%s/unpin", providerID), strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer test-admin-token")
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -518,13 +518,13 @@ func TestUnpinDiscoveryClaims_UnknownModel(t *testing.T) {
 	// validation, which only runs once the request reaches UnpinDiscoveryClaims.
 	// An unmounted route would 404 before that, so this proves the 404s below
 	// mean "no matching model" rather than "no matching route".
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":[]}`, providerID)); code != http.StatusBadRequest {
+	if code := post(`{"model_ids":[]}`); code != http.StatusBadRequest {
 		t.Fatalf("empty model_ids = %d, want 400 (anchor: proves the route is mounted)", code)
 	}
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["not-a-model"]}`, providerID)); code != http.StatusNotFound {
+	if code := post(`{"model_ids":["not-a-model"]}`); code != http.StatusNotFound {
 		t.Errorf("unknown model = %d, want 404", code)
 	}
-	if code := post(fmt.Sprintf(`{"provider_id":%q,"model_ids":["never-pinned"]}`, providerID)); code != http.StatusNotFound {
+	if code := post(`{"model_ids":["never-pinned"]}`); code != http.StatusNotFound {
 		t.Errorf("unpinned model = %d, want 404", code)
 	}
 }

--- a/internal/audit/resolve.go
+++ b/internal/audit/resolve.go
@@ -31,15 +31,48 @@ var entityKinds = map[string]entityKind{
 	"users":           {"users", "username"},
 }
 
-// entityKindOf returns the route segment following /api/, or "" when the
-// route pattern is not under /api.
+// paramKinds maps a spelled-out URL parameter to the family it names, for
+// routes that act on a provider from outside its own family: a circuit-breaker
+// reset, a discovery verdict.
+var paramKinds = map[string]string{"provider_id": "providers"}
+
+// entityKindOf returns the family whose id the route's entity is, or "" when
+// the route pattern is not under /api. It follows the rule the middleware
+// uses to pick the entity: a plain {id} first, otherwise the last spelled-out
+// parameter. A spelled-out parameter paramKinds knows names its family; any
+// other falls back to the route's first segment, which is right for a
+// same-family route and at worst resolves nothing.
 func entityKindOf(route string) string {
 	rest, ok := strings.CutPrefix(route, "/api/")
 	if !ok {
 		return ""
 	}
 	seg, _, _ := strings.Cut(rest, "/")
+	if strings.Contains(rest, "{id}") {
+		return seg
+	}
+	if name := lastSpelledParam(rest); name != "" {
+		if kind, ok := paramKinds[name]; ok {
+			return kind
+		}
+	}
 	return seg
+}
+
+// lastSpelledParam returns the name of the last {..._id} or {..._uuid}
+// parameter in a route pattern, the one the middleware records, or "".
+func lastSpelledParam(rest string) string {
+	segs := strings.Split(rest, "/")
+	for i := len(segs) - 1; i >= 0; i-- {
+		name, ok := strings.CutPrefix(segs[i], "{")
+		if !ok {
+			continue
+		}
+		if name, ok = strings.CutSuffix(name, "}"); ok && (strings.HasSuffix(name, "_id") || strings.HasSuffix(name, "_uuid")) {
+			return name
+		}
+	}
+	return ""
 }
 
 // ResolveEntityNames fills EntityName on entries whose entity still exists,

--- a/internal/audit/resolve_test.go
+++ b/internal/audit/resolve_test.go
@@ -13,8 +13,19 @@ func TestEntityKindOf(t *testing.T) {
 		"/api/failover-groups/{id}": "failover-groups",
 		"/api/users/{id}/password":  "users",
 		"/api/settings":             "settings",
-		"/models/{id}":              "", // unmounted pattern is not the real route
-		"":                          "",
+		// A spelled-out parameter names its own family, so a provider acted on
+		// from another route still resolves to its name.
+		"/api/discovery/{provider_id}/dismiss":                     "providers",
+		"/api/failover-groups/circuit-breaker/{provider_id}/reset": "providers",
+		// A plain {id} wins over a spelled-out parameter beside it.
+		"/api/failover-groups/{id}/circuit-breaker/{provider_id}/reset": "failover-groups",
+		// The last spelled-out parameter is the entity, as in the middleware.
+		"/api/discovery/{model_id}/x/{provider_id}": "providers",
+		// A spelled-out parameter no family claims falls back to the route's own
+		// family, so a same-family route still resolves.
+		"/api/virtual-keys/{vk_id}/rotate": "virtual-keys",
+		"/models/{id}":                     "", // unmounted pattern is not the real route
+		"":                                 "",
 	}
 	for route, want := range cases {
 		if got := entityKindOf(route); got != want {
@@ -32,11 +43,17 @@ func TestResolveEntityNames(t *testing.T) {
 		_, _ = pool.Exec(ctx, `DELETE FROM model_failover_groups WHERE display_model = 'hotel/resolve-me'`)
 		_, _ = pool.Exec(ctx, `DELETE FROM virtual_keys WHERE name = 'resolve-vk'`)
 		_, _ = pool.Exec(ctx, `DELETE FROM models WHERE model_id IN ('bare-model', 'named-model')`)
+		_, _ = pool.Exec(ctx, `DELETE FROM providers WHERE name = 'resolve-provider'`)
 	}
 	cleanup()
 	t.Cleanup(cleanup)
 
-	var groupID, vkID, bareModelID, namedModelID string
+	var groupID, vkID, bareModelID, namedModelID, providerID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO providers (name, base_url, encrypted_key, key_nonce, key_salt) VALUES ('resolve-provider', 'https://example.invalid', ''::bytea, ''::bytea, ''::bytea) RETURNING id::text`,
+	).Scan(&providerID); err != nil {
+		t.Fatalf("seed provider: %v", err)
+	}
 	if err := pool.QueryRow(ctx,
 		`INSERT INTO model_failover_groups (display_model) VALUES ('hotel/resolve-me') RETURNING id::text`,
 	).Scan(&groupID); err != nil {
@@ -64,6 +81,8 @@ func TestResolveEntityNames(t *testing.T) {
 		{Route: "/api/virtual-keys/{id}", EntityID: vkID},
 		{Route: "/api/models/{id}/test", EntityID: bareModelID},
 		{Route: "/api/models/{id}", EntityID: namedModelID},
+		// A provider acted on through a discovery verdict resolves by name.
+		{Route: "/api/discovery/{provider_id}/dismiss", EntityID: providerID},
 		// Deleted entity: a UUID with no row stays unresolved.
 		{Route: "/api/providers/{id}", EntityID: uuid.NewString()},
 		// Non-UUID id must not poison the batch for its family.
@@ -74,7 +93,7 @@ func TestResolveEntityNames(t *testing.T) {
 	}
 	rec.ResolveEntityNames(ctx, entries)
 
-	want := []string{"hotel/resolve-me", "resolve-vk", "bare-model", "Nice Name", "", "", "", ""}
+	want := []string{"hotel/resolve-me", "resolve-vk", "bare-model", "Nice Name", "resolve-provider", "", "", "", ""}
 	for i, w := range want {
 		if entries[i].EntityName != w {
 			t.Errorf("entries[%d] (%s) EntityName = %q, want %q", i, entries[i].Route, entries[i].EntityName, w)

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -460,12 +460,12 @@ func TestReadOnlyGuard(t *testing.T) {
 	// this wrong, so it is asserted explicitly.
 	called = false
 	rec := httptest.NewRecorder()
-	guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/discovery/dismiss", http.NoBody))
+	guard.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/discovery/p1/dismiss", http.NoBody))
 	if called {
-		t.Error("POST /api/discovery/dismiss: next handler must not be called in read-only mode")
+		t.Error("POST /api/discovery/p1/dismiss: next handler must not be called in read-only mode")
 	}
 	if rec.Code != http.StatusForbidden {
-		t.Errorf("read-only POST /api/discovery/dismiss = %d, want 403", rec.Code)
+		t.Errorf("read-only POST /api/discovery/p1/dismiss = %d, want 403", rec.Code)
 	}
 }
 
@@ -474,7 +474,7 @@ func TestIsReadOnlyExemptPost(t *testing.T) {
 		"/api/discovery/changes/ack":  true,
 		"/discovery/changes/ack":      true,
 		"/api/auth/webauthn/logout":   true,
-		"/api/discovery/dismiss":      false,
+		"/api/discovery/p1/dismiss":   false,
 		"/api/providers":              false,
 		"/api/discovery/changes/acks": false,
 	}

--- a/web/src/api/__tests__/client.discovery.test.ts
+++ b/web/src/api/__tests__/client.discovery.test.ts
@@ -63,7 +63,7 @@ describe("api.discovery", () => {
 	});
 
 	describe("dismiss", () => {
-		it("posts provider_id and model_ids in the body", async () => {
+		it("posts model_ids to the provider's dismiss route", async () => {
 			// No `dismissed` flag: the endpoint only stamps. A dismissal is reversed by
 			// discovery sighting the model again, not by a second call.
 			const mockResult = { dismissed: ["model-a", "model-b"], updated: 2 };
@@ -77,16 +77,13 @@ describe("api.discovery", () => {
 			]);
 			expect(result).toEqual(mockResult);
 			expect(globalThis.fetch).toHaveBeenCalledWith(
-				"/api/discovery/dismiss",
+				"/api/discovery/prov-1/dismiss",
 				expect.objectContaining({
 					method: "POST",
 					headers: expect.objectContaining({
 						"Content-Type": "application/json",
 					}),
-					body: JSON.stringify({
-						provider_id: "prov-1",
-						model_ids: ["model-a", "model-b"],
-					}),
+					body: JSON.stringify({ model_ids: ["model-a", "model-b"] }),
 				}),
 			);
 		});

--- a/web/src/api/endpoints/providers.ts
+++ b/web/src/api/endpoints/providers.ts
@@ -194,7 +194,6 @@ export const discovery = {
 			"Failed to load discovery status",
 		);
 	},
-	// Suppress (or, with dismissed=false, restore) a discrepancy.
 	// Dismiss only. There is deliberately no un-dismiss: a dismissal self-heals
 	// when discovery next sights the model, which is the only reversal the modal
 	// needs.
@@ -203,14 +202,11 @@ export const discovery = {
 		modelIds: string[],
 	): Promise<{ dismissed: string[]; updated: number }> => {
 		return fetchJSON<{ dismissed: string[]; updated: number }>(
-			`${API_BASE}/api/discovery/dismiss`,
+			`${API_BASE}/api/discovery/${encodeURIComponent(providerId)}/dismiss`,
 			{
 				method: "POST",
 				headers: getAuthHeaders(),
-				body: JSON.stringify({
-					provider_id: providerId,
-					model_ids: modelIds,
-				}),
+				body: JSON.stringify({ model_ids: modelIds }),
 			},
 			"Failed to dismiss discovery claims",
 		);
@@ -227,14 +223,11 @@ export const discovery = {
 		modelIds: string[],
 	): Promise<{ unpinned: string[] }> => {
 		return fetchJSON<{ unpinned: string[] }>(
-			`${API_BASE}/api/discovery/unpin`,
+			`${API_BASE}/api/discovery/${encodeURIComponent(providerId)}/unpin`,
 			{
 				method: "POST",
 				headers: getAuthHeaders(),
-				body: JSON.stringify({
-					provider_id: providerId,
-					model_ids: modelIds,
-				}),
+				body: JSON.stringify({ model_ids: modelIds }),
 			},
 			"Failed to unpin discovery claims",
 		);

--- a/web/src/components/ModelDiscrepancyModal.tsx
+++ b/web/src/components/ModelDiscrepancyModal.tsx
@@ -328,8 +328,8 @@ export function ModelDiscrepancyModal({
 	/**
 	 * Every dismissible model in the modal, batched by provider.
 	 *
-	 * Batched because the endpoint is provider-scoped: `POST /api/discovery/dismiss`
-	 * takes one provider_id and its model_ids, so a modal-wide dismiss is N requests
+	 * Batched because the endpoint is provider-scoped: `POST /api/discovery/{provider}/dismiss`
+	 * takes one provider's model_ids, so a modal-wide dismiss is N requests
 	 * however it is presented. Suspect ids are excluded here for the same reason as
 	 * on the pill: the server refuses a still-enabled model.
 	 */

--- a/web/src/components/__tests__/Layout.discovery-badge.test.tsx
+++ b/web/src/components/__tests__/Layout.discovery-badge.test.tsx
@@ -416,7 +416,7 @@ describe("Layout", () => {
 						}),
 					);
 				}),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
+				http.post("/api/discovery/:providerId/dismiss", async ({ request }) => {
 					const body = (await request.json()) as { model_ids: string[] };
 					bodies.push(body);
 					for (const m of body.model_ids) dismissed.add(m);
@@ -481,16 +481,16 @@ describe("Layout", () => {
 						}),
 					);
 				}),
-				http.post("/api/discovery/unpin", async ({ request }) => {
-					const body = (await request.json()) as {
-						provider_id: string;
-						model_ids: string[];
-					};
-					bodies.push(body);
-					for (const m of body.model_ids) unpinned.add(m);
-					// No `updated` key: the endpoint names the rows it cleared.
-					return HttpResponse.json({ unpinned: body.model_ids });
-				}),
+				http.post(
+					"/api/discovery/:providerId/unpin",
+					async ({ request, params }) => {
+						const body = (await request.json()) as { model_ids: string[] };
+						bodies.push({ provider_id: String(params.providerId), ...body });
+						for (const m of body.model_ids) unpinned.add(m);
+						// No `updated` key: the endpoint names the rows it cleared.
+						return HttpResponse.json({ unpinned: body.model_ids });
+					},
+				),
 			);
 			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
 
@@ -603,7 +603,7 @@ describe("Layout", () => {
 				http.get("/api/discovery/status", () =>
 					HttpResponse.json(cleared ? status() : pinOnlyStatus()),
 				),
-				http.post("/api/discovery/unpin", () => {
+				http.post("/api/discovery/:providerId/unpin", () => {
 					cleared = true;
 					return HttpResponse.json({ error: "boom" }, { status: 500 });
 				}),
@@ -646,7 +646,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
+				http.post("/api/discovery/:providerId/dismiss", async ({ request }) => {
 					const body = (await request.json()) as { model_ids: string[] };
 					bodies.push(body);
 					return HttpResponse.json({
@@ -680,7 +680,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					// One of the two took, and the response names it.
 					HttpResponse.json({ dismissed: ["a"], updated: 1 }),
 				),
@@ -712,7 +712,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					HttpResponse.json({ error: "boom" }, { status: 500 }),
 				),
 			);
@@ -753,7 +753,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
+				http.post("/api/discovery/:providerId/dismiss", async ({ request }) => {
 					const body = (await request.json()) as { model_ids: string[] };
 					if (body.model_ids.includes("b")) {
 						return HttpResponse.json({ error: "boom" }, { status: 500 });
@@ -798,7 +798,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					HttpResponse.json({ error: "boom" }, { status: 500 }),
 				),
 			);
@@ -852,7 +852,7 @@ describe("Layout", () => {
 					);
 				}),
 				// Two requested, one applied: membership unknown.
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					// One of the two took, and the response names it.
 					HttpResponse.json({ dismissed: ["a"], updated: 1 }),
 				),
@@ -897,7 +897,7 @@ describe("Layout", () => {
 
 		it("dismisses every provider at once, one request per provider", async () => {
 			// The endpoint is provider-scoped, so a modal-wide dismiss is N requests.
-			const bodies: { model_ids: string[] }[] = [];
+			const bodies: { provider_id: string; model_ids: string[] }[] = [];
 			server.use(
 				http.get("/api/discovery/status", () =>
 					HttpResponse.json(
@@ -910,14 +910,17 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
-					const body = (await request.json()) as { model_ids: string[] };
-					bodies.push(body);
-					return HttpResponse.json({
-						dismissed: body.model_ids,
-						updated: body.model_ids.length,
-					});
-				}),
+				http.post(
+					"/api/discovery/:providerId/dismiss",
+					async ({ request, params }) => {
+						const body = (await request.json()) as { model_ids: string[] };
+						bodies.push({ provider_id: String(params.providerId), ...body });
+						return HttpResponse.json({
+							dismissed: body.model_ids,
+							updated: body.model_ids.length,
+						});
+					},
+				),
 			);
 			const { user } = renderWithProviders(<Layout>{mockChildren}</Layout>);
 
@@ -930,7 +933,14 @@ describe("Layout", () => {
 			);
 
 			await waitFor(() => expect(bodies).toHaveLength(2));
-			expect(bodies.flatMap((b) => b.model_ids).sort()).toEqual(["a", "b"]);
+			// One request per provider, each carrying only that provider's models:
+			// the provider rides in the URL, so this is what the audit row names.
+			expect(
+				bodies.sort((x, y) => x.provider_id.localeCompare(y.provider_id)),
+			).toEqual([
+				{ provider_id: "p1", model_ids: ["a"] },
+				{ provider_id: "p2", model_ids: ["b"] },
+			]);
 		});
 
 		/**
@@ -961,7 +971,7 @@ describe("Layout", () => {
 						}),
 					);
 				}),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
+				http.post("/api/discovery/:providerId/dismiss", async ({ request }) => {
 					const body = (await request.json()) as { model_ids: string[] };
 					for (const m of body.model_ids) dismissed.add(m);
 					return HttpResponse.json({
@@ -1072,7 +1082,7 @@ describe("Layout", () => {
 						}),
 					);
 				}),
-				http.post("/api/discovery/dismiss", () => {
+				http.post("/api/discovery/:providerId/dismiss", () => {
 					dismissed = true;
 					return HttpResponse.json({ error: "boom" }, { status: 500 });
 				}),
@@ -1210,7 +1220,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					HttpResponse.json({ updated: 0 }),
 				),
 			);
@@ -1269,7 +1279,7 @@ describe("Layout", () => {
 					discovered = true;
 					return HttpResponse.json({ discovered: 0, diff: {} });
 				}),
-				http.post("/api/discovery/dismiss", async ({ request }) => {
+				http.post("/api/discovery/:providerId/dismiss", async ({ request }) => {
 					const body = (await request.json()) as { model_ids: string[] };
 					for (const m of body.model_ids) dismissed.add(m);
 					return HttpResponse.json({
@@ -1322,7 +1332,7 @@ describe("Layout", () => {
 						}),
 					),
 				),
-				http.post("/api/discovery/dismiss", () =>
+				http.post("/api/discovery/:providerId/dismiss", () =>
 					HttpResponse.json({ error: "boom" }, { status: 500 }),
 				),
 			);

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -636,7 +636,7 @@ export const handlers: RequestHandler[] = [
 		});
 	}),
 
-	http.post("/api/discovery/dismiss", ({ request }) => {
+	http.post("/api/discovery/:providerId/dismiss", ({ request }) => {
 		if (!hasValidAuth(request)) {
 			return HttpResponse.json({ error: "Unauthorized" }, { status: 401 });
 		}


### PR DESCRIPTION
## Why

A modal-wide "Dismiss everything" on the model discrepancies fans out one `POST /api/discovery/dismiss` per provider. The provider id lived in the request body, which the audit middleware never reads, so the audit trail showed N identical rows with an empty Entity column. Dismiss is a real state change (it stamps `discovery_dismissed_at`), so exempting it from the trail was the wrong fix; naming the provider is the right one.

## What

- `POST /api/discovery/{provider_id}/dismiss` and `POST /api/discovery/{provider_id}/unpin` replace the flat routes. The body carries `model_ids` only. The audit middleware already records a spelled-out `{..._id}` param as the entity.
- Audit name resolution keyed on the route's first segment, so a provider acted on from `discovery/...` (and, already before this, from the circuit-breaker reset route) resolved no name. The resolver now mirrors the middleware's entity rule: a plain `{id}` names the route's own family, otherwise the last spelled-out parameter names its own.
- Frontend endpoints, MSW mocks and tests follow. The modal-wide dismiss test now asserts one request per provider with only that provider's models.

## Verification

- Go: discovery tests go through the router on the new paths; malformed-request tests still prove 400 for an undecodable body and for a non-UUID path segment; resolver tests cover the spelled-out param, the `{id}`-first rule, last-wins, and the fallback.
- Vitest, `tsc -b`, eslint, biome clean.
- Dev stack: a dismiss through the new route produced an audit row with the provider id and the resolved name "OpenCode Zen"; a bad id returns 400; the old flat route is gone (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCs6zxZ2UmdoeDFh8mj9bx
