### PR TITLE
feat(gemini): serve /v1/audio/transcriptions through generateContent

### DIFF
--- a/internal/gemini/response.go
+++ b/internal/gemini/response.go
@@ -53,6 +53,12 @@ type genRespPart struct {
 	// request whose response modalities named IMAGE): base64 bytes and
 	// their mime type.
 	InlineData *genRespBlob `json:"inlineData"`
+	// AudioTranscription is how a dedicated transcription model
+	// (gemini-3.5-transcribe) answers: the transcript under its own key
+	// rather than as a text part.
+	AudioTranscription *struct {
+		Text string `json:"text"`
+	} `json:"audioTranscription"`
 }
 
 type genRespBlob struct {

--- a/internal/gemini/transcribe.go
+++ b/internal/gemini/transcribe.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/jsonfault"
@@ -41,28 +42,47 @@ var ErrTranscriptionNoText = errors.New("gemini: no text in transcription respon
 // the client gave no prompt of its own: asked nothing about an audio clip it
 // tends to converse with it rather than transcribe it. A dedicated
 // transcription model (gemini-3.5-transcribe) takes the audio alone and
-// answers an instruction beside it with an empty reply, so it gets none.
+// answers any text beside it, the client's prompt included, with an empty
+// reply, so it gets none.
 const defaultTranscriptionPrompt = "Transcribe this audio verbatim. Reply with the transcript only."
 
 // audioMimeByExt maps the upload's file extension to the mime type Gemini
 // takes for that container. OpenAI clients commonly send the file as
-// application/octet-stream, so the name is the reliable signal.
+// application/octet-stream, so the name is the reliable signal. mp4 is the
+// same container as m4a, under the name OpenAI's own API lists.
 var audioMimeByExt = map[string]string{
 	"wav": "audio/wav", "mp3": "audio/mp3", "mpeg": "audio/mpeg", "mpga": "audio/mpeg",
-	"m4a": "audio/m4a", "aac": "audio/aac", "aiff": "audio/aiff", "aif": "audio/aiff",
+	"m4a": "audio/m4a", "mp4": "audio/m4a", "aac": "audio/aac", "aiff": "audio/aiff", "aif": "audio/aiff",
 	"ogg": "audio/ogg", "oga": "audio/ogg", "opus": "audio/opus", "flac": "audio/flac", "webm": "audio/webm",
 }
 
+// audioMimeAliases folds the content types browsers and curl send for the
+// same containers onto Gemini's names; anything else that is not already a
+// Gemini name is refused rather than passed on to the provider's 400.
+var audioMimeAliases = map[string]string{
+	"audio/x-wav": "audio/wav", "audio/wave": "audio/wav", "audio/vnd.wave": "audio/wav",
+	"audio/x-m4a": "audio/m4a", "audio/mp4": "audio/m4a", "audio/x-aiff": "audio/aiff",
+	"audio/x-flac": "audio/flac", "audio/mpeg3": "audio/mp3", "audio/x-mpeg-3": "audio/mp3",
+}
+
 // TranscriptionRequest is what the adapter needs off an OpenAI multipart
-// transcription form.
+// transcription form. language has no counterpart on generateContent (the
+// model detects it) and is dropped; timestamp_granularities only matters to
+// the formats the adapter refuses.
 type TranscriptionRequest struct {
 	Audio          []byte
 	FileName       string
 	ContentType    string
 	Prompt         string
 	ResponseFormat string
+	// Temperature is the form's temperature field as sent, mapped onto the
+	// generation config when it parses as a number.
+	Temperature string
+	// Stream is the form's stream field: the adapter delivers one body, so a
+	// streaming request is refused rather than quietly downgraded.
+	Stream bool
 	// Dedicated marks a transcription-only model, which is sent the audio
-	// with no instruction beside it.
+	// with no text beside it.
 	Dedicated bool
 }
 
@@ -80,42 +100,70 @@ func TranscriptionFormat(format string) (string, error) {
 }
 
 // AudioMimeType resolves the upload's mime type from its file name, falling
-// back to the part's own content type when that names an audio container.
+// back to the part's own content type when that names a container Gemini
+// takes.
 func AudioMimeType(fileName, contentType string) (string, bool) {
 	if mime, ok := audioMimeByExt[strings.ToLower(strings.TrimPrefix(path.Ext(fileName), "."))]; ok {
 		return mime, true
 	}
 	mime, _, _ := strings.Cut(contentType, ";")
 	mime = strings.TrimSpace(strings.ToLower(mime))
-	return mime, strings.HasPrefix(mime, "audio/")
+	if alias, ok := audioMimeAliases[mime]; ok {
+		return alias, true
+	}
+	for _, known := range audioMimeByExt {
+		if mime == known {
+			return mime, true
+		}
+	}
+	return mime, false
+}
+
+// ValidateTranscriptionRequest checks what the adapter can serve without
+// touching the upload's bytes, returning the container and the delivery
+// format. An unsupported response_format is ErrTranscriptionFormat; a
+// streaming request, an empty upload or one whose container cannot be named
+// is a plain error, since the model would answer it with a 400 of its own.
+// The refusal path runs this once per candidate, so the base64 of the upload
+// is left to the translation proper.
+func ValidateTranscriptionRequest(req TranscriptionRequest) (mime, format string, err error) {
+	format, err = TranscriptionFormat(req.ResponseFormat)
+	if err != nil {
+		return "", "", err
+	}
+	if req.Stream {
+		return "", "", errors.New("gemini: a transcription through generateContent is delivered whole; stream is not available")
+	}
+	if len(req.Audio) == 0 {
+		return "", "", errors.New("gemini: transcription request carries no audio")
+	}
+	mime, ok := AudioMimeType(req.FileName, req.ContentType)
+	if !ok {
+		return "", "", errors.New("gemini: cannot tell the audio container; name the file with its extension (wav, mp3, m4a, ogg, flac, webm)")
+	}
+	return mime, format, nil
 }
 
 // TranslateTranscriptionRequest maps an OpenAI transcription form onto a
 // generateContent request, returning the format the answer is to be
-// delivered in. An unsupported response_format is ErrTranscriptionFormat; an
-// empty upload or one whose container cannot be named is a plain error, since
-// the model would answer it with a 400 of its own.
+// delivered in. Its errors are ValidateTranscriptionRequest's.
 func TranslateTranscriptionRequest(req TranscriptionRequest) (geminiBody []byte, format string, err error) {
-	format, err = TranscriptionFormat(req.ResponseFormat)
+	mime, format, err := ValidateTranscriptionRequest(req)
 	if err != nil {
 		return nil, "", err
 	}
-	if len(req.Audio) == 0 {
-		return nil, "", errors.New("gemini: transcription request carries no audio")
-	}
-	mime, ok := AudioMimeType(req.FileName, req.ContentType)
-	if !ok {
-		return nil, "", fmt.Errorf("gemini: cannot tell the audio container of %q; name the file with its extension (wav, mp3, m4a, ogg, flac, webm)", req.FileName)
-	}
 	parts := []genPart{{InlineData: &genBlob{MimeType: mime, Data: base64.StdEncoding.EncodeToString(req.Audio)}}}
-	prompt := strings.TrimSpace(req.Prompt)
-	if prompt == "" && !req.Dedicated {
-		prompt = defaultTranscriptionPrompt
-	}
-	if prompt != "" {
+	if !req.Dedicated {
+		prompt := strings.TrimSpace(req.Prompt)
+		if prompt == "" {
+			prompt = defaultTranscriptionPrompt
+		}
 		parts = append(parts, genPart{Text: prompt})
 	}
 	out := genRequest{Contents: []genContent{{Role: "user", Parts: parts}}}
+	if temp, err := strconv.ParseFloat(strings.TrimSpace(req.Temperature), 64); err == nil {
+		out.GenerationConfig = &genConfig{Temperature: &temp}
+	}
 	geminiBody, err = json.Marshal(out)
 	if err != nil {
 		return nil, "", fmt.Errorf("gemini: marshal transcription request: %w", err)
@@ -141,9 +189,11 @@ func BuildTranscriptionResponse(body []byte, format string) (out []byte, content
 	if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
 		return nil, "", usage, fmt.Errorf("%w: prompt blocked (%s)", ErrTranscriptionNoText, resp.PromptFeedback.BlockReason)
 	}
+	// The first candidate alone: a second one would be the same transcript
+	// again.
 	var text strings.Builder
-	for _, c := range resp.Candidates {
-		for _, p := range c.Content.Parts {
+	if len(resp.Candidates) > 0 {
+		for _, p := range resp.Candidates[0].Content.Parts {
 			if p.AudioTranscription != nil {
 				text.WriteString(p.AudioTranscription.Text)
 				continue

--- a/internal/gemini/transcribe.go
+++ b/internal/gemini/transcribe.go
@@ -149,7 +149,9 @@ func ValidateTranscriptionRequest(req TranscriptionRequest) (mime, format string
 
 // TranslateTranscriptionRequest maps an OpenAI transcription form onto a
 // generateContent request, returning the format the answer is to be
-// delivered in. Its errors are ValidateTranscriptionRequest's.
+// delivered in. Its refusals are ValidateTranscriptionRequest's; a
+// temperature that is not a finite number in Gemini's 0 to 2 range is
+// dropped rather than refused, the way the unparsable one is.
 func TranslateTranscriptionRequest(req TranscriptionRequest) (geminiBody []byte, format string, err error) {
 	mime, format, err := ValidateTranscriptionRequest(req)
 	if err != nil {
@@ -164,7 +166,7 @@ func TranslateTranscriptionRequest(req TranscriptionRequest) (geminiBody []byte,
 		parts = append(parts, genPart{Text: text})
 	}
 	out := genRequest{Contents: []genContent{{Role: "user", Parts: parts}}}
-	if temp, err := strconv.ParseFloat(strings.TrimSpace(req.Temperature), 64); err == nil {
+	if temp, err := strconv.ParseFloat(strings.TrimSpace(req.Temperature), 64); err == nil && temp >= 0 && temp <= 2 {
 		out.GenerationConfig = &genConfig{Temperature: &temp}
 	}
 	geminiBody, err = json.Marshal(out)
@@ -192,8 +194,8 @@ func BuildTranscriptionResponse(body []byte, format string) (out []byte, content
 	if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
 		return nil, "", usage, fmt.Errorf("%w: prompt blocked (%s)", ErrTranscriptionNoText, resp.PromptFeedback.BlockReason)
 	}
-	// The first candidate alone: a second one would be the same transcript
-	// again.
+	// The first candidate alone: the request asks for one, and were a
+	// second ever present it would be the same audio transcribed again.
 	var text strings.Builder
 	if len(resp.Candidates) > 0 {
 		for _, p := range resp.Candidates[0].Content.Parts {

--- a/internal/gemini/transcribe.go
+++ b/internal/gemini/transcribe.go
@@ -1,0 +1,175 @@
+package gemini
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/jsonfault"
+)
+
+// Speech-to-text through generateContent.
+//
+// Google's OpenAI-compatibility layer does not serve /v1/audio/transcriptions,
+// so a Gemini model that hears (gemini-3.5-transcribe, or any Gemini chat
+// model with audio input) is reached through generateContent: the uploaded
+// audio becomes an inlineData part, the client's prompt (or a fixed
+// transcription instruction) a text part, and the text the model answers
+// with is delivered in OpenAI's transcription shape. Only json and text are
+// honoured as response formats: verbose_json, srt and vtt need timestamps a
+// plain generateContent answer does not carry.
+
+// TranscriptionFormatJSON and TranscriptionFormatText are the response
+// formats a Gemini transcription can be delivered in.
+const (
+	TranscriptionFormatJSON = "json"
+	TranscriptionFormatText = "text"
+)
+
+// ErrTranscriptionFormat reports a response_format the adapter cannot
+// produce. The wrapped message names what it can, for the client.
+var ErrTranscriptionFormat = errors.New("gemini: unsupported transcription response_format")
+
+// ErrTranscriptionNoText reports a generateContent answer that carried no
+// text: the provider answered, and its answer was not a transcript.
+var ErrTranscriptionNoText = errors.New("gemini: no text in transcription response")
+
+// defaultTranscriptionPrompt is the instruction sent to a chat model when
+// the client gave no prompt of its own: asked nothing about an audio clip it
+// tends to converse with it rather than transcribe it. A dedicated
+// transcription model (gemini-3.5-transcribe) takes the audio alone and
+// answers an instruction beside it with an empty reply, so it gets none.
+const defaultTranscriptionPrompt = "Transcribe this audio verbatim. Reply with the transcript only."
+
+// audioMimeByExt maps the upload's file extension to the mime type Gemini
+// takes for that container. OpenAI clients commonly send the file as
+// application/octet-stream, so the name is the reliable signal.
+var audioMimeByExt = map[string]string{
+	"wav": "audio/wav", "mp3": "audio/mp3", "mpeg": "audio/mpeg", "mpga": "audio/mpeg",
+	"m4a": "audio/m4a", "aac": "audio/aac", "aiff": "audio/aiff", "aif": "audio/aiff",
+	"ogg": "audio/ogg", "oga": "audio/ogg", "opus": "audio/opus", "flac": "audio/flac", "webm": "audio/webm",
+}
+
+// TranscriptionRequest is what the adapter needs off an OpenAI multipart
+// transcription form.
+type TranscriptionRequest struct {
+	Audio          []byte
+	FileName       string
+	ContentType    string
+	Prompt         string
+	ResponseFormat string
+	// Dedicated marks a transcription-only model, which is sent the audio
+	// with no instruction beside it.
+	Dedicated bool
+}
+
+// TranscriptionFormat resolves an OpenAI transcription response_format to
+// one the adapter can deliver: absent means json, and anything but json or
+// text is ErrTranscriptionFormat.
+func TranscriptionFormat(format string) (string, error) {
+	switch strings.ToLower(format) {
+	case "", TranscriptionFormatJSON:
+		return TranscriptionFormatJSON, nil
+	case TranscriptionFormatText:
+		return TranscriptionFormatText, nil
+	}
+	return "", fmt.Errorf("%w: %q; a Gemini transcription carries no timestamps, so response_format must be json or text", ErrTranscriptionFormat, format)
+}
+
+// AudioMimeType resolves the upload's mime type from its file name, falling
+// back to the part's own content type when that names an audio container.
+func AudioMimeType(fileName, contentType string) (string, bool) {
+	if mime, ok := audioMimeByExt[strings.ToLower(strings.TrimPrefix(path.Ext(fileName), "."))]; ok {
+		return mime, true
+	}
+	mime, _, _ := strings.Cut(contentType, ";")
+	mime = strings.TrimSpace(strings.ToLower(mime))
+	return mime, strings.HasPrefix(mime, "audio/")
+}
+
+// TranslateTranscriptionRequest maps an OpenAI transcription form onto a
+// generateContent request, returning the format the answer is to be
+// delivered in. An unsupported response_format is ErrTranscriptionFormat; an
+// empty upload or one whose container cannot be named is a plain error, since
+// the model would answer it with a 400 of its own.
+func TranslateTranscriptionRequest(req TranscriptionRequest) (geminiBody []byte, format string, err error) {
+	format, err = TranscriptionFormat(req.ResponseFormat)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(req.Audio) == 0 {
+		return nil, "", errors.New("gemini: transcription request carries no audio")
+	}
+	mime, ok := AudioMimeType(req.FileName, req.ContentType)
+	if !ok {
+		return nil, "", fmt.Errorf("gemini: cannot tell the audio container of %q; name the file with its extension (wav, mp3, m4a, ogg, flac, webm)", req.FileName)
+	}
+	parts := []genPart{{InlineData: &genBlob{MimeType: mime, Data: base64.StdEncoding.EncodeToString(req.Audio)}}}
+	prompt := strings.TrimSpace(req.Prompt)
+	if prompt == "" && !req.Dedicated {
+		prompt = defaultTranscriptionPrompt
+	}
+	if prompt != "" {
+		parts = append(parts, genPart{Text: prompt})
+	}
+	out := genRequest{Contents: []genContent{{Role: "user", Parts: parts}}}
+	geminiBody, err = json.Marshal(out)
+	if err != nil {
+		return nil, "", fmt.Errorf("gemini: marshal transcription request: %w", err)
+	}
+	return geminiBody, format, nil
+}
+
+// BuildTranscriptionResponse turns a generateContent answer into the
+// transcription body the client asked for, with its content type and the
+// usage the answer carried. A chat model answers with text parts, a
+// dedicated transcription model with audioTranscription parts; both are
+// read. A blocked prompt or an answer without text is
+// ErrTranscriptionNoText, wrapped with what the answer said instead; a body
+// that is not a generateContent object at all is a plain decode error.
+func BuildTranscriptionResponse(body []byte, format string) (out []byte, contentType string, usage SpeechUsage, err error) {
+	var resp genResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, "", usage, fmt.Errorf("gemini: invalid transcription response: %s", jsonfault.Describe(err, len(body)))
+	}
+	if u := translateUsage(resp.UsageMetadata); u != nil {
+		usage = SpeechUsage{PromptTokens: u.PromptTokens, CompletionTokens: u.CompletionTokens}
+	}
+	if resp.PromptFeedback != nil && resp.PromptFeedback.BlockReason != "" {
+		return nil, "", usage, fmt.Errorf("%w: prompt blocked (%s)", ErrTranscriptionNoText, resp.PromptFeedback.BlockReason)
+	}
+	var text strings.Builder
+	for _, c := range resp.Candidates {
+		for _, p := range c.Content.Parts {
+			if p.AudioTranscription != nil {
+				text.WriteString(p.AudioTranscription.Text)
+				continue
+			}
+			if p.Thought || p.Text == "" {
+				continue
+			}
+			text.WriteString(p.Text)
+		}
+	}
+	transcript := strings.TrimSpace(text.String())
+	if transcript == "" {
+		detail := "no text part"
+		if len(resp.Candidates) > 0 && resp.Candidates[0].FinishReason != "" {
+			detail += " (finish reason " + resp.Candidates[0].FinishReason + ")"
+		}
+		return nil, "", usage, fmt.Errorf("%w: %s", ErrTranscriptionNoText, detail)
+	}
+	if format == TranscriptionFormatText {
+		return []byte(transcript), "text/plain; charset=utf-8", usage, nil
+	}
+	out, err = json.Marshal(struct {
+		Text string `json:"text"`
+	}{transcript})
+	if err != nil {
+		return nil, "", usage, fmt.Errorf("gemini: marshal transcription: %w", err)
+	}
+	return out, "application/json", usage, nil
+}

--- a/internal/gemini/transcribe.go
+++ b/internal/gemini/transcribe.go
@@ -38,13 +38,16 @@ var ErrTranscriptionFormat = errors.New("gemini: unsupported transcription respo
 // text: the provider answered, and its answer was not a transcript.
 var ErrTranscriptionNoText = errors.New("gemini: no text in transcription response")
 
-// defaultTranscriptionPrompt is the instruction sent to a chat model when
-// the client gave no prompt of its own: asked nothing about an audio clip it
-// tends to converse with it rather than transcribe it. A dedicated
-// transcription model (gemini-3.5-transcribe) takes the audio alone and
-// answers any text beside it, the client's prompt included, with an empty
-// reply, so it gets none.
-const defaultTranscriptionPrompt = "Transcribe this audio verbatim. Reply with the transcript only."
+// transcriptionInstruction is the text sent to a chat model beside the
+// audio: asked nothing about a clip it converses with it rather than
+// transcribing it, and OpenAI's prompt field is a context hint (names,
+// spellings) rather than an instruction, so the client's prompt rides along
+// as context under the instruction instead of replacing it (verified live:
+// gemini-3.5-flash-lite answered a bare hint with "Understood. Your pass
+// phrase is..."). A dedicated transcription model (gemini-3.5-transcribe)
+// takes the audio alone and answers any text beside it with an empty reply,
+// so it gets none.
+const transcriptionInstruction = "Transcribe this audio verbatim. Reply with the transcript only."
 
 // audioMimeByExt maps the upload's file extension to the mime type Gemini
 // takes for that container. OpenAI clients commonly send the file as
@@ -154,11 +157,11 @@ func TranslateTranscriptionRequest(req TranscriptionRequest) (geminiBody []byte,
 	}
 	parts := []genPart{{InlineData: &genBlob{MimeType: mime, Data: base64.StdEncoding.EncodeToString(req.Audio)}}}
 	if !req.Dedicated {
-		prompt := strings.TrimSpace(req.Prompt)
-		if prompt == "" {
-			prompt = defaultTranscriptionPrompt
+		text := transcriptionInstruction
+		if hint := strings.TrimSpace(req.Prompt); hint != "" {
+			text += " Context: " + hint
 		}
-		parts = append(parts, genPart{Text: prompt})
+		parts = append(parts, genPart{Text: text})
 	}
 	out := genRequest{Contents: []genContent{{Role: "user", Parts: parts}}}
 	if temp, err := strconv.ParseFloat(strings.TrimSpace(req.Temperature), 64); err == nil {

--- a/internal/gemini/transcribe_test.go
+++ b/internal/gemini/transcribe_test.go
@@ -69,9 +69,11 @@ func TestTranslateTranscriptionRequest_Temperature(t *testing.T) {
 	if err != nil || !strings.Contains(string(body), `"generationConfig":{"temperature":0.2}`) {
 		t.Errorf("temperature: err=%v body=%s", err, body)
 	}
-	body, _, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Temperature: "warm"})
-	if err != nil || strings.Contains(string(body), `generationConfig`) {
-		t.Errorf("unparsable temperature must be dropped: err=%v body=%s", err, body)
+	for _, bad := range []string{"warm", "NaN", "Inf", "-1", "3"} {
+		body, _, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Temperature: bad})
+		if err != nil || strings.Contains(string(body), `generationConfig`) {
+			t.Errorf("temperature %q must be dropped: err=%v body=%s", bad, err, body)
+		}
 	}
 }
 

--- a/internal/gemini/transcribe_test.go
+++ b/internal/gemini/transcribe_test.go
@@ -56,9 +56,42 @@ func TestTranslateTranscriptionRequest_Dedicated(t *testing.T) {
 	if strings.Contains(string(body), `"text"`) {
 		t.Errorf("dedicated model got an instruction: %s", body)
 	}
+	// The client's prompt is dropped too: the model answers any text beside
+	// the audio with an empty reply.
 	body, _, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Dedicated: true, Prompt: "Names: Prague."})
-	if err != nil || !strings.Contains(string(body), `"text":"Names: Prague."`) {
+	if err != nil || strings.Contains(string(body), `"text"`) {
 		t.Errorf("dedicated with client prompt: err=%v body=%s", err, body)
+	}
+}
+
+func TestTranslateTranscriptionRequest_Temperature(t *testing.T) {
+	body, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Temperature: "0.2"})
+	if err != nil || !strings.Contains(string(body), `"generationConfig":{"temperature":0.2}`) {
+		t.Errorf("temperature: err=%v body=%s", err, body)
+	}
+	body, _, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Temperature: "warm"})
+	if err != nil || strings.Contains(string(body), `generationConfig`) {
+		t.Errorf("unparsable temperature must be dropped: err=%v body=%s", err, body)
+	}
+}
+
+func TestAudioMimeType(t *testing.T) {
+	cases := []struct {
+		name, contentType, want string
+		ok                      bool
+	}{
+		{"clip.mp4", "application/octet-stream", "audio/m4a", true},
+		{"clip.MP3", "", "audio/mp3", true},
+		{"clip", "audio/x-wav", "audio/wav", true},
+		{"clip", "audio/mp4", "audio/m4a", true},
+		{"clip", "audio/flac; rate=44100", "audio/flac", true},
+		{"clip", "audio/x-foo", "audio/x-foo", false},
+		{"clip.txt", "text/plain", "text/plain", false},
+	}
+	for _, tc := range cases {
+		if got, ok := AudioMimeType(tc.name, tc.contentType); got != tc.want || ok != tc.ok {
+			t.Errorf("%s %q: got %q %v, want %q %v", tc.name, tc.contentType, got, ok, tc.want, tc.ok)
+		}
 	}
 }
 
@@ -70,8 +103,11 @@ func TestTranslateTranscriptionRequest_Refusals(t *testing.T) {
 	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{FileName: "a.wav"}); err == nil || !strings.Contains(err.Error(), "no audio") {
 		t.Errorf("empty upload: err = %v", err)
 	}
-	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "blob", ContentType: "application/octet-stream"}); err == nil || !strings.Contains(err.Error(), "audio container") {
-		t.Errorf("unknown container: err = %v", err)
+	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "blob", ContentType: "application/octet-stream"}); err == nil || !strings.Contains(err.Error(), "audio container") || strings.Contains(err.Error(), "blob") {
+		t.Errorf("unknown container: err = %v (must not echo the file name)", err)
+	}
+	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "a.wav", Stream: true}); err == nil || !strings.Contains(err.Error(), "stream") {
+		t.Errorf("stream: err = %v", err)
 	}
 }
 
@@ -103,6 +139,15 @@ func TestBuildTranscriptionResponse_DedicatedShape(t *testing.T) {
 	}
 	if string(out) != `{"text":"The pass phrase is orange elephant seven."}` || usage.PromptTokens != 66 || usage.CompletionTokens != 0 {
 		t.Errorf("out=%s usage=%+v", out, usage)
+	}
+}
+
+// A second candidate is the same transcript again and is not appended.
+func TestBuildTranscriptionResponse_FirstCandidateOnly(t *testing.T) {
+	body := []byte(`{"candidates":[{"content":{"parts":[{"text":"once"}]}},{"content":{"parts":[{"text":"once"}]}}]}`)
+	out, _, _, err := BuildTranscriptionResponse(body, TranscriptionFormatText)
+	if err != nil || string(out) != "once" {
+		t.Errorf("err=%v out=%s", err, out)
 	}
 }
 

--- a/internal/gemini/transcribe_test.go
+++ b/internal/gemini/transcribe_test.go
@@ -29,21 +29,21 @@ func TestTranslateTranscriptionRequest(t *testing.T) {
 	if inline["mimeType"] != "audio/wav" || inline["data"] != base64.StdEncoding.EncodeToString(audio) {
 		t.Errorf("inlineData = %v", inline)
 	}
-	if parts[1].(map[string]any)["text"] != defaultTranscriptionPrompt {
+	if parts[1].(map[string]any)["text"] != transcriptionInstruction {
 		t.Errorf("instruction = %v", parts[1])
 	}
 	if _, ok := sent["generationConfig"]; ok {
 		t.Error("generationConfig present; a transcription asks for nothing but text")
 	}
 
-	// A client prompt replaces the default instruction; text format rides
-	// through; the container comes from the content type when the name
-	// gives none.
+	// A client prompt rides along as context under the instruction; text
+	// format rides through; the container comes from the content type when
+	// the name gives none.
 	body, format, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "clip", ContentType: "audio/ogg; codecs=opus", Prompt: "Names: Prague.", ResponseFormat: "text"})
 	if err != nil || format != TranscriptionFormatText {
 		t.Fatalf("text format: err=%v format=%q", err, format)
 	}
-	if !strings.Contains(string(body), `"mimeType":"audio/ogg"`) || !strings.Contains(string(body), `"text":"Names: Prague."`) {
+	if !strings.Contains(string(body), `"mimeType":"audio/ogg"`) || !strings.Contains(string(body), `"text":"`+transcriptionInstruction+` Context: Names: Prague."`) {
 		t.Errorf("body = %s", body)
 	}
 }

--- a/internal/gemini/transcribe_test.go
+++ b/internal/gemini/transcribe_test.go
@@ -1,0 +1,122 @@
+package gemini
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTranslateTranscriptionRequest(t *testing.T) {
+	audio := []byte("RIFFfakewav")
+	body, format, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "speech.WAV", ContentType: "application/octet-stream"})
+	if err != nil {
+		t.Fatalf("TranslateTranscriptionRequest: %v", err)
+	}
+	if format != TranscriptionFormatJSON {
+		t.Errorf("format = %q, want json by default", format)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	parts := sent["contents"].([]any)[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 2 {
+		t.Fatalf("parts = %v, want audio + instruction", parts)
+	}
+	inline := parts[0].(map[string]any)["inlineData"].(map[string]any)
+	if inline["mimeType"] != "audio/wav" || inline["data"] != base64.StdEncoding.EncodeToString(audio) {
+		t.Errorf("inlineData = %v", inline)
+	}
+	if parts[1].(map[string]any)["text"] != defaultTranscriptionPrompt {
+		t.Errorf("instruction = %v", parts[1])
+	}
+	if _, ok := sent["generationConfig"]; ok {
+		t.Error("generationConfig present; a transcription asks for nothing but text")
+	}
+
+	// A client prompt replaces the default instruction; text format rides
+	// through; the container comes from the content type when the name
+	// gives none.
+	body, format, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "clip", ContentType: "audio/ogg; codecs=opus", Prompt: "Names: Prague.", ResponseFormat: "text"})
+	if err != nil || format != TranscriptionFormatText {
+		t.Fatalf("text format: err=%v format=%q", err, format)
+	}
+	if !strings.Contains(string(body), `"mimeType":"audio/ogg"`) || !strings.Contains(string(body), `"text":"Names: Prague."`) {
+		t.Errorf("body = %s", body)
+	}
+}
+
+func TestTranslateTranscriptionRequest_Dedicated(t *testing.T) {
+	body, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Dedicated: true})
+	if err != nil {
+		t.Fatalf("dedicated: %v", err)
+	}
+	if strings.Contains(string(body), `"text"`) {
+		t.Errorf("dedicated model got an instruction: %s", body)
+	}
+	body, _, err = TranslateTranscriptionRequest(TranscriptionRequest{Audio: []byte("x"), FileName: "a.wav", Dedicated: true, Prompt: "Names: Prague."})
+	if err != nil || !strings.Contains(string(body), `"text":"Names: Prague."`) {
+		t.Errorf("dedicated with client prompt: err=%v body=%s", err, body)
+	}
+}
+
+func TestTranslateTranscriptionRequest_Refusals(t *testing.T) {
+	audio := []byte("x")
+	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "a.wav", ResponseFormat: "srt"}); !errors.Is(err, ErrTranscriptionFormat) {
+		t.Errorf("srt: err = %v, want ErrTranscriptionFormat", err)
+	}
+	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{FileName: "a.wav"}); err == nil || !strings.Contains(err.Error(), "no audio") {
+		t.Errorf("empty upload: err = %v", err)
+	}
+	if _, _, err := TranslateTranscriptionRequest(TranscriptionRequest{Audio: audio, FileName: "blob", ContentType: "application/octet-stream"}); err == nil || !strings.Contains(err.Error(), "audio container") {
+		t.Errorf("unknown container: err = %v", err)
+	}
+}
+
+func TestBuildTranscriptionResponse(t *testing.T) {
+	body := []byte(`{"candidates":[{"content":{"parts":[{"text":"thinking","thought":true},{"text":"The pass phrase is "},{"text":"orange elephant seven.\n"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":66,"candidatesTokenCount":9,"totalTokenCount":75}}`)
+	out, ct, usage, err := BuildTranscriptionResponse(body, TranscriptionFormatJSON)
+	if err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	if ct != "application/json" || string(out) != `{"text":"The pass phrase is orange elephant seven."}` {
+		t.Errorf("json: ct=%q out=%s", ct, out)
+	}
+	if usage.PromptTokens != 66 || usage.CompletionTokens != 9 {
+		t.Errorf("usage = %+v", usage)
+	}
+	out, ct, _, err = BuildTranscriptionResponse(body, TranscriptionFormatText)
+	if err != nil || !strings.HasPrefix(ct, "text/plain") || string(out) != "The pass phrase is orange elephant seven." {
+		t.Errorf("text: err=%v ct=%q out=%s", err, ct, out)
+	}
+}
+
+// gemini-3.5-transcribe answers with an audioTranscription part and no
+// candidatesTokenCount, as observed live.
+func TestBuildTranscriptionResponse_DedicatedShape(t *testing.T) {
+	body := []byte(`{"candidates":[{"content":{"parts":[{"audioTranscription":{"text":"The pass phrase is orange elephant seven."}}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":66,"totalTokenCount":66},"modelVersion":"gemini-3.5-transcribe"}`)
+	out, _, usage, err := BuildTranscriptionResponse(body, TranscriptionFormatJSON)
+	if err != nil {
+		t.Fatalf("dedicated: %v", err)
+	}
+	if string(out) != `{"text":"The pass phrase is orange elephant seven."}` || usage.PromptTokens != 66 || usage.CompletionTokens != 0 {
+		t.Errorf("out=%s usage=%+v", out, usage)
+	}
+}
+
+func TestBuildTranscriptionResponse_NoText(t *testing.T) {
+	cases := map[string]string{
+		"empty answer": `{"candidates":[{"content":{"parts":[],"role":"model"},"finishReason":"MAX_TOKENS"}]}`,
+		"blocked":      `{"promptFeedback":{"blockReason":"SAFETY"}}`,
+	}
+	for name, body := range cases {
+		if _, _, _, err := BuildTranscriptionResponse([]byte(body), TranscriptionFormatJSON); !errors.Is(err, ErrTranscriptionNoText) {
+			t.Errorf("%s: err = %v, want ErrTranscriptionNoText", name, err)
+		}
+	}
+	if _, _, _, err := BuildTranscriptionResponse([]byte(`not json`), TranscriptionFormatJSON); err == nil || errors.Is(err, ErrTranscriptionNoText) {
+		t.Errorf("garbage: err = %v, want a plain decode error", err)
+	}
+}

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -305,12 +305,14 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 // Charging for it would take a healthy provider out of rotation for every tenant
 // after five blocked prompts, which is exactly what a client retries.
 //
