### PR TITLE
fix(gemini): forward input_audio and file parts through the egress adapter

### DIFF
--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -52,11 +52,21 @@ type oaiMessage struct {
 }
 
 type oaiContentPart struct {
-	Type     string `json:"type"` // "text" | "image_url"
+	Type     string `json:"type"` // "text" | "image_url" | "input_audio" | "file"
 	Text     string `json:"text"`
 	ImageURL *struct {
 		URL string `json:"url"`
 	} `json:"image_url"`
+	InputAudio *struct {
+		Data   string `json:"data"`
+		Format string `json:"format"`
+	} `json:"input_audio"`
+	// File carries a document as a data: URI in file_data. A file_id refers
+	// to OpenAI's Files store, which Gemini cannot fetch, so a part with only
+	// an id is dropped like a malformed image.
+	File *struct {
+		FileData string `json:"file_data"`
+	} `json:"file"`
 }
 
 type oaiToolCall struct {
@@ -418,7 +428,21 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 			if p.ImageURL == nil || p.ImageURL.URL == "" {
 				continue
 			}
-			if part, ok := imagePart(p.ImageURL.URL); ok {
+			if part, ok := mediaPart(p.ImageURL.URL); ok {
+				parts = append(parts, part)
+			}
+		case "input_audio":
+			// OpenAI names the container (wav, mp3); Gemini's audio mime
+			// types use the same words (audio/wav, audio/mp3).
+			if p.InputAudio == nil || p.InputAudio.Data == "" || p.InputAudio.Format == "" {
+				continue
+			}
+			parts = append(parts, genPart{InlineData: &genBlob{MimeType: "audio/" + p.InputAudio.Format, Data: p.InputAudio.Data}})
+		case "file":
+			if p.File == nil || p.File.FileData == "" {
+				continue
+			}
+			if part, ok := mediaPart(p.File.FileData); ok {
 				parts = append(parts, part)
 			}
 		}
@@ -426,9 +450,9 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 	return parts, nil
 }
 
