### PR TITLE
feat(bellhop): warning-coloured badge value when a provider's quota is spent

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -218,6 +218,7 @@ data class ZaiCodingLimit(
     val type: String = "",
     val unit: Int = 0,
     val percentage: Double = 0.0,
+    val remaining: Long = 0,
     val nextResetTime: Long = 0,
     val usageDetails: List<ZaiCodingUsageDetail> = emptyList(),
 )
@@ -276,8 +277,12 @@ data class MiniMaxModelRemain(
     @SerialName("remains_time") val remainsTime: Long = 0,
     @SerialName("weekly_remains_time") val weeklyRemainsTime: Long = 0,
     @SerialName("current_interval_status") val currentIntervalStatus: Int = 0,
+    @SerialName("current_interval_total_count") val currentIntervalTotalCount: Long = 0,
+    @SerialName("current_interval_usage_count") val currentIntervalUsageCount: Long = 0,
     @SerialName("current_interval_remaining_percent") val currentIntervalRemainingPercent: Double = 0.0,
     @SerialName("current_weekly_status") val currentWeeklyStatus: Int = 0,
+    @SerialName("current_weekly_total_count") val currentWeeklyTotalCount: Long = 0,
+    @SerialName("current_weekly_usage_count") val currentWeeklyUsageCount: Long = 0,
     @SerialName("current_weekly_remaining_percent") val currentWeeklyRemainingPercent: Double = 0.0,
 )
 
@@ -370,7 +375,15 @@ data class ProviderQuota(
     val available: Boolean,
 )
 
-private val quotaPayloadJson = Json { ignoreUnknownKeys = true }
+// coerceInputValues: a Go nil slice marshals as an explicit null
+// ("model_remains": null on an empty MiniMax plan, "balance_infos": null on
+// DeepSeek), which must land on the field's default rather than fail the
+// whole decode and turn a readable payload into an unavailable badge.
+private val quotaPayloadJson =
+    Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
 
 /**
  * providerQuotaOf maps one [QuotaWire] entry to a [ProviderQuota], decoding
@@ -711,7 +724,7 @@ private fun amountMeter(
  * so both arrive here as null and what the omission means is the caller's to
  * decide, field by field. Mirrors `parseKimiNumber` in web-shared/quota/kimi.ts.
  */
