### PR TITLE
docs(wiki): redraw three diagrams to match the current code

### DIFF
--- a/wiki/failover-flow.svg
+++ b/wiki/failover-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 880" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 896" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/>
@@ -9,7 +9,7 @@
   </defs>
 
   <!-- Background (transparent) -->
-  <rect width="720" height="880" fill="none" rx="8"/>
+  <rect width="720" height="896" fill="none" rx="8"/>
 
   <!-- Client Request Box -->
   <rect x="110" y="20" width="500" height="60" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
@@ -20,7 +20,7 @@
   <line x1="360" y1="80" x2="360" y2="100" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
   <!-- Proxy Layer Outer Box -->
-  <rect x="40" y="100" width="640" height="640" rx="10" fill="none" stroke="#475569" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <rect x="40" y="100" width="640" height="656" rx="10" fill="none" stroke="#475569" stroke-width="1.5" stroke-dasharray="6,3"/>
   <text x="360" y="125" text-anchor="middle" fill="#64748b" font-size="12" font-weight="600" letter-spacing="1">PROXY LAYER  (internal/proxy)</text>
 
   <!-- Step 1: Model Resolution -->
@@ -47,28 +47,29 @@
   <rect x="80" y="350" width="560" height="26" rx="8" fill="#a78bfa" opacity="0.15"/>
   <text x="100" y="367" fill="#c4b5fd" font-size="12" font-weight="700">3. Provider Selection</text>
   <text x="100" y="387" fill="#cbd5e1" font-size="11">• Load priority_order [uuid1, uuid2, uuid3]</text>
-  <text x="100" y="403" fill="#cbd5e1" font-size="11">• Load entry_enabled {uuid1: true, uuid2: false}  •  Skip disabled/circuit-breaker-open</text>
+  <text x="100" y="403" fill="#cbd5e1" font-size="11">• Load entry_enabled {uuid1: true, uuid2: false}  •  Skip disabled / breaker-open / busy</text>
   <text x="100" y="419" fill="#cbd5e1" font-size="11">• Decrypt API keys (AES-256-GCM + Argon2id)</text>
   <text x="100" y="435" fill="#cbd5e1" font-size="11">• Build candidate list in priority order</text>
 
   <!-- Arrow -->
   <line x1="360" y1="480" x2="360" y2="500" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Step 4: Sequential Failover Loop -->
-  <rect x="80" y="500" width="560" height="120" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
+  <!-- Step 4: Failover Loop -->
+  <rect x="80" y="500" width="560" height="136" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
   <rect x="80" y="500" width="560" height="26" rx="8" fill="#10b981" opacity="0.15"/>
-  <text x="100" y="517" fill="#34d399" font-size="12" font-weight="700">4. Sequential Failover Loop</text>
-  <text x="100" y="537" fill="#cbd5e1" font-size="11">• Try #1 → retriable error → #2 → error → #3</text>
-  <text x="100" y="553" fill="#cbd5e1" font-size="11">• Exponential backoff (100ms → 200ms → 400ms...)</text>
-  <text x="100" y="569" fill="#cbd5e1" font-size="11">• RecordFailure on 5xx / 429 / 401 / 403 / 402  (404 / 499 fail over, breaker no-op)</text>
-  <text x="100" y="585" fill="#cbd5e1" font-size="11">• RecordSuccess on any non-failover (incl. 400)</text>
-  <text x="100" y="601" fill="#cbd5e1" font-size="11">• TTFT probe + stall watchdog protection</text>
+  <text x="100" y="517" fill="#34d399" font-size="12" font-weight="700">4. Failover Loop</text>
+  <text x="100" y="537" fill="#cbd5e1" font-size="11">• Try #1 → retriable error → #2 → error → #3  (hedged race when hedging_enabled)</text>
+  <text x="100" y="553" fill="#cbd5e1" font-size="11">• Exponential backoff (100ms → 200ms → 400ms…, cap 2s, + jitter)</text>
+  <text x="100" y="569" fill="#cbd5e1" font-size="11">• RecordFailure on 5xx / 401 / 403 / unclassified 429  (404 / 499 fail over, breaker no-op)</text>
+  <text x="100" y="585" fill="#cbd5e1" font-size="11">• 429 busy → breaker no-op  •  429 spent / 402 → RecordExhausted (opens at once)</text>
+  <text x="100" y="601" fill="#cbd5e1" font-size="11">• 400 → RecordAlive  •  2xx → verdict deferred until the body is read</text>
+  <text x="100" y="617" fill="#cbd5e1" font-size="11">• TTFT probe + stall watchdog protection</text>
 
   <!-- Arrow out of proxy layer -->
