### PR TITLE
fix(provider): advertise audio input on Google AI Studio Gemini chat models

### DIFF
--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -201,9 +201,10 @@ func googleModalities(modelID string) (inputMods, outputMods string) {
 	if isGoogleVisionModel(modelID) {
 		inputMods = `["text","image"]`
 		// Gemini chat models also hear: the OpenAI-compatibility route
-		// accepts an input_audio part (verified live, gemini-3.5-flash-lite
-		// transcribed the sweep fixture). Gemma is image-only there. PDF is
-		// left out on purpose: the same route answers a file part with 400.
+		// accepts an input_audio part (verified live: gemini-3.5-flash-lite
+		// transcribed a wav, gemma-4-31b-it answered the same request with
+		// 400, so Gemma stays image-only). PDF is left out on purpose: the
+		// same route answers a file part with 400.
 		if strings.Contains(strings.ToLower(modelID), "gemini-") {
 			inputMods = `["text","image","audio"]`
 		}

--- a/internal/provider/discovery_google.go
+++ b/internal/provider/discovery_google.go
@@ -200,6 +200,13 @@ func googleModalities(modelID string) (inputMods, outputMods string) {
 	outputMods = `["text"]`
 	if isGoogleVisionModel(modelID) {
 		inputMods = `["text","image"]`
+		// Gemini chat models also hear: the OpenAI-compatibility route
+		// accepts an input_audio part (verified live, gemini-3.5-flash-lite
+		// transcribed the sweep fixture). Gemma is image-only there. PDF is
+		// left out on purpose: the same route answers a file part with 400.
+		if strings.Contains(strings.ToLower(modelID), "gemini-") {
+			inputMods = `["text","image","audio"]`
+		}
 	}
 	if isGoogleImageGenModel(modelID) {
 		outputMods = `["text","image"]`

--- a/internal/provider/discovery_google_test.go
+++ b/internal/provider/discovery_google_test.go
@@ -246,7 +246,9 @@ func TestGoogleModalities(t *testing.T) {
 	cases := []struct {
 		model, wantIn, wantOut, wantClass string
 	}{
-		{"gemini-2.5-flash", `["text","image"]`, `["text"]`, "chat"},
+		{"gemini-2.5-flash", `["text","image","audio"]`, `["text"]`, "chat"},
+		{"gemini-3.5-flash-lite", `["text","image","audio"]`, `["text"]`, "chat"},
+		{"gemma-4-31b-it", `["text","image"]`, `["text"]`, "chat"},
 		{"gemini-3-pro-image", `["text","image"]`, `["text","image"]`, "chat"},
 		{"gemini-2.5-flash-preview-tts", `["text"]`, `["audio"]`, "tts"},
 		{"gemini-2.5-flash-native-audio-preview", `["text","image","audio","video"]`, `["text","audio"]`, "chat"},


### PR DESCRIPTION
## What

Google AI Studio's model list carries no modality information, so `googleModalities` derives each model's input and output arrays from its name. Gemini chat models came out as `["text","image"]`, so `/v1/models` reported `audio_input: false` for them, a client gating on that flag never sent audio, and the `hotel/gemini-*` failover groups inherited the same underclaim. The live sweep skipped the `audio_in` probe on Google direct for the same reason.

The model hears fine. Verified through the gateway against prod, gemini-3.5-flash-lite via Google's OpenAI-compatibility route:

```
input_audio (wav)   -> "The pass phrase is orange elephant 7."
file (pdf data URI) -> upstream HTTP 400
```

Google's own docs list audio understanding for the compat route and say nothing about PDF.

## Change

Gemini chat models (`gemini-` in the id, inside the vision branch) now derive `["text","image","audio"]`. Gemma stays image-only. Image-generation, TTS, live/native-audio and embedding models keep their own lists via the later branches. PDF is deliberately left out: the same route answers a `file` part with 400, and claiming it would route PDFs to a certain error.

Re-discovery rewrites the stored modalities (`input_modalities = EXCLUDED.input_modalities`), so existing rows pick this up on the next Discover run; no migration.

## Tests

`TestGoogleModalities` gains gemini-3.5-flash-lite (audio) and gemma-4-31b-it (no audio) beside the updated gemini-2.5-flash case; the image-gen, TTS, live and embedding cases are unchanged and still pass, proving the later branches reset the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kbTmEU2CS4jhxkUhi4aG6