-// The speech adapter's refusals are the same two shapes: an answer without an
-// audio part (a blocked prompt, a text reply) is the model answering, and a
-// body past speechBodyCap is this gateway's own limit.
+// The speech and transcription adapters' refusals are the same two shapes:
+// an answer without an audio part or without text (a blocked prompt, a reply
+// of the other kind) is the model answering, and a body past the adapter's
+// cap is this gateway's own limit.
 func translationIsProviderFault(err error) bool {
 	return !errors.Is(err, gemini.ErrPromptBlocked) && !errors.Is(err, errEgressBodyOversized) &&
-		!errors.Is(err, gemini.ErrSpeechNoAudio) && !errors.Is(err, errSpeechBodyOversized)
+		!errors.Is(err, gemini.ErrSpeechNoAudio) && !errors.Is(err, errSpeechBodyOversized) &&
+		!errors.Is(err, gemini.ErrTranscriptionNoText) && !errors.Is(err, errTranscriptionBodyOversized)
 }
 
 // answerCarriesSomething reports whether a completion carries anything at all

--- a/internal/proxy/gemini_speech.go
+++ b/internal/proxy/gemini_speech.go
@@ -57,16 +57,25 @@ func speechRequestRefusal(st *requestState, candidate modelCandidate) string {
 	return ""
 }
 
