### PR TITLE
feat(virtualkeys): filter keys by name, lift the note above the quickstart

### DIFF
--- a/web/src/i18n/locales/af.json
+++ b/web/src/i18n/locales/af.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Misluk: {{message}}",
 			"usageExamples": "Gebruiksvoorbeelde",
 			"rateLimitTpmLabel": "Koersbeperking TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filter sleutels…",
+		"noMatch": "Geen virtuele sleutels pas by die filter nie."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -1451,7 +1451,9 @@
 			"keyUpdateFailed": "فشل: {{message}}",
 			"usageExamples": "أمثلة على الاستخدام",
 			"rateLimitTpmLabel": "حد معدل TPM (رموز/دقيقة)"
-		}
+		},
+		"filterPlaceholder": "تصفية المفاتيح…",
+		"noMatch": "لا توجد مفاتيح افتراضية تطابق التصفية."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ca.json
+++ b/web/src/i18n/locales/ca.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Fallat: {{message}}",
 			"usageExamples": "Exemples d'ús",
 			"rateLimitTpmLabel": "Límit de velocitat TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtra les claus…",
+		"noMatch": "Cap clau virtual no coincideix amb el filtre."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1365,7 +1365,9 @@
 			"keyUpdateFailed": "Selhalo: {{message}}",
 			"usageExamples": "Příklady použití",
 			"rateLimitTpmLabel": "Limit rychlosti TPM (tokeny/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrovat klíče…",
+		"noMatch": "Filtru neodpovídají žádné virtuální klíče."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/da.json
+++ b/web/src/i18n/locales/da.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Mislykkedes: {{message}}",
 			"usageExamples": "Eksempler på brug",
 			"rateLimitTpmLabel": "Rate Limit TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrer nøgler…",
+		"noMatch": "Ingen virtuelle nøgler matcher filteret."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Fehler: {{message}}",
 			"usageExamples": "Anwendungsbeispiele",
 			"rateLimitTpmLabel": "Ratenbegrenzung TPM (Token/Min.)"
-		}
+		},
+		"filterPlaceholder": "Schlüssel filtern…",
+		"noMatch": "Keine virtuellen Schlüssel entsprechen dem Filter."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/el.json
+++ b/web/src/i18n/locales/el.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Αποτυχία: {{message}}",
 			"usageExamples": "Παραδείγματα χρήσης",
 			"rateLimitTpmLabel": "Όριο ρυθμού TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Φιλτράρισμα κλειδιών…",
+		"noMatch": "Κανένα εικονικό κλειδί δεν ταιριάζει με το φίλτρο."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1279,7 +1279,9 @@
 			"keyCreatedFailed": "Failed: {{message}}",
 			"keyUpdated": "Virtual key updated",
 			"keyUpdateFailed": "Failed: {{message}}"
-		}
+		},
+		"filterPlaceholder": "Filter keys…",
+		"noMatch": "No virtual keys match the filter."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Error: {{message}}",
 			"usageExamples": "Ejemplos de uso",
 			"rateLimitTpmLabel": "Límite de tasa TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrar claves…",
+		"noMatch": "Ninguna clave virtual coincide con el filtro."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/fi.json
+++ b/web/src/i18n/locales/fi.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Epäonnistui: {{message}}",
 			"usageExamples": "Käyttöesimerkkejä",
 			"rateLimitTpmLabel": "Nopeusrajoitus TPM (tokenia/min)"
-		}
+		},
+		"filterPlaceholder": "Suodata avaimia…",
+		"noMatch": "Yksikään virtuaalinen avain ei vastaa suodatinta."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Échec: {{message}}",
 			"usageExamples": "Exemples d'utilisation",
 			"rateLimitTpmLabel": "Limite de débit TPM (jetons/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrer les clés…",
+		"noMatch": "Aucune clé virtuelle ne correspond au filtre."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/he.json
+++ b/web/src/i18n/locales/he.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "נכשל: {{message}}",
 			"usageExamples": "דוגמאות לשימוש",
 			"rateLimitTpmLabel": "מגבלת קצב TPM (אסימונים/דקה)"
