### PR TITLE
refactor: fold the post-#888 duplicates into one helper each

### DIFF
--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -119,6 +118,9 @@ type backupEntry struct {
 	// signature is actually checked on download, where a single file is read
 	// anyway and a mismatch can stop the transfer.
 	Signed bool `json:"signed"`
+	// modTime is CreatedAt before formatting, for the callers that compare
+	// or do arithmetic on it (the listing's order, the scheduler's anchor).
+	modTime time.Time
 }
 
 // hasSignature reports whether a usable signature sidecar exists beside a dump.
@@ -203,41 +205,15 @@ func (h *BackupHandler) CreateBackup(w http.ResponseWriter, r *http.Request) {
 
 // ListBackups returns all backup files sorted by creation time (newest first).
 func (h *BackupHandler) ListBackups(w http.ResponseWriter, r *http.Request) {
-	entries, err := os.ReadDir(h.backupDir)
+	backups, err := h.listBackupFiles()
 	if err != nil {
-		if os.IsNotExist(err) {
-			writeJSON(w, []backupEntry{})
-			return
-		}
 		respondError(w, "failed to read backup directory", err, http.StatusInternalServerError)
 		return
 	}
-
-	var backups []backupEntry
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".dump") {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil {
-			continue
-		}
-		backups = append(backups, backupEntry{
-			Filename:  entry.Name(),
-			SizeBytes: info.Size(),
-			CreatedAt: info.ModTime().Format(time.RFC3339),
-			Origin:    backupOrigin(entry.Name()),
-			Signed:    hasSignature(filepath.Join(h.backupDir, entry.Name())),
-		})
-	}
-
-	// Sort newest first
-	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].CreatedAt > backups[j].CreatedAt
-	})
-
-	if backups == nil {
-		backups = []backupEntry{}
+	// The signature stat is the listing's alone: the rotation and the
+	// scheduler read the same files and never look at the sidecars.
+	for i := range backups {
+		backups[i].Signed = hasSignature(filepath.Join(h.backupDir, backups[i].Filename))
 	}
 	writeJSON(w, backups)
 }

