### PR TITLE
fix(providers): refresh quota and run discovery when a provider is re-enabled

### DIFF
--- a/internal/api/handler_providers_test.go
+++ b/internal/api/handler_providers_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/db"
 	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/quota"
 )
 
 func TestListProviders_Empty(t *testing.T) {
@@ -1788,4 +1789,104 @@ func TestUpdateProvider_ScheduledDisable(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestUpdateProvider_EnableRefreshesQuota verifies that re-enabling a provider
+// refreshes its quota snapshot before the response is written: the poller
+// skips disabled providers, so the stored snapshot is as old as the disable,
+// and the badge the dashboard reads straight after the toggle must not show it.
+func TestUpdateProvider_EnableRefreshesQuota(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-reenable", "https://api.nano-gpt.com/v1", false)
+	stale := []byte(`{"dailyInputTokens":{"used":1,"limit":1000}}`)
+	if err := h.quotaRepo.Upsert(context.Background(), quota.Snapshot{ProviderID: id, Kind: "usage", Payload: stale, HTTPStatus: http.StatusOK, Source: "poll"}); err != nil {
+		t.Fatalf("seed stale snapshot: %v", err)
+	}
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(9) }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/providers/"+id.String(), strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	snap, err := h.quotaRepo.Get(context.Background(), id, "usage")
+	if err != nil || snap == nil {
+		t.Fatalf("get snapshot: %v (nil=%v)", err, snap == nil)
+	}
+	var got struct {
+		DailyInputTokens struct {
+			Used int64 `json:"used"`
+		} `json:"dailyInputTokens"`
+	}
+	if uerr := json.Unmarshal(snap.Payload, &got); uerr != nil {
+		t.Fatalf("decode payload: %v (%s)", uerr, string(snap.Payload))
+	}
+	if got.DailyInputTokens.Used != 9 {
+		t.Fatalf("enable should refresh the stale snapshot: want used=9, got %d", got.DailyInputTokens.Used)
+	}
+}
+
+// TestUpdateProvider_EnableWithoutTransitionDoesNotRefetch verifies an update
+// that leaves an already-enabled provider enabled costs no upstream quota call.
+func TestUpdateProvider_EnableWithoutTransitionDoesNotRefetch(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-stays-on", "https://api.nano-gpt.com/v1", true)
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(9) }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/providers/"+id.String(), strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	snap, err := h.quotaRepo.Get(context.Background(), id, "usage")
+	if err != nil {
+		t.Fatalf("get snapshot: %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("no transition, no fetch: want no snapshot, got source=%q", snap.Source)
+	}
+}
+
+// TestUpdateProvider_EnableWithoutQuotaEndpointSkipsFetch verifies enabling a
+// provider whose type exposes no quota endpoint writes no snapshot.
+func TestUpdateProvider_EnableWithoutQuotaEndpointSkipsFetch(t *testing.T) {
+	h := newTestHandler(t)
+	r := chi.NewRouter()
+	h.Register(r)
+
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "openai-reenable", "https://api.openai.com/v1", false)
+	h.newDiscovery = func() *provider.DiscoveryService { return nanoGPTPollDiscovery(9) }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/providers/"+id.String(), strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	for _, kind := range []string{"usage", "balance", "account"} {
+		snap, err := h.quotaRepo.Get(context.Background(), id, kind)
+		if err != nil {
+			t.Fatalf("get %s snapshot: %v", kind, err)
+		}
+		if snap != nil {
+			t.Fatalf("type without a quota endpoint must not be fetched: got %s snapshot source=%q", kind, snap.Source)
+		}
+	}
 }

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -442,6 +442,8 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		util.HoldSecret(*req.APIKey)
 	}
 