-		}
+		},
+		"filterPlaceholder": "סינון מפתחות…",
+		"noMatch": "אין מפתחות וירטואליים התואמים לסינון."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/hu.json
+++ b/web/src/i18n/locales/hu.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Hiba: {{message}}",
 			"usageExamples": "Használati példák",
 			"rateLimitTpmLabel": "Rate Limit TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Kulcsok szűrése…",
+		"noMatch": "Egyetlen virtuális kulcs sem felel meg a szűrőnek."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Fallito: {{message}}",
 			"usageExamples": "Esempi di utilizzo",
 			"rateLimitTpmLabel": "Limite di velocità TPM (token/min)"
-		}
+		},
+		"filterPlaceholder": "Filtro chiavi…",
+		"noMatch": "Nessuna chiave virtuale corrisponde al filtro."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "失敗: {{message}}",
 			"usageExamples": "使用例",
 			"rateLimitTpmLabel": "レート制限 TPM（トークン/分）"
-		}
+		},
+		"filterPlaceholder": "キーを絞り込み…",
+		"noMatch": "フィルターに一致する仮想キーはありません。"
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "실패: {{message}}",
 			"usageExamples": "사용 예시",
 			"rateLimitTpmLabel": "요청 제한 TPM (토큰/분)"
-		}
+		},
+		"filterPlaceholder": "키 필터…",
+		"noMatch": "필터와 일치하는 가상 키가 없습니다."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Mislukt: {{message}}",
 			"usageExamples": "Gebruiksvoorbeelden",
 			"rateLimitTpmLabel": "Rate Limit TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Sleutels filteren…",
+		"noMatch": "Geen virtuele sleutels komen overeen met het filter."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/no.json
+++ b/web/src/i18n/locales/no.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Mislyktes: {{message}}",
 			"usageExamples": "Eksempler på bruk",
 			"rateLimitTpmLabel": "Rate Limit TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrer nøkler…",
+		"noMatch": "Ingen virtuelle nøkler samsvarer med filteret."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/pl.json
+++ b/web/src/i18n/locales/pl.json
@@ -1365,7 +1365,9 @@
 			"keyUpdateFailed": "Niepowodzenie: {{message}}",
 			"usageExamples": "Przykłady użycia",
 			"rateLimitTpmLabel": "Limit szybkości TPM (tokeny/min)"
-		}
+		},
+		"filterPlaceholder": "Filtruj klucze…",
+		"noMatch": "Żaden klucz wirtualny nie pasuje do filtra."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Falhou: {{message}}",
 			"usageExamples": "Exemplos de uso",
 			"rateLimitTpmLabel": "Limite de taxa TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrar chaves…",
+		"noMatch": "Nenhuma chave virtual corresponde ao filtro."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ro.json
+++ b/web/src/i18n/locales/ro.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Eșec: {{message}}",
 			"usageExamples": "Exemple de utilizare",
 			"rateLimitTpmLabel": "Limită de rată TPM (tokeni/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrează cheile…",
+		"noMatch": "Nicio cheie virtuală nu corespunde filtrului."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -1365,7 +1365,9 @@
 			"keyUpdateFailed": "Ошибка: {{message}}",
 			"usageExamples": "Примеры использования",
 			"rateLimitTpmLabel": "Ограничение скорости TPM (токены/мин)"
-		}
+		},
+		"filterPlaceholder": "Фильтр ключей…",
+		"noMatch": "Ни один виртуальный ключ не соответствует фильтру."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/sk.json
+++ b/web/src/i18n/locales/sk.json
@@ -1365,7 +1365,9 @@
 			"keyUpdateFailed": "Neúspešné: {{message}}",
 			"usageExamples": "Príklady použitia",
 			"rateLimitTpmLabel": "Limit rýchlosti TPM (tokeny/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrovanie kľúčov…",