-  <line x1="360" y1="740" x2="360" y2="780" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="360" y1="756" x2="360" y2="796" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
   <!-- Upstream Provider Box -->
-  <rect x="210" y="780" width="300" height="70" rx="8" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="360" y="805" text-anchor="middle" fill="#fb7185" font-size="13" font-weight="600">UPSTREAM PROVIDER</text>
-  <text x="360" y="823" text-anchor="middle" fill="#94a3b8" font-size="11">OpenAI  •  Anthropic  •  Ollama  •  ...</text>
+  <rect x="210" y="796" width="300" height="70" rx="8" fill="#1e293b" stroke="#f43f5e" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="360" y="821" text-anchor="middle" fill="#fb7185" font-size="13" font-weight="600">UPSTREAM PROVIDER</text>
+  <text x="360" y="839" text-anchor="middle" fill="#94a3b8" font-size="11">OpenAI  •  Anthropic  •  Ollama  •  ...</text>
 </svg>

--- a/wiki/failover-mechanics.svg
+++ b/wiki/failover-mechanics.svg
@@ -32,7 +32,7 @@
   <rect x="260" y="156" width="300" height="58" rx="8" fill="#1e293b" stroke="#a78bfa" stroke-width="1.5" filter="url(#shadow)"/>
   <rect x="260" y="156" width="300" height="26" rx="8" fill="#a78bfa" opacity="0.15"/>
   <text x="410" y="173" text-anchor="middle" fill="#c4b5fd" font-size="12" font-weight="700">Attempt next available provider</text>
-  <text x="410" y="201" text-anchor="middle" fill="#cbd5e1" font-size="11">in priority order &#8226; skip disabled / breaker-open</text>
+  <text x="410" y="201" text-anchor="middle" fill="#cbd5e1" font-size="11">in priority order &#8226; skip disabled / breaker-open / busy</text>
 
   <line x1="410" y1="214" x2="410" y2="238" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
 
@@ -48,17 +48,17 @@
   <line x1="245" y1="284" x2="95" y2="284" stroke="#fb7185" stroke-width="1.5"/>
   <text x="240" y="277" text-anchor="end" fill="#fb7185" font-size="10.5" font-weight="600">timeout</text>
 
-  <!-- first token confirmed: RecordSuccess is recorded HERE, then the stream commits -->
+  <!-- first token confirmed: the stream commits; the breaker verdict waits for the stream to end -->
   <line x1="410" y1="330" x2="410" y2="354" stroke="#34d399" stroke-width="1.5" marker-end="url(#arrow-green)"/>
-  <text x="420" y="341" fill="#34d399" font-size="10.5" font-weight="600">first token &#8594; RecordSuccess</text>
-  <text x="420" y="352" fill="#34d399" font-size="9.5">commit + stream to client</text>
+  <text x="420" y="341" fill="#34d399" font-size="10.5" font-weight="600">first token &#8594; commit</text>
+  <text x="420" y="352" fill="#34d399" font-size="9.5">stream to client, no breaker verdict yet</text>
 
   <!-- Stall watchdog -->
   <rect x="245" y="354" width="330" height="122" rx="8" fill="#1e293b" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)"/>
   <rect x="245" y="354" width="330" height="26" rx="8" fill="#10b981" opacity="0.15"/>
   <text x="410" y="371" text-anchor="middle" fill="#34d399" font-size="12" font-weight="700">Stall watchdog (committed stream)</text>
   <text x="262" y="393" fill="#cbd5e1" font-size="11">&#8226; Silence &gt; configured window (default 30s) &#8594; terminate</text>