--- a/internal/api/backup_retention.go
+++ b/internal/api/backup_retention.go
@@ -267,8 +267,9 @@ func (h *BackupHandler) ApplyPrune(w http.ResponseWriter, r *http.Request) {
 
 // listBackupFiles reads all backup entries from disk (newest first). A missing
 // directory is an empty listing, never an error. It is the one reader of the
-// backup directory: the listing endpoint, the rotation and the scheduler's
-// interval anchor all see the same files through it.
+// finished dumps: the listing endpoint, the rotation and the scheduler's
+// interval anchor all see the same files through it. The partials a killed
+// run left behind are not dumps and are swept separately.
 func (h *BackupHandler) listBackupFiles() ([]backupEntry, error) {
 	entries, err := os.ReadDir(h.backupDir)
 	if err != nil {

--- a/internal/api/backup_retention.go
+++ b/internal/api/backup_retention.go
@@ -265,7 +265,10 @@ func (h *BackupHandler) ApplyPrune(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, classification)
 }
 
-// listBackupFiles reads all backup entries from disk (newest first).
+// listBackupFiles reads all backup entries from disk (newest first). A missing
+// directory is an empty listing, never an error. It is the one reader of the
+// backup directory: the listing endpoint, the rotation and the scheduler's
+// interval anchor all see the same files through it.
 func (h *BackupHandler) listBackupFiles() ([]backupEntry, error) {
 	entries, err := os.ReadDir(h.backupDir)
 	if err != nil {
@@ -289,11 +292,12 @@ func (h *BackupHandler) listBackupFiles() ([]backupEntry, error) {
 			SizeBytes: info.Size(),
 			CreatedAt: info.ModTime().Format(time.RFC3339),
 			Origin:    backupOrigin(entry.Name()),
+			modTime:   info.ModTime(),
 		})
 	}
 
 	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].CreatedAt > backups[j].CreatedAt
+		return backups[i].modTime.After(backups[j].modTime)
 	})
 
 	if backups == nil {

--- a/internal/api/backup_scheduler.go
+++ b/internal/api/backup_scheduler.go
@@ -110,17 +110,16 @@ func (h *BackupHandler) schedulerTick(ctx context.Context) time.Duration {
 // Desk backups do not count: they are the operator's, and a scheduled backup
 // is due on its own clock regardless. An unreadable directory reads as due.
 func (h *BackupHandler) scheduledBackupWait(interval time.Duration, now time.Time) time.Duration {
-	entries, err := os.ReadDir(h.backupDir)
+	backups, err := h.listBackupFiles()
 	if err != nil {
 		return 0
 	}
+	// Newest first, so the first scheduled entry is the anchor.
 	var newest time.Time
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".dump") || backupOrigin(e.Name()) != "scheduled" {
-			continue
-		}
-		if info, err := e.Info(); err == nil && info.ModTime().After(newest) {
-			newest = info.ModTime()
+	for _, b := range backups {
+		if b.Origin == "scheduled" {
+			newest = b.modTime
+			break
 		}
 	}
 	if newest.IsZero() {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -208,11 +208,18 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 func entityParam(rctx *chi.Context) string {
 	keys, values := rctx.URLParams.Keys, rctx.URLParams.Values
 	for i := min(len(keys), len(values)) - 1; i >= 0; i-- {
-		if strings.HasSuffix(keys[i], "_id") || strings.HasSuffix(keys[i], "_uuid") {
+		if isEntityParam(keys[i]) {
 			return values[i]
 		}
 	}
 	return ""
+}
+
+// isEntityParam reports whether a spelled-out route parameter names an
+// entity: the one rule entityParam records by and the name resolver reads
+// route patterns by, so the two cannot pick different parameters.
+func isEntityParam(name string) bool {
+	return strings.HasSuffix(name, "_id") || strings.HasSuffix(name, "_uuid")
 }
 
 // isAuditExempt reports whether a resolved route is excluded from the audit

--- a/internal/audit/resolve.go
+++ b/internal/audit/resolve.go
@@ -59,8 +59,8 @@ func entityKindOf(route string) string {
 	return seg
 }
 
-// lastSpelledParam returns the name of the last {..._id} or {..._uuid}
-// parameter in a route pattern, the one the middleware records, or "".
+// lastSpelledParam returns the name of the last entity parameter
+// (isEntityParam) in a route pattern, the one the middleware records, or "".
 func lastSpelledParam(rest string) string {
 	segs := strings.Split(rest, "/")
 	for i := len(segs) - 1; i >= 0; i-- {
@@ -68,7 +68,7 @@ func lastSpelledParam(rest string) string {
 		if !ok {
 			continue
 		}
-		if name, ok = strings.CutSuffix(name, "}"); ok && (strings.HasSuffix(name, "_id") || strings.HasSuffix(name, "_uuid")) {
+		if name, ok = strings.CutSuffix(name, "}"); ok && isEntityParam(name) {
 			return name
 		}
 	}

--- a/internal/failover/circuit_quota.go
+++ b/internal/failover/circuit_quota.go
@@ -90,6 +90,15 @@ func pinProbes(source string) bool {
 	return source == pinSourceResponse || source == pinSourceAccount
 }
 
+// pinSpeaksForAccount reports whether a pin of this source indicts the whole
+// provider on its own: the advisor measured the provider's account, and an
+// account pin carries a refusal the provider made about its balance rather
+// than about a model. A plain response pin is one model's evidence and does
+// not; see providerReport.
+func pinSpeaksForAccount(source string) bool {
+	return source == pinSourceAdvisor || source == pinSourceAccount
+}
+
 // ReleaseQuotaPins lifts the quota cooldown override from every circuit whose
 // provider appears in recovered, and reports how many pins it lifted. It is how
 // a provider that has recovered (a topped-up plan, a reset window observed early

--- a/internal/failover/model_circuits.go
+++ b/internal/failover/model_circuits.go
@@ -340,18 +340,17 @@ func (cb *CircuitBreaker) providerReport(models modelCircuits, r *cooldownReads)
 		blocked = append(blocked, model)
 		if cb.quotaPinnedForWith(c, r) {
 			pinned = true
-			if c.pinSource == pinSourceAdvisor || c.pinSource == pinSourceAccount {
+			if pinSpeaksForAccount(c.pinSource) {
 				providerPinned = true
 			}
 		}
 	}
 	slices.Sort(blocked)
-	// A pin that speaks for the ACCOUNT indicts the provider on its own: the
-	// advisor measured the provider's account, and an account pin carries a
-	// refusal the provider made about its balance rather than about a model.
-	// A plain response pin is inferred from one model's 429 (a plan excluding
-	// ONE model, answered with a balance error), so it darkens that model
-	// alone. Corroboration across models (the span) still reaches the provider.
+	// A pin that speaks for the ACCOUNT indicts the provider on its own
+	// (pinSpeaksForAccount). A plain response pin is inferred from one model's
+	// 429 (a plan excluding ONE model, answered with a balance error), so it
+	// darkens that model alone. Corroboration across models (the span) still
+	// reaches the provider.
 	return providerPinned || len(blocked) >= cb.effectiveSpan(), blocked, pinned
 }
 

--- a/internal/paramrewrite/schema_fallback.go
+++ b/internal/paramrewrite/schema_fallback.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // SchemaFallbackKey is the pseudo-param the learned caches carry for a
@@ -35,11 +36,11 @@ var jsonModeOnlyProviders = map[string]bool{
 // the prompt; each of those hosts then answers bare, schema-shaped JSON. A
 // provider type that only serves JSON mode, or a learned 400, puts the
 // request in JSON mode instead, with the same fold. The family name opens a
-// segment of the id, after any vendor path or prefix (z-ai/glm-5.3-flash,
-// glm4:9b, zai.glm-4.7, zai-glm-4.7), so a name that merely contains the
-// letters does not match.
+// segment of the id (util.ModelIDSegments), after any vendor path or prefix
+// (z-ai/glm-5.3-flash, glm4:9b, zai.glm-4.7, zai-glm-4.7), so a name that
+// merely contains the letters does not match.
 func schemaIgnoredByModel(modelID string) bool {
-	for _, segment := range strings.FieldsFunc(strings.ToLower(modelID), func(r rune) bool { return r == '/' || r == '.' || r == '-' }) {
+	for _, segment := range util.ModelIDSegments(modelID) {
 		if strings.HasPrefix(segment, "glm") {
 			return true
 		}
@@ -111,7 +112,16 @@ func DropSchemaFallbackUnlessRequested(rejected map[string]bool, requestBody []b
 	if !rejected[SchemaFallbackKey] || RequestsJSONSchema(requestBody) {
 		return rejected
 	}
-	delete(rejected, SchemaFallbackKey)
+	return WithoutParams(rejected, SchemaFallbackKey)
+}
+
+// WithoutParams drops names from a learned set and returns it, or nil when
+// nothing is left: the param learner reads nil as "nothing to learn", and an
+// empty map would cache a no-op strip against the model.
+func WithoutParams(rejected map[string]bool, names ...string) map[string]bool {
+	for _, name := range names {
+		delete(rejected, name)
+	}
 	if len(rejected) == 0 {
 		return nil
 	}

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -237,7 +237,7 @@ func googleModalities(modelID string) (inputMods, outputMods string) {
 // speak alongside text. It matches "tts" as a whole name segment so a chat
 // model that merely contains the letters cannot lose its chat class.
 func isGoogleTTSModel(modelID string) bool {
-	return slices.Contains(splitModelIDSegments(strings.ToLower(modelID)), "tts")
+	return slices.Contains(util.ModelIDSegments(modelID), "tts")
 }
 
 // isGoogleAudioModel reports a model that hears and speaks alongside text; a

--- a/internal/provider/local_modality.go
+++ b/internal/provider/local_modality.go
@@ -1,6 +1,10 @@
 package provider
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
 
 // inferNonChatModality guesses a non-chat modality ("embedding", "rerank" or
 // "image") from a model ID when the provider does not report one.
@@ -44,7 +48,7 @@ func inferNonChatModality(modelID string) string {
 	// speech endpoints (tts-1, gpt-4o-mini-tts, whisper-1, gpt-4o-transcribe).
 	// Match them as whole segments (split on the usual id separators) so a
 	// substring can't trip a chat model that merely contains these letters.
-	for _, seg := range splitModelIDSegments(id) {
+	for _, seg := range util.ModelIDSegments(id) {
 		switch seg {
 		case "bge", "gte", "e5", "minilm":
 			return "embedding"
@@ -56,17 +60,4 @@ func inferNonChatModality(modelID string) string {
 	}
 
 	return ""
-}
-
-// splitModelIDSegments splits a lower-cased model ID on the separators commonly
-// found in HuggingFace-style IDs (org/name-with-parts).
-func splitModelIDSegments(id string) []string {
-	return strings.FieldsFunc(id, func(r rune) bool {
-		switch r {
-		case '/', '-', '_', '.', ':', ' ':
-			return true
-		default:
-			return false
-		}
-	})
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -583,47 +583,29 @@ var legacyMask = regexp.MustCompile(`^..\.{3}..$`)
 // Rows already written are reported alongside an error, so a caller can
 // invalidate the provider cache for them.
 func (r *Repository) BackfillMaskedKeys(ctx context.Context, masterKey string) (int, error) {
-	rows, err := r.pool.Query(ctx, `SELECT id, encrypted_key, key_nonce, key_salt, COALESCE(masked_key, '') FROM providers WHERE length(encrypted_key) > 0`)
+	providers, err := r.List(ctx)
 	if err != nil {
 		return 0, err
 	}
-	type stored struct {
-		ID                              uuid.UUID
-		EncryptedKey, KeyNonce, KeySalt []byte
-		Mask                            string
-	}
-	all, err := pgx.CollectRows(rows, pgx.RowToStructByPos[stored])
-	if err != nil {
-		return 0, err
-	}
-	type pending struct {
-		id   uuid.UUID
-		mask string
-	}
-	var todo []pending
-	undecryptable := 0
-	for _, row := range all {
-		if row.Mask != "" && !legacyMask.MatchString(row.Mask) {
-			continue
-		}
-		key, err := auth.Decrypt(row.EncryptedKey, row.KeyNonce, row.KeySalt, masterKey)
-		if err != nil {
-			undecryptable++
-			continue
-		}
-		todo = append(todo, pending{id: row.ID, mask: MaskAPIKey(key)})
-	}
-	if undecryptable > 0 {
-		debuglog.Warn("provider: mask backfill skipped keys it could not decrypt under this master key", "count", undecryptable)
-	}
-	written := 0
+	written, undecryptable := 0, 0
 	defer func() {
 		if written > 0 {
 			InvalidateProviderCache()
 		}
+		if undecryptable > 0 {
+			debuglog.Warn("provider: mask backfill skipped keys it could not decrypt under this master key", "count", undecryptable)
+		}
 	}()
-	for _, p := range todo {
-		if _, err := r.pool.Exec(ctx, `UPDATE providers SET masked_key = $1 WHERE id = $2`, p.mask, p.id); err != nil {
+	for _, p := range providers {
+		if len(p.EncryptedKey) == 0 || (p.MaskedKey != nil && *p.MaskedKey != "" && !legacyMask.MatchString(*p.MaskedKey)) {
+			continue
+		}
+		key, err := auth.Decrypt(p.EncryptedKey, p.KeyNonce, p.KeySalt, masterKey)
+		if err != nil {
+			undecryptable++
+			continue
+		}
+		if _, err := r.pool.Exec(ctx, `UPDATE providers SET masked_key = $1 WHERE id = $2`, MaskAPIKey(key), p.ID); err != nil {
 			return written, err
 		}
 		written++

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -142,16 +142,15 @@ func (h *Handler) recordRateLimitOutcome(ctx context.Context, st *requestState, 
 			h.circuitBreaker.RecordRateLimited(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), failover.UpstreamStatus(http.StatusTooManyRequests, "exhausted, not opened by setting"))
 			return
 		}
+		reason, record := "upstream 429 (exhausted)", h.circuitBreaker.RecordExhausted
 		if rl.account {
 			// The account behind the provider is what refused, so the pin
 			// speaks for every model of the provider: the next request to a
 			// sibling is skipped rather than sent to draw the same refusal.
-			debuglog.Warn("proxy: recording circuit breaker exhaustion", "reason", "upstream 429 (account exhausted)", "status", http.StatusTooManyRequests, "pin_hint_ms", rl.pinHint.Milliseconds(), "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
-			h.circuitBreaker.RecordExhaustedAccount(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), http.StatusTooManyRequests, rl.pinHint)
-			return
+			reason, record = "upstream 429 (account exhausted)", h.circuitBreaker.RecordExhaustedAccount
 		}
-		debuglog.Warn("proxy: recording circuit breaker exhaustion", "reason", "upstream 429 (exhausted)", "status", http.StatusTooManyRequests, "pin_hint_ms", rl.pinHint.Milliseconds(), "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
-		h.circuitBreaker.RecordExhausted(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), http.StatusTooManyRequests, rl.pinHint)
+		debuglog.Warn("proxy: recording circuit breaker exhaustion", "reason", reason, "status", http.StatusTooManyRequests, "pin_hint_ms", rl.pinHint.Milliseconds(), "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidateModelID(candidate))
+		record(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), http.StatusTooManyRequests, rl.pinHint)
 	case rateLimitUnknown:
 		// Not reached: the caller only routes classified verdicts here. Listed
 		// so the switch stays exhaustive over rateLimitClass.

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -160,11 +160,7 @@ func (h *Handler) learnRejectedParams(st *requestState, candidate modelCandidate
 func learnableRejections(st *requestState, body []byte) map[string]bool {
 	rejected := paramrewrite.ParseProviderParamError(body)
 	if !st.sentChatCompletionsBody() {
-		delete(rejected, paramrewrite.SchemaFallbackKey)
-		if len(rejected) == 0 {
-			return nil
-		}
-		return rejected
+		return paramrewrite.WithoutParams(rejected, paramrewrite.SchemaFallbackKey)
 	}
 	return paramrewrite.DropSchemaFallbackUnlessRequested(rejected, st.bodyBytes)
 }
@@ -175,17 +171,12 @@ func learnableRejections(st *requestState, body []byte) map[string]bool {
 // translator regenerates it from reasoning_effort. The learned scope is
 // provider+model and shared by both dialects, so a strip learned from that 400
 // would delete the caller's object on the compat path.
+//
+// json_schema lives under text.format on the Responses body, so a 400 there
+// is about that dialect's field; the fallback key is shared with the compat
+// path and must not be learned from it either.
 func responsesRejectedParams(body []byte) map[string]bool {
-	rejected := paramrewrite.ParseProviderParamError(body)
-	delete(rejected, "reasoning")
-	// json_schema lives under text.format on the Responses body, so a 400
-	// there is about that dialect's field; the fallback key is shared with
-	// the compat path and must not be learned from it.
-	delete(rejected, paramrewrite.SchemaFallbackKey)
-	if len(rejected) == 0 {
-		return nil
-	}
-	return rejected
+	return paramrewrite.WithoutParams(paramrewrite.ParseProviderParamError(body), "reasoning", paramrewrite.SchemaFallbackKey)
 }
 
 // mergeLearnedParams is the caching half of the param learner, shared by the

--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -656,13 +656,21 @@ func (h *Handler) peekRateLimitVerdict(ctx context.Context, resp *http.Response)
 // It absorbs a short slot-freeing gap rather than building a queue:
 // st.saturationRetried caps it at one.
 func (h *Handler) deferSaturatedRetry(st *requestState, candidate modelCandidate, resp *http.Response, attempt int) candidateOutcome {
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
 	st.saturationRetried = true
-	st.setReqErr(rateLimitReqErr(st.rateLimit, attempt, candidate.provider.Name))
-	st.logData.failoverAttempt = attempt
-	// The attempt ended here; the retry is its own attempt with its own record.
-	st.logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, st.rateLimit.detail, st.rateLimit.phrase, 0)
+	closeDeferredAttempt(st, resp, attempt, rateLimitReqErr(st.rateLimit, attempt, candidate.provider.Name), st.rateLimit.detail, st.rateLimit.phrase)
 	debuglog.Info("proxy: last candidate saturated, waiting to retry it once", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "retry_after", st.rateLimit.retryAfter, "attempt", attempt+1)
 	return outcomeRetrySaturated
+}
+
+// closeDeferredAttempt ends an attempt the loop will retry: the response is
+// drained and closed, its error becomes the request's, and the attempt is
+// closed on the trail with the detail and phrase given. The retry is its own
+// attempt with its own record. Shared by the saturation and server-error
+// deferrals so the two cannot record an attempt differently.
+func closeDeferredAttempt(st *requestState, resp *http.Response, attempt int, reqErr reqError, detail, phrase string) {
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	st.setReqErr(reqErr)
+	st.logData.failoverAttempt = attempt
+	st.logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, detail, phrase, 0)
 }

--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -661,16 +661,3 @@ func (h *Handler) deferSaturatedRetry(st *requestState, candidate modelCandidate
 	debuglog.Info("proxy: last candidate saturated, waiting to retry it once", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "retry_after", st.rateLimit.retryAfter, "attempt", attempt+1)
 	return outcomeRetrySaturated
 }
-
-// closeDeferredAttempt ends an attempt the loop will retry: the response is
-// drained and closed, its error becomes the request's, and the attempt is
-// closed on the trail with the detail and phrase given. The retry is its own
-// attempt with its own record. Shared by the saturation and server-error
-// deferrals so the two cannot record an attempt differently.
-func closeDeferredAttempt(st *requestState, resp *http.Response, attempt int, reqErr reqError, detail, phrase string) {
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
-	st.setReqErr(reqErr)
-	st.logData.failoverAttempt = attempt
-	st.logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, detail, phrase, 0)
-}

--- a/internal/proxy/transient_retry.go
+++ b/internal/proxy/transient_retry.go
@@ -110,13 +110,8 @@ func (h *Handler) deferLastCandidateRetry(st *requestState, candidate modelCandi
 // does; a 5xx never reads it, but the request-scoped copy is not reached for.
 func (h *Handler) deferServerErrorRetry(st *requestState, candidate modelCandidate, resp *http.Response, attempt int, rl rateLimitVerdict) candidateOutcome {
 	drained, _ := io.ReadAll(io.LimitReader(resp.Body, failoverErrorClassifyCap))
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
 	st.serverErrorRetried = true
-	st.setReqErr(failoverReqErr(rl, attempt, candidate.provider.Name, resp.StatusCode))
-	st.logData.failoverAttempt = attempt
-	// The attempt ended here; the retry is its own attempt with its own record.
-	st.logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, util.SanitizeLogBody(string(drained), 10000), "", 0)
+	closeDeferredAttempt(st, resp, attempt, failoverReqErr(rl, attempt, candidate.provider.Name, resp.StatusCode), util.SanitizeLogBody(string(drained), 10000), "")
 	debuglog.Info("proxy: last candidate answered a retryable server error, retrying it once", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "status", resp.StatusCode, "attempt", attempt+1)
 	return outcomeRetryServerError
 }

--- a/internal/proxy/transient_retry.go
+++ b/internal/proxy/transient_retry.go
@@ -101,6 +101,19 @@ func (h *Handler) deferLastCandidateRetry(st *requestState, candidate modelCandi
 	return outcomeFailover, false
 }
 
+// closeDeferredAttempt ends an attempt the loop will retry: the response is
+// drained and closed, its error becomes the request's, and the attempt is
+// closed on the trail with the detail and phrase given. The retry is its own
+// attempt with its own record. Shared by the saturation and server-error
+// deferrals so the two cannot record an attempt differently.
+func closeDeferredAttempt(st *requestState, resp *http.Response, attempt int, reqErr reqError, detail, phrase string) {
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	st.setReqErr(reqErr)
+	st.logData.failoverAttempt = attempt
+	st.logData.closeAttemptRecord(resp.StatusCode, st.lastReqErr.Kind, detail, phrase, 0)
+}
+
 // deferServerErrorRetry ends an attempt whose last candidate answered a
 // retryable 5xx: the body is drained, the attempt is closed on the trail with
 // the provider's sentence (the breaker has already been charged for it), and

--- a/internal/util/modelid.go
+++ b/internal/util/modelid.go
@@ -1,0 +1,18 @@
+package util
+
+import "strings"
+
+// ModelIDSegments splits a model ID into its name segments: lower-cased and
+// cut on the separators HuggingFace-style ids and vendor prefixes use
+// (org/name-with_parts:tag, vendor.name). A family or endpoint token is then
+// matched as a whole segment or a segment prefix, so a name that merely
+// contains the letters does not match.
+func ModelIDSegments(modelID string) []string {
+	return strings.FieldsFunc(strings.ToLower(modelID), func(r rune) bool {
+		switch r {
+		case '/', '-', '_', '.', ':', ' ':
+			return true
+		}
+		return false
+	})
+}

--- a/internal/util/modelid_test.go
+++ b/internal/util/modelid_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestModelIDSegments(t *testing.T) {
+	cases := map[string][]string{
+		"THUDM/GLM-4":                  {"thudm", "glm", "4"},
+		"glm4:9b":                      {"glm4", "9b"},
+		"zai.glm-4.7":                  {"zai", "glm", "4", "7"},
+		"nomic_embed text":             {"nomic", "embed", "text"},
+		"gemini-2.5-flash-preview-tts": {"gemini", "2", "5", "flash", "preview", "tts"},
+		"":                             nil,
+		"///":                          nil,
+	}
+	for id, want := range cases {
+		if got := ModelIDSegments(id); !slices.Equal(got, want) {
+			t.Errorf("ModelIDSegments(%q) = %v, want %v", id, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A behaviour-preserving cleanup of duplication that landed in the seventeen PRs after #888 (#889 to #906), the same class #888 folded. No functional change intended; net -30 lines.

- **audit (#904):** the `_id`/`_uuid` entity rule was written twice, once in the middleware that records the entity and once in the resolver that reads route patterns. One `isEntityParam` predicate now, so the two cannot pick different parameters.
- **paramrewrite (#895/#896):** "delete a learned name, return nil when nothing is left" was hand-rolled three times (`learnableRejections`, `responsesRejectedParams`, `DropSchemaFallbackUnlessRequested`). One `WithoutParams`.
- **provider (#891):** `BackfillMaskedKeys` carried its own `SELECT` and row struct for columns `Repository.List` already returns. It walks `List` now; the undecryptable warning and the cache invalidation sit in one deferred close.
- **backup (#903):** `listBackupFiles` is the one reader of the backup directory. `ListBackups` was a verbatim copy plus the signature stat, and the scheduler's interval anchor re-walked the directory with the same `.dump` + origin filter. The entry keeps its `ModTime` (unexported) so both callers compare times rather than RFC3339 strings.
- **proxy (#900/#894):** `closeDeferredAttempt` is the shared close of an attempt the loop retries (drain, request error, trail record), used by the saturation and server-error deferrals. The account-exhausted arm of `recordRateLimitOutcome` picks its reason and recorder instead of repeating the log line and call.
  The one observable side effect: two dumps written in the same second used to sort in arbitrary order (RFC3339 has no fraction, and `sort.Slice` is not stable); they now sort by the full modification time. Only a restored or copied dump set can produce such a pair.
- **failover (#892/#894):** `pinSpeaksForAccount` names the advisor-or-account predicate `providerReport` had inline, beside its complement `pinProbes`.
- **util.ModelIDSegments** replaces provider's `splitModelIDSegments` and the narrower tokenizer `schemaIgnoredByModel` grew in #896. The separator set is the union, so a GLM id behind `_` or `:` now matches the way that function's comment already said it would.

## Verification

- `go build ./...`, `go vet`, `golangci-lint run` clean; `make size-check` passes.
- `go test`: util, audit, failover, paramrewrite, provider, proxy, and the api backup/scheduler/configsync scope against the 5433 test DB, all green.
- Every changed production line is covered (checked via `-coverprofile` on the touched packages intersected with the diff).
- Two adversarial review rounds on different models: the first confirmed equivalence path by path and found no defect; the second's two findings (an overstated comment, the attempt-closer's file) are the follow-up commit.
- Rebuilt dev stack and exercised the touched paths live: backup listing (signed, newest first) and a manual backup, the scheduler's anchor ("last scheduled backup is recent, waiting 19h29m57s" against the 16:29 auto dump), a discovery dismiss whose audit row resolves the provider name through the spelled-out parameter, a breaker reset and the circuit status, and a `json_schema` chat request to `glm-4.5-flash` that logged `json_schema folded into the prompt` and answered schema-shaped JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpBFxwtsBQsM5e6BcsPYoj