+		"noMatch": "Filtru nezodpovedajú žiadne virtuálne kľúče."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/sr.json
+++ b/web/src/i18n/locales/sr.json
@@ -1322,7 +1322,9 @@
 			"keyUpdateFailed": "Неуспело: {{message}}",
 			"usageExamples": "Примери употребе",
 			"rateLimitTpmLabel": "Ограничење брзине TPM (токени/мин)"
-		}
+		},
+		"filterPlaceholder": "Филтрирај кључеве…",
+		"noMatch": "Ниједан виртуелни кључ не одговара филтеру."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/sv.json
+++ b/web/src/i18n/locales/sv.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Misslyckades: {{message}}",
 			"usageExamples": "Användningsexempel",
 			"rateLimitTpmLabel": "Rate Limit TPM (tokens/min)"
-		}
+		},
+		"filterPlaceholder": "Filtrera nycklar…",
+		"noMatch": "Inga virtuella nycklar matchar filtret."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Başarısız: {{message}}",
 			"usageExamples": "Kullanım örnekleri",
 			"rateLimitTpmLabel": "Hız Sınırı TPM (token/dk)"
-		}
+		},
+		"filterPlaceholder": "Anahtarları filtrele…",
+		"noMatch": "Filtreyle eşleşen sanal anahtar yok."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -1365,7 +1365,9 @@
 			"keyUpdateFailed": "Помилка: {{message}}",
 			"usageExamples": "Приклади використання",
 			"rateLimitTpmLabel": "Обмеження швидкості TPM (токенів/хв)"
-		}
+		},
+		"filterPlaceholder": "Фільтр ключів…",
+		"noMatch": "Жоден віртуальний ключ не відповідає фільтру."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/vi.json
+++ b/web/src/i18n/locales/vi.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "Không thành công: {{message}}",
 			"usageExamples": "Ví dụ sử dụng",
 			"rateLimitTpmLabel": "Giới hạn tốc độ TPM (token/phút)"
-		}
+		},
+		"filterPlaceholder": "Lọc khóa…",
+		"noMatch": "Không có khóa ảo nào khớp với bộ lọc."
 	},
 	"logs": {
 		"title": {

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -1279,7 +1279,9 @@
 			"keyUpdateFailed": "失败： {{message}}",
 			"usageExamples": "使用示例",
 			"rateLimitTpmLabel": "速率限制 TPM（令牌/分钟）"
-		}
+		},
+		"filterPlaceholder": "过滤密钥…",
+		"noMatch": "没有与过滤条件匹配的虚拟密钥。"
 	},
 	"logs": {
 		"title": {

--- a/web/src/pages/VirtualKeys/__tests__/VirtualKeys.filter.test.tsx
+++ b/web/src/pages/VirtualKeys/__tests__/VirtualKeys.filter.test.tsx
@@ -1,0 +1,61 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import { mockVirtualKey } from "../../../test/mocks/data";
+import { server } from "../../../test/mocks/server";
+import { renderWithProviders } from "../../../test/utils";
+import { VirtualKeys } from "../../VirtualKeys";
+
+const alpha = { ...mockVirtualKey, id: "vk-a", name: "Alpha Key" };
+const beta = { ...mockVirtualKey, id: "vk-b", name: "Beta Key" };
+
+describe("VirtualKeys name filter", () => {
+	beforeEach(() => {
+		server.use(
+			http.get("/api/virtual-keys", () => HttpResponse.json([alpha, beta])),
+		);
+	});
+
+	it("narrows the table to keys whose name contains the text", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<VirtualKeys />);
+		await waitFor(() => {
+			expect(screen.getByText("Alpha Key")).toBeInTheDocument();
+		});
+		expect(screen.getByText("Beta Key")).toBeInTheDocument();
+
+		await user.type(screen.getByRole("textbox"), "  BETA ");
+
+		expect(screen.getByText("Beta Key")).toBeInTheDocument();
+		expect(screen.queryByText("Alpha Key")).not.toBeInTheDocument();
+	});
+
+	it("drops the table but keeps the filter and quickstart when nothing matches", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<VirtualKeys />);
+		await waitFor(() => {
+			expect(screen.getByText("Alpha Key")).toBeInTheDocument();
+		});
+
+		await user.type(screen.getByRole("textbox"), "zzz");
+
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
+		expect(screen.queryByText("Alpha Key")).not.toBeInTheDocument();
+		expect(screen.getByRole("textbox")).toHaveValue("zzz");
+		expect(screen.getByText("1")).toBeInTheDocument();
+
+		await user.clear(screen.getByRole("textbox"));
+		expect(screen.getByText("Alpha Key")).toBeInTheDocument();
+		expect(screen.getByText("Beta Key")).toBeInTheDocument();
+	});
+
+	it("does not render the filter when there are no keys at all", async () => {
+		server.use(http.get("/api/virtual-keys", () => HttpResponse.json([])));
+		renderWithProviders(<VirtualKeys />);
+		await waitFor(() => {
+			expect(screen.queryByRole("status")).not.toBeInTheDocument();
+		});
+		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+	});
+});