-  <text x="262" y="411" fill="#cbd5e1" font-size="11">&#8226; RecordFailure (on top of the earlier TTFT success)</text>
+  <text x="262" y="411" fill="#cbd5e1" font-size="11">&#8226; RecordFailure; a clean [DONE] earns RecordSuccess</text>
   <text x="262" y="429" fill="#cbd5e1" font-size="11">&#8226; After 50 chunks, stall threshold &#215; 3</text>
   <text x="278" y="444" fill="#94a3b8" font-size="10">(tolerates tool-call pauses &amp; long reasoning chains)</text>
   <text x="262" y="463" fill="#cbd5e1" font-size="11">&#8226; Both timeouts in Settings &#8594; Proxy (0s to disable)</text>

--- a/wiki/security-architecture.svg
+++ b/wiki/security-architecture.svg
@@ -1,13 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1100" width="900" role="img" aria-label="Request Security Pipeline Diagram">
   <defs>
-    <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#1f2937;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#111827;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient id="grad2" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e3a5f;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0f172a;stop-opacity:1" />
-    </linearGradient>
     <filter id="shadow" x="-5%" y="-5%" width="110%" height="110%">
       <feDropShadow dx="0" dy="3" stdDeviation="4" flood-color="#000000" flood-opacity="0.3"/>
     </filter>
@@ -21,117 +13,104 @@
 
   <!-- Title -->
   <text x="450" y="45" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="26" font-weight="600" fill="#f8fafc">Request Security Pipeline</text>
+  <text x="450" y="66" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#64748b">order of the middleware chain in cmd/server (global first, then per route)</text>
 
-  <!-- Box 1: IP Rate Limiter -->
-  <rect x="150" y="70" width="600" height="110" fill="url(#grad1)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="150" y="70" width="600" height="36" fill="#2563eb" rx="12"/>
-  <rect x="150" y="94" width="600" height="12" fill="#2563eb"/>
-  <clipPath id="cp1"><rect x="150" y="70" width="600" height="110" rx="12"/></clipPath>
+
+  <!-- 1. Security Headers (every response) -->
+  <rect x="150" y="80" width="600" height="130" fill="#1e293b" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="150" y="80" width="600" height="36" fill="#16a34a" rx="12"/>
+  <rect x="150" y="104" width="600" height="12" fill="#16a34a"/>
+  <clipPath id="cp1"><rect x="150" y="80" width="600" height="130" rx="12"/></clipPath>
   <g clip-path="url(#cp1)">
-    <text x="450" y="95" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">1. IP Rate Limiter (DoS Protection)</text>
+    <text x="450" y="105" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">1. Security Headers (every response)</text>
   </g>
-  <text x="450" y="128" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Token bucket per IP, runs before auth</text>
-  <text x="450" y="150" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">30 RPS default / 60 burst, respects X-Forwarded-For behind trusted proxy</text>
+  <text x="450" y="138" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">X-Content-Type-Options: nosniff, X-Frame-Options: DENY (unless ALLOW_EMBED)</text>
+  <text x="450" y="160" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Referrer-Policy, Strict-Transport-Security (when TLS)</text>
+  <text x="450" y="182" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Content-Security-Policy (frame-ancestors none unless ALLOW_EMBED)</text>
+  <line x1="450" y1="210" x2="450" y2="230" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Arrow 1→2 -->
-  <line x1="450" y1="180" x2="450" y2="200" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-
-  <!-- Box 2: Request Size Limiting -->
-  <rect x="200" y="200" width="500" height="85" fill="url(#grad1)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="200" y="200" width="500" height="36" fill="#059669" rx="12"/>
-  <rect x="200" y="224" width="500" height="12" fill="#059669"/>
-  <clipPath id="cp2"><rect x="200" y="200" width="500" height="85" rx="12"/></clipPath>
+  <!-- 2. CORS Middleware -->
+  <rect x="250" y="230" width="400" height="110" fill="#1e293b" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="250" y="230" width="400" height="36" fill="#0891b2" rx="12"/>
+  <rect x="250" y="254" width="400" height="12" fill="#0891b2"/>
+  <clipPath id="cp2"><rect x="250" y="230" width="400" height="110" rx="12"/></clipPath>
   <g clip-path="url(#cp2)">
-    <text x="450" y="225" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">2. Request Size Limiting</text>
+    <text x="450" y="255" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">2. CORS Middleware</text>
   </g>
