### PR TITLE
fix(providers): rediscover on the primary when a save changes the catalogue

### DIFF
--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -252,6 +252,9 @@ func (h *Handler) AckDiscoveryChanges(w http.ResponseWriter, r *http.Request) {
 }
 
 // DiscoverProviderModels discovers and imports models from a specific provider.
+// It keeps its own request-bound copy of the scan rather than calling
+// discoverOne because every failure here is answered as an HTTP error, while
+// the shared scan records failures and carries on.
 func (h *Handler) DiscoverProviderModels(w http.ResponseWriter, r *http.Request) {
 	providerID, ok := parseUUIDParam(w, r, "id", "provider ID")
 	if !ok {
@@ -434,146 +437,164 @@ func (h *Handler) discoverAllProviders(ctx context.Context, recordMisses bool) (
 		if !prov.Enabled || !prov.AutodiscoveryEnabled {
 			continue
 		}
-
-		events.Publish(events.Event{
-			Type:     "request.discovery.provider_starting",
-			Severity: "info",
-			Source:   "proxy",
-			Message:  fmt.Sprintf("Discovering models from %s…", prov.Name),
-			Metadata: map[string]any{"provider_id": prov.ID, "provider": prov.Name},
-		})
-
-		provCtx, provCancel := context.WithTimeout(context.WithoutCancel(ctx), 180*time.Second)
-		result := DiscoverAllResult{
-			ProviderName: prov.Name,
-		}
-
-		models, discoverErr := discovery.DiscoverModels(provCtx, prov, h.cfg.MasterKey)
-
-		if discoverErr != nil {
-			result.Error = discoverErr.Error()
+		result := h.discoverOne(ctx, discovery, modelRepo, failoverRepo, prov, recordMisses)
+		if result.Error != "" {
 			failed++
-			provCancel()
-			events.Publish(events.Event{
-				Type:     "discovery.provider_failed",
-				Severity: "error",
-				Source:   "discovery",
-				Message:  fmt.Sprintf("Failed to discover models from %s: %s", prov.Name, discoverErr.Error()),
-				Metadata: map[string]any{"provider": prov.Name, "error": discoverErr.Error()},
-			})
-			results = append(results, result)
-			continue
-		}
-
-		result.Discovered = len(models)
-		totalDiscovered += len(models)
-		succeeded++
-
-		events.Publish(events.Event{
-			Type:     "discovery.provider_fetched",
-			Severity: "success",
-			Source:   "discovery",
-			Message:  fmt.Sprintf("Fetched %s from %s", util.Count(len(models), "model", "models"), prov.Name),
-			Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
-		})
-
-		// Enrich models with data from models.dev.
-		if cache := provider.GetModelsDevCache(); cache != nil {
-			enriched := cache.EnrichModels(models, provider.TypeOf(prov))
-			if enriched > 0 {
-				events.Publish(events.Event{
-					Type:     "discovery.enriched",
-					Severity: "info",
-					Source:   "discovery",
-					Message:  fmt.Sprintf("Enriched %d/%d models from models.dev catalogue", enriched, len(models)),
-					Metadata: map[string]any{"provider": prov.Name, "enriched": enriched, "total": len(models)},
-				})
-			}
-		}
-		// Runs unconditionally: modality arrays and the derived endpoint class
-		// must be consistent even when models.dev is unreachable.
-		provider.NormalizeModels(models)
-
-		snapshot, snapErr := SnapshotProviderModels(provCtx, modelRepo, prov.ID)
-		if snapErr != nil {
-			debuglog.Debug("discovery: failed to snapshot models", "provider", prov.Name, "error", snapErr)
-		}
-		DampenOpenRouterPriceJitter(provider.TypeOf(prov), snapshot, models)
-
-		existingModelIDs := make([]string, 0, len(models))
-		upsertedModels := make([]*model.Model, 0, len(models))
-		upsertFailed := false
-		for _, m := range models {
-			if err := modelRepo.Upsert(provCtx, m); err != nil {
-				debuglog.Warn("discovery: failed to upsert model", "model", m.ModelID, "provider", prov.Name, "error", err)
-				upsertFailed = true
-				continue
-			}
-			existingModelIDs = append(existingModelIDs, m.ModelID)
-			upsertedModels = append(upsertedModels, m)
-		}
-
-		// Miss recording needs a trustworthy membership picture: skip it when a
-		// snapshot is unavailable (cannot confirm absentees), when any upsert
-		// failed (a DB error must not count a listed model as missing), or when
-		// the confirmation probes flag the scan as suspect. Disabling happens
-		// only after MissingScanThreshold consecutive confirmed-missing scans.
-		// recordMisses is false on request-bound callers so the ~70s probe
-		// backoff never overruns their HTTP timeout (see the doc comment).
-		var disabledRefs []model.DisabledModelRef
-		if recordMisses && snapErr == nil && !upsertFailed {
-			confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot, NewSuspectStreak(h.dbPool.Pool()))
-			if suspect {
-				debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", prov.ID)
-			} else {
-				var pendingRefs []model.DisabledModelRef
-				disabledRefs, pendingRefs, err = modelRepoRecordMissing(modelRepo, provCtx, prov.ID, prov.Name, confirmedIDs)
-				if err != nil {
-					debuglog.Debug("discovery: failed to record missing models", "provider", prov.Name, "error", err)
-				}
-				if len(pendingRefs) > 0 {
-					debuglog.Info("discovery: models confirmed missing but below disable threshold",
-						"provider", prov.Name, "provider_id", prov.ID, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
-				}
-			}
-		}
-
-		// Without the before-snapshot the diff cannot be classified; the scan
-		// itself still completes and the result just omits the diff.
-		var diff *DiscoveryDiff
-		if snapErr == nil {
-			diff = BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
-		}
-
-		syncFailoverForScan(provCtx, failoverRepo, existingModelIDs, disabledRefs, diff, func(modelID string, disabled bool, err error) bool {
-			label := "model"
-			if disabled {
-				label = "disabled model"
-			}
-			debuglog.Debug("discovery: failed to sync failover for "+label, "model_id", modelID, "error", err)
-			return true
-		})
-		result.Diff = diff
-
-		now := time.Now()
-		if _, err := dbExec(h.dbPool.Pool(), provCtx,
-			`UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, prov.ID); err != nil {
-			debuglog.Debug("discovery: failed to update last_discovered_at", "provider_id", prov.ID, "error", err)
 		} else {
-			// Raw UPDATE bypasses the repository; evict this provider's cache
-			// entries so read-through Get sees the new last_discovered_at.
-			provider.EvictProviderCacheByID(prov.ID)
+			succeeded++
+			totalDiscovered += result.Discovered
 		}
-
-		provCancel()
 		results = append(results, result)
 	}
 
-	// Reflect the discovery in the failover "Last Sync" label whenever at least
-	// one provider's groups were actually (re)synced.
-	if succeeded > 0 {
-		stampFailoverSynced(context.WithoutCancel(ctx), h.settingsRepo)
+	return results, succeeded, failed, totalDiscovered, nil
+}
+
+// discoverOne scans a single provider and upserts what it lists: the
+// per-provider half of discoverAllProviders, shared with the rediscovery an
+// enabled provider gets when a save changes its address, type, key or enabled
+// flag. Each run has its own detached timeout so a caller's cancellation never
+// aborts a scan mid-upsert. Success is result.Error == "".
+func (h *Handler) discoverOne(ctx context.Context, discovery *provider.DiscoveryService, modelRepo *model.Repository, failoverRepo *failover.Repository, prov *provider.Provider, recordMisses bool) DiscoverAllResult {
+	events.Publish(events.Event{
+		Type:     "request.discovery.provider_starting",
+		Severity: "info",
+		Source:   "proxy",
+		Message:  fmt.Sprintf("Discovering models from %s…", prov.Name),
+		Metadata: map[string]any{"provider_id": prov.ID, "provider": prov.Name},
+	})
+
+	provCtx, provCancel := context.WithTimeout(context.WithoutCancel(ctx), 180*time.Second)
+	defer provCancel()
+	result := DiscoverAllResult{
+		ProviderName: prov.Name,
 	}
 
-	return results, succeeded, failed, totalDiscovered, nil
+	models, discoverErr := discovery.DiscoverModels(provCtx, prov, h.cfg.MasterKey)
+
+	if discoverErr != nil {
+		result.Error = discoverErr.Error()
+		events.Publish(events.Event{
+			Type:     "discovery.provider_failed",
+			Severity: "error",
+			Source:   "discovery",
+			Message:  fmt.Sprintf("Failed to discover models from %s: %s", prov.Name, discoverErr.Error()),
+			Metadata: map[string]any{"provider": prov.Name, "error": discoverErr.Error()},
+		})
+		return result
+	}
+
+	result.Discovered = len(models)
+
+	events.Publish(events.Event{
+		Type:     "discovery.provider_fetched",
+		Severity: "success",
+		Source:   "discovery",
+		Message:  fmt.Sprintf("Fetched %s from %s", util.Count(len(models), "model", "models"), prov.Name),
+		Metadata: map[string]any{"provider": prov.Name, "count": len(models)},
+	})
+
+	// Enrich models with data from models.dev.
+	if cache := provider.GetModelsDevCache(); cache != nil {
+		enriched := cache.EnrichModels(models, provider.TypeOf(prov))
+		if enriched > 0 {
+			events.Publish(events.Event{
+				Type:     "discovery.enriched",
+				Severity: "info",
+				Source:   "discovery",
+				Message:  fmt.Sprintf("Enriched %d/%d models from models.dev catalogue", enriched, len(models)),
+				Metadata: map[string]any{"provider": prov.Name, "enriched": enriched, "total": len(models)},
+			})
+		}
+	}
+	// Runs unconditionally: modality arrays and the derived endpoint class
+	// must be consistent even when models.dev is unreachable.
+	provider.NormalizeModels(models)
+
+	snapshot, snapErr := SnapshotProviderModels(provCtx, modelRepo, prov.ID)
+	if snapErr != nil {
+		debuglog.Debug("discovery: failed to snapshot models", "provider", prov.Name, "error", snapErr)
+	}
+	DampenOpenRouterPriceJitter(provider.TypeOf(prov), snapshot, models)
+
+	existingModelIDs := make([]string, 0, len(models))
+	upsertedModels := make([]*model.Model, 0, len(models))
+	upsertFailed := false
+	for _, m := range models {
+		if err := modelRepo.Upsert(provCtx, m); err != nil {
+			debuglog.Warn("discovery: failed to upsert model", "model", m.ModelID, "provider", prov.Name, "error", err)
+			upsertFailed = true
+			continue
+		}
+		existingModelIDs = append(existingModelIDs, m.ModelID)
+		upsertedModels = append(upsertedModels, m)
+	}
+
+	// Miss recording needs a trustworthy membership picture: skip it when a
+	// snapshot is unavailable (cannot confirm absentees), when any upsert
+	// failed (a DB error must not count a listed model as missing), or when
+	// the confirmation probes flag the scan as suspect. Disabling happens
+	// only after MissingScanThreshold consecutive confirmed-missing scans.
+	// recordMisses is false on request-bound callers so the ~70s probe
+	// backoff never overruns their HTTP timeout (see the doc comment).
+	var disabledRefs []model.DisabledModelRef
+	if recordMisses && snapErr == nil && !upsertFailed {
+		confirmedIDs, suspect := ConfirmMissingModels(provCtx, discovery, prov, h.cfg.MasterKey, existingModelIDs, snapshot, NewSuspectStreak(h.dbPool.Pool()))
+		if suspect {
+			debuglog.Warn("discovery: suspect scan, skipping missing-model recording", "provider", prov.Name, "provider_id", prov.ID)
+		} else {
+			var pendingRefs []model.DisabledModelRef
+			var err error
+			disabledRefs, pendingRefs, err = modelRepoRecordMissing(modelRepo, provCtx, prov.ID, prov.Name, confirmedIDs)
+			if err != nil {
+				debuglog.Debug("discovery: failed to record missing models", "provider", prov.Name, "error", err)
+			}
+			if len(pendingRefs) > 0 {
+				debuglog.Info("discovery: models confirmed missing but below disable threshold",
+					"provider", prov.Name, "provider_id", prov.ID, "pending", len(pendingRefs), "threshold", model.MissingScanThreshold)
+			}
+		}
+	}
+
+	// Without the before-snapshot the diff cannot be classified; the scan
+	// itself still completes and the result just omits the diff.
+	var diff *DiscoveryDiff
+	if snapErr == nil {
+		diff = BuildDiscoveryDiff(snapshot, upsertedModels, disabledRefs)
+	}
+
+	syncFailoverForScan(provCtx, failoverRepo, existingModelIDs, disabledRefs, diff, func(modelID string, disabled bool, err error) bool {
+		label := "model"
+		if disabled {
+			label = "disabled model"
+		}
+		debuglog.Debug("discovery: failed to sync failover for "+label, "model_id", modelID, "error", err)
+		return true
+	})
+	result.Diff = diff
+	// Reflect the scan in the failover "Last Sync" label.
+	stampFailoverSynced(provCtx, h.settingsRepo)
+
+	now := time.Now()
+	if _, err := dbExec(h.dbPool.Pool(), provCtx,
+		`UPDATE providers SET last_discovered_at = $1 WHERE id = $2`, now, prov.ID); err != nil {
+		debuglog.Debug("discovery: failed to update last_discovered_at", "provider_id", prov.ID, "error", err)
+	} else {
+		// Raw UPDATE bypasses the repository; evict this provider's cache
+		// entries so read-through Get sees the new last_discovered_at.
+		provider.EvictProviderCacheByID(prov.ID)
+	}
+	// Last, once every row this scan writes is committed: the dashboard re-reads
+	// its lists on this event, and the earlier fetched/enriched events fire
+	// before the upserts, so a re-read on those would still see the old
+	// catalogue. The request. prefix keeps it out of the toast stream like the
+	// matching provider_starting event.
+	events.Publish(events.Event{
+		Type:     "request.discovery.provider_completed",
+		Severity: "info",
+		Source:   "discovery",
+		Message:  fmt.Sprintf("Finished discovery for %s", prov.Name),
+		Metadata: map[string]any{"provider_id": prov.ID, "provider": prov.Name, "count": len(models)},
+	})
+	return result
 }

--- a/internal/api/handler_providers_test.go
+++ b/internal/api/handler_providers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -365,7 +366,10 @@ func TestCreateProvider_Duplicate(t *testing.T) {
 // Test for admin.go - UpdateProvider_ChangeURL
 
 func TestUpdateProvider_ChangeURL(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
+	// The identity change rediscovers in the background; keep that scan off
+	// the network.
+	h.newDiscovery = rejectingDiscovery
 
 	// Create a provider first
 	providerData := `{"name": "test-update-url", "base_url": "https://api.openai.com", "api_key": "test-api-key"}`
@@ -879,7 +883,10 @@ func TestUpdateProvider_InvalidBody(t *testing.T) {
 // TestUpdateProvider_WithNewAPIKey tests updating with a new API key
 
 func TestUpdateProvider_WithNewAPIKey(t *testing.T) {
-	_, r := newTestHandlerWithRouter(t)
+	h, r := newTestHandlerWithRouter(t)
+	// The identity change rediscovers in the background; keep that scan off
+	// the network.
+	h.newDiscovery = rejectingDiscovery
 
 	// Create a provider first
 	body := `{"name":"test-update-key","base_url":"https://api.openai.com","api_key":"sk-old123"}`
@@ -1889,4 +1896,16 @@ func TestUpdateProvider_EnableWithoutQuotaEndpointSkipsFetch(t *testing.T) {
 			t.Fatalf("type without a quota endpoint must not be fetched: got %s snapshot source=%q", kind, snap.Source)
 		}
 	}
+}
+
+// rejectingDiscovery answers every upstream call with 401 so a background scan
+// a test triggers fails fast without leaving the process.
+func rejectingDiscovery() *provider.DiscoveryService {
+	ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{Transport: &mockTransport{
+		roundTripFunc: func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+		},
+	}})
+	ds.SetRetryBaseDelay(time.Millisecond)
+	return ds
 }

--- a/internal/api/provider_rediscover_test.go
+++ b/internal/api/provider_rediscover_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+func TestShouldRediscover(t *testing.T) {
+	base := func() *provider.Provider {
+		return &provider.Provider{ID: uuid.New(), BaseURL: "https://api.openai.com/v1", ProviderType: "openai", Enabled: true, AutodiscoveryEnabled: true}
+	}
+	cases := []struct {
+		name       string
+		noPrior    bool
+		prior      func(p *provider.Provider)
+		updated    func(p *provider.Provider)
+		keyChanged bool
+		want       bool
+	}{
+		{name: "rename only", want: false},
+		{name: "enable transition", prior: func(p *provider.Provider) { p.Enabled = false }, want: true},
+		{name: "autodiscovery switched on", prior: func(p *provider.Provider) { p.AutodiscoveryEnabled = false }, want: true},
+		{name: "disable transition", updated: func(p *provider.Provider) { p.Enabled = false }, want: false},
+		{name: "base url change", updated: func(p *provider.Provider) { p.BaseURL = "https://other.example.com/v1" }, want: true},
+		{name: "type change", updated: func(p *provider.Provider) { p.ProviderType = "custom" }, want: true},
+		{name: "key change", keyChanged: true, want: true},
+		{name: "key change while disabled", updated: func(p *provider.Provider) { p.Enabled = false }, keyChanged: true, want: false},
+		{name: "url change with autodiscovery off", updated: func(p *provider.Provider) {
+			p.BaseURL = "https://other.example.com/v1"
+			p.AutodiscoveryEnabled = false
+		}, want: false},
+		{name: "no prior row", noPrior: true, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var prior *provider.Provider
+			if !tc.noPrior {
+				prior = base()
+				if tc.prior != nil {
+					tc.prior(prior)
+				}
+			}
+			updated := base()
+			if tc.updated != nil {
+				tc.updated(updated)
+			}
+			if got := shouldRediscover(prior, updated, tc.keyChanged); got != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestUpdateProvider_BaseURLChangeRediscovers verifies a save that moves a
+// provider to another address rediscovers its catalogue on this node without a
+// Discover click, the way a config-sync import does on fleet members.
+func TestUpdateProvider_BaseURLChangeRediscovers(t *testing.T) {
+	h, r := newTestHandlerWithRouter(t)
+
+	listing := func(modelID string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.URL.Path != "/v1/models" {
+				http.NotFound(w, req)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"id": modelID, "owned_by": "test", "object": "model"}},
+			})
+		}))
+	}
+	old := listing("original-model-a")
+	defer old.Close()
+	moved := listing("moved-model-a")
+	defer moved.Close()
+
+	create := fmt.Sprintf(`{"name":"rediscover-on-move","base_url":"%s/v1","api_key":"sk-test"}`, old.URL)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/providers", strings.NewReader(create))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.MustParse(created.ID)
+
+	// Create runs no discovery server-side, so any model row below comes from
+	// the update.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/providers/"+created.ID, strings.NewReader(fmt.Sprintf(`{"base_url":"%s/v1"}`, moved.URL)))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// last_discovered_at is the scan's final write, so once it is stamped the
+	// background goroutine has nothing left to touch in the shared test DB.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		prov, err := h.providerRepo.Get(context.Background(), id)
+		if err != nil {
+			t.Fatalf("get provider: %v", err)
+		}
+		if prov.LastDiscoveredAt != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background discovery did not stamp last_discovered_at")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	models, err := newModelRepo(h.dbPool.Pool()).List(context.Background(), &id)
+	if err != nil {
+		t.Fatalf("list models: %v", err)
+	}
+	if len(models) != 1 || models[0].ModelID != "moved-model-a" {
+		t.Fatalf("want the moved listing, got %d models", len(models))
+	}
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -442,7 +442,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		util.HoldSecret(*req.APIKey)
 	}
 
-	enabling := h.isEnabling(r.Context(), id, req)
+	prior := h.priorProvider(r.Context(), id, req)
 
 	p, err := h.providerRepo.Update(r.Context(), id, req, encryptedKey, keyNonce, keySalt)
 	if err != nil {
@@ -458,23 +458,62 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	disabling := req.Enabled != nil && !*req.Enabled
-	h.settleProviderToggle(context.WithoutCancel(r.Context()), p, disabling, enabling)
+	h.settleProviderUpdate(context.WithoutCancel(r.Context()), prior, p, req)
 
 	response := provider.ToResponse(p)
 	writeJSON(w, response)
 }
 
-// isEnabling reports whether req switches provider id from disabled to enabled.
-// Read before the write so an enable can be told apart from an update that
-// leaves an already-enabled provider on: only the transition costs an upstream
-// quota call.
-func (h *Handler) isEnabling(ctx context.Context, id uuid.UUID, req provider.UpdateProviderRequest) bool {
-	if req.Enabled == nil || !*req.Enabled {
-		return false
+// priorProvider reads the row a save is about to replace, but only when the
+// save touches something whose before-and-after matters: the enabled flag or
+// the provider's identity. A rename never needs it.
+func (h *Handler) priorProvider(ctx context.Context, id uuid.UUID, req provider.UpdateProviderRequest) *provider.Provider {
+	if req.Enabled == nil && req.AutodiscoveryEnabled == nil && req.BaseURL == nil && req.ProviderType == nil && req.APIKey == nil {
+		return nil
 	}
 	prior, err := h.providerRepo.Get(ctx, id)
-	return err == nil && !prior.Enabled
+	if err != nil {
+		return nil
+	}
+	return prior
+}
+
+// settleProviderUpdate runs what a committed save owes the rest of the system:
+// the enabled-flag settlement, then a background rediscovery when the save
+// changed something that can change the catalogue.
+func (h *Handler) settleProviderUpdate(ctx context.Context, prior, p *provider.Provider, req provider.UpdateProviderRequest) {
+	disabling := req.Enabled != nil && !*req.Enabled
+	enabling := prior != nil && !prior.Enabled && p.Enabled
+	h.settleProviderToggle(ctx, p, disabling, enabling)
+	if shouldRediscover(prior, p, req.APIKey != nil) {
+		h.rediscoverInBackground(ctx, p)
+	}
+}
+
+// shouldRediscover reports whether a save changed something that can change
+// the provider's catalogue: it or its autodiscovery was switched on, or its
+// address, type or key moved. A config-sync import rediscovers on every fleet
+// member after such a change, so the node the save landed on scans too rather
+// than keeping the catalogue from before the edit until the next sweep.
+func shouldRediscover(prior, updated *provider.Provider, keyChanged bool) bool {
+	if prior == nil || !updated.Enabled || !updated.AutodiscoveryEnabled {
+		return false
+	}
+	return !prior.Enabled || !prior.AutodiscoveryEnabled || keyChanged ||
+		prior.BaseURL != updated.BaseURL ||
+		provider.TypeOf(prior) != provider.TypeOf(updated)
+}
+
+// rediscoverInBackground scans one provider without holding the response:
+// discovery can take minutes on a slow upstream. The dashboard follows the
+// scan through the discovery events (lists re-read on completion, failures
+// toasted) rather than the diff modal a manual Discover click shows; the scan
+// itself bounds its own upstream time.
+func (h *Handler) rediscoverInBackground(ctx context.Context, prov *provider.Provider) {
+	if h.dbPool == nil {
+		return
+	}
+	go h.discoverOne(ctx, h.discoveryService(), newModelRepo(h.dbPool.Pool()), newFailoverRepo(h.dbPool.Pool()), prov, false)
 }
 
 // settleProviderToggle runs what an enabled-flag change owes the rest of the

--- a/web/src/context/EventContext.tsx
+++ b/web/src/context/EventContext.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useEffect, useRef } from "react";
 import { API_BASE, clearAuth, isAuthenticated } from "../api/client";
 import { readSSEStream } from "../utils/sse";
@@ -14,6 +15,7 @@ interface ServerEvent {
 
 export function EventProvider({ children }: { children: ReactNode }) {
 	const { toast } = useToast();
+	const queryClient = useQueryClient();
 	const reconnectDelay = useRef(1000);
 	const abortRef = useRef<AbortController | null>(null);
 	const connectingRef = useRef(false);
@@ -72,6 +74,20 @@ export function EventProvider({ children }: { children: ReactNode }) {
 							if (!event.type.startsWith("request.")) {
 								toast(event.message, event.severity);
 							}
+							// Discovery also runs with no dashboard action behind it: a
+							// provider save that changed its address or key scans in the
+							// background, so the lists follow the completion event. Only
+							// that one: the fetched/enriched events fire before the scan's
+							// rows are written. exact on the badge key, for the reason
+							// useRefreshDiscoveryBadge gives.
+							if (event.type === "request.discovery.provider_completed") {
+								queryClient.invalidateQueries({ queryKey: ["providers"] });
+								queryClient.invalidateQueries({ queryKey: ["models"] });
+								queryClient.invalidateQueries({
+									queryKey: ["discovery-status"],
+									exact: true,
+								});
+							}
 						},
 					}).catch(() => {
 						// Stream ended or errored
@@ -105,7 +121,7 @@ export function EventProvider({ children }: { children: ReactNode }) {
 				reconnectTimerRef.current = null;
 			}
 		};
-	}, [toast]);
+	}, [toast, queryClient]);
 
 	return <>{children}</>;
 }

--- a/web/src/context/__tests__/EventContext.test.tsx
+++ b/web/src/context/__tests__/EventContext.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,14 +16,34 @@ interface ServerEvent {
 	timestamp: string;
 }
 
-function renderWithEventProvider(ui: React.ReactElement) {
+function renderWithEventProvider(
+	ui: React.ReactElement,
+	queryClient = new QueryClient(),
+) {
 	return render(ui, {
 		wrapper: ({ children }) => (
-			<ToastProvider>
-				<EventProvider>{children}</EventProvider>
-			</ToastProvider>
+			<QueryClientProvider client={queryClient}>
+				<ToastProvider>
+					<EventProvider>{children}</EventProvider>
+				</ToastProvider>
+			</QueryClientProvider>
 		),
 	});
+}
+
+function sseOnce(event: ServerEvent) {
+	server.use(
+		http.get("/api/events", () => {
+			const stream = createSSEStream([event], { doneSentinel: null });
+			return new HttpResponse(stream, {
+				status: 200,
+				headers: {
+					"Content-Type": "text/event-stream",
+					"Cache-Control": "no-cache",
+				},
+			});
+		}),
+	);
 }
 
 describe("EventContext", () => {
@@ -83,6 +104,56 @@ describe("SSE connection and event handling", () => {
 
 		expect(authHeader).toBeUndefined();
 		expect(cookieHeader).toContain("mh_csrf=");
+	});
+
+	it("re-reads providers, models and the badge when a discovery completes", async () => {
+		// Discovery can run server-side with no dashboard action behind it (a
+		// provider save that changed its address), so the lists follow the
+		// completion event rather than a mutation's settle.
+		const queryClient = new QueryClient();
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		sseOnce({
+			id: "evt-d",
+			type: "request.discovery.provider_completed",
+			severity: "info",
+			message: "Finished discovery for Test",
+			timestamp: new Date().toISOString(),
+		});
+		renderWithEventProvider(<div />, queryClient);
+		await waitFor(() => {
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: ["providers"] });
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: ["models"] });
+			// exact: a prefix match would also refetch the discrepancy modal's
+			// query, which stamps the server's last-reviewed marker.
+			expect(invalidate).toHaveBeenCalledWith({
+				queryKey: ["discovery-status"],
+				exact: true,
+			});
+		});
+	});
+
+	it.each([
+		"backup.created",
+		"request.discovery.provider_starting",
+		"discovery.provider_fetched",
+	])("does not re-read lists on %s", async (type) => {
+		// The mid-scan events fire before the scan's rows are written, so a
+		// re-read on them would still see the old catalogue.
+		const queryClient = new QueryClient();
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		const seen = vi.fn();
+		window.addEventListener("server-event", seen);
+		sseOnce({
+			id: "evt-x",
+			type,
+			severity: "info",
+			message: "something happened",
+			timestamp: new Date().toISOString(),
+		});
+		renderWithEventProvider(<div />, queryClient);
+		await waitFor(() => expect(seen).toHaveBeenCalledTimes(1));
+		window.removeEventListener("server-event", seen);
+		expect(invalidate).not.toHaveBeenCalled();
 	});
 
 	it("dispatches server-event CustomEvent for each SSE chunk", async () => {

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -527,10 +527,6 @@ export function Providers() {
 					providers={providers}
 					onClose={() => setEditProvider(null)}
 					onToast={toast}
-					onEnabled={(p) => {
-						// The discover route refuses a provider with autodiscovery off.
-						if (p.autodiscovery_enabled) discoverMutation.mutate(p.id);
-					}}
 				/>
 			)}
 

--- a/web/src/pages/Providers/EditProviderModal.tsx
+++ b/web/src/pages/Providers/EditProviderModal.tsx
@@ -36,17 +36,12 @@ export function EditProviderModal({
 	providers,
 	onClose,
 	onToast,
-	onEnabled,
 }: {
 	provider: Provider;
 	/** Every provider, so a URL edit can warn when it collides with another. */
 	providers?: Provider[];
 	onClose: () => void;
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
-	/** Called with the saved provider when this save switched it on. A provider
-	 * that sat disabled has a catalogue as old as the disable, so the page runs
-	 * discovery for it the way it does for a freshly added one. */
-	onEnabled?: (updated: Provider) => void;
 }) {
 	const queryClient = useQueryClient();
 	// Claims are read per enabled provider, so switching one off takes every
@@ -91,7 +86,6 @@ export function EditProviderModal({
 				"success",
 			);
 			onClose();
-			if (updated.enabled && !provider.enabled) onEnabled?.(updated);
 		},
 		onError: (err: Error) => {
 			// A new address that does not answer as the stored type is rejected;

--- a/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/EditProviderModal.test.tsx
@@ -253,45 +253,6 @@ describe("EditProviderModal", () => {
 			});
 		});
 
-		it("reports a disabled-to-enabled save through onEnabled", async () => {
-			server.use(
-				http.put("/api/providers/:id", () =>
-					HttpResponse.json({ ...mockProvider, enabled: true }),
-				),
-			);
-			const onEnabled = vi.fn();
-			const { user } = renderWithProviders(
-				<EditProviderModal
-					{...defaultProps}
-					provider={{ ...mockProvider, enabled: false }}
-					onEnabled={onEnabled}
-				/>,
-			);
-			await user.click(screen.getByLabelText("Provider enabled"));
-			await user.click(screen.getByRole("button", { name: "Save Changes" }));
-			await waitFor(() => {
-				expect(onEnabled).toHaveBeenCalledWith(
-					expect.objectContaining({ id: "provider-123", enabled: true }),
-				);
-			});
-		});
-
-		it("does not call onEnabled when the provider was already enabled", async () => {
-			server.use(
-				http.put("/api/providers/:id", () =>
-					HttpResponse.json({ ...mockProvider, name: "Renamed" }),
-				),
-			);
-			const onEnabled = vi.fn();
-			const { user } = renderWithProviders(
-				<EditProviderModal {...defaultProps} onEnabled={onEnabled} />,
-			);
-			await user.type(screen.getByLabelText("Name"), "x");
-			await user.click(screen.getByRole("button", { name: "Save Changes" }));
-			await waitFor(() => expect(onClose).toHaveBeenCalled());
-			expect(onEnabled).not.toHaveBeenCalled();
-		});
-
 		it("disables base URL input for known provider URLs", () => {
 			const knownProvider = {
 				...mockProvider,

--- a/web/src/pages/__tests__/Providers.test.tsx
+++ b/web/src/pages/__tests__/Providers.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { api } from "../../api/client";
+import { beforeEach, describe, expect, it } from "vitest";
 import { Layout } from "../../components/Layout";
 import { mockModel, mockProvider } from "../../test/mocks/data";
 import { server } from "../../test/mocks/server";
@@ -675,69 +674,6 @@ describe("Providers", () => {
 			await waitFor(() => {
 				expect(screen.getByText("Edit Provider")).toBeInTheDocument();
 			});
-		});
-	});
-
-	describe("Enable Flow", () => {
-		// The card's own Discover button is hidden for a disabled provider, so a
-		// save that switches the provider on is the only path that reaches the
-		// discover route here.
-		async function saveEnabled(user: {
-			click: (el: Element) => Promise<void>;
-		}) {
-			await waitFor(() => {
-				expect(screen.getByText("Test Provider")).toBeInTheDocument();
-			});
-			await user.click(screen.getByRole("button", { name: "Edit" }));
-			await user.click(await screen.findByLabelText("Provider enabled"));
-			await user.click(screen.getByRole("button", { name: "Save Changes" }));
-		}
-
-		it("runs discovery for a provider the save switched on", async () => {
-			let discovered = 0;
-			server.use(
-				http.get("/api/providers", () =>
-					HttpResponse.json([{ ...mockProvider, enabled: false }]),
-				),
-				http.put("/api/providers/:id", () =>
-					HttpResponse.json({ ...mockProvider, enabled: true }),
-				),
-				http.post("/api/providers/:id/discover", () => {
-					discovered++;
-					return HttpResponse.json({ discovered: 0, diff: {} });
-				}),
-			);
-			const { user } = renderWithProviders(<Providers />);
-			await saveEnabled(user);
-			await waitFor(() => expect(discovered).toBe(1));
-		});
-
-		it("skips discovery when the switched-on provider has autodiscovery off", async () => {
-			// Spied rather than counted at the mock server: the discover call is
-			// fire-and-forget from the save, so a request counter read right after
-			// the modal closes would still be 0 even without the guard.
-			const discover = vi.spyOn(api.providers, "discover");
-			server.use(
-				http.get("/api/providers", () =>
-					HttpResponse.json([
-						{ ...mockProvider, enabled: false, autodiscovery_enabled: false },
-					]),
-				),
-				http.put("/api/providers/:id", () =>
-					HttpResponse.json({
-						...mockProvider,
-						enabled: true,
-						autodiscovery_enabled: false,
-					}),
-				),
-			);
-			const { user } = renderWithProviders(<Providers />);
-			await saveEnabled(user);
-			await waitFor(() =>
-				expect(screen.queryByText("Edit Provider")).not.toBeInTheDocument(),
-			);
-			expect(discover).not.toHaveBeenCalled();
-			discover.mockRestore();
 		});
 	});
 

--- a/web/src/test/utils.tsx
+++ b/web/src/test/utils.tsx
@@ -62,13 +62,11 @@ export function AllProviders({
 					<StorageProvider>
 						<SidebarModeProvider>
 							<ToastSlot>
-								<EventProvider>
-									<QuotaModalProvider>
-										<QueryClientProvider client={queryClient}>
-											{children}
-										</QueryClientProvider>
-									</QuotaModalProvider>
-								</EventProvider>
+								<QueryClientProvider client={queryClient}>
+									<EventProvider>
+										<QuotaModalProvider>{children}</QuotaModalProvider>
+									</EventProvider>
+								</QueryClientProvider>
 							</ToastSlot>
 						</SidebarModeProvider>
 					</StorageProvider>


### PR DESCRIPTION
## Problem

Front Desk syncs every provider change on the primary to the members, and each member's config import ends with a full discovery run. The primary itself only rediscovered on create (browser-triggered), on enable (browser-triggered since #912), or on the 6 h sweep. A key, URL or type change on the primary rediscovered nothing there, so after an edit the members could hold a newer catalogue than the node the edit landed on. Observed today: OpenRouter re-enabled on MH1 stayed on the 21 Aug catalogue with 407 models while MH2 to MH4 discovered 442 within a minute.

## Fix

**Backend** (`internal/api/providers.go`, `internal/api/discovery.go`)
- `priorProvider` reads the row a save replaces when the request touches `enabled`, `autodiscovery_enabled`, `base_url`, `provider_type` or `api_key`.
- `shouldRediscover` is true when the save switched the provider or its autodiscovery on, or moved its address, type or key, and the provider is enabled with autodiscovery on.
- `rediscoverInBackground` runs the scan in a goroutine. The scan is `discoverOne`, the per-provider body of `discoverAllProviders` extracted so the discover-all path, the config-sync import and this trigger share one implementation. The failover "last sync" stamp moved into it.
- `discoverOne` ends with a `request.discovery.provider_completed` event published after the last row is committed. The existing `discovery.provider_fetched` event fires before the upserts, so a dashboard re-read on it would still see the old catalogue. The `request.` prefix keeps it out of the toast stream like the matching `provider_starting` event.

**Frontend**
- `EventContext` re-reads providers, models and the discovery badge on the completion event. The badge invalidation is `exact`, for the reason `useRefreshDiscoveryBadge` documents: a prefix match would refetch the discrepancy modal's query, which stamps the server's last-reviewed marker.
- The browser-side discovery on enable from #912 is removed, so enable no longer scans twice.
- The shared test wrapper now nests `EventProvider` inside `QueryClientProvider`, matching `main.tsx`.

## Tests

- Go: table test for `shouldRediscover` (rename, enable, disable, autodiscovery on, URL, type, key, key while disabled, URL with autodiscovery off, no prior row); integration test that a base URL change to a second mock listing rediscovers in the background, waiting on the `last_discovered_at` stamp which is the scan's final write. The two existing identity-change tests point the background scan at a rejecting mock so they stay off the network.
- Frontend: completion event invalidates the three keys with `exact` on the badge; `backup.created`, `request.discovery.provider_starting` and `discovery.provider_fetched` invalidate nothing.

## Verification

- `internal/api` package green, golangci-lint clean, size gate clean, full vitest suite green (6091), `tsc -b`, ESLint, Biome clean.
- Dev stack: disable then enable OpenRouter. Enable answered in 2.8 s with a fresh quota snapshot, the background scan ran 3 s later, `last_discovered_at` moved, model count went from 455 to 463, failover groups regrouped.

## Left as is

- `DiscoverProviderModels` (the manual Discover button) keeps its own request-bound copy of the scan because every failure there is answered as an HTTP error; its doc comment now says so.
- Members still rediscover every provider on each sync. Heavier than needed, separate change.
- No per-provider lock around discovery: a background scan can overlap a manual click on the same provider. Pre-existing, a save now makes it likelier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rKscgDphpxkv6R12FGwYy
