### PR TITLE
fix(web): align provider card badges and cap grid at two columns

### DIFF
--- a/web/src/components/CapNoteBadge.tsx
+++ b/web/src/components/CapNoteBadge.tsx
@@ -20,7 +20,7 @@ export function CapNoteBadge({ note }: { note: CapNote }) {
 		: t("components.capNote.tipNoPhrase", { when, model: note.model });
 	return (
 		<span
-			className="px-2 py-1.5 text-xs font-medium ui-badge ui-badge-warning cursor-help"
+			className="px-2 py-px leading-[1.6] text-xs font-medium ui-badge ui-badge-warning cursor-help"
 			data-testid="cap-note-badge"
 			title={tip}
 		>

--- a/web/src/components/QuotaBadge.tsx
+++ b/web/src/components/QuotaBadge.tsx
@@ -34,7 +34,7 @@ export type QuotaBadgeVariant = "sidebar" | "card";
 
 const VARIANT_CLASSES: Record<QuotaBadgeVariant, string> = {
 	sidebar: "",
-	card: "px-2 py-1.5 text-xs font-medium cursor-pointer transition-colors ui-badge",
+	card: "px-2 py-px leading-[1.6] text-xs font-medium cursor-pointer transition-colors ui-badge",
 };
 
 /** Type-safe prefix lookup - backed by the central brand map. */

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -397,7 +397,7 @@ export function Providers() {
 				</div>
 			</div>
 
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
 				{filteredProviders?.map((provider) => (
 					<ProviderCard
 						key={provider.id}

--- a/web/src/pages/Providers/ProviderCard.tsx
+++ b/web/src/pages/Providers/ProviderCard.tsx
@@ -126,7 +126,7 @@ export function ProviderCard({
 						</button>
 					)}
 					{provider.enabled && (
-						<span className="ml-auto inline-flex items-center gap-2">
+						<span className="inline-flex items-center gap-2">
 							<QuotaBadges
 								quotaData={quotaData}
 								variant="card"


### PR DESCRIPTION
## Summary

The Ollama Cloud provider card (the one in the README screenshot) rendered its badge row broken into two lines, with the second line flush right and the two right-hand pills visibly taller than the two on the left.

Cause: the quota and cap-note badges sat in an `ml-auto` group, so when the row wrapped the group became a right-aligned second line. They also used `py-1.5` while the tokens and models badges use `py-px leading-[1.6]`.

Changes:
- `ProviderCard.tsx`: drop `ml-auto` on the quota group so wrapped badges stay left-aligned.
- `QuotaBadge.tsx` (card variant) and `CapNoteBadge.tsx`: same `py-px leading-[1.6]` height as the other card badges.
- `Providers.tsx`: cap the grid at two columns so cards are wide enough for a full badge row.

## Test plan

- [x] `pnpm vitest run` on QuotaBadge, CapNoteBadge and Providers suites (105 passed)
- [x] `pnpm lint`, `pnpm exec tsc -b`, `make size-check` clean
- [x] Dev stack rebuilt and checked visually on the Providers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ykv71ZZZx5uRPBSW68zaK