-private fun parseKimiNumber(v: String?): Double? {
+internal fun parseKimiNumber(v: String?): Double? {
     val trimmed = v?.trim().orEmpty()
     if (trimmed.isEmpty()) return null
     val n = trimmed.toDoubleOrNull() ?: return null
@@ -727,7 +740,7 @@ private fun parseKimiNumber(v: String?): Double? {
  * used, hence the full limit. A `used` that is present but unreadable yields
  * null: an unparseable window must not be turned into a number, ever.
  */
-private fun resolveKimiRemaining(
+internal fun resolveKimiRemaining(
     limit: Double,
     remainingStr: String?,
     usedStr: String?,

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaSpent.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaSpent.kt
@@ -1,0 +1,132 @@
+package com.hugalafutro.bellhop.data
+
+// Whether a readable payload says the account can serve nothing until it
+// resets or is topped up. A port of web-shared/quota/spent.ts, which itself
+// mirrors the gateway's quota normalizer (internal/quota/normalize.go): the
+// same windows judged by the same fields, so a badge here, on the Model Hotel
+// dashboard and on Front Desk all read one snapshot the same way. Web treats
+// an absent field as unknown, never spent; here the model defaults stand in
+// for absent, which is safe because Front Desk relays Go structs whose
+// non-pointer fields are always on the wire. The one field a provider can
+// really omit, NeuralWatt's credits balance, is nullable and guarded.
+
+/**
+ * Below this balance NeuralWatt credits count as spent. NeuralWatt blocks the
+ * account with a sub-cent residue that never drains, so an exact zero test
+ * would never become true.
+ */
+private const val NEURALWATT_CREDITS_SPENT_FLOOR_USD = 0.01
+
+/**
+ * isQuotaSpent is the badge's spent gate. An unavailable quota has no readable
+ * payload, so it never reads as spent; Ollama Cloud's account payload names
+ * the plan and never the usage, so it cannot either.
+ */
+fun isQuotaSpent(pq: ProviderQuota): Boolean {
+    val data = pq.data
+    if (!pq.available || data == null) return false
+    return when (data) {
+        is QuotaData.NanoGpt -> isNanoGptSpent(data)
+        is QuotaData.ZaiCoding -> isZaiCodingSpent(data)
+        is QuotaData.KimiCode -> isKimiCodeSpent(data)
+        is QuotaData.MiniMax -> isMiniMaxSpent(data)
+        is QuotaData.DeepSeek -> isDeepSeekSpent(data)
+        is QuotaData.OpenRouter -> isOpenRouterSpent(data)
+        is QuotaData.OllamaCloud -> false
+        is QuotaData.NeuralWatt -> isNeuralWattSpent(data)
+    }
+}
+
+private fun isNanoGptSpent(u: QuotaData.NanoGpt): Boolean {
+    if (u.allowOverage) return false
+    val limit = u.limits.weeklyInputTokens ?: return false
+    val used = u.weeklyInputTokens?.used ?: return false
+    return limit > 0 && used >= limit
+}
+
+// A sane percentage decides; Z.ai sends an explicit remaining: 0 on windows
+// that are only partially used, so remaining is the fallback, not the rule.
+private fun isZaiCodingWindowSpent(l: ZaiCodingLimit): Boolean {
+    val pct = l.percentage
+    if (pct >= 0.0 && pct <= 100.0) return pct >= 100.0
+    return l.remaining <= 0
+}
+
+// Every rolling (unit 3) and weekly (unit 6) token window, as the gateway
+// walks them.
+private fun isZaiCodingSpent(u: QuotaData.ZaiCoding): Boolean =
+    u.data.limits.any {
+        it.type == "TOKENS_LIMIT" && (it.unit == 3 || it.unit == 6) && isZaiCodingWindowSpent(it)
+    }
+
+// A window whose limit or remaining cannot be read is skipped, the same
+// windows kimiUsedPercent renders as "-".
+private fun isKimiWindowSpent(detail: KimiCodeDetail): Boolean {
+    val limit = parseKimiNumber(detail.limit) ?: return false
+    val remaining = resolveKimiRemaining(limit, detail.remaining, detail.used) ?: return false
+    return remaining <= 0.0
+}
+
+// The weekly block plus every rolling window, as the gateway walks them.
+private fun isKimiCodeSpent(u: QuotaData.KimiCode): Boolean =
+    isKimiWindowSpent(u.usage) || u.limits.any { isKimiWindowSpent(it.detail) }
+
+// One MiniMax window: only a window the plan covers (status 1) counts;
+// request counts decide when the payload carries them, else a remaining
+// percent inside [0, 100]; anything else is skipped.
+private fun isMiniMaxWindowSpent(
+    status: Int,
+    total: Long,
+    used: Long,
+    remainingPercent: Double,
+): Boolean {
+    if (status != 1) return false
+    if (total > 0) return used >= total
+    if (remainingPercent >= 0.0 && remainingPercent <= 100.0) return remainingPercent <= 0.0
+    return false
+}
+
+// Every model class: the breaker is per provider, so any spent window on any
+// class pins it.
+private fun isMiniMaxSpent(u: QuotaData.MiniMax): Boolean =
+    u.modelRemains.any {
+        isMiniMaxWindowSpent(
+            it.currentIntervalStatus,
+            it.currentIntervalTotalCount,
+            it.currentIntervalUsageCount,
+            it.currentIntervalRemainingPercent,
+        ) ||
+            isMiniMaxWindowSpent(
+                it.currentWeeklyStatus,
+                it.currentWeeklyTotalCount,
+                it.currentWeeklyUsageCount,
+                it.currentWeeklyRemainingPercent,
+            )
+    }
+
+private fun isDeepSeekSpent(b: QuotaData.DeepSeek): Boolean {
+    if (!b.isAvailable) return true
+    if (b.balanceInfos.isEmpty()) return false
+    return b.balanceInfos.all {
+        val n = it.totalBalance.trim().toDoubleOrNull() ?: return@all false
+        n.isFinite() && n <= 0.0
+    }
+}
+
+// A key that never bought credits reports credits_remaining 0 (the gateway
+// clamps total minus usage) yet still serves the free models, so only a
+// funded key can spend its credits. A spent per-key cap blocks regardless.
+private fun isOpenRouterSpent(b: QuotaData.OpenRouter): Boolean {
+    val funded = !b.isFreeTier && b.creditsTotal > 0.0
+    val limitRemaining = b.limitRemaining
+    return (funded && b.creditsRemaining <= 0.0) || (limitRemaining != null && limitRemaining <= 0.0)
+}
+
+// Spent means both meters are gone: the energy allowance (kwh_remaining at
+// zero, or the in_overage flag NeuralWatt sets on entering overage) and the
+// credits that overage draws on.
+private fun isNeuralWattSpent(q: QuotaData.NeuralWatt): Boolean {
+    val energySpent = q.subscription.kwhRemaining <= 0.0 || q.subscription.inOverage
+    val credits = q.balance.creditsRemainingUsd ?: return false
+    return energySpent && credits < NEURALWATT_CREDITS_SPENT_FLOOR_USD
+}

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/WidgetState.kt
@@ -39,12 +39,15 @@ data class WidgetEvent(
  * wire name so a future build's new type degrades gracefully, same stance as
  * [WidgetMember.state]) and a precomputed [label] so the Glance render stays
  * a pure string (no [ProviderQuota]/formatting logic in the render path).
+ * [spent] is [isQuotaSpent]'s verdict, precomputed for the same reason; it
+ * defaults to false so a state written by an older build still decodes.
  */
 @Serializable
 data class WidgetQuotaBadge(
     val providerName: String,
     val type: String,
     val label: String,
+    val spent: Boolean = false,
 ) {
     /** Decoded [type], UNKNOWN for a name this build doesn't know (see the class note). */
     val quotaType: QuotaType
@@ -241,6 +244,7 @@ fun widgetQuotaOf(
                 providerName = it.providerName,
                 type = it.type.name,
                 label = "${quotaShortCode(it.type)} ${quotaBadgeLabel(it, mode)}",
+                spent = isQuotaSpent(it),
             )
         }
 

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
@@ -37,11 +37,13 @@ import com.hugalafutro.bellhop.data.QuotaBarMode
 import com.hugalafutro.bellhop.data.QuotaData
 import com.hugalafutro.bellhop.data.QuotaMeter
 import com.hugalafutro.bellhop.data.QuotaMeterKind
+import com.hugalafutro.bellhop.data.isQuotaSpent
 import com.hugalafutro.bellhop.data.quotaBadgeLabel
 import com.hugalafutro.bellhop.data.quotaMeters
 import com.hugalafutro.bellhop.ui.common.TightTouchTarget
 import com.hugalafutro.bellhop.ui.theme.SeverityErrorBg
 import com.hugalafutro.bellhop.ui.theme.SeverityWarnBg
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnTextLight
 import com.hugalafutro.bellhop.ui.theme.quotaBrandColor
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -96,7 +98,9 @@ fun QuotaBadgeRow(
  * badges is scannable by colour rather than eight identical pills. An
  * unavailable badge drops to the scheme's neutrals (matching a disabled-looking
  * control) but stays a live tap target either way: the detail sheet is what
- * explains the "-".
+ * explains the "-". A spent account keeps its brand pill and turns only the
+ * value warning coloured, the same reading the web dashboards give the same
+ * snapshot.
  */
 @Composable
 private fun QuotaBadgeChip(
@@ -141,6 +145,12 @@ private fun QuotaBadgeChip(
             Text(
                 text = quotaBadgeLabel(pq, mode),
                 style = MaterialTheme.typography.labelMedium,
+                color =
+                    when {
+                        !isQuotaSpent(pq) -> Color.Unspecified
+                        dark -> SeverityWarnBg
+                        else -> SeverityWarnTextLight
+                    },
             )
         }
     }

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/Color.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/theme/Color.kt
@@ -60,6 +60,11 @@ val EmberContainerLight = Color(0xFFF6DDD6)
 val SeverityErrorBg = Color(0xFFC62828) // red
 val SeverityErrorFg = Color(0xFFFFFFFF)
 val SeverityWarnBg = Color(0xFFE8820C) // orange
+
+// Warning as standalone text on the light Paper ground, where SeverityWarnBg
+// (a fill colour) falls short of AA contrast; the web dashboards' light-mode
+// spent tone. On the dark ground SeverityWarnBg itself reads fine.
+val SeverityWarnTextLight = Color(0xFFB45309)
 val SeverityWarnFg = Color(0xFF241100) // near-black: higher contrast on orange than white
 val SeverityInfoBg = Color(0xFF1E6FD9) // blue
 val SeverityInfoFg = Color(0xFFFFFFFF)

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/widget/BellhopWidget.kt
@@ -78,6 +78,8 @@ import com.hugalafutro.bellhop.ui.theme.Moss600
 import com.hugalafutro.bellhop.ui.theme.Paper200
 import com.hugalafutro.bellhop.ui.theme.PaperInk
 import com.hugalafutro.bellhop.ui.theme.PaperInkMuted
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnBg
+import com.hugalafutro.bellhop.ui.theme.SeverityWarnTextLight
 import com.hugalafutro.bellhop.ui.theme.SteelContainerDark
 import com.hugalafutro.bellhop.ui.theme.SteelContainerLight
 import com.hugalafutro.bellhop.ui.theme.quotaBrand
@@ -256,6 +258,7 @@ private val BrandAccent = ColorProvider(day = Brass600, night = Brass300)
 private val BarTint = ColorProvider(day = SteelContainerLight, night = SteelContainerDark)
 private val TextPrimary = ColorProvider(day = PaperInk, night = Ink100)
 private val TextMuted = ColorProvider(day = PaperInkMuted, night = Ink300)
+private val SpentText = ColorProvider(day = SeverityWarnTextLight, night = SeverityWarnBg)
 
 // Hairline rules. Same tones the row and pill fills use, which on the widget
 // background read as a line rather than a second surface.
@@ -647,8 +650,17 @@ private fun WidgetContent(
                                                 // Provider brand colour, same source as the
                                                 // dashboard chips and the Model Hotel sidebar
                                                 // pills, so a strip of badges is scannable
-                                                // instead of eight identical pills.
-                                                color = quotaBadgeColor(badge.quotaType),
+                                                // instead of eight identical pills. A spent
+                                                // account reads in the warning colour, as
+                                                // the dashboard chip's value does.
+                                                color =
+                                                    if (badge.spent) {
+                                                        SpentText
+                                                    } else {
+                                                        quotaBadgeColor(
+                                                            badge.quotaType,
+                                                        )
+                                                    },
                                                 fontSize = 9.sp,
                                                 fontWeight = FontWeight.Medium,
                                             ),

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaSpentTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaSpentTest.kt
@@ -1,0 +1,279 @@
+package com.hugalafutro.bellhop.data
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [isQuotaSpent] to the rules in web-shared/quota/spent.ts, case for
+ * case: each arm pairs a payload that must read as spent with one that must
+ * not, and the healthy twin is the spent one with a single field changed, so
+ * the test also says which field decides. Payloads go through the wire decoder
+ * so the fields the rules read are proven to parse, not only to compute.
+ */
+class QuotaSpentTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun quota(
+        type: String,
+        payload: String,
+        status: Int = 200,
+    ): ProviderQuota =
+        providerQuotaOf(
+            QuotaWire(
+                providerName = "p",
+                type = type,
+                kind = "usage",
+                payload = json.decodeFromString<JsonElement>(payload),
+                httpStatus = status,
+                fetchedAt = "2026-09-04T00:00:00Z",
+            ),
+        )
+
+    private fun assertPair(
+        type: String,
+        spent: String,
+        healthy: String,
+    ) {
+        assertTrue("$type must read as spent: $spent", isQuotaSpent(quota(type, spent)))
+        assertFalse("$type must read as healthy: $healthy", isQuotaSpent(quota(type, healthy)))
+    }
+
+    private fun kimiWindow(remaining: String) =
+        """{"limit":"1000","remaining":"$remaining","resetTime":"2026-09-05T00:00:00Z"}"""
+
+    private fun kimi(
+        weekly: String,
+        duration: Int,
+        rolling: String,
+    ): String {
+        val window = """{"duration":$duration,"timeUnit":"TIME_UNIT_MINUTE"}"""
+        return """{"usage":${kimiWindow(weekly)},"limits":[{"window":$window,"detail":${kimiWindow(rolling)}}]}"""
+    }
+
+    private fun minimax(
+        interval: Double,
+        weekly: Double,
+        extra: String = "",
+    ) =
+        """{"model_remains":[{"model_name":"general","current_interval_status":1,"current_interval_remaining_percent":$interval,
+        "current_weekly_status":1,"current_weekly_remaining_percent":$weekly$extra}]}"""
+
+    private fun zai(vararg limits: String) = """{"success":true,"data":{"limits":[${limits.joinToString(",")}]}}"""
+
+    @Test
+    fun nanogptWeeklyAllowanceUsedUp() =
+        assertPair(
+            "nanogpt",
+            spent = """{"limits":{"weeklyInputTokens":1000},"weeklyInputTokens":{"used":1000}}""",
+            healthy = """{"limits":{"weeklyInputTokens":1000},"weeklyInputTokens":{"used":999}}""",
+        )
+
+    @Test
+    fun nanogptOverageKeepsServingPastTheAllowance() =
+        assertPair(
+            "nanogpt",
+            spent = """{"limits":{"weeklyInputTokens":1000},"weeklyInputTokens":{"used":1000},"allowOverage":false}""",
+            healthy = """{"limits":{"weeklyInputTokens":1000},"weeklyInputTokens":{"used":1000},"allowOverage":true}""",
+        )
+
+    @Test
+    fun zaiWindowAtFullPercentIsSpentEvenWithAResidue() =
+        assertPair(
+            "zai-coding",
+            spent = zai("""{"type":"TOKENS_LIMIT","unit":6,"percentage":100,"remaining":3}"""),
+            healthy = zai("""{"type":"TOKENS_LIMIT","unit":6,"percentage":99,"remaining":0}"""),
+        )
+
+    @Test
+    fun zaiRemainingDecidesWithoutASanePercentage() =
+        assertPair(
+            "zai-coding",
+            spent = zai("""{"type":"TOKENS_LIMIT","unit":3,"percentage":250,"remaining":0}"""),
+            healthy = zai("""{"type":"TOKENS_LIMIT","unit":3,"percentage":250,"remaining":1}"""),
+        )
+
+    @Test
+    fun zaiSecondEntryForTheSameWindowCounts() =
+        assertPair(
+            "zai-coding",
+            spent =
+                zai(
+                    """{"type":"TOKENS_LIMIT","unit":6,"percentage":10}""",
+                    """{"type":"TOKENS_LIMIT","unit":6,"percentage":100}""",
+                ),
+            healthy =
+                zai(
+                    """{"type":"TOKENS_LIMIT","unit":6,"percentage":10}""",
+                    """{"type":"TOKENS_LIMIT","unit":6,"percentage":90}""",
+                ),
+        )
+
+    @Test
+    fun zaiNonTokenWindowsAreSkipped() {
+        assertFalse(isQuotaSpent(quota("zai-coding", zai("""{"type":"TIME_LIMIT","unit":5,"percentage":100}"""))))
+    }
+
+    @Test
+    fun kimiEitherWindowSpentBlocksTheAccount() =
+        assertPair(
+            "kimi-code",
+            spent = kimi(weekly = "5", duration = 300, rolling = "0"),
+            healthy = kimi(weekly = "5", duration = 300, rolling = "1"),
+        )
+
+    @Test
+    fun kimiEveryRollingWindowCountsNotOnlyTheFiveHour() =
+        assertPair(
+            "kimi-code",
+            spent = kimi(weekly = "5", duration = 60, rolling = "0"),
+            healthy = kimi(weekly = "5", duration = 60, rolling = "1"),
+        )
+
+    @Test
+    fun kimiWeeklyBlockSpentOnItsOwn() =
+        assertPair(
+            "kimi-code",
+            spent = kimi(weekly = "0", duration = 300, rolling = "5"),
+            healthy = kimi(weekly = "1", duration = 300, rolling = "5"),
+        )
+
+    @Test
+    fun kimiUnreadableWindowIsSkippedNotSpent() {
+        val unreadable = """{"usage":{"limit":"1000","remaining":"","used":"lots"}}"""
+        assertFalse(isQuotaSpent(quota("kimi-code", unreadable)))
+    }
+
+    @Test
+    fun minimaxWeeklyWindowWithNothingRemaining() =
+        assertPair("minimax", spent = minimax(40.0, 0.0), healthy = minimax(40.0, 1.0))
+
+    @Test
+    fun minimaxRollingWindowJudgedOnItsOwn() =
+        assertPair("minimax", spent = minimax(0.0, 40.0), healthy = minimax(1.0, 40.0))
+
+    @Test
+    fun minimaxRequestCountsWinOverThePercent() =
+        assertPair(
+            "minimax",
+            spent = minimax(40.0, 40.0, ""","current_interval_total_count":100,"current_interval_usage_count":100"""),
+            healthy = minimax(0.0, 40.0, ""","current_interval_total_count":100,"current_interval_usage_count":99"""),
+        )
+
+    @Test
+    fun minimaxWindowThePlanDoesNotCoverIsSkipped() =
+        assertPair(
+            "minimax",
+            spent = minimax(40.0, 0.0),
+            healthy =
+                """{"model_remains":[{"model_name":"general","current_interval_status":1,"current_interval_remaining_percent":40,
+                "current_weekly_status":3,"current_weekly_remaining_percent":0}]}""",
+        )
+
+    @Test
+    fun minimaxNullModelListDecodesAsAnEmptyPlanNotAnUnavailableBadge() {
+        val pq = quota("minimax", """{"model_remains":null,"base_resp":{"status_code":0}}""")
+        assertTrue(pq.available)
+        assertFalse(isQuotaSpent(pq))
+    }
+
+    @Test
+    fun minimaxPercentOutsideRangeIsNonsenseNotASignal() =
+        assertPair("minimax", spent = minimax(40.0, 0.0), healthy = minimax(40.0, -1.0))
+
+    @Test
+    fun deepseekAvailableAccountWithZeroBalance() =
+        assertPair(
+            "deepseek",
+            spent = """{"is_available":true,"balance_infos":[{"currency":"USD","total_balance":"0.00"}]}""",
+            healthy = """{"is_available":true,"balance_infos":[{"currency":"USD","total_balance":"0.01"}]}""",
+        )
+
+    @Test
+    fun deepseekUnavailableIsSpentEmptyListOrBlankBalanceIsNot() {
+        assertTrue(isQuotaSpent(quota("deepseek", """{"is_available":false}""")))
+        assertFalse(isQuotaSpent(quota("deepseek", """{"is_available":true,"balance_infos":[]}""")))
+        assertFalse(isQuotaSpent(quota("deepseek", """{"is_available":true,"balance_infos":null}""")))
+        assertFalse(
+            isQuotaSpent(quota("deepseek", """{"is_available":true,"balance_infos":[{"total_balance":" "}]}""")),
+        )
+    }
+
+    @Test
+    fun openrouterFundedKeyWithCreditsAtZero() =
+        assertPair(
+            "openrouter",
+            spent = """{"credits_total":10,"credits_remaining":0,"limit_remaining":null}""",
+            healthy = """{"credits_total":10,"credits_remaining":0.5,"limit_remaining":null}""",
+        )
+
+    @Test
+    fun openrouterFreeTierKeyAtZeroStillServesTheFreeModels() =
+        assertPair(
+            "openrouter",
+            spent = """{"credits_total":10,"credits_remaining":0,"is_free_tier":false}""",
+            healthy = """{"credits_total":10,"credits_remaining":0,"is_free_tier":true}""",
+        )
+
+    @Test
+    fun openrouterKeyThatNeverBoughtCreditsHasNoneToSpend() =
+        assertPair(
+            "openrouter",
+            spent = """{"credits_total":10,"credits_remaining":0,"is_free_tier":false}""",
+            healthy = """{"credits_total":0,"credits_remaining":0,"is_free_tier":false}""",
+        )
+
+    @Test
+    fun openrouterUnfundedKeyNeverReadsSpentOnCreditsAlone() {
+        assertFalse(isQuotaSpent(quota("openrouter", """{"credits_remaining":0}""")))
+    }
+
+    @Test
+    fun openrouterPerKeyCapDecidesOnItsOwn() =
+        assertPair(
+            "openrouter",
+            spent = """{"credits_total":10,"credits_remaining":12,"limit_remaining":0}""",
+            healthy = """{"credits_total":10,"credits_remaining":12,"limit_remaining":5}""",
+        )
+
+    @Test
+    fun neuralwattEnergyAtZeroCountsWithoutTheOverageFlag() =
+        assertPair(
+            "neuralwatt",
+            spent = """{"subscription":{"plan":"basic","kwh_remaining":0},"balance":{"credits_remaining_usd":0}}""",
+            healthy = """{"subscription":{"plan":"basic","kwh_remaining":0.2},"balance":{"credits_remaining_usd":0}}""",
+        )
+
+    @Test
+    fun neuralwattInOverageWithCreditsBelowTheSubCentFloor() =
+        assertPair(
+            "neuralwatt",
+            spent = neuralwattOverage(credits = "0.0035"),
+            healthy = neuralwattOverage(credits = "0.01"),
+        )
+
+    // kwh_remaining is pinned above zero so in_overage is the field under
+    // test: the wire always carries it, and the model default of zero would
+    // otherwise read as energy spent on its own.
+    private fun neuralwattOverage(credits: String) =
+        """{"subscription":{"plan":"basic","kwh_remaining":1,"in_overage":true},"balance":{"credits_remaining_usd":$credits}}"""
+
+    @Test
+    fun neuralwattAbsentBalanceIsUnknownNotSpent() {
+        assertFalse(isQuotaSpent(quota("neuralwatt", """{"subscription":{"in_overage":true},"balance":{}}""")))
+    }
+
+    @Test
+    fun ollamaCloudNeverReadsAsSpent() {
+        assertFalse(isQuotaSpent(quota("ollama-cloud", """{"plan":"pro"}""")))
+    }
+
+    @Test
+    fun unavailableQuotaNeverReadsAsSpent() {
+        val spentBody = """{"is_available":false}"""
+        assertTrue(isQuotaSpent(quota("deepseek", spentBody)))
+        assertFalse(isQuotaSpent(quota("deepseek", spentBody, status = 424)))
+    }
+}

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/WidgetStateTest.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.data
 
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -150,6 +151,31 @@ class WidgetStateTest {
         // "+N" understate what is missing.
         assertEquals(14, badges.size)
         assertFalse(badges.any { it.providerName == "P2" })
+    }
+
+    @Test
+    fun widgetQuotaCarriesTheSpentVerdictAndOlderStateDecodesWithoutIt() {
+        val funded = QuotaData.OpenRouter(creditsTotal = 10.0, creditsRemaining = 0.0)
+        val quota =
+            ProviderQuota(
+                providerName = "OR",
+                type = QuotaType.OPENROUTER,
+                data = funded,
+                fetchedAt = "t",
+                available = true,
+            )
+        val cfg = QuotaBadgeConfig(order = listOf("OR"))
+
+        val badge = widgetQuotaOf(listOf(quota), cfg, QuotaBarMode.REMAINING).single()
+        assertTrue(badge.spent)
+        assertFalse(widgetQuotaOf(listOf(quota.copy(available = false)), cfg, QuotaBarMode.REMAINING).single().spent)
+
+        // A state persisted before the flag existed decodes as not spent.
+        val old =
+            Json.decodeFromString<WidgetQuotaBadge>(
+                """{"providerName":"OR","type":"OPENROUTER","label":"OR $0.00"}""",
+            )
+        assertFalse(old.spent)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bellhop parity for the spent-quota badge the web dashboards gained in #918. A provider whose quota is spent keeps its brand pill and turns only the badge value warning coloured, on the dashboard chip and on the home-screen widget.

- `data/QuotaSpent.kt`: `isQuotaSpent(ProviderQuota)`, a rule-for-rule port of `web-shared/quota/spent.ts`. NanoGPT weekly allowance, every Z.ai and Kimi window, every MiniMax model class (request counts over percent), DeepSeek balance, a funded OpenRouter key or its per-key cap, NeuralWatt energy plus sub-cent credits. Ollama Cloud never reads as spent. An unavailable quota never does either.
- Light ground gets a darker warning tone (`SeverityWarnTextLight`, 4.66:1 on Paper50) so the value keeps AA contrast; the dark ground uses `SeverityWarnBg`.
- The widget's persisted `WidgetQuotaBadge` gains a `spent` flag with a default, so state written by an older build still decodes.
- The quota payload decoder now coerces an explicit JSON null onto the field default. A Go nil slice (`"model_remains": null` on an empty MiniMax plan, `"balance_infos": null` on DeepSeek) used to fail the whole decode and degrade a readable payload to an unavailable badge.
- Models gain Z.ai `remaining` and the four MiniMax request-count fields the rules read.

## Test plan

- [x] `QuotaSpentTest`: 28 cases mirroring `web/src/hooks/__tests__/quotaSpent.test.ts`, each pairing a spent payload with a healthy twin one field apart, decoded through the wire path.
- [x] `WidgetStateTest`: spent flag precomputed, older state decodes without it.
- [x] Android gate: ktlint, lint, 623 unit tests, 0 failures. Size gate clean.
- [x] Two review rounds (Opus, then Sonnet on the fixes).

No Bellhop version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4SR7WpAPgUEsB3HsB189b