-// refuseSpeechRequest answers a speech request with a 400 before any attempt
-// is made when every candidate refuses it. Reports whether the request was
-// answered.
-func (h *Handler) refuseSpeechRequest(w http.ResponseWriter, st *requestState, candidates []modelCandidate) bool {
-	if st.endpointPath != speechEndpointPath || len(candidates) == 0 {
+// geminiRequestRefusal is the reason a Gemini speech or transcription
+// attempt cannot serve the request as asked, or empty.
+func geminiRequestRefusal(st *requestState, candidate modelCandidate) string {
+	if reason := speechRequestRefusal(st, candidate); reason != "" {
+		return reason
+	}
+	return transcriptionRequestRefusal(st, candidate)
+}
+
+// refuseGeminiRequest answers a speech or transcription request with a 400
+// before any attempt is made when every candidate refuses it. Reports whether
+// the request was answered.
+func (h *Handler) refuseGeminiRequest(w http.ResponseWriter, st *requestState, candidates []modelCandidate) bool {
+	if (st.endpointPath != speechEndpointPath && st.endpointPath != transcriptionEndpointPath) || len(candidates) == 0 {
 		return false
 	}
 	reason := ""
 	for _, c := range candidates {
-		reason = speechRequestRefusal(st, c)
+		reason = geminiRequestRefusal(st, c)
 		if reason == "" {
 			return false
 		}

--- a/internal/proxy/gemini_transcribe.go
+++ b/internal/proxy/gemini_transcribe.go
@@ -1,0 +1,138 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/gemini"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+	"github.com/hugalafutro/model-hotel/internal/util"
+)
+
+// Gemini speech-to-text: /v1/audio/transcriptions on a provider whose hearing
+// models are served by generateContent alone. Google's OpenAI-compatibility
+// layer has no transcription route (gemini-3.5-transcribe answers 404 there,
+// and null through chat), so the upload is translated to the native call and
+// the text it answers with is delivered as the json or text the client asked
+// for. The twin of gemini_speech.go, one direction over.
+
+// transcriptionEndpointPath is the pass-through endpoint the adapter serves.
+const transcriptionEndpointPath = "/audio/transcriptions"
+
+// transcriptionBodyCap bounds the generateContent answer read for a
+// transcription: an hour of speech is well under a megabyte of text.
+const transcriptionBodyCap = 4 << 20
+
+// isGeminiTranscriptionAttempt reports a transcription request landing on a
+// provider whose hearing models are served by Google's native route: Google
+// AI Studio and Vertex AI express. A model whose discovered input modalities
+// name no audio keeps the pass-through; a model discovery left without
+// modalities is treated as hearing.
+func isGeminiTranscriptionAttempt(st *requestState, providerType, inputModalities string) bool {
+	if st.endpointPath != transcriptionEndpointPath || (providerType != "google" && providerType != "vertex-express") {
+		return false
+	}
+	declared := declaredModalities(inputModalities)
+	return len(declared) == 0 || slices.Contains(declared, "audio")
+}
+
+// transcriptionRequestFromParts lifts what the adapter needs off the parsed
+// multipart form: the upload and the prompt and response_format fields. A
+// model with a transcribe segment in its id (gemini-3.5-transcribe) is a
+// dedicated transcriber and is sent the audio alone.
+func transcriptionRequestFromParts(parts []multipartPart, modelID string) gemini.TranscriptionRequest {
+	req := gemini.TranscriptionRequest{Dedicated: slices.Contains(util.ModelIDSegments(modelID), "transcribe")}
+	for _, p := range parts {
+		switch p.fieldName {
+		case "file":
+			req.Audio, req.FileName, req.ContentType = p.data, p.fileName, p.contentType
+		case multipartPromptField:
+			req.Prompt = string(p.data)
+		case "response_format":
+			req.ResponseFormat = string(p.data)
+		}
+	}
+	return req
+}
+
+// transcriptionRequestRefusal is the reason a Gemini transcription attempt
+// cannot serve the request as asked, or empty: a response format the adapter
+// does not produce (the timestamped ones), or an upload the translation cannot
+// read. Checked before the attempt is made, so the request can fail over to a
+// candidate that can serve it.
+func transcriptionRequestRefusal(st *requestState, candidate modelCandidate) string {
+	if !isGeminiTranscriptionAttempt(st, provider.TypeOf(candidate.provider), candidate.model.InputModalities) {
+		return ""
+	}
+	if _, _, err := gemini.TranslateTranscriptionRequest(transcriptionRequestFromParts(st.multipartParts, candidate.model.ModelID)); err != nil {
+		return strings.TrimPrefix(err.Error(), "gemini: ")
+	}
+	return ""
+}
+
+// buildGeminiTranscriptionRequest builds the native generateContent request
+// for a transcription attempt and records the format the answer is to take.
+func (h *Handler) buildGeminiTranscriptionRequest(ctx context.Context, st *requestState, candidate modelCandidate, providerType string) (*http.Request, string, string, error) {
+	body, format, err := gemini.TranslateTranscriptionRequest(transcriptionRequestFromParts(st.multipartParts, candidate.model.ModelID))
+	if err != nil {
+		return nil, providerType, "", err
+	}
+	st.transcriptionFormat = format
+	endpoint := geminiEgressEndpoint(providerType, candidate.model.ModelID, false)
+	baseURL := candidate.provider.BaseURL
+	if providerType == "google" {
+		baseURL = provider.GoogleNativeBaseURL(baseURL)
+	}
+	targetURL := util.BuildProviderTargetURL(baseURL, providerType, endpoint)
+	debuglog.Info("proxy: routing transcription via gemini egress adapter", "target_url", targetURL, "model", candidate.model.ModelID, "provider", candidate.provider.Name, "format", format)
+	proxyReq, err := newRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, providerType, targetURL, err
+	}
+	setGeminiEgressAuth(proxyReq, providerType, candidate.apiKey)
+	proxyReq.Header.Set("Content-Type", "application/json")
+	return proxyReq, providerType, targetURL, nil
+}
+
+// serveGeminiTranscriptionResponse delivers a transcription attempt's 2xx:
+// the generateContent answer is read whole (bounded), its text becomes the
+// json or text the client asked for, and the body goes out through the
+// pass-through's buffered path, which owns the commit point, the breaker
+// credit, the request log and the metering. The usage the answer reported
+// rides along on the request state, since the re-shaped body carries none.
+// An answer without text (a blocked prompt, an empty reply) is handed to the
+// loop as an untranslatable body and fails over.
+func (h *Handler) serveGeminiTranscriptionResponse(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64) candidateOutcome {
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, transcriptionBodyCap+1))
+	_ = resp.Body.Close()
+	if readErr == nil && len(body) > transcriptionBodyCap {
+		readErr = errTranscriptionBodyOversized
+	}
+	if readErr != nil {
+		return h.rejectUntranslatableBody(st, candidate, st.logData, "gemini transcription", resp.StatusCode, readErr, attempt, r)
+	}
+	out, contentType, usage, err := gemini.BuildTranscriptionResponse(body, st.transcriptionFormat)
+	if err != nil {
+		return h.rejectUntranslatableBody(st, candidate, st.logData, "gemini transcription", resp.StatusCode, err, attempt, r)
+	}
+	st.passthroughUsage = &passthroughUsage{prompt: usage.PromptTokens, completion: usage.CompletionTokens}
+	delivered := &http.Response{
+		StatusCode: resp.StatusCode,
+		Header:     http.Header{"Content-Type": {contentType}, "Content-Length": {strconv.Itoa(len(out))}},
+		Body:       io.NopCloser(bytes.NewReader(out)),
+	}
+	h.servePassthroughResponse(w, r, st, candidate, delivered, attempt, responseHeaderMs)
+	return outcomeServed
+}
+
+// errTranscriptionBodyOversized reports a generateContent answer past
+// transcriptionBodyCap: this gateway's own limit, never a provider fault for
+// the breaker.
+var errTranscriptionBodyOversized = fmt.Errorf("gemini transcription response exceeds %d bytes", transcriptionBodyCap)