+	enabling := h.isEnabling(r.Context(), id, req)
+
 	p, err := h.providerRepo.Update(r.Context(), id, req, encryptedKey, keyNonce, keySalt)
 	if err != nil {
 		if db.IsUniqueViolation(err) {
@@ -456,21 +458,56 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// A newly disabled provider syncs failover groups to remove stale entries from
-	// auto-created groups; routing already skips them, but the UI and group
-	// membership must reflect the new state.
-	if req.Enabled != nil && !*req.Enabled {
-		if h.dbPool != nil {
-			failoverRepo := failover.NewRepository(h.dbPool.Pool())
-			if _, err := failoverRepo.SyncAllModels(context.WithoutCancel(r.Context())); err != nil {
-				debuglog.Info("admin: failed to sync failover groups after provider disable", "error", err)
-			}
-		}
-	}
+	disabling := req.Enabled != nil && !*req.Enabled
+	h.settleProviderToggle(context.WithoutCancel(r.Context()), p, disabling, enabling)
 
 	response := provider.ToResponse(p)
 	writeJSON(w, response)
 }
+
+// isEnabling reports whether req switches provider id from disabled to enabled.
+// Read before the write so an enable can be told apart from an update that
+// leaves an already-enabled provider on: only the transition costs an upstream
+// quota call.
+func (h *Handler) isEnabling(ctx context.Context, id uuid.UUID, req provider.UpdateProviderRequest) bool {
+	if req.Enabled == nil || !*req.Enabled {
+		return false
+	}
+	prior, err := h.providerRepo.Get(ctx, id)
+	return err == nil && !prior.Enabled
+}
+
+// settleProviderToggle runs what an enabled-flag change owes the rest of the
+// system. A disable syncs failover groups to remove stale entries from
+// auto-created groups, and an enable syncs them to put its models back; routing
+// already follows the flag, but the UI and group membership must reflect the
+// new state. An enable also refreshes the quota snapshot inline (bounded by the
+// poll timeout): the background poller skips disabled providers, so the stored
+// snapshot is as old as the disable, and the badge the dashboard reads straight
+// after this response must show the current balance rather than that one.
+func (h *Handler) settleProviderToggle(ctx context.Context, p *provider.Provider, disabling, enabling bool) {
+	if (disabling || enabling) && h.dbPool != nil {
+		failoverRepo := failover.NewRepository(h.dbPool.Pool())
+		if _, err := failoverRepo.SyncAllModels(ctx); err != nil {
+			debuglog.Info("admin: failed to sync failover groups after provider enable/disable", "error", err)
+		}
+	}
+	if !enabling {
+		return
+	}
+	if kind, ok := quotaKindFor(provider.TypeOf(p)); ok {
+		// Tighter than the poll's own budget: this runs on an interactive save,
+		// and the background poller is the backstop for a slow upstream.
+		pollCtx, cancel := context.WithTimeout(ctx, enableQuotaRefreshTimeout)
+		defer cancel()
+		h.pollQuotaForProvider(pollCtx, h.discoveryService(), p, kind)
+		h.RefreshQuotaAdvice(ctx)
+	}
+}
+
+// enableQuotaRefreshTimeout bounds the upstream quota call an enable makes
+// before its response is written.
+const enableQuotaRefreshTimeout = 10 * time.Second
 
 // DeleteProvider removes a provider by ID and cleans up associated data.
 func (h *Handler) DeleteProvider(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -486,7 +486,11 @@ func (h *Handler) isEnabling(ctx context.Context, id uuid.UUID, req provider.Upd
 // snapshot is as old as the disable, and the badge the dashboard reads straight
 // after this response must show the current balance rather than that one.
 func (h *Handler) settleProviderToggle(ctx context.Context, p *provider.Provider, disabling, enabling bool) {
-	if (disabling || enabling) && h.dbPool != nil {
+	// A handler without a pool has none of the repositories this needs.
+	if h.dbPool == nil {
+		return
+	}
+	if disabling || enabling {
 		failoverRepo := failover.NewRepository(h.dbPool.Pool())
 		if _, err := failoverRepo.SyncAllModels(ctx); err != nil {
 			debuglog.Info("admin: failed to sync failover groups after provider enable/disable", "error", err)

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -527,6 +527,10 @@ export function Providers() {
 					providers={providers}
 					onClose={() => setEditProvider(null)}
 					onToast={toast}
+					onEnabled={(p) => {
+						// The discover route refuses a provider with autodiscovery off.
+						if (p.autodiscovery_enabled) discoverMutation.mutate(p.id);
+					}}
 				/>
 			)}
 

--- a/web/src/pages/Providers/EditProviderModal.tsx
+++ b/web/src/pages/Providers/EditProviderModal.tsx
@@ -36,12 +36,17 @@ export function EditProviderModal({
 	providers,
 	onClose,
 	onToast,
+	onEnabled,
 }: {
 	provider: Provider;
 	/** Every provider, so a URL edit can warn when it collides with another. */
 	providers?: Provider[];
 	onClose: () => void;
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
+	/** Called with the saved provider when this save switched it on. A provider
+	 * that sat disabled has a catalogue as old as the disable, so the page runs
+	 * discovery for it the way it does for a freshly added one. */
+	onEnabled?: (updated: Provider) => void;
 }) {
 	const queryClient = useQueryClient();
 	// Claims are read per enabled provider, so switching one off takes every
@@ -86,6 +91,7 @@ export function EditProviderModal({
 				"success",
 			);
 			onClose();
+			if (updated.enabled && !provider.enabled) onEnabled?.(updated);
 		},
 		onError: (err: Error) => {
 			// A new address that does not answer as the stored type is rejected;

--- a/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
@@ -253,6 +253,45 @@ describe("EditProviderModal", () => {
 			});
 		});
 
+		it("reports a disabled-to-enabled save through onEnabled", async () => {
+			server.use(
+				http.put("/api/providers/:id", () =>
+					HttpResponse.json({ ...mockProvider, enabled: true }),
+				),
+			);
+			const onEnabled = vi.fn();
+			const { user } = renderWithProviders(
+				<EditProviderModal
+					{...defaultProps}
+					provider={{ ...mockProvider, enabled: false }}
+					onEnabled={onEnabled}
+				/>,
+			);
+			await user.click(screen.getByLabelText("Provider enabled"));
+			await user.click(screen.getByRole("button", { name: "Save Changes" }));
+			await waitFor(() => {
+				expect(onEnabled).toHaveBeenCalledWith(
+					expect.objectContaining({ id: "provider-123", enabled: true }),
+				);
+			});
+		});
+
+		it("does not call onEnabled when the provider was already enabled", async () => {
+			server.use(
+				http.put("/api/providers/:id", () =>
+					HttpResponse.json({ ...mockProvider, name: "Renamed" }),
+				),
+			);
+			const onEnabled = vi.fn();
+			const { user } = renderWithProviders(
+				<EditProviderModal {...defaultProps} onEnabled={onEnabled} />,
+			);
+			await user.type(screen.getByLabelText("Name"), "x");
+			await user.click(screen.getByRole("button", { name: "Save Changes" }));
+			await waitFor(() => expect(onClose).toHaveBeenCalled());
+			expect(onEnabled).not.toHaveBeenCalled();
+		});
+
 		it("disables base URL input for known provider URLs", () => {
 			const knownProvider = {
 				...mockProvider,

--- a/web/src/pages/__tests__/Providers.test.tsx
+++ b/web/src/pages/__tests__/Providers.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../api/client";
 import { Layout } from "../../components/Layout";
 import { mockModel, mockProvider } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
@@ -674,6 +675,68 @@ describe("Providers", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Edit Provider")).toBeInTheDocument();
 			});
+		});
+	});
+
+	describe("Enable Flow", () => {
+		// The card's own Discover button is hidden for a disabled provider, so a
+		// save that switches the provider on is the only path that reaches the
+		// discover route here.
+		async function saveEnabled(user: {
+			click: (el: Element) => Promise<void>;
+		}) {
+			await waitFor(() => {
+				expect(screen.getByText("Test Provider")).toBeInTheDocument();
+			});
+			await user.click(screen.getByRole("button", { name: "Edit" }));
+			await user.click(await screen.findByLabelText("Provider enabled"));
+			await user.click(screen.getByRole("button", { name: "Save Changes" }));
+		}
+
+		it("runs discovery for a provider the save switched on", async () => {
+			let discovered = 0;
+			server.use(
+				http.get("/api/providers", () =>
+					HttpResponse.json([{ ...mockProvider, enabled: false }]),
+				),
+				http.put("/api/providers/:id", () =>
+					HttpResponse.json({ ...mockProvider, enabled: true }),
+				),
+				http.post("/api/providers/:id/discover", () => {
+					discovered++;
+					return HttpResponse.json({ discovered: 0, diff: {} });
+				}),
+			);
+			const { user } = renderWithProviders(<Providers />);
+			await saveEnabled(user);
+			await waitFor(() => expect(discovered).toBe(1));
+		});
+
+		it("skips discovery when the switched-on provider has autodiscovery off", async () => {
+			// Spied rather than counted at the mock server: the discover call is
+			// fire-and-forget from the save, so a request counter read right after
+			// the modal closes would still be 0 even without the guard.
+			const discover = vi.spyOn(api.providers, "discover");
+			server.use(
+				http.get("/api/providers", () =>
+					HttpResponse.json([
+						{ ...mockProvider, enabled: false, autodiscovery_enabled: false },
+					]),
+				),
+				http.put("/api/providers/:id", () =>
+					HttpResponse.json({
+						...mockProvider,
+						enabled: true,
+						autodiscovery_enabled: false,
+					}),
+				),
+			);
+			const { user } = renderWithProviders(<Providers />);
+			await saveEnabled(user);
+			await waitFor(() =>
+				expect(screen.queryByText("Edit Provider")).not.toBeInTheDocument(),
+			);
+			expect(discover).not.toHaveBeenCalled();
 		});
 	});
 

--- a/web/src/pages/__tests__/Providers.test.tsx
+++ b/web/src/pages/__tests__/Providers.test.tsx
@@ -737,6 +737,7 @@ describe("Providers", () => {
 				expect(screen.queryByText("Edit Provider")).not.toBeInTheDocument(),
 			);
 			expect(discover).not.toHaveBeenCalled();
+			discover.mockRestore();
 		});
 	});
 


### PR DESCRIPTION
## Problem

Re-enabling a provider in the dashboard only flipped the row. Two things went stale:

- **Quota badge.** The background poller skips disabled providers and `GET /api/providers/{id}/usage` serves the stored snapshot, so the card and sidebar badge showed the pre-disable balance (in the reported case `$0.00` after a top-up) until the next five-minute poll. The sidebar refresh sweep also skips disabled providers, so a refresh clicked before the enable did nothing for it.
- **Model catalogue.** No discovery ran on the member that received the PUT. Fleet followers did discover, but only because the config-sync import runs `discoverAll`; the primary kept the catalogue from before the disable.

Observed on prod: enable at 08:46:27, badge stayed at `$0.00`, a page reload at 08:46:40 showed `$9.98` only because the poller happened to tick at 08:46:35.

## Fix

**Backend** (`internal/api/providers.go`)
- `isEnabling` reads the row before the write so a disabled-to-enabled transition is told apart from a save that leaves an enabled provider on.
- `settleProviderToggle` syncs failover groups on enable as well as disable (its models rejoin auto groups), and on enable refreshes that provider's quota snapshot inline (10 s cap, quota-capable types only) and rebuilds quota advice, so the usage GET the dashboard fires right after the response reads the current balance.

**Frontend**
- `EditProviderModal` gains an optional `onEnabled(updated)` callback fired when the save switched the provider on.
- The Providers page wires it to the existing per-provider Discover mutation (spinner, diff summary modal), skipped when autodiscovery is off since that route refuses such providers.

## Tests

- Go: stale snapshot replaced on enable; no upstream call when the flag does not transition; no snapshot written for a type without a quota endpoint.
- Frontend: modal fires `onEnabled` only on the transition; page runs discovery for an enabled provider and skips it when autodiscovery is off (spy-based, so the negative test can actually fail).

## Verification

- `internal/api` package green, golangci-lint clean, size gate clean, `tsc -b`, ESLint, Biome clean.
- Dev stack: disable then enable OpenRouter via PUT. Enable answered in 0.78 s, `X-Quota-Fetched-At` on the next usage GET matched the enable second, failover synced 127 groups, and the poller's previous tick was four minutes earlier.

## Left as is

- Config-sync import on followers does not refresh quota on an enable flip, but Front Desk pushes the primary's snapshots to members every minute, so they lag at most 60 s.
- Two concurrent enables of the same provider can each fetch once. Admin path, idempotent writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rKscgDphpxkv6R12FGwYy