--- a/web/src/pages/VirtualKeys/__tests__/VirtualKeys.filter.test.tsx
+++ b/web/src/pages/VirtualKeys/__tests__/VirtualKeys.filter.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
+import i18n from "../../../i18n";
 import { mockVirtualKey } from "../../../test/mocks/data";
 import { server } from "../../../test/mocks/server";
 import { renderWithProviders } from "../../../test/utils";
@@ -42,6 +43,10 @@ describe("VirtualKeys name filter", () => {
 
 		expect(screen.queryByRole("table")).not.toBeInTheDocument();
 		expect(screen.queryByText("Alpha Key")).not.toBeInTheDocument();
+		expect(screen.getByText(i18n.t("virtualkeys.noMatch"))).toBeInTheDocument();
+		expect(
+			screen.queryByText(i18n.t("virtualkeys.emptyState")),
+		).not.toBeInTheDocument();
 		expect(screen.getByRole("textbox")).toHaveValue("zzz");
 		expect(screen.getByText("1")).toBeInTheDocument();
 
@@ -57,5 +62,8 @@ describe("VirtualKeys name filter", () => {
 			expect(screen.queryByRole("status")).not.toBeInTheDocument();
 		});
 		expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+		expect(
+			screen.getByText(i18n.t("virtualkeys.emptyState")),
+		).toBeInTheDocument();
 	});
 });

--- a/web/src/pages/VirtualKeys/index.tsx
+++ b/web/src/pages/VirtualKeys/index.tsx
@@ -13,6 +13,7 @@ import {
 	StaticHeader,
 } from "../../components/DataTable";
 import { EmptyState } from "../../components/EmptyState";
+import { FilterInput } from "../../components/FilterInput";
 import { LoadingSpinner } from "../../components/LoadingSpinner";
 import { ManagedBanner } from "../../components/ManagedBanner";
 import { PageHeader } from "../../components/PageHeader";
@@ -45,6 +46,7 @@ export function VirtualKeys() {
 		field: "name",
 		dir: "asc",
 	});
+	const [nameFilter, setNameFilter] = useState("");
 	const [pageSize, setPageSize] = useState(10);
 	const [currentPage, setCurrentPage] = useState(1);
 