-  <text x="450" y="258" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">MAX_REQUEST_SIZE default 50MB (1KB&#8211;100MB), enforced via http.MaxBytesReader</text>
+  <text x="450" y="288" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Origin allowlist (CORS_ORIGINS), preflight caching (24h)</text>
+  <text x="450" y="310" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Credentials allowed</text>
+  <line x1="450" y1="340" x2="450" y2="360" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Arrow 2→3 -->
-  <line x1="450" y1="285" x2="450" y2="305" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-
-  <!-- Box 3: Split into two paths -->
-  <rect x="250" y="305" width="400" height="40" fill="#1e293b" rx="8" stroke="#475569" stroke-width="1.5"/>
-  <text x="450" y="330" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#e2e8f0">3. Authentication Split</text>
-
-  <!-- Arrow 3→3a (left) -->
-  <line x1="350" y1="345" x2="250" y2="370" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-  <!-- Arrow 3→3b (right) -->
-  <line x1="550" y1="345" x2="650" y2="370" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-
-  <!-- Box 3a: Admin API Path -->
-  <rect x="50" y="370" width="380" height="130" fill="url(#grad2)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="50" y="370" width="380" height="36" fill="#7c3aed" rx="12"/>
-  <rect x="50" y="394" width="380" height="12" fill="#7c3aed"/>
-  <clipPath id="cp3a"><rect x="50" y="370" width="380" height="130" rx="12"/></clipPath>
-  <g clip-path="url(#cp3a)">
-    <text x="240" y="395" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#ffffff">3a. Admin API Path (/api/*)</text>
+  <!-- 3. Request Size Limiting -->
+  <rect x="200" y="360" width="500" height="85" fill="#1e293b" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="200" y="360" width="500" height="36" fill="#059669" rx="12"/>
+  <rect x="200" y="384" width="500" height="12" fill="#059669"/>
+  <clipPath id="cp3"><rect x="200" y="360" width="500" height="85" rx="12"/></clipPath>
+  <g clip-path="url(#cp3)">
+    <text x="450" y="385" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">3. Request Size Limiting</text>
   </g>
-  <text x="240" y="425" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#94a3b8">Admin Token / Session Validation</text>
-  <text x="240" y="445" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#94a3b8">Bearer token (SHA-256) or HttpOnly session cookie</text>
-  <text x="240" y="465" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">sessions: token exchange &#183; WebAuthn &#183; login &#183; GitHub SSO</text>
-  <text x="240" y="485" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#f87171">HTTP 401 on failure &#183; CSRF 403 on cookie-authed writes</text>
+  <text x="450" y="418" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">MAX_REQUEST_SIZE default 50MB (1KB&#8211;100MB), enforced via http.MaxBytesReader</text>
+  <line x1="450" y1="445" x2="450" y2="465" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Box 3b: Proxy API Path -->
-  <rect x="470" y="370" width="380" height="130" fill="url(#grad2)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="470" y="370" width="380" height="36" fill="#d97706" rx="12"/>
-  <rect x="470" y="394" width="380" height="12" fill="#d97706"/>
-  <clipPath id="cp3b"><rect x="470" y="370" width="380" height="130" rx="12"/></clipPath>
-  <g clip-path="url(#cp3b)">
-    <text x="660" y="395" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#ffffff">3b. Proxy API Path (/v1/chat/completions)</text>
-  </g>
-  <text x="660" y="425" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#94a3b8">Virtual Key Validation</text>
-  <text x="660" y="445" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#94a3b8">Bearer key sk-..., SHA-256 hash + DB lookup</text>
-  <text x="660" y="465" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#94a3b8">last-used timestamp updated async</text>
-  <text x="660" y="485" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="12" fill="#f87171">HTTP 401 on failure</text>
-
-  <!-- Arrows 3a→4 and 3b→4 (converge) -->
-  <line x1="240" y1="500" x2="350" y2="550" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-  <line x1="660" y1="500" x2="550" y2="550" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
-
-  <!-- Box 4: Per-Key Rate Limiter -->
-  <rect x="250" y="550" width="400" height="110" fill="url(#grad1)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="250" y="550" width="400" height="36" fill="#db2777" rx="12"/>
-  <rect x="250" y="574" width="400" height="12" fill="#db2777"/>
-  <clipPath id="cp4"><rect x="250" y="550" width="400" height="110" rx="12"/></clipPath>
+  <!-- 4. IP Rate Limiter (DoS Protection) -->
+  <rect x="150" y="465" width="600" height="110" fill="#1e293b" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="150" y="465" width="600" height="36" fill="#2563eb" rx="12"/>
+  <rect x="150" y="489" width="600" height="12" fill="#2563eb"/>
+  <clipPath id="cp4"><rect x="150" y="465" width="600" height="110" rx="12"/></clipPath>
   <g clip-path="url(#cp4)">