-// imagePart maps an OpenAI image_url value to inlineData (data: URIs) or
-// fileData (plain URLs).
-func imagePart(u string) (genPart, bool) {
+// mediaPart maps an OpenAI image_url or file_data value to inlineData (data:
+// URIs) or fileData (plain URLs).
+func mediaPart(u string) (genPart, bool) {
 	if rest, ok := strings.CutPrefix(u, "data:"); ok {
 		mime, data, found := strings.Cut(rest, ";base64,")
 		if !found || data == "" {

--- a/internal/gemini/request.go
+++ b/internal/gemini/request.go
@@ -61,13 +61,20 @@ type oaiContentPart struct {
 		Data   string `json:"data"`
 		Format string `json:"format"`
 	} `json:"input_audio"`
-	// File carries a document as a data: URI in file_data. A file_id refers
-	// to OpenAI's Files store, which Gemini cannot fetch, so a part with only
-	// an id is dropped like a malformed image.
+	// File carries a document as a data: URI in file_data, the only field
+	// read here: a file_id refers to OpenAI's Files store, which Gemini
+	// cannot fetch, so a part without file_data is dropped like a malformed
+	// image.
 	File *struct {
 		FileData string `json:"file_data"`
 	} `json:"file"`
 }
+
+// audioFormats are the input_audio format words Gemini accepts as an
+// audio/<format> inlineData mime type. OpenAI's chat spec names wav and mp3;
+// the rest are Gemini's own list. Anything else (pcm16, webm, m4a) is dropped
+// like a malformed image rather than sent on to a certain 400.
+var audioFormats = map[string]bool{"wav": true, "mp3": true, "aiff": true, "aac": true, "ogg": true, "flac": true}
 
 type oaiToolCall struct {
 	ID string `json:"id"`
@@ -432,14 +439,19 @@ func translateParts(raw json.RawMessage) ([]genPart, error) {
 				parts = append(parts, part)
 			}
 		case "input_audio":
-			// OpenAI names the container (wav, mp3); Gemini's audio mime
-			// types use the same words (audio/wav, audio/mp3).
-			if p.InputAudio == nil || p.InputAudio.Data == "" || p.InputAudio.Format == "" {
+			if p.InputAudio == nil || p.InputAudio.Data == "" {
 				continue
 			}
-			parts = append(parts, genPart{InlineData: &genBlob{MimeType: "audio/" + p.InputAudio.Format, Data: p.InputAudio.Data}})
+			format := strings.ToLower(p.InputAudio.Format)
+			if !audioFormats[format] {
+				continue
+			}
+			parts = append(parts, genPart{InlineData: &genBlob{MimeType: "audio/" + format, Data: p.InputAudio.Data}})
 		case "file":
-			if p.File == nil || p.File.FileData == "" {
+			// file_data is base64 inline by definition, so only a data: URI
+			// is honoured; a plain URL here is not a fetch Gemini should make
+			// on the client's behalf.
+			if p.File == nil || !strings.HasPrefix(p.File.FileData, "data:") {
 				continue
 			}
 			if part, ok := mediaPart(p.File.FileData); ok {

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -473,8 +473,11 @@ func TestTranslateRequest_AudioAndFileParts(t *testing.T) {
 			{"type": "text", "text": "Transcribe, then read the code."},
 			{"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
 			{"type": "file", "file": {"filename": "doc.pdf", "file_data": "data:application/pdf;base64,JVBERi0="}},
+			{"type": "input_audio", "input_audio": {"data": "SUQz", "format": "MP3"}},
 			{"type": "file", "file": {"file_id": "file-abc"}},
-			{"type": "input_audio", "input_audio": {"data": "", "format": "mp3"}}
+			{"type": "file", "file": {"filename": "x.pdf", "file_data": "https://example.com/x.pdf"}},
+			{"type": "input_audio", "input_audio": {"data": "", "format": "wav"}},
+			{"type": "input_audio", "input_audio": {"data": "AAAA", "format": "pcm16"}}
 		]}]
 	}`)
 
@@ -483,17 +486,22 @@ func TestTranslateRequest_AudioAndFileParts(t *testing.T) {
 		t.Fatalf("TranslateRequest failed: %v", err)
 	}
 	parts := decodeGemini(t, out)["contents"].([]any)[0].(map[string]any)["parts"].([]any)
-	// Text, audio, pdf. The id-only file and the empty audio are dropped.
-	if len(parts) != 3 {
-		t.Fatalf("parts len = %d, want 3: %v", len(parts), parts)
+	var got []string
+	for _, p := range parts {
+		if inline, ok := p.(map[string]any)["inlineData"].(map[string]any); ok {
+			got = append(got, inline["mimeType"].(string)+":"+inline["data"].(string))
+		} else if p.(map[string]any)["fileData"] != nil {
+			got = append(got, "fileData")
+		} else {
+			got = append(got, "text")
+		}
 	}
-	audio := parts[1].(map[string]any)["inlineData"].(map[string]any)
-	if audio["mimeType"] != "audio/wav" || audio["data"] != "UklGRg==" {
-		t.Errorf("audio inlineData = %v", audio)
-	}
-	pdf := parts[2].(map[string]any)["inlineData"].(map[string]any)
-	if pdf["mimeType"] != "application/pdf" || pdf["data"] != "JVBERi0=" {
-		t.Errorf("pdf inlineData = %v", pdf)
+	// The id-only file, the URL-shaped file_data, the empty audio and the
+	// unsupported pcm16 format are all dropped; the uppercase format is
+	// lowercased.
+	want := []string{"text", "audio/wav:UklGRg==", "application/pdf:JVBERi0=", "audio/mp3:SUQz"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("parts = %v, want %v", got, want)
 	}
 }
 

--- a/internal/gemini/request_test.go
+++ b/internal/gemini/request_test.go
@@ -466,6 +466,37 @@ func TestTranslateRequest_SystemAsParts(t *testing.T) {
 	}
 }
 
+func TestTranslateRequest_AudioAndFileParts(t *testing.T) {
+	body := []byte(`{
+		"model": "gemini-3.5-flash-lite",
+		"messages": [{"role": "user", "content": [
+			{"type": "text", "text": "Transcribe, then read the code."},
+			{"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
+			{"type": "file", "file": {"filename": "doc.pdf", "file_data": "data:application/pdf;base64,JVBERi0="}},
+			{"type": "file", "file": {"file_id": "file-abc"}},
+			{"type": "input_audio", "input_audio": {"data": "", "format": "mp3"}}
+		]}]
+	}`)
+
+	out, _, _, err := TranslateRequest(body)
+	if err != nil {
+		t.Fatalf("TranslateRequest failed: %v", err)
+	}
+	parts := decodeGemini(t, out)["contents"].([]any)[0].(map[string]any)["parts"].([]any)
+	// Text, audio, pdf. The id-only file and the empty audio are dropped.
+	if len(parts) != 3 {
+		t.Fatalf("parts len = %d, want 3: %v", len(parts), parts)
+	}
+	audio := parts[1].(map[string]any)["inlineData"].(map[string]any)
+	if audio["mimeType"] != "audio/wav" || audio["data"] != "UklGRg==" {
+		t.Errorf("audio inlineData = %v", audio)
+	}
+	pdf := parts[2].(map[string]any)["inlineData"].(map[string]any)
+	if pdf["mimeType"] != "application/pdf" || pdf["data"] != "JVBERi0=" {
+		t.Errorf("pdf inlineData = %v", pdf)
+	}
+}
+
 func TestTranslateRequest_EdgeCases(t *testing.T) {
 	body := []byte(`{
 		"model": "gemini-2.5-flash",


### PR DESCRIPTION
## What

The chat-completions to Gemini `generateContent` translator (`internal/gemini/request.go`) mapped only `text` and `image_url` content parts. An `input_audio` or `file` part was silently dropped, so a Gemini model reached through OpenCode Zen or a Vertex express key saw a text-only prompt and asked for the attachment it had just been sent, while the catalogue advertised audio and PDF input for it. The 2026-09-04 live sweep showed this as eight weak cells (`audio_in` and `pdf` on `OpenCode-Zen/gemini-3.5-flash-lite`, all four members).

## Fix

- `input_audio {data, format}` becomes an `inlineData` part with mime `audio/<format>`. OpenAI's format words (`wav`, `mp3`) are the same words Gemini uses for its audio containers.
- `file.file_data` (a `data:` URI) goes through the same helper as an image URL, now named `mediaPart`.
- A `file` part carrying only a `file_id` refers to OpenAI's Files store, which Gemini cannot fetch. It is dropped the way a malformed image already is, documented on the struct.

## Verification

- New adapter test: text + wav audio + PDF data URI translate to three parts with the right mime types; id-only file and empty audio are dropped.
- Dev stack rebuilt on this branch; the live sweep tool against it:

```
PASS vision    OpenCode-Zen/gemini-3.5-flash-lite   shape✓ colour✓ code✓
PASS audio_in  OpenCode-Zen/gemini-3.5-flash-lite   3/3 keywords :: the pass phrase is orange elephant 7.
PASS pdf       OpenCode-Zen/gemini-3.5-flash-lite   read PLUM-7431 via openai-file
```

Vertex express could not be exercised on dev: its test key answers 401 on a plain text request too, so that provider's dev credentials have lapsed. Same adapter path, so the fix applies there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kbTmEU2CS4jhxkUhi4aG6
