### PR TITLE
fix(web): equal spacing around the managed banner

### DIFF
--- a/web/src/components/ManagedBanner.tsx
+++ b/web/src/components/ManagedBanner.tsx
@@ -43,7 +43,7 @@ export function ManagedBanner({ fleetBoundary }: ManagedBannerProps) {
 		<div
 			role="status"
 			data-testid={primary ? "primary-banner" : "managed-banner"}
-			className="ui-fleet-banner mb-2 flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs"
+			className="ui-fleet-banner flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs"
 		>
 			<Server size={14} className="shrink-0" aria-hidden="true" />
 			<span>


### PR DESCRIPTION
## Summary

The managed/primary fleet banner on Settings had a 24px gap above it and an 8px gap below it. The banner carried its own `mb-2` while every page that renders it (Settings, Providers, Virtual Keys, Failover Groups, Users) lays children out with `space-y-6`, so the local bottom margin overrode the parent spacing on one side only.

Dropped the `mb-2` so the parent spacing governs both sides equally.

## Test plan

- [x] `ManagedBanner` and `Settings.managed` vitest suites pass
- [x] Dev stack rebuilt, Settings banner now sits with equal gaps above and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnaoX3jQV1VKr8jhA32fgv