-    <text x="450" y="575" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">4. Per-Key Rate Limiter (Usage Control)</text>
+    <text x="450" y="490" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">4. IP Rate Limiter (DoS Protection)</text>
   </g>
-  <text x="450" y="608" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Token bucket per virtual key hash</text>
-  <text x="450" y="630" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Configurable RPS/burst, graceful backpressure (max_wait_ms)</text>
+  <text x="450" y="523" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Token bucket per IP, mounted on /api, /api/chat and /v1 ahead of auth</text>
+  <text x="450" y="545" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">30 RPS default / 60 burst, respects X-Forwarded-For behind trusted proxy</text>
+  <line x1="450" y1="575" x2="450" y2="595" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Arrow 4→5 -->
-  <line x1="450" y1="660" x2="450" y2="680" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
+  <!-- Box 5: Split into two paths -->
+  <rect x="250" y="595" width="400" height="40" fill="#1e293b" rx="8" stroke="#475569" stroke-width="1.5"/>
+  <text x="450" y="620" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#e2e8f0">5. Authentication Split</text>
+  <line x1="350" y1="635" x2="250" y2="660" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="550" y1="635" x2="650" y2="660" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Box 5: CORS Middleware -->
-  <rect x="250" y="680" width="400" height="110" fill="url(#grad1)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="250" y="680" width="400" height="36" fill="#0891b2" rx="12"/>
-  <rect x="250" y="704" width="400" height="12" fill="#0891b2"/>
-  <clipPath id="cp5"><rect x="250" y="680" width="400" height="110" rx="12"/></clipPath>
-  <g clip-path="url(#cp5)">
-    <text x="450" y="705" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">5. CORS Middleware</text>
+  <!-- 5a. Admin API Path (/api/*) -->
+  <rect x="50" y="660" width="380" height="130" fill="#172554" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="50" y="660" width="380" height="36" fill="#7c3aed" rx="12"/>
+  <rect x="50" y="684" width="380" height="12" fill="#7c3aed"/>
+  <clipPath id="cp5a"><rect x="50" y="660" width="380" height="130" rx="12"/></clipPath>
+  <g clip-path="url(#cp5a)">
+    <text x="240" y="685" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#ffffff">5a. Admin API Path (/api/*)</text>
   </g>
-  <text x="450" y="738" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Origin allowlist (CORS_ORIGINS), preflight caching (24h)</text>
-  <text x="450" y="760" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Credentials allowed</text>
+  <text x="240" y="718" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">Admin Token / Session Validation</text>
+  <text x="240" y="740" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">Bearer token (SHA-256) or HttpOnly session cookie</text>
+  <text x="240" y="762" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">sessions: token exchange &#183; WebAuthn &#183; login &#183; GitHub SSO &#183; OIDC</text>
+  <text x="240" y="784" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#f87171">HTTP 401 on failure &#183; CSRF 403 on cookie-authed writes</text>
 
-  <!-- Arrow 5→6 -->
-  <line x1="450" y1="790" x2="450" y2="810" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
+  <!-- 5b. Proxy API Path (/v1/chat/completions) -->
+  <rect x="470" y="660" width="380" height="130" fill="#172554" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="470" y="660" width="380" height="36" fill="#d97706" rx="12"/>
+  <rect x="470" y="684" width="380" height="12" fill="#d97706"/>
+  <clipPath id="cp5b"><rect x="470" y="660" width="380" height="130" rx="12"/></clipPath>
+  <g clip-path="url(#cp5b)">
+    <text x="660" y="685" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="14" font-weight="600" fill="#ffffff">5b. Proxy API Path (/v1/chat/completions)</text>
+  </g>
+  <text x="660" y="718" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">Virtual Key Validation</text>
+  <text x="660" y="740" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">Bearer key sk-..., SHA-256 hash + DB lookup</text>
+  <text x="660" y="762" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#94a3b8">last-used timestamp updated async</text>
+  <text x="660" y="784" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="11" fill="#f87171">HTTP 401 on failure</text>
+  <line x1="240" y1="790" x2="350" y2="840" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="660" y1="790" x2="550" y2="840" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Box 6: Security Headers -->
-  <rect x="200" y="810" width="500" height="130" fill="url(#grad1)" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
-  <rect x="200" y="810" width="500" height="36" fill="#16a34a" rx="12"/>
-  <rect x="200" y="834" width="500" height="12" fill="#16a34a"/>
-  <clipPath id="cp6"><rect x="200" y="810" width="500" height="130" rx="12"/></clipPath>
+  <!-- 6. Usage Rate Limiters (after auth) -->
+  <rect x="200" y="840" width="500" height="110" fill="#1e293b" rx="12" filter="url(#shadow)" stroke="#374151" stroke-width="1.5"/>
+  <rect x="200" y="840" width="500" height="36" fill="#db2777" rx="12"/>
+  <rect x="200" y="864" width="500" height="12" fill="#db2777"/>
+  <clipPath id="cp6"><rect x="200" y="840" width="500" height="110" rx="12"/></clipPath>
   <g clip-path="url(#cp6)">
-    <text x="450" y="835" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">6. Security Headers</text>
+    <text x="450" y="865" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="15" font-weight="600" fill="#ffffff">6. Usage Rate Limiters (after auth)</text>
   </g>
-  <text x="450" y="868" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">X-Content-Type-Options: nosniff, X-Frame-Options: DENY</text>
-  <text x="450" y="890" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Referrer-Policy, Strict-Transport-Security (when TLS)</text>
-  <text x="450" y="912" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Content-Security-Policy</text>
-
-  <!-- Arrow 6→Target -->
-  <line x1="450" y1="940" x2="450" y2="965" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="450" y="898" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Proxy path: per-virtual-key RPS/burst + tokens-per-minute (TPM) buckets</text>
+  <text x="450" y="920" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="13" fill="#94a3b8">Admin chat: per-user buckets &#183; graceful backpressure (max_wait_ms)</text>
+  <line x1="450" y1="950" x2="450" y2="975" stroke="#9ca3af" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Target Handler -->
-  <rect x="325" y="970" width="250" height="55" fill="#0f172a" rx="12" stroke="#22c55e" stroke-width="2" filter="url(#shadow)"/>
-  <text x="450" y="1003" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="16" font-weight="600" fill="#22c55e">Target Handler</text>
+  <rect x="325" y="980" width="250" height="55" fill="#0f172a" rx="12" stroke="#22c55e" stroke-width="2" filter="url(#shadow)"/>
+  <text x="450" y="1013" text-anchor="middle" font-family="Inter, Segoe UI, Roboto, sans-serif" font-size="16" font-weight="600" fill="#22c55e">Target Handler</text>
 </svg>


### PR DESCRIPTION
Redraws the three wiki diagrams that had drifted from the code. Diagram-only change; no Go, no web.

**failover-flow.svg / failover-mechanics.svg**
- The breaker no longer credits a provider on the first token or on any non-failover status. Verdict waits for the body: a clean `[DONE]` earns `RecordSuccess`, a 400 is `RecordAlive`, a classified 429 splits into busy (no-op) and spent (`RecordExhausted`), a 402 opens the circuit at once.
- Candidate skip list gains the busy in-flight skip; the loop notes the hedged race when `hedging_enabled`.

**security-architecture.svg**
- Middleware order now matches `cmd/server`: security headers, CORS and size limit run globally first, the IP limiter is mounted per route ahead of auth, usage limiters (per-key RPS + TPM, per-user for admin chat) run after it.
- Session list gains OIDC; header notes mention the `ALLOW_EMBED` conditions.
- Gradient fills replaced with the solid fills the other diagrams use. Viewers that ignore CSS on gradient stops rendered the pills black.

Unchanged and re-verified against the code: `ha-architecture.svg`, `virtual-keys-flow.svg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kbTmEU2CS4jhxkUhi4aG6