--- a/internal/proxy/gemini_transcribe.go
+++ b/internal/proxy/gemini_transcribe.go
@@ -44,9 +44,9 @@ func isGeminiTranscriptionAttempt(st *requestState, providerType, inputModalitie
 }
 
 // transcriptionRequestFromParts lifts what the adapter needs off the parsed
-// multipart form: the upload and the prompt and response_format fields. A
-// model with a transcribe segment in its id (gemini-3.5-transcribe) is a
-// dedicated transcriber and is sent the audio alone.
+// multipart form: the upload and the fields the translation reads. A model
+// with a transcribe segment in its id (gemini-3.5-transcribe) is a dedicated
+// transcriber and is sent the audio alone.
 func transcriptionRequestFromParts(parts []multipartPart, modelID string) gemini.TranscriptionRequest {
 	req := gemini.TranscriptionRequest{Dedicated: slices.Contains(util.ModelIDSegments(modelID), "transcribe")}
 	for _, p := range parts {
@@ -57,6 +57,10 @@ func transcriptionRequestFromParts(parts []multipartPart, modelID string) gemini
 			req.Prompt = string(p.data)
 		case "response_format":
 			req.ResponseFormat = string(p.data)
+		case "temperature":
+			req.Temperature = string(p.data)
+		case "stream":
+			req.Stream = strings.EqualFold(strings.TrimSpace(string(p.data)), "true")
 		}
 	}
 	return req