@@ -69,7 +71,11 @@ export function VirtualKeys() {
 	const sortedKeys = useMemo(() => {
 		if (!keys) return [];
 		const dir = sort.dir === "asc" ? 1 : -1;
-		return [...keys].sort((a, b) => {
+		const needle = nameFilter.trim().toLowerCase();
+		const filtered = needle
+			? keys.filter((k) => k.name.toLowerCase().includes(needle))
+			: keys;
+		return [...filtered].sort((a, b) => {
 			switch (sort.field) {
 				case "name":
 					return dir * a.name.localeCompare(b.name);
@@ -105,8 +111,9 @@ export function VirtualKeys() {
 					return 0;
 			}
 		});
-	}, [keys, sort]);
+	}, [keys, sort, nameFilter]);
 
+	const hasKeys = (keys?.length ?? 0) > 0;
 	const totalPages = Math.ceil(sortedKeys.length / pageSize);
 	const paginatedKeys = sortedKeys.slice(
 		(currentPage - 1) * pageSize,
@@ -158,20 +165,31 @@ export function VirtualKeys() {
 
 			<ManagedBanner />
 
-			{sortedKeys.length > 0 && (
-				<div className="flex items-center justify-end">
-					<PaginationBar
-						page={currentPage}
-						totalPages={totalPages}
-						totalItems={sortedKeys.length}
-						pageSize={pageSize}
-						onPageChange={setCurrentPage}
-						onPageSizeChange={(s) => {
-							setPageSize(s);
+			{hasKeys && (
+				<div className="flex items-center justify-between gap-2">
+					<FilterInput
+						value={nameFilter}
+						onChange={(v) => {
+							setNameFilter(v);
 							setCurrentPage(1);
 						}}
-						label={t("virtualkeys.table.keys")}
+						placeholder={t("virtualkeys.filterPlaceholder")}
+						className="w-[200px]"
 					/>
+					{sortedKeys.length > 0 && (
+						<PaginationBar
+							page={currentPage}
+							totalPages={totalPages}
+							totalItems={sortedKeys.length}
+							pageSize={pageSize}
+							onPageChange={setCurrentPage}
+							onPageSizeChange={(s) => {
+								setPageSize(s);
+								setCurrentPage(1);
+							}}
+							label={t("virtualkeys.table.keys")}
+						/>
+					)}
 				</div>
 			)}
 
@@ -373,62 +391,68 @@ export function VirtualKeys() {
 					</table>
 				</div>
 			) : (
-				<EmptyState message={t("virtualkeys.emptyState")} />
+				<EmptyState
+					message={t(
+						hasKeys ? "virtualkeys.noMatch" : "virtualkeys.emptyState",
+					)}
+				/>
 			)}
 
-			{sortedKeys.length > 0 && (
-				<div className="ui-card p-6 space-y-5">
-					<div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-						<div className="flex items-start gap-3 p-4 ui-card">
-							<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
-								1
-							</div>
-							<div>
-								<h3 className="text-sm font-medium text-gray-200">
-									{t("virtualkeys.steps.createKey")}
-								</h3>
-								<p className="text-xs text-gray-400 mt-1">
-									{t("virtualkeys.stepDescriptions.createKey")}
-								</p>
-							</div>
-						</div>
-						<div className="flex items-start gap-3 p-4 ui-card">
-							<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
-								2
-							</div>
-							<div>
-								<h3 className="text-sm font-medium text-gray-200">
-									{t("virtualkeys.steps.copyKey")}
-								</h3>
-								<p className="text-xs text-gray-400 mt-1">
-									{t("virtualkeys.stepDescriptions.copyKey")}
-								</p>
-							</div>
-						</div>
-						<div className="flex items-start gap-3 p-4 ui-card">
-							<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
-								3
-							</div>
-							<div>
-								<h3 className="text-sm font-medium text-gray-200">
-									{t("virtualkeys.steps.makeRequests")}
-								</h3>
-								<p className="text-xs text-gray-400 mt-1">
-									{t("virtualkeys.stepDescriptions.makeRequests")}
-								</p>
-							</div>
-						</div>
-					</div>
-
-					<UsageSnippets />
-
+			{hasKeys && (
+				<>
 					<div className="ui-note-pill flex items-start gap-3 p-4 rounded-lg bg-(--accent-light) border border-(--accent-lighter)">
 						<div className="w-1.5 h-1.5 rounded-(--radius-pill) bg-(--accent) mt-1.5 shrink-0" />
 						<p className="text-xs text-gray-300 leading-relaxed">
 							{t("virtualkeys.note.text")}
 						</p>
 					</div>
-				</div>
+
+					<div className="ui-card p-6 space-y-5">
+						<div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+							<div className="flex items-start gap-3 p-4 ui-card">
+								<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
+									1
+								</div>
+								<div>
+									<h3 className="text-sm font-medium text-gray-200">
+										{t("virtualkeys.steps.createKey")}
+									</h3>
+									<p className="text-xs text-gray-400 mt-1">
+										{t("virtualkeys.stepDescriptions.createKey")}
+									</p>
+								</div>
+							</div>
+							<div className="flex items-start gap-3 p-4 ui-card">
+								<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
+									2
+								</div>
+								<div>
+									<h3 className="text-sm font-medium text-gray-200">
+										{t("virtualkeys.steps.copyKey")}
+									</h3>
+									<p className="text-xs text-(--warning-text) mt-1">
+										{t("virtualkeys.stepDescriptions.copyKey")}
+									</p>
+								</div>
+							</div>
+							<div className="flex items-start gap-3 p-4 ui-card">
+								<div className="flex items-center justify-center w-7 h-7 rounded-(--radius-pill) bg-(--accent)/15 text-(--accent) ring-1 ring-(--accent)/30 text-sm font-bold shrink-0">
+									3
+								</div>
+								<div>
+									<h3 className="text-sm font-medium text-gray-200">
+										{t("virtualkeys.steps.makeRequests")}
+									</h3>
+									<p className="text-xs text-gray-400 mt-1">
+										{t("virtualkeys.stepDescriptions.makeRequests")}
+									</p>
+								</div>
+							</div>
+						</div>
+
+						<UsageSnippets />
+					</div>
+				</>
 			)}
 
 			{showCreate && (

--- a/web/src/pages/VirtualKeys/index.tsx
+++ b/web/src/pages/VirtualKeys/index.tsx
@@ -63,6 +63,11 @@ export function VirtualKeys() {
 		setCurrentPage(1);
 	}, []);
 
+	const handleFilter = useCallback((value: string) => {
+		setNameFilter(value);
+		setCurrentPage(1);
+	}, []);
+
 	const proxyOrigin =
 		typeof window !== "undefined"
 			? window.location.origin
@@ -169,10 +174,7 @@ export function VirtualKeys() {
 				<div className="flex items-center justify-between gap-2">
 					<FilterInput
 						value={nameFilter}
-						onChange={(v) => {
-							setNameFilter(v);
-							setCurrentPage(1);
-						}}
+						onChange={handleFilter}
 						placeholder={t("virtualkeys.filterPlaceholder")}
 						className="w-[200px]"
 					/>


### PR DESCRIPTION
## Summary

- **Name filter on the Virtual Keys table.** The shared `FilterInput` (same one Providers and App Logs use, so it inherits the `ui-input` theming for all three themes) sits to the left of the pagination bar and narrows the table by a case-insensitive name substring. Changing the filter resets to page 1. A filter that matches nothing shows a dedicated "no virtual keys match the filter" empty state instead of the "create one" message, and keeps the filter + quickstart visible so the text can be cleared.
- **Note pill moved** from the bottom of the quickstart card to between the table and the card.
- **Step 2 description** ("The complete key is shown only once on creation") is set in the theme's `--warning-text` (orange in every theme); the step heading is unchanged.
- New keys `virtualkeys.filterPlaceholder` and `virtualkeys.noMatch` hand-translated into all 29 locales.

## Test plan

- [x] New `VirtualKeys.filter.test.tsx`: substring match trims/ignores case, no-match hides the table but keeps the filter + quickstart, clearing restores, no filter rendered when there are no keys.
- [x] VirtualKeys suite green (137), `tsc -b`, `pnpm lint`, `make i18n-check`, `make size-check` all green.
- [x] Dev stack rebuilt from this branch and serving the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpBFxwtsBQsM5e6BcsPYoj
