### PR TITLE
ci: stop installing postgresql-client, check the runner's own pg_dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,15 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install pg_dump / pg_restore for backup tests
+      - name: Check pg_dump / pg_restore are present for backup tests
         # The backup integration tests (internal/api/backup_test.go) exec
         # pg_dump and pg_restore; without these binaries ~26 tests t.Skip and
-        # the backup/restore round-trip goes entirely untested. ubuntu-latest's
-        # postgresql-client meta-package ships v16, matching the postgres:16
-        # service container.
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+        # the backup/restore round-trip goes entirely untested. The runner image
+        # ships PostgreSQL 16 client tools, matching the postgres:16 service
+        # container, so nothing is installed here: an apt fetch from the
+        # runner's Azure mirror can stall for 20+ minutes on an 11 kB package.
+        # This fails loudly if an image update ever drops them.
+        run: pg_dump --version && pg_restore --version
 
       - name: Run tests
         env:
@@ -180,9 +182,11 @@ jobs:
           cache: true
 
       # internal/api's backup tests exec these; without them ~26 tests skip and
-      # the race job silently stops covering the backup round-trip.
-      - name: Install pg_dump / pg_restore for backup tests
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+      # the race job silently stops covering the backup round-trip. The runner
+      # image already ships them (see the Go Test job for why nothing is
+      # installed here).
+      - name: Check pg_dump / pg_restore are present for backup tests
+        run: pg_dump --version && pg_restore --version
 
       # A longer clock than go-test's 10m: the detector's slowdown lands on
       # internal/api, the one package already near that limit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
 
       - name: Check pg_dump / pg_restore are present for backup tests
         # The backup integration tests (internal/api/backup_test.go) exec
-        # pg_dump and pg_restore; without these binaries ~26 tests t.Skip and
-        # the backup/restore round-trip goes entirely untested. The runner image
+        # pg_dump and pg_restore and t.Fatal without them. The runner image
         # ships PostgreSQL 16 client tools, matching the postgres:16 service
         # container, so nothing is installed here: an apt fetch from the
         # runner's Azure mirror can stall for 20+ minutes on an 11 kB package.
-        # This fails loudly if an image update ever drops them.
+        # This names the missing binary up front if an image update ever
+        # drops them, instead of a wall of backup test failures.
         run: pg_dump --version && pg_restore --version
 
       - name: Run tests
@@ -181,10 +181,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # internal/api's backup tests exec these; without them ~26 tests skip and
-      # the race job silently stops covering the backup round-trip. The runner
-      # image already ships them (see the Go Test job for why nothing is
-      # installed here).
+      # internal/api's backup tests exec these and t.Fatal without them. The
+      # runner image already ships them (see the Go Test job for why nothing
+      # is installed here).
       - name: Check pg_dump / pg_restore are present for backup tests
         run: pg_dump --version && pg_restore --version
 


### PR DESCRIPTION
## Problem

The `Go Test` and `Go Race` jobs each ran `apt-get update && apt-get install postgresql-client` so the backup integration tests find `pg_dump` / `pg_restore`. The runner image (`ubuntu-24.04`, PostgreSQL 16.15 preinstalled) already has them: the install log shows only the 11.6 kB `postgresql-client` meta package as "newly installed".

That fetch goes through the runner's Azure Ubuntu mirror first. When the mirror accepts the connection and never sends the body, apt waits out its retries before falling back to `archive.ubuntu.com`. On the master run for #912 the step logged:

```
Fetched 11.6 kB in 22min 11s (8 B/s)
```

and `go test -race` did not start for 22 minutes. Index fetches from the same mirror seconds earlier ran at 644 kB/s, so this is a mirror stall, not DNS.

## Fix

Both apt steps are replaced by `pg_dump --version && pg_restore --version`. Nothing is installed; the check fails the job loudly if an image update ever drops the client tools, instead of the 26 backup tests silently skipping.

`actionlint` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rKscgDphpxkv6R12FGwYy