@@ -64,14 +68,15 @@ func transcriptionRequestFromParts(parts []multipartPart, modelID string) gemini
 
 // transcriptionRequestRefusal is the reason a Gemini transcription attempt
 // cannot serve the request as asked, or empty: a response format the adapter
-// does not produce (the timestamped ones), or an upload the translation cannot
-// read. Checked before the attempt is made, so the request can fail over to a
-// candidate that can serve it.
+// does not produce (the timestamped ones), a streaming request, or an upload
+// whose container cannot be named. Checked before the attempt is made, so the
+// request can fail over to a candidate that can serve it. The check reads the
+// form's fields only; the upload is encoded once, when the attempt is built.
 func transcriptionRequestRefusal(st *requestState, candidate modelCandidate) string {
 	if !isGeminiTranscriptionAttempt(st, provider.TypeOf(candidate.provider), candidate.model.InputModalities) {
 		return ""
 	}
-	if _, _, err := gemini.TranslateTranscriptionRequest(transcriptionRequestFromParts(st.multipartParts, candidate.model.ModelID)); err != nil {
+	if _, _, err := gemini.ValidateTranscriptionRequest(transcriptionRequestFromParts(st.multipartParts, candidate.model.ModelID)); err != nil {
 		return strings.TrimPrefix(err.Error(), "gemini: ")
 	}
 	return ""

--- a/internal/proxy/gemini_transcribe_test.go
+++ b/internal/proxy/gemini_transcribe_test.go
@@ -9,8 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/gemini"
 	"github.com/hugalafutro/model-hotel/internal/model"
 )
 
@@ -168,5 +173,55 @@ func TestAudioTranscriptions_GeminiTextOnlyModelStaysPassthrough(t *testing.T) {
 	defer up.mu.Unlock()
 	if len(up.paths) != 1 || up.paths[0] != "/v1beta/openai/audio/transcriptions" {
 		t.Errorf("upstream paths = %v, want the compat transcription route", up.paths)
+	}
+}
+
+// The adapter's refusals are not the provider's fault for the breaker: an
+// answer without text is the model answering, and the body cap is the
+// gateway's own.
+func TestTranslationIsProviderFault_TranscriptionSentinels(t *testing.T) {
+	if translationIsProviderFault(fmt.Errorf("%w: no text part", gemini.ErrTranscriptionNoText)) {
+		t.Error("an answer without text must not charge the breaker")
+	}
+	if translationIsProviderFault(errTranscriptionBodyOversized) {
+		t.Error("the gateway's own body cap must not charge the breaker")
+	}
+	if !translationIsProviderFault(fmt.Errorf("gemini: invalid transcription response: not JSON")) {
+		t.Error("a body that is not a generateContent object is the provider's fault")
+	}
+}
+
+// In a group mixing a Gemini model with one served by pass-through, a format
+// the adapter refuses skips the Gemini candidate without a request and the
+// other model serves it as asked.
+func TestAudioTranscriptions_MixedGroupFailsOverToAModelThatServesTheFormat(t *testing.T) {
+	gem := &speechUpstream{answer: transcriptionAnswer("x")}
+	envGemini := newMultimodalEnvTyped(t, gem, `["text"]`, "google", "/v1beta/openai")
+	var srtCalls atomic.Int32
+	srtUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		srtCalls.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("1\n00:00:00,000 --> 00:00:01,000\nhello\n"))
+	}))
+	t.Cleanup(srtUpstream.Close)
+	_, _, srtModelUUID, _ := createMultimodalProvider(t, srtUpstream.URL)
+	groupName := envGemini.modelName
+	if _, err := failover.NewRepository(testDB.Pool()).UpsertWithConfig(context.Background(), groupName,
+		[]uuid.UUID{envGemini.modelUUID, srtModelUUID},
+		map[string]bool{envGemini.modelUUID.String(): true, srtModelUUID.String(): true},
+		nil, nil, nil, nil); err != nil {
+		t.Fatalf("failover group: %v", err)
+	}
+	form, contentType := buildTranscriptionForm(t, "hotel/"+groupName, map[string]string{"response_format": "srt"})
+	w := httptest.NewRecorder()
+	envGemini.handler.AudioTranscriptions(w, envGemini.request("/v1/audio/transcriptions", contentType, form))
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "-->") {
+		t.Fatalf("status %d body %q, want the srt model's answer", w.Code, w.Body.String())
+	}
+	gem.mu.Lock()
+	gemCalls := len(gem.paths)
+	gem.mu.Unlock()
+	if gemCalls != 0 || srtCalls.Load() != 1 {
+		t.Errorf("gemini saw %d requests, srt model %d; want 0 and 1", gemCalls, srtCalls.Load())
 	}
 }

