### PR TITLE
fix(virtualkeys): render the note as an info callout, not accent red

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3695,11 +3695,10 @@ html[data-ui-style="cyber-terminal"] .toast-monitor {
 	border-radius: 10px;
 }
 
-/* Terminal corner squaring: dashboard stat-card icon chips, the Virtual
-   Keys note pill, the mock-terminal snippet frames, and chart tooltips. */
+/* Terminal corner squaring: dashboard stat-card icon chips, the
+   mock-terminal snippet frames, and chart tooltips. */
 html[data-ui-style="cyber-terminal"] .ui-stat-icon,
 html[data-ui-style="cyber-terminal"] .ui-wizard-icon,
-html[data-ui-style="cyber-terminal"] .ui-note-pill,
 html[data-ui-style="cyber-terminal"] .terminal-frame,
 html[data-ui-style="cyber-terminal"] .chart-tooltip {
 	border-radius: 0;

--- a/web/src/pages/VirtualKeys/index.tsx
+++ b/web/src/pages/VirtualKeys/index.tsx
@@ -402,9 +402,9 @@ export function VirtualKeys() {
 
 			{hasKeys && (
 				<>
-					<div className="ui-callout ui-callout-info flex items-start gap-3 p-4">
+					<div className="ui-callout ui-callout-info flex items-start gap-3">
 						<div className="w-1.5 h-1.5 rounded-(--radius-pill) bg-current mt-1.5 shrink-0" />
-						<p className="text-xs leading-relaxed">
+						<p className="text-xs leading-relaxed text-left">
 							{t("virtualkeys.note.text")}
 						</p>
 					</div>

--- a/web/src/pages/VirtualKeys/index.tsx
+++ b/web/src/pages/VirtualKeys/index.tsx
@@ -402,9 +402,9 @@ export function VirtualKeys() {
 
 			{hasKeys && (
 				<>
-					<div className="ui-note-pill flex items-start gap-3 p-4 rounded-lg bg-(--accent-light) border border-(--accent-lighter)">
-						<div className="w-1.5 h-1.5 rounded-(--radius-pill) bg-(--accent) mt-1.5 shrink-0" />
-						<p className="text-xs text-gray-300 leading-relaxed">
+					<div className="ui-callout ui-callout-info flex items-start gap-3 p-4">
+						<div className="w-1.5 h-1.5 rounded-(--radius-pill) bg-current mt-1.5 shrink-0" />
+						<p className="text-xs leading-relaxed">
 							{t("virtualkeys.note.text")}
 						</p>
 					</div>


### PR DESCRIPTION
## Summary

- The Virtual Keys note ("Virtual keys are used to authenticate requests...") was tinted with the theme accent, which is red in the default theme and read as an error. It now uses the shared `ui-callout ui-callout-info` (blue in every theme, light and dark variants already defined, corners squared on Terminal via `--radius-box`).
- The dot and text inherit the callout colour (`bg-current`, no explicit text colour), so the whole block follows the theme.
- The one-off `.ui-note-pill` Terminal radius rule is removed since the callout already handles it and nothing else used the class.

## Test plan

- [x] VirtualKeys suite green (137), `tsc -b`, Biome, `make size-check` green.
- [x] Dev stack rebuilt from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpBFxwtsBQsM5e6BcsPYoj