--- a/internal/proxy/gemini_transcribe_test.go
+++ b/internal/proxy/gemini_transcribe_test.go
@@ -1,0 +1,172 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/model"
+)
+
+// transcriptionAnswer is a generateContent answer carrying a transcript.
+func transcriptionAnswer(text string) func(w http.ResponseWriter) {
+	return func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"candidates":[{"content":{"parts":[{"text":%q}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":66,"candidatesTokenCount":9,"totalTokenCount":75}}`, text)
+	}
+}
+
+// buildTranscriptionForm builds an OpenAI transcription form with the given
+// extra fields beside the model and the upload.
+func buildTranscriptionForm(t *testing.T, modelValue string, fields map[string]string) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	if err := mw.WriteField("model", modelValue); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField %s: %v", k, err)
+		}
+	}
+	fw, err := mw.CreateFormFile("file", "speech.wav")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write([]byte("RIFFfakewavdata")); err != nil {
+		t.Fatalf("file write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+// A transcription request to a Google AI Studio model goes to the native
+// generateContent route (the compat base folded up one segment, the model's
+// own path, the key in x-goog-api-key), carries the upload as an inlineData
+// audio part beside the client's prompt, and comes back as OpenAI's
+// transcription JSON built from the text the model produced, metered from
+// the usage the answer carried.
+func TestAudioTranscriptions_GeminiNativeRoute(t *testing.T) {
+	up := &speechUpstream{answer: transcriptionAnswer("The pass phrase is orange elephant seven.")}
+	env := newMultimodalEnvTyped(t, up, `["text"]`, "google", "/v1beta/openai")
+
+	form, contentType := buildTranscriptionForm(t, env.providerName+"/"+env.modelName, map[string]string{"language": "en", "prompt": "Names: Prague."})
+	w := httptest.NewRecorder()
+	env.handler.AudioTranscriptions(w, env.request("/v1/audio/transcriptions", contentType, form))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != `{"text":"The pass phrase is orange elephant seven."}` {
+		t.Errorf("body = %s", got)
+	}
+
+	up.mu.Lock()
+	defer up.mu.Unlock()
+	if len(up.paths) != 1 || up.paths[0] != "/v1beta/models/"+env.modelName+":generateContent" {
+		t.Fatalf("upstream paths = %v, want the native generateContent route under the folded base", up.paths)
+	}
+	if up.auth[0] != "test-api-key|" {
+		t.Errorf("auth headers = %q, want the key in x-goog-api-key and no Bearer", up.auth[0])
+	}
+	var sent map[string]any
+	if err := json.Unmarshal([]byte(up.bodies[0]), &sent); err != nil {
+		t.Fatalf("upstream body not JSON: %v", err)
+	}
+	parts := sent["contents"].([]any)[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 2 {
+		t.Fatalf("parts = %v, want audio + prompt", parts)
+	}
+	inline := parts[0].(map[string]any)["inlineData"].(map[string]any)
+	if inline["mimeType"] != "audio/wav" || inline["data"] != "UklGRmZha2V3YXZkYXRh" {
+		t.Errorf("inlineData = %v", inline)
+	}
+	if parts[1].(map[string]any)["text"] != "Names: Prague." {
+		t.Errorf("prompt part = %v", parts[1])
+	}
+	if strings.Contains(up.bodies[0], `"language"`) || strings.Contains(up.bodies[0], `"model"`) {
+		t.Errorf("form fields leaked into the native request: %s", up.bodies[0])
+	}
+}
+
+// text delivers the transcript as plain text.
+func TestAudioTranscriptions_GeminiTextFormat(t *testing.T) {
+	env := newMultimodalEnvTyped(t, &speechUpstream{answer: transcriptionAnswer("hello there")}, `["text"]`, "google", "/v1beta/openai")
+	form, contentType := buildTranscriptionForm(t, env.providerName+"/"+env.modelName, map[string]string{"response_format": "text"})
+	w := httptest.NewRecorder()
+	env.handler.AudioTranscriptions(w, env.request("/v1/audio/transcriptions", contentType, form))
+	if w.Code != http.StatusOK || !strings.HasPrefix(w.Header().Get("Content-Type"), "text/plain") || w.Body.String() != "hello there" {
+		t.Fatalf("status %d, type %q, body %q; want the transcript as text/plain", w.Code, w.Header().Get("Content-Type"), w.Body.String())
+	}
+}
+
+// A format the adapter cannot produce, on a request no candidate can serve
+// otherwise, is the client's 400 before any upstream request.
+func TestAudioTranscriptions_GeminiRefusesTimestampedFormats(t *testing.T) {
+	up := &speechUpstream{answer: transcriptionAnswer("x")}
+	env := newMultimodalEnvTyped(t, up, `["text"]`, "google", "/v1beta/openai")
+	form, contentType := buildTranscriptionForm(t, env.providerName+"/"+env.modelName, map[string]string{"response_format": "srt"})
+	w := httptest.NewRecorder()
+	env.handler.AudioTranscriptions(w, env.request("/v1/audio/transcriptions", contentType, form))
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "json or text") {
+		t.Fatalf("status %d body %s; want a 400 naming the formats the adapter produces", w.Code, w.Body.String())
+	}
+	up.mu.Lock()
+	defer up.mu.Unlock()
+	if len(up.paths) != 0 {
+		t.Errorf("upstream contacted: %v", up.paths)
+	}
+}
+
+// An answer without text is untranslatable: with no other candidate the
+// request fails, and nothing is served as a transcript.
+func TestAudioTranscriptions_GeminiEmptyAnswerFails(t *testing.T) {
+	env := newMultimodalEnvTyped(t, &speechUpstream{answer: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"candidates":[{"content":{"parts":[],"role":"model"},"finishReason":"STOP"}]}`)
+	}}, `["text"]`, "google", "/v1beta/openai")
+	form, contentType := buildTranscriptionForm(t, env.providerName+"/"+env.modelName, nil)
+	w := httptest.NewRecorder()
+	env.handler.AudioTranscriptions(w, env.request("/v1/audio/transcriptions", contentType, form))
+	if w.Code == http.StatusOK {
+		t.Fatalf("status 200 with body %s; want the request to fail", w.Body.String())
+	}
+}
+
+// A Google model whose discovered input modalities name no audio keeps the
+// pass-through: the form goes to the compat route as it is.
+func TestAudioTranscriptions_GeminiTextOnlyModelStaysPassthrough(t *testing.T) {
+	up := &speechUpstream{answer: func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"text":"passed through"}`)
+	}}
+	env := newMultimodalEnvTyped(t, up, `["text"]`, "google", "/v1beta/openai")
+	if _, err := testDB.Pool().Exec(context.Background(), `UPDATE models SET input_modalities = '["text","image"]' WHERE id = $1`, env.modelUUID); err != nil {
+		t.Fatalf("update model: %v", err)
+	}
+	model.InvalidateModelCache()
+
+	form, contentType := buildTranscriptionForm(t, env.providerName+"/"+env.modelName, nil)
+	w := httptest.NewRecorder()
+	env.handler.AudioTranscriptions(w, env.request("/v1/audio/transcriptions", contentType, form))
+	if w.Code != http.StatusOK || strings.TrimSpace(w.Body.String()) != `{"text":"passed through"}` {
+		t.Fatalf("status %d body %s; want the compat answer verbatim", w.Code, w.Body.String())
+	}
+	up.mu.Lock()
+	defer up.mu.Unlock()
+	if len(up.paths) != 1 || up.paths[0] != "/v1beta/openai/audio/transcriptions" {
+		t.Errorf("upstream paths = %v, want the compat transcription route", up.paths)
+	}
+}

--- a/internal/proxy/gemini_transcribe_test.go
+++ b/internal/proxy/gemini_transcribe_test.go
@@ -98,8 +98,8 @@ func TestAudioTranscriptions_GeminiNativeRoute(t *testing.T) {
 	if inline["mimeType"] != "audio/wav" || inline["data"] != "UklGRmZha2V3YXZkYXRh" {
 		t.Errorf("inlineData = %v", inline)
 	}
-	if parts[1].(map[string]any)["text"] != "Names: Prague." {
-		t.Errorf("prompt part = %v", parts[1])
+	if text, _ := parts[1].(map[string]any)["text"].(string); !strings.HasPrefix(text, "Transcribe this audio verbatim.") || !strings.HasSuffix(text, "Context: Names: Prague.") {
+		t.Errorf("prompt part = %v, want the instruction with the client's hint as context", parts[1])
 	}
 	if strings.Contains(up.bodies[0], `"language"`) || strings.Contains(up.bodies[0], `"model"`) {
 		t.Errorf("form fields leaked into the native request: %s", up.bodies[0])

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -119,6 +119,7 @@ func (h *Handler) serveMultipartPassthrough(w http.ResponseWriter, r *http.Reque
 	}
 	st.endpointPath = endpointPath
 	st.longRunning = isLongRunningEndpoint(endpointType)
+	st.multipartParts = parts
 	st.makeUpstreamBody = newMultipartBodyBuilder(parts)
 	h.servePassthroughPipeline(w, r, st)
 }
@@ -133,7 +134,7 @@ func (h *Handler) servePassthroughPipeline(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	h.loadFailoverConfig(r, st)
-	if h.refuseSpeechRequest(w, st, candidates) {
+	if h.refuseGeminiRequest(w, st, candidates) {
 		return
 	}
 	debuglog.Debug("proxy: model resolved (pre-loop)", "endpoint", st.logData.endpointType, "model", st.logData.modelID, "provider", st.logData.providerName, "candidates", len(candidates), "overhead_ms", st.proxyOverhead)
@@ -358,9 +359,8 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 
 	promptTokens, completionTokens := extractPassthroughUsage(body)
 	if u := st.passthroughUsage; u != nil {
-		// A translating adapter read the provider's figures off the answer
-		// it re-shaped into this body (none does for JSON today; the binary
-		// twin below is where the speech adapter lands).
+		// A translating adapter (Gemini transcription) read the provider's
+		// figures off the answer it re-shaped into this body.
 		promptTokens, completionTokens = u.prompt, u.completion
 	}
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -34,7 +34,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 		st.setReqErr(reqError{Kind: KindProviderBadRequest, Attempt: attempt, Provider: candidate.provider.Name, Underlying: reason})
 		logData.failoverAttempt = attempt
 		logData.appendSkip(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), reason)
-		debuglog.Info("proxy: speech candidate skipped", "endpoint", logData.endpointType, "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "reason", reason)
+		debuglog.Info("proxy: gemini candidate skipped", "endpoint", logData.endpointType, "attempt", attempt+1, "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "reason", reason)
 		return outcomeSkipped
 	}
 

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -25,11 +25,12 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	defer failoverCancel()
 	failoverCtx = context.WithValue(failoverCtx, ctxkeys.CancelOriginKey, "failover_timeout")
 
-	// A Gemini TTS candidate that cannot produce the requested format is
-	// skipped before any request is built, so another candidate in the group
-	// can serve it. Nothing was contacted, so the skip is recorded on the
-	// trail like a breaker skip and pays no failover backoff.
-	if reason := speechRequestRefusal(st, candidate); reason != "" {
+	// A Gemini TTS or STT candidate that cannot serve the request as asked
+	// (a format it does not produce, an upload it cannot read) is skipped
+	// before any request is built, so another candidate in the group can
+	// serve it. Nothing was contacted, so the skip is recorded on the trail
+	// like a breaker skip and pays no failover backoff.
+	if reason := geminiRequestRefusal(st, candidate); reason != "" {
 		st.setReqErr(reqError{Kind: KindProviderBadRequest, Attempt: attempt, Provider: candidate.provider.Name, Underlying: reason})
 		logData.failoverAttempt = attempt
 		logData.appendSkip(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate), reason)
@@ -106,6 +107,9 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"))
 	if st.speechFormat != "" {
 		return h.serveGeminiSpeechResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
+	}
+	if st.transcriptionFormat != "" {
+		return h.serveGeminiTranscriptionResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	}
 	h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	return outcomeServed

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -521,6 +521,7 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	st.geminiAttempt = false
 	st.anthropicEgressAttempt = false
 	st.speechFormat = ""
+	st.transcriptionFormat = ""
 	st.passthroughUsage = nil
 	// The Messages self-heal is per candidate too. Within one attempt it cannot
 	// fire twice, since attemptCandidate consults it from a single branch rather
@@ -534,6 +535,9 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 	}
 	if isGeminiSpeechAttempt(st, providerType, candidate.model.OutputModalities) { // Gemini TTS via generateContent
 		return h.buildGeminiSpeechRequest(ctx, st, candidate, providerType)
+	}
+	if isGeminiTranscriptionAttempt(st, providerType, candidate.model.InputModalities) { // Gemini STT via generateContent
+		return h.buildGeminiTranscriptionRequest(ctx, st, candidate, providerType)
 	}
 
 	// OpenAI Responses re-route: a model learned (from a prior 400) to reject

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -265,6 +265,15 @@ type requestState struct {
 	// part is delivered as. Empty on every other attempt, which is how the
 	// pass-through dispatch tells the two apart.
 	speechFormat string
+	// transcriptionFormat is the same for a /v1/audio/transcriptions attempt
+	// served through generateContent: the json or text the answer's text is
+	// delivered as.
+	transcriptionFormat string
+	// multipartParts are the parsed parts of a multipart request, kept so a
+	// translating adapter can read the upload and its fields; the
+	// pass-through rebuilds its upstream body from the same parts through
+	// makeUpstreamBody. Nil on every other request.
+	multipartParts []multipartPart
 	// passthroughUsage is the usage a translating adapter read off the
 	// provider's answer before re-shaping it into a body that carries none.
 	// The binary pass-through path meters from it in place of the estimate.


### PR DESCRIPTION
## What

`/v1/audio/transcriptions` now works for Gemini models. Google's OpenAI-compatibility layer has no transcription route: the new `gemini-3.5-transcribe` (announced 26 Aug 2026, discovered the same day, classed `stt` since #922) answered 404 there and `content: null` through chat, so nothing could serve it. The gateway translates the OpenAI multipart upload into a native `generateContent` call for a Google AI Studio or Vertex express model whose input modalities name audio, and re-shapes the answer into OpenAI's transcription body. It is the twin of the TTS adapter (`gemini_speech.go`), one direction over.

## Behaviour

- The upload becomes an `inlineData` part. Its container comes from the file extension (OpenAI clients commonly send `application/octet-stream`), falling back to the part's own `audio/*` content type. Unknown containers are refused with a message naming the extensions.
- A chat model (gemini-3.5-flash-lite) also gets the client's `prompt`, or a fixed "transcribe verbatim" instruction when there is none, since asked nothing about a clip it converses with it.
- A dedicated transcriber (a `transcribe` segment in the id) gets the audio alone: it answers an instruction with an empty reply. It returns the transcript as a `parts[].audioTranscription.text` part rather than a text part, observed live and now read beside text.
- `response_format` json (default) and text are delivered. verbose_json, srt and vtt need timestamps a generateContent answer does not carry: refused with a 400 naming the two formats before any upstream call, unless another candidate in the group can serve them.
- A Google model whose discovered input modalities name no audio keeps the pass-through, untouched.
- Usage read off the answer meters the request in place of the estimate (the buffered JSON path already honoured `passthroughUsage`).
- The parsed multipart parts now ride on the request state so the adapter can read the upload; the pass-through still rebuilds its body from the same parts. No second copy of the upload.

`/v1/audio/translations` is deliberately not covered.

## Verification

Dev stack, both models through the gateway:

```
gemini-3.5-transcribe   {"text":"The pass phrase is orange elephant seven."}
gemini-3.5-flash-lite   {"text":"The pass phrase is orange elephant 7."}
sweep stt check         PASS  3/3 keywords
```

Tests: adapter unit tests (request shape, dedicated shape, format and container refusals, response shapes including the audioTranscription part, blocked/empty answers); proxy tests for the native route with auth and body assertions, text format, srt refusal before any upstream call, empty answer failing over, and a text-only Google model staying on the compat pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kbTmEU2CS4jhxkUhi4aG6
