### PR TITLE
fix: surface swallowed DB and storage errors across backend handlers

### DIFF
--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -75,11 +75,18 @@ func publishDiscoveryEvent(source string, result DiscoveryResult) {
 			Message:  fmt.Sprintf("Discovery failed: %s", result.Errors[0]),
 			Metadata: map[string]any{"source": source, "errors": result.Errors},
 		})
-	case result.ProvidersFailed > 0:
+	case result.ProvidersFailed > 0 || len(result.Errors) > 0:
+		// Errors without a failed provider come from the failover sync input
+		// (a model list that could not be read): the scan itself succeeded,
+		// but the run is still not a clean success.
+		msg := fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %s found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, util.Count(result.ModelsDiscovered, "model", "models"))
+		if result.ProvidersFailed == 0 {
+			msg = fmt.Sprintf("Discovery complete with %s: %s found", util.Count(len(result.Errors), "error", "errors"), util.Count(result.ModelsDiscovered, "model", "models"))
+		}
 		events.Publish(events.Event{
 			Type:     "discovery.complete",
 			Severity: "warning",
-			Message:  fmt.Sprintf("Discovery partially failed: %d/%d providers OK, %s found", result.ProvidersScanned-result.ProvidersFailed, result.ProvidersScanned, util.Count(result.ModelsDiscovered, "model", "models")),
+			Message:  msg,
 			Metadata: map[string]any{"source": source, "errors": result.Errors, "models_pruned": result.ModelsPruned},
 		})
 	default:
@@ -378,7 +385,12 @@ func syncFailoverAfterDiscovery(ctx context.Context, deps discoveryDeps, source 
 		if !p.Enabled {
 			continue
 		}
-		models, _ := deps.modelRepo.List(ctx, &p.ID)
+		models, err := deps.modelRepo.List(ctx, &p.ID)
+		if err != nil {
+			debuglog.Error("discovery: failed to list models for failover sync", "provider", p.Name, "error", err)
+			result.Errors = append(result.Errors, fmt.Sprintf("provider %s: list models for failover sync: %v", p.Name, err))
+			continue
+		}
 		for _, m := range models {
 			seenModelIDs[m.ModelID] = true
 		}

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -905,5 +907,53 @@ func TestAnyRecentlyDiscovered(t *testing.T) {
 				t.Errorf("anyRecentlyDiscovered = %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+// TestSyncFailoverAfterDiscovery_ModelListFailureIsRecorded covers a provider
+// whose model list cannot be read during failover sync: the failure lands in
+// result.Errors instead of the provider silently contributing an empty list.
+// Seam: repositories over a one-connection pool with a short statement_timeout,
+// and an ACCESS EXCLUSIVE lock on models held by another transaction.
+func TestSyncFailoverAfterDiscovery_ModelListFailureIsRecorded(t *testing.T) {
+	ctx := context.Background()
+	u, err := url.Parse(cmdTestDBURL)
+	if err != nil {
+		t.Fatalf("parse test DB URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("statement_timeout", "250")
+	u.RawQuery = q.Encode()
+	slow, err := db.New(ctx, u.String(), 1, 1)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer slow.Close()
+
+	deps := testDiscoveryDeps(t)
+	deps.modelRepo = model.NewRepository(slow.Pool())
+	// The custom-group revalidation later in the same call reads models too;
+	// route it through the timing-out pool so it fails fast instead of waiting
+	// on the lock forever.
+	deps.failoverRepo = failover.NewRepository(slow.Pool())
+
+	p := &provider.Provider{ID: uuid.New(), Name: "locked-models", Enabled: true}
+	if _, err := deps.modelRepo.List(ctx, &p.ID); err != nil {
+		t.Fatalf("warm-up List: %v", err)
+	}
+
+	holder, err := cmdTestDB.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer func() { _ = holder.Rollback(ctx) }()
+	if _, err := holder.Exec(ctx, "LOCK TABLE models IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+
+	var result DiscoveryResult
+	syncFailoverAfterDiscovery(ctx, deps, "test", []*provider.Provider{p}, &result)
+	if len(result.Errors) != 1 || !strings.Contains(result.Errors[0], "list models for failover sync") {
+		t.Fatalf("result.Errors = %v, want one model-list failure for the locked provider", result.Errors)
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -52,6 +52,14 @@ func TestPublishDiscoveryEvent(t *testing.T) {
 			wantPruned: 2,
 		},
 		{
+			// No provider failed, but the failover sync could not read one
+			// provider's model list: still a warning, never a clean success.
+			name:       "sync_input_error_without_failed_provider",
+			result:     DiscoveryResult{ProvidersScanned: 3, ModelsDiscovered: 9, ModelsPruned: 1, Errors: []string{"provider x: list models for failover sync: boom"}},
+			severity:   "warning",
+			wantPruned: 1,
+		},
+		{
 			name:       "success",
 			result:     DiscoveryResult{ProvidersScanned: 3, ModelsDiscovered: 9, ModelsPruned: 4},
 			severity:   "success",

--- a/internal/adminauth/totp.go
+++ b/internal/adminauth/totp.go
@@ -364,16 +364,16 @@ func (h *TotpHandler) Login(w http.ResponseWriter, r *http.Request) {
 	tokenValid := h.adminMgr.Validate(req.Token)
 	codeValid := false
 	if tokenValid {
-		if ok, err := h.totpRepo.Verify(r.Context(), req.Code); err == nil && ok {
-			codeValid = true
-		} else {
-			if err != nil {
-				debuglog.Error("totp: login verify failed", "error", err, "remote_addr", clientip.From(r))
-			}
-			if ok, _ := h.totpRepo.ConsumeRecoveryCode(r.Context(), req.Code); ok {
-				codeValid = true
-			}
+		ok, err := h.totpRepo.Verify(r.Context(), req.Code)
+		if err == nil && !ok {
+			ok, err = h.totpRepo.ConsumeRecoveryCode(r.Context(), req.Code)
 		}
+		if err != nil {
+			// A storage failure is not a wrong code: no throttle charge, no 401.
+			respondError(w, "totp: login verify failed", err, http.StatusInternalServerError)
+			return
+		}
+		codeValid = ok
 	}
 	if !tokenValid || !codeValid {
 		h.loginThrottle.RecordFailure(throttleKey)

--- a/internal/adminauth/totp_test.go
+++ b/internal/adminauth/totp_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	otptotp "github.com/pquerna/otp/totp"
 
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
@@ -1132,5 +1133,32 @@ func TestTotpLogin_BadJSONBody(t *testing.T) {
 	doEnrollVerify(t, th) // login requires TOTP enabled
 	if w := doTotpPost(th, "/totp/login", "", "{not json"); w.Code != http.StatusBadRequest {
 		t.Errorf("login bad body: expected 400, got %d", w.Code)
+	}
+}
+
+// TestTotpLogin_StorageErrorIs500 covers a TOTP store failure during login: it
+// answers 500 rather than 401, and does not charge the per-IP login throttle,
+// because no code was actually checked. The store is a repository over a
+// closed pool, which fails every read.
+func TestTotpLogin_StorageErrorIs500(t *testing.T) {
+	_, th := newTotpTestHandler(t)
+	doEnrollVerify(t, th)
+
+	deadPool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	deadPool.Close()
+	th.totpRepo = totpsvc.NewRepository(deadPool, testMasterKey)
+
+	body := []byte(`{"token":"admin-token","code":"123456"}`)
+	for range 10 {
+		req := httptest.NewRequest(http.MethodPost, "/totp/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		serveTotpRouter(th).ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500 for storage failure, got %d: %s (a 429 here means the throttle was charged)", w.Code, w.Body.String())
+		}
 	}
 }

--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -217,16 +217,21 @@ func (h *UserLoginHandler) checkSecondFactor(w http.ResponseWriter, r *http.Requ
 		writeJSONStatus(w, http.StatusUnauthorized, map[string]bool{"totp_required": true})
 		return false
 	}
-	if ok, verr := repo.Verify(r.Context(), code); verr == nil && ok {
+	ok, err := repo.Verify(r.Context(), code)
+	if err == nil && ok {
 		return true
-	} else if verr != nil {
-		debuglog.Error("userlogin: totp verify failed", "error", verr)
 	}
-	if ok, cerr := repo.ConsumeRecoveryCode(r.Context(), code); cerr == nil && ok {
-		debuglog.Info("userlogin: recovery code used", "username", u.Username)
-		return true
-	} else if cerr != nil {
-		debuglog.Error("userlogin: recovery code check failed", "error", cerr)
+	if err == nil {
+		ok, err = repo.ConsumeRecoveryCode(r.Context(), code)
+		if err == nil && ok {
+			debuglog.Info("userlogin: recovery code used", "username", u.Username)
+			return true
+		}
+	}
+	if err != nil {
+		// A storage failure is not a wrong code: no throttle charge, no 401.
+		respondError(w, "login failed", err, http.StatusInternalServerError)
+		return false
 	}
 	h.throttle.RecordFailure(throttleKey)
 	h.userThrottle.RecordFailure(userKey)

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -632,19 +632,36 @@ func TestUserLogin_TotpWiredButNotEnabled(t *testing.T) {
 	}
 }
 
-// TestUserLogin_TotpCodeCheckErrorsDeny covers the branches where the second
-// factor is enabled but both the TOTP verify and the recovery-code check error
-// out at the store: the failures are logged and login falls through to a
-// throttled 401, never a silent pass.
-func TestUserLogin_TotpCodeCheckErrorsDeny(t *testing.T) {
+// TestUserLogin_TotpCodeCheckErrorsAre500 covers the branches where the second
+// factor is enabled but the store fails during the code check: a storage
+// failure is a 500, never a silent pass and never a 401 that charges the
+// throttle for a code that was never actually checked. Repeating the failing
+// login must therefore never reach 429.
+func TestUserLogin_TotpCodeCheckErrorsAre500(t *testing.T) {
 	u := testUser(t, "alice", "correct-horse", true)
-	fake, _, r := newTotpLoginFixture(t, u)
-	fake.loadErr = errors.New("verify read boom")
-	fake.consumeErr = errors.New("recovery read boom")
+	fake, secret, r := newTotpLoginFixture(t, u)
 
-	w := doLogin(t, r, `{"username":"alice","password":"correct-horse","code":"123456"}`)
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, body = %s, want 401", w.Code, w.Body.String())
+	fake.loadErr = errors.New("verify read boom")
+	for range 10 {
+		w := doLogin(t, r, `{"username":"alice","password":"correct-horse","code":"123456"}`)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("verify error: status = %d, body = %s, want 500", w.Code, w.Body.String())
+		}
+	}
+
+	// A wrong code that falls through to a failing recovery-code read is the
+	// same storage failure, not an invalid code.
+	fake.loadErr = nil
+	fake.consumeErr = errors.New("recovery read boom")
+	w := doLogin(t, r, `{"username":"alice","password":"correct-horse","code":"000000"}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("recovery error: status = %d, body = %s, want 500", w.Code, w.Body.String())
+	}
+
+	// None of the failures above counted as an attempt: a valid code still logs in.
+	fake.consumeErr = nil
+	if w := doLogin(t, r, `{"username":"alice","password":"correct-horse","code":"`+validCode(t, secret)+`"}`); w.Code != http.StatusOK {
+		t.Fatalf("valid code after storage errors: status = %d, body = %s, want 200 (throttle must not have been charged)", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -267,22 +267,16 @@ func (h *Handler) getAppLogCounts(ctx context.Context) (map[string]int, map[stri
 	`
 	rows, err := h.dbPool.Pool().Query(ctx, countsSQL)
 	if err == nil {
-		for rows.Next() {
-			var kind, key string
-			var cnt int
-			if err = rows.Scan(&kind, &key, &cnt); err != nil {
-				break
-			}
+		var kind, key string
+		var cnt int
+		_, err = pgx.ForEachRow(rows, []any{&kind, &key, &cnt}, func() error {
 			if kind == "level" {
 				levelCounts[key] = cnt
 			} else {
 				sourceCounts[key] = cnt
 			}
-		}
-		rows.Close()
-		if err == nil {
-			err = rows.Err()
-		}
+			return nil
+		})
 	}
 	if err != nil {
 		// Keep whatever the cache already holds rather than publishing zeros
@@ -388,7 +382,7 @@ func appLogWhereClause(conditions []string) string {
 
 // scanAppLogRow scans one row of the cursor projection
 // (id, created_at, timestamp, level, source, message, escaped, attrs_at) into an AppLogEntry.
-func scanAppLogRow(rows pgx.Rows) (AppLogEntry, error) {
+func scanAppLogRow(rows pgx.CollectableRow) (AppLogEntry, error) {
 	var e AppLogEntry
 	var id string
 	var cat, ts time.Time
@@ -588,17 +582,13 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 
 	// per_page is clamped to [1, 100]; prealloc with the hard upper bound (CodeQL).
 	entries := make([]AppLogEntry, 0, 100)
-	for rows.Next() {
-		var e AppLogEntry
-		var ts time.Time
-		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt); err != nil {
-			respondError(w, "failed to scan app log row", err, http.StatusInternalServerError)
-			return
-		}
+	var e AppLogEntry
+	var ts time.Time
+	if _, err := pgx.ForEachRow(rows, []any{&ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt}, func() error {
 		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)
 		entries = append(entries, e)
-	}
-	if err := rows.Err(); err != nil {
+		return nil
+	}); err != nil {
 		respondError(w, "failed to read app logs", err, http.StatusInternalServerError)
 		return
 	}
@@ -676,15 +666,8 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	// limit is clamped to [1, 200]; prealloc with the hard upper bound so user
 	// input never flows into make() capacity (CodeQL guard).
 	entries := make([]AppLogEntry, 0, 201) // limit+1 for has_more detection
-	for rows.Next() {
-		e, err := scanAppLogRow(rows)
-		if err != nil {
-			respondError(w, "failed to scan app log row", err, http.StatusInternalServerError)
-			return
-		}
-		entries = append(entries, e)
-	}
-	if err := rows.Err(); err != nil {
+	entries, err = pgx.AppendRows(entries, rows, scanAppLogRow)
+	if err != nil {
 		respondError(w, "failed to read app logs", err, http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -270,15 +270,31 @@ func (h *Handler) getAppLogCounts(ctx context.Context) (map[string]int, map[stri
 		for rows.Next() {
 			var kind, key string
 			var cnt int
-			if rows.Scan(&kind, &key, &cnt) == nil {
-				if kind == "level" {
-					levelCounts[key] = cnt
-				} else {
-					sourceCounts[key] = cnt
-				}
+			if err = rows.Scan(&kind, &key, &cnt); err != nil {
+				break
+			}
+			if kind == "level" {
+				levelCounts[key] = cnt
+			} else {
+				sourceCounts[key] = cnt
 			}
 		}
 		rows.Close()
+		if err == nil {
+			err = rows.Err()
+		}
+	}
+	if err != nil {
+		// Keep whatever the cache already holds rather than publishing zeros
+		// from a failed query; the next request past the TTL retries.
+		debuglog.Error("applogs: count query failed", "error", err)
+		appLogCountCache.RLock()
+		lc, sc := appLogCountCache.levelCounts, appLogCountCache.sourceCounts
+		appLogCountCache.RUnlock()
+		if lc != nil {
+			return lc, sc
+		}
+		return levelCounts, sourceCounts
 	}
 
 	appLogCountCache.Lock()
@@ -558,14 +574,14 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 
 	total, err := h.appLogTotal(ctx, q, levelCounts)
 	if err != nil {
-		writeJSON(w, map[string]string{"error": "failed to count logs"})
+		respondError(w, "failed to count logs", err, http.StatusInternalServerError)
 		return
 	}
 
 	query, args := buildAppLogHistoryQuery(p, q)
 	rows, err := h.dbPool.Pool().Query(ctx, query, args...)
 	if err != nil {
-		writeJSON(w, map[string]string{"error": "failed to query logs"})
+		respondError(w, "failed to query logs", err, http.StatusInternalServerError)
 		return
 	}
 	defer rows.Close()
@@ -576,10 +592,15 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 		var e AppLogEntry
 		var ts time.Time
 		if err := rows.Scan(&ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt); err != nil {
-			continue
+			respondError(w, "failed to scan app log row", err, http.StatusInternalServerError)
+			return
 		}
 		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)
 		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		respondError(w, "failed to read app logs", err, http.StatusInternalServerError)
+		return
 	}
 
 	writeJSON(w, appLogsHistoryResponse{
@@ -658,9 +679,14 @@ func (h *Handler) GetAppLogsCursor(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		e, err := scanAppLogRow(rows)
 		if err != nil {
-			continue
+			respondError(w, "failed to scan app log row", err, http.StatusInternalServerError)
+			return
 		}
 		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		respondError(w, "failed to read app logs", err, http.StatusInternalServerError)
+		return
 	}
 
 	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")

--- a/internal/api/applogs_cursor_test.go
+++ b/internal/api/applogs_cursor_test.go
@@ -123,18 +123,12 @@ func TestGetAppLogsHistory_CancelledContext(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	// The handler returns an error message in the body (status 200)
-	// Note: handler doesn't set 500 status, just returns error JSON
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	// A query that cannot run is a 500, not a success with an error body.
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d: %s", http.StatusInternalServerError, rec.Code, rec.Body.String())
 	}
-	// Verify error response is returned
-	var resp map[string]string
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if resp["error"] == "" {
-		t.Error("expected error message in response")
+	if !strings.Contains(rec.Body.String(), "failed to query logs") {
+		t.Errorf("body = %q, want the query-failure error", rec.Body.String())
 	}
 }
 
@@ -864,13 +858,12 @@ func TestGetAppLogsHistory_QueryFailsWithCancelledContext(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.getAppLogsHistory(w, req)
 
-	// Should return an error JSON response (countAppLogs fails with closed pool)
-	var resp map[string]string
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
+	// The closed pool fails the history query: a 500, not an error body under 200.
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d: %s", http.StatusInternalServerError, w.Code, w.Body.String())
 	}
-	if _, hasError := resp["error"]; !hasError {
-		t.Error("expected error response for closed pool in getAppLogsHistory")
+	if !strings.Contains(w.Body.String(), "failed to query logs") {
+		t.Errorf("body = %q, want the query-failure error", w.Body.String())
 	}
 }
 

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -1006,8 +1006,8 @@ func TestGetAppLogs_HistoryWithDB(t *testing.T) {
 
 // TestGetAppLogs_HistoryCountFailure covers the filtered-count error branch:
 // a filter forces a real COUNT query, and a cancelled request context makes it
-// fail. The handler answers 200 with an {"error": ...} body rather than an
-// empty page, so the dashboard can tell the two apart.
+// fail. The handler answers 500 rather than an empty page, so the dashboard's
+// generic error handling applies instead of a success with no rows.
 func TestGetAppLogs_HistoryCountFailure(t *testing.T) {
 	_, r := newTestHandlerWithRouter(t)
 
@@ -1024,15 +1024,11 @@ func TestGetAppLogs_HistoryCountFailure(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer test-admin-token")
 	r.ServeHTTP(rec, req)
 
-	if rec.Header().Get("Content-Type") != "application/json" {
-		t.Errorf("Content-Type = %q, want application/json", rec.Header().Get("Content-Type"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
 	}
-	var body map[string]string
-	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if body["error"] != "failed to count logs" {
-		t.Errorf("body = %v, want the count-failure error", body)
+	if !strings.Contains(rec.Body.String(), "failed to count logs") {
+		t.Errorf("body = %q, want the count-failure error", rec.Body.String())
 	}
 }
 

--- a/internal/api/backup_restore.go
+++ b/internal/api/backup_restore.go
@@ -399,14 +399,14 @@ func (h *BackupHandler) saveUploadedDump(w http.ResponseWriter, r *http.Request)
 	}
 	tmpPath := tmpFile.Name()
 
-	if _, err := io.Copy(tmpFile, file); err != nil {
-		tmpFile.Close()        //nolint:errcheck,gosec // error path: closing after copy failure
-		_ = os.Remove(tmpPath) // error path: discard partial temp file
-		respondError(w, "failed to save uploaded file", err, http.StatusInternalServerError)
-		return uploadedDump{}, false
+	_, err = io.Copy(tmpFile, file)
+	// Close is part of the write: a delayed write failure surfaces here, and
+	// an incomplete dump must never reach validation.
+	if cerr := tmpFile.Close(); err == nil {
+		err = cerr
 	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpPath) // error path: a delayed write failure means the dump is incomplete
+	if err != nil {
+		_ = os.Remove(tmpPath) // error path: discard partial temp file
 		respondError(w, "failed to save uploaded file", err, http.StatusInternalServerError)
 		return uploadedDump{}, false
 	}

--- a/internal/api/backup_restore.go
+++ b/internal/api/backup_restore.go
@@ -405,7 +405,11 @@ func (h *BackupHandler) saveUploadedDump(w http.ResponseWriter, r *http.Request)
 		respondError(w, "failed to save uploaded file", err, http.StatusInternalServerError)
 		return uploadedDump{}, false
 	}
-	tmpFile.Close() //nolint:errcheck,gosec // cleanup: file fully written, closing for pg_restore
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath) // error path: a delayed write failure means the dump is incomplete
+		respondError(w, "failed to save uploaded file", err, http.StatusInternalServerError)
+		return uploadedDump{}, false
+	}
 
 	name := ""
 	if header != nil {
@@ -536,6 +540,7 @@ func (h *BackupHandler) runPgRestore(w http.ResponseWriter, pgRestorePath, tmpPa
 	restoreCmd := exec.CommandContext(restoreCtx, pgRestorePath,
 		"--clean",
 		"--if-exists",
+		"--single-transaction",
 		"--no-password",
 		"-d", restoreConnURL,
 		tmpPath,

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -184,15 +184,13 @@ func (h *FailoverHandler) getTokenCounts(ctx context.Context) (map[string]int, e
 	defer rows.Close()
 
 	counts := make(map[string]int)
-	for rows.Next() {
-		var modelID string
-		var total int
-		if err := rows.Scan(&modelID, &total); err != nil {
-			return nil, err
-		}
+	var modelID string
+	var total int
+	_, err = pgx.ForEachRow(rows, []any{&modelID, &total}, func() error {
 		counts[modelID] = total
-	}
-	return counts, rows.Err()
+		return nil
+	})
+	return counts, err
 }
 
 // Get retrieves a failover group by ID.

--- a/internal/api/failover.go
+++ b/internal/api/failover.go
@@ -188,11 +188,11 @@ func (h *FailoverHandler) getTokenCounts(ctx context.Context) (map[string]int, e
 		var modelID string
 		var total int
 		if err := rows.Scan(&modelID, &total); err != nil {
-			continue
+			return nil, err
 		}
 		counts[modelID] = total
 	}
-	return counts, nil
+	return counts, rows.Err()
 }
 
 // Get retrieves a failover group by ID.
@@ -277,7 +277,11 @@ func (h *FailoverHandler) Create(w http.ResponseWriter, r *http.Request) {
 		entryEnabled[id.String()] = true
 	}
 
-	existing, _ := h.failoverRepo.GetByModel(r.Context(), req.DisplayModel)
+	existing, err := h.failoverRepo.GetByModel(r.Context(), req.DisplayModel)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		respondError(w, fmt.Sprintf("failed to look up failover group %q", req.DisplayModel), err, http.StatusInternalServerError)
+		return
+	}
 	if existing != nil {
 		http.Error(w, "A failover group for '"+req.DisplayModel+"' already exists (auto-created from shared model). Edit the existing group instead.", http.StatusConflict)
 		return

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -253,15 +253,8 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	// satisfy CodeQL's uncontrolled-allocation-size check, which forbids user input
 	// flowing into make() capacity even after clamping.
 	entries := make([]LogEntry, 0, 201) // limit+1 for has_more detection
-	for rows.Next() {
-		entry, err := scanLogEntry(rows)
-		if err != nil {
-			respondError(w, "failed to scan log row", err, http.StatusInternalServerError)
-			return
-		}
-		entries = append(entries, entry)
-	}
-	if err := rows.Err(); err != nil {
+	entries, err = pgx.AppendRows(entries, rows, scanLogEntry)
+	if err != nil {
 		respondError(w, "failed to read logs", err, http.StatusInternalServerError)
 		return
 	}
@@ -406,21 +399,17 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 
 	entries := make([]LogEntry, 0)
 	var total int
-	for rows.Next() {
-		var entry LogEntry
-		var totalCount int
-		// Windowed COUNT(*) OVER() comes first; the rest is the shared projection.
-		err := rows.Scan(append([]any{&totalCount}, logEntryScanDests(&entry)...)...)
-		if err != nil {
-			respondError(w, "failed to scan log row", err, http.StatusInternalServerError)
-			return
-		}
+	var entry LogEntry
+	var totalCount int
+	// Windowed COUNT(*) OVER() comes first; the rest is the shared projection.
+	if _, err := pgx.ForEachRow(rows, append([]any{&totalCount}, logEntryScanDests(&entry)...), func() error {
 		if total == 0 {
 			total = totalCount
 		}
 		entries = append(entries, entry)
-	}
-	if err := rows.Err(); err != nil {
+		entry = LogEntry{}
+		return nil
+	}); err != nil {
 		// Never cache a page that lost rows to an interrupted query.
 		respondError(w, "failed to read logs", err, http.StatusInternalServerError)
 		return

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -256,10 +256,14 @@ func (h *Handler) ListLogsCursor(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		entry, err := scanLogEntry(rows)
 		if err != nil {
-			debuglog.Error("logs-cursor: row scan failed", "error", err)
-			continue
+			respondError(w, "failed to scan log row", err, http.StatusInternalServerError)
+			return
 		}
 		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		respondError(w, "failed to read logs", err, http.StatusInternalServerError)
+		return
 	}
 
 	entries, hasAfter, hasBefore := paginateCursor(entries, p.direction, p.limit, p.cursorStr != "")
@@ -408,13 +412,18 @@ func (h *Handler) ListLogs(w http.ResponseWriter, r *http.Request) {
 		// Windowed COUNT(*) OVER() comes first; the rest is the shared projection.
 		err := rows.Scan(append([]any{&totalCount}, logEntryScanDests(&entry)...)...)
 		if err != nil {
-			debuglog.Error("logs: row scan failed", "error", err)
-			continue
+			respondError(w, "failed to scan log row", err, http.StatusInternalServerError)
+			return
 		}
 		if total == 0 {
 			total = totalCount
 		}
 		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		// Never cache a page that lost rows to an interrupted query.
+		respondError(w, "failed to read logs", err, http.StatusInternalServerError)
+		return
 	}
 
 	response := LogsResponse{

--- a/internal/api/logs_query.go
+++ b/internal/api/logs_query.go
@@ -162,7 +162,7 @@ func logEntryScanDests(entry *LogEntry) []any {
 
 // scanLogEntry scans one request_logs row (the 38-column projection shared by
 // ListLogsCursor and ListLogs) into a LogEntry.
-func scanLogEntry(rows pgx.Rows) (LogEntry, error) {
+func scanLogEntry(rows pgx.CollectableRow) (LogEntry, error) {
 	var entry LogEntry
 	err := rows.Scan(logEntryScanDests(&entry)...)
 	return entry, err

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -176,6 +176,10 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 		}
 		modelCounts[providerID] = count
 	}
+	if err := rows.Err(); err != nil {
+		respondError(w, "failed to read model counts", err, http.StatusInternalServerError)
+		return
+	}
 
 	// Non-admins only see their own traffic in these totals: the same owner
 	// predicate the logs and stats surfaces apply, so a usage-granted user cannot
@@ -202,6 +206,10 @@ func (h *Handler) ListProviders(w http.ResponseWriter, r *http.Request) {
 		if since != nil {
 			tokensSince[providerID] = *since
 		}
+	}
+	if err := tokenRows.Err(); err != nil {
+		respondError(w, "failed to read token counts", err, http.StatusInternalServerError)
+		return
 	}
 
 	responses := make([]provider.ProviderResponse, len(providers))

--- a/internal/api/readfailure_test.go
+++ b/internal/api/readfailure_test.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/hugalafutro/model-hotel/internal/db"
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// lockedReadDB returns a *db.DB with a single connection and a short
+// statement_timeout, plus a lock function that takes ACCESS EXCLUSIVE on table
+// through a holder transaction on the shared test pool.
+//
+// Recipe for reaching a rows.Err() branch deterministically: run the query once
+// through the returned pool (pgx prepares the statement on its one connection),
+// lock the table, run it again. The prepared statement's execute phase blocks
+// on the lock, statement_timeout cancels it, and pgx reports the failure from
+// rows.Err() after Query itself returned rows. Without the warm-up the prepare
+// would block instead and fail at Query.
+func lockedReadDB(t *testing.T, table string) (pool *db.DB, lock func() (unlock func())) {
+	t.Helper()
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	u, err := url.Parse(apiTestDBURL)
+	if err != nil {
+		t.Fatalf("parse test DB URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("statement_timeout", "250")
+	u.RawQuery = q.Encode()
+
+	pool, err = db.New(context.Background(), u.String(), 1, 1)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	lock = func() func() {
+		tx, err := apiTestDB.Pool().Begin(context.Background())
+		if err != nil {
+			t.Fatalf("begin holder tx: %v", err)
+		}
+		if _, err := tx.Exec(context.Background(), "LOCK TABLE "+table+" IN ACCESS EXCLUSIVE MODE"); err != nil {
+			t.Fatalf("lock %s: %v", table, err)
+		}
+		unlock := func() { _ = tx.Rollback(context.Background()) }
+		t.Cleanup(unlock)
+		return unlock
+	}
+	return pool, lock
+}
+
+var errReadBack = errors.New("read-back failed")
+
+func adminGet(path string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	return req
+}
+
+// expectReadFailure runs the request twice through handler: once to warm the
+// prepared statement (must succeed), then again with the table locked (must be
+// a 500 carrying wantMsg).
+func expectReadFailure(t *testing.T, handler http.HandlerFunc, warm, locked *http.Request, lock func() func(), wantMsg string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	handler(rec, warm)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("warm-up: status = %d, body = %s, want 200", rec.Code, rec.Body.String())
+	}
+	unlock := lock()
+	defer unlock()
+	rec = httptest.NewRecorder()
+	handler(rec, locked)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("locked: status = %d, body = %s, want 500", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), wantMsg) {
+		t.Errorf("locked: body = %q, want %q", rec.Body.String(), wantMsg)
+	}
+}
+
+func TestGetTimeSeries_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "request_logs")
+	h := NewStatsHandler(pool.Pool(), &mockAdminAuth{validateFn: func(string) bool { return true }})
+	expectReadFailure(t, h.GetTimeSeries, adminGet("/stats/timeseries?period=24h"), adminGet("/stats/timeseries?period=24h"), lock, "failed to read time series")
+}
+
+func TestGetProviderDistribution_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "request_logs")
+	h := NewStatsHandler(pool.Pool(), &mockAdminAuth{validateFn: func(string) bool { return true }})
+	expectReadFailure(t, h.GetProviderDistribution, adminGet("/stats/providers?period=24h"), adminGet("/stats/providers?period=24h"), lock, "failed to read provider distribution")
+}
+
+// TestStatsQueries_ReadFailurePropagates covers the two per-query readers that
+// GetStats never reaches with a locked table (an earlier query fails first):
+// the virtual-key ranking returns the read error, the best-effort latency
+// breakdown logs it and leaves the slice empty.
+func TestStatsQueries_ReadFailurePropagates(t *testing.T) {
+	pool, lock := lockedReadDB(t, "request_logs")
+	h := NewStatsHandler(pool.Pool(), nil)
+	ctx := context.Background()
+	since := time.Now().Add(-24 * time.Hour)
+
+	warm := &StatsResponse{ByVirtualKey: map[string]int64{}}
+	if err := h.statByVirtualKey(ctx, warm, "requests", since, true, ""); err != nil {
+		t.Fatalf("warm-up statByVirtualKey: %v", err)
+	}
+	h.statLatencyBreakdown(ctx, warm, "", "", nil, since)
+
+	unlock := lock()
+	defer unlock()
+	stats := &StatsResponse{ByVirtualKey: map[string]int64{}}
+	if err := h.statByVirtualKey(ctx, stats, "requests", since, true, ""); err == nil {
+		t.Error("statByVirtualKey: want read error under lock, got nil")
+	}
+	h.statLatencyBreakdown(ctx, stats, "", "", nil, since)
+	if len(stats.ByProviderLatency) != 0 {
+		t.Errorf("statLatencyBreakdown under lock: got %d entries, want none", len(stats.ByProviderLatency))
+	}
+}
+
+func TestListLogs_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "request_logs")
+	h := &Handler{dbPool: pool, adminMgr: &mockAdminAuth{validateFn: func(string) bool { return true }}}
+	// Different pages so the second call misses the response cache and reaches
+	// the database; the SQL text is identical, so the statement is already prepared.
+	expectReadFailure(t, h.ListLogs, adminGet("/logs?page=1&per_page=5"), adminGet("/logs?page=2&per_page=5"), lock, "failed to read logs")
+}
+
+func TestListLogsCursor_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "request_logs")
+	h := &Handler{dbPool: pool, adminMgr: &mockAdminAuth{validateFn: func(string) bool { return true }}}
+	expectReadFailure(t, h.ListLogsCursor, adminGet("/logs/cursor?limit=5"), adminGet("/logs/cursor?limit=5"), lock, "failed to read logs")
+}
+
+func TestGetAppLogsHistory_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "app_logs")
+	t.Cleanup(invalidateAppLogCountCache)
+	h := &Handler{dbPool: pool, adminMgr: &mockAdminAuth{validateFn: func(string) bool { return true }}}
+	expectReadFailure(t, h.getAppLogsHistory, adminGet("/logs/app?history=true"), adminGet("/logs/app?history=true"), lock, "failed to read app logs")
+}
+
+func TestGetAppLogsCursor_ReadFailureIs500(t *testing.T) {
+	pool, lock := lockedReadDB(t, "app_logs")
+	t.Cleanup(invalidateAppLogCountCache)
+	h := &Handler{dbPool: pool, adminMgr: &mockAdminAuth{validateFn: func(string) bool { return true }}}
+	expectReadFailure(t, h.GetAppLogsCursor, adminGet("/logs/app/cursor?limit=5"), adminGet("/logs/app/cursor?limit=5"), lock, "failed to read app logs")
+}
+
+// TestGetAppLogCounts_FailureKeepsCachedCounts covers the stale-cache path: a
+// count query that fails after the TTL expired returns the previous counts
+// instead of publishing zeros.
+func TestGetAppLogCounts_FailureKeepsCachedCounts(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	t.Cleanup(invalidateAppLogCountCache)
+	ctx := context.Background()
+	if _, err := apiTestDB.Pool().Exec(ctx, `INSERT INTO app_logs (timestamp, level, source, message) VALUES (now(), 'error', 'stale-test', 'seed')`); err != nil {
+		t.Fatalf("seed app log: %v", err)
+	}
+	t.Cleanup(func() { _, _ = apiTestDB.Pool().Exec(ctx, `DELETE FROM app_logs WHERE source = 'stale-test'`) })
+
+	invalidateAppLogCountCache()
+	live := &Handler{dbPool: apiTestDB}
+	primed, _ := live.getAppLogCounts(ctx)
+	if primed["error"] < 1 {
+		t.Fatalf("priming counts: error = %d, want >= 1", primed["error"])
+	}
+
+	// Expire the cache, then fail the refresh with a closed pool.
+	appLogCountCache.Lock()
+	appLogCountCache.fetchedAt = time.Time{}
+	appLogCountCache.Unlock()
+	dead, err := db.New(ctx, apiTestDBURL, 1, 1)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	dead.Close()
+	got, _ := (&Handler{dbPool: dead}).getAppLogCounts(ctx)
+	if got["error"] != primed["error"] {
+		t.Errorf("after failed refresh: error = %d, want the cached %d", got["error"], primed["error"])
+	}
+}
+
+// TestListProviders_ReadFailureIs500 covers both result sets: model counts
+// (models) and token totals (request_logs).
+func TestListProviders_ReadFailureIs500(t *testing.T) {
+	for _, tc := range []struct{ table, msg string }{
+		{"models", "failed to read model counts"},
+		{"request_logs", "failed to read token counts"},
+	} {
+		t.Run(tc.table, func(t *testing.T) {
+			pool, lock := lockedReadDB(t, tc.table)
+			h := &Handler{
+				dbPool:       pool,
+				adminMgr:     &mockAdminAuth{validateFn: func(string) bool { return true }},
+				providerRepo: &mockProviderStore{listFn: func(context.Context) ([]*provider.Provider, error) { return nil, nil }},
+			}
+			expectReadFailure(t, h.ListProviders, adminGet("/providers"), adminGet("/providers"), lock, tc.msg)
+		})
+	}
+}
+
+// TestSettingsWrite_PostCommitReadFailureIs500 covers the update and reset
+// handlers when the write commits but the read-back fails: the client gets a
+// 500, never a 200 with an empty settings map.
+func TestSettingsWrite_PostCommitReadFailureIs500(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("test database not available")
+	}
+	sets := &mockSettingsStore{
+		getAllFn:       func(context.Context) (map[string]string, error) { return nil, errReadBack },
+		setTxFn:        func(context.Context, pgx.Tx, string, string) error { return nil },
+		deleteKeysTxFn: func(context.Context, pgx.Tx, []string) error { return nil },
+	}
+	h := testHandler(nil, nil, sets, &mockAdminAuth{validateFn: func(string) bool { return true }}, apiTestDB)
+
+	req := httptest.NewRequest(http.MethodPut, "/settings", strings.NewReader(`{"rate_limit_rps": "10"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.UpdateSettings(rec, req)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "failed to read settings") {
+		t.Errorf("update: status = %d, body = %q, want 500 read-back failure", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodDelete, "/settings", strings.NewReader(`{"keys": ["rate_limit_rps"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	h.ResetSettings(rec, req)
+	if rec.Code != http.StatusInternalServerError || !strings.Contains(rec.Body.String(), "failed to read settings") {
+		t.Errorf("reset: status = %d, body = %q, want 500 read-back failure", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -351,7 +351,11 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 	sort.Strings(keys)
 	debuglog.Info("settings: updated", "keys", keys)
 
-	all, _ := h.settingsRepo.GetAll(r.Context())
+	all, err := h.settingsRepo.GetAll(r.Context())
+	if err != nil {
+		respondError(w, "failed to read settings", err, http.StatusInternalServerError)
+		return
+	}
 	all = h.injectReadOnlyStatus(all)
 
 	writeJSON(w, all)
@@ -428,7 +432,11 @@ func (h *Handler) ResetSettings(w http.ResponseWriter, r *http.Request) {
 	sort.Strings(keys)
 	debuglog.Info("settings: reset to defaults", "keys", keys)
 
-	all, _ := h.settingsRepo.GetAll(r.Context())
+	all, err := h.settingsRepo.GetAll(r.Context())
+	if err != nil {
+		respondError(w, "failed to read settings", err, http.StatusInternalServerError)
+		return
+	}
 	all = h.injectReadOnlyStatus(all)
 
 	writeJSON(w, all)

--- a/internal/api/stats_queries.go
+++ b/internal/api/stats_queries.go
@@ -22,8 +22,8 @@ const modelKeySQL = `
 			END`
 
 // statByModel fills stats.ByModel with the top-10 models by the requested
-// metric (Q2). A query failure is fatal (returned); a per-row scan error skips
-// the row, matching the original loop.
+// metric (Q2). Query, scan, and iteration failures are all returned: a partial
+// top-10 would rank the wrong models without any signal that rows were lost.
 func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, metric string, since time.Time) error {
 	query := `
 		SELECT
@@ -47,15 +47,15 @@ func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vk
 		var modelID string
 		var val int64
 		if err := rows.Scan(&modelID, &val); err != nil {
-			continue
+			return err
 		}
 		stats.ByModel[modelID] = val
 	}
-	return nil
+	return rows.Err()
 }
 
 // statByProvider fills stats.ByProvider with the top-10 providers by the
-// requested metric (Q3). Query failure fatal; per-row scan error skips the row.
+// requested metric (Q3). Query, scan, and iteration failures are all returned.
 func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, metric string, since time.Time) error {
 	query := `
 		SELECT p.name, ` + metricValueSelect(metric) + `
@@ -77,11 +77,11 @@ func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse,
 		var providerName string
 		var val int64
 		if err := rows.Scan(&providerName, &val); err != nil {
-			continue
+			return err
 		}
 		stats.ByProvider[providerName] = val
 	}
-	return nil
+	return rows.Err()
 }
 
 // statByVirtualKey fills stats.ByVirtualKey from live virtual keys (Q4), plus
@@ -111,9 +111,12 @@ func (h *StatsHandler) statByVirtualKey(ctx context.Context, stats *StatsRespons
 		var name string
 		var val int64
 		if err := rows.Scan(&name, &val); err != nil {
-			continue
+			return err
 		}
 		stats.ByVirtualKey[name] = val
+	}
+	if err := rows.Err(); err != nil {
+		return err
 	}
 
 	// Queries 4b/4c only make sense unscoped: deleted-key rows cannot be
@@ -333,9 +336,9 @@ func (h *StatsHandler) statTotals(ctx context.Context, stats *StatsResponse, vkJ
 }
 
 // statLatencyBreakdown fills ByProviderLatency with the top-N provider (Q13)
-// latency breakdown. Best-effort: a query failure logs and leaves the slice
-// empty; a per-row scan error skips the row. Only invoked when the caller
-// requested latency data.
+// latency breakdown. Best-effort: query, scan, and iteration failures are
+// logged and leave the slice as far as it got, never failing the whole stats
+// response. Only invoked when the caller requested latency data.
 func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsResponse, vkJoin, vkFilter string, filterArgs []any, since time.Time) {
 	// Query 13: Per-provider latency breakdown (top 6 by avg total latency).
 	query := `
@@ -364,10 +367,14 @@ func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsRes
 		for rows.Next() {
 			var entry ProviderLatencyEntry
 			if err := rows.Scan(&entry.ProviderName, &entry.RequestCount, &entry.TotalMs, &entry.OverheadMs, &entry.ProviderMs); err != nil {
-				continue
+				debuglog.Error("stats: scan failed", "query", "by_provider_latency", "error", err)
+				break
 			}
 			stats.ByProviderLatency = append(stats.ByProviderLatency, entry)
 		}
 		rows.Close()
+		if err := rows.Err(); err != nil {
+			debuglog.Error("stats: iteration failed", "query", "by_provider_latency", "error", err)
+		}
 	}
 }

--- a/internal/api/stats_queries.go
+++ b/internal/api/stats_queries.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
 
@@ -41,17 +43,13 @@ func (h *StatsHandler) statByModel(ctx context.Context, stats *StatsResponse, vk
 		debuglog.Error("stats: query failed", "query", "by_model", "error", err)
 		return err
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var modelID string
-		var val int64
-		if err := rows.Scan(&modelID, &val); err != nil {
-			return err
-		}
+	var modelID string
+	var val int64
+	_, err = pgx.ForEachRow(rows, []any{&modelID, &val}, func() error {
 		stats.ByModel[modelID] = val
-	}
-	return rows.Err()
+		return nil
+	})
+	return err
 }
 
 // statByProvider fills stats.ByProvider with the top-10 providers by the
@@ -71,17 +69,13 @@ func (h *StatsHandler) statByProvider(ctx context.Context, stats *StatsResponse,
 		debuglog.Error("stats: query failed", "query", "by_provider", "error", err)
 		return err
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var providerName string
-		var val int64
-		if err := rows.Scan(&providerName, &val); err != nil {
-			return err
-		}
+	var providerName string
+	var val int64
+	_, err = pgx.ForEachRow(rows, []any{&providerName, &val}, func() error {
 		stats.ByProvider[providerName] = val
-	}
-	return rows.Err()
+		return nil
+	})
+	return err
 }
 
 // statByVirtualKey fills stats.ByVirtualKey from live virtual keys (Q4), plus
@@ -105,17 +99,12 @@ func (h *StatsHandler) statByVirtualKey(ctx context.Context, stats *StatsRespons
 		debuglog.Error("stats: query failed", "query", "by_virtual_key", "error", err)
 		return err
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var name string
-		var val int64
-		if err := rows.Scan(&name, &val); err != nil {
-			return err
-		}
+	var name string
+	var val int64
+	if _, err := pgx.ForEachRow(rows, []any{&name, &val}, func() error {
 		stats.ByVirtualKey[name] = val
-	}
-	if err := rows.Err(); err != nil {
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -364,17 +353,12 @@ func (h *StatsHandler) statLatencyBreakdown(ctx context.Context, stats *StatsRes
 	if err != nil {
 		debuglog.Error("stats: query failed", "query", "by_provider_latency", "error", err)
 	} else {
-		for rows.Next() {
-			var entry ProviderLatencyEntry
-			if err := rows.Scan(&entry.ProviderName, &entry.RequestCount, &entry.TotalMs, &entry.OverheadMs, &entry.ProviderMs); err != nil {
-				debuglog.Error("stats: scan failed", "query", "by_provider_latency", "error", err)
-				break
-			}
+		var entry ProviderLatencyEntry
+		if _, err := pgx.ForEachRow(rows, []any{&entry.ProviderName, &entry.RequestCount, &entry.TotalMs, &entry.OverheadMs, &entry.ProviderMs}, func() error {
 			stats.ByProviderLatency = append(stats.ByProviderLatency, entry)
-		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			debuglog.Error("stats: iteration failed", "query", "by_provider_latency", "error", err)
+			return nil
+		}); err != nil {
+			debuglog.Error("stats: read failed", "query", "by_provider_latency", "error", err)
 		}
 	}
 }

--- a/internal/api/stats_timeseries.go
+++ b/internal/api/stats_timeseries.go
@@ -90,7 +90,8 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		var latency, overheadMs, providerLatencyMs, avgTTFTMs float64
 		var cacheHit, cacheMiss int
 		if err := rows.Scan(&p.Bucket, &p.Count, &p.Tokens, &cacheHit, &cacheMiss, &p.Errors, &latency, &overheadMs, &providerLatencyMs, &p.RateLimitHits, &avgTTFTMs); err != nil {
-			continue
+			respondError(w, "failed to scan time series row", err, http.StatusInternalServerError)
+			return
 		}
 		p.Latency = latency
 		p.OverheadMs = overheadMs
@@ -99,6 +100,12 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		p.TokensCacheHit = cacheHit
 		p.TokensCacheMiss = cacheMiss
 		result.Points = append(result.Points, p)
+	}
+	if err := rows.Err(); err != nil {
+		// Missing buckets are synthesized as zeros below, so an interrupted
+		// query must fail here rather than render as a quiet period.
+		respondError(w, "failed to read time series", err, http.StatusInternalServerError)
+		return
 	}
 
 	if len(result.Points) > 0 && len(result.Points) < expectedBuckets {
@@ -202,10 +209,15 @@ func (h *StatsHandler) GetProviderDistribution(w http.ResponseWriter, r *http.Re
 	for rows.Next() {
 		var i item
 		if err := rows.Scan(&i.Name, &i.Val); err != nil {
-			continue
+			respondError(w, "failed to scan provider distribution row", err, http.StatusInternalServerError)
+			return
 		}
 		total += i.Val
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		respondError(w, "failed to read provider distribution", err, http.StatusInternalServerError)
+		return
 	}
 
 	result := ProviderDistributionStats{Items: make([]ProviderDistributionItem, len(items))}

--- a/internal/api/stats_timeseries.go
+++ b/internal/api/stats_timeseries.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"net/http"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // GetTimeSeries returns time-series statistics with hourly or daily buckets.
@@ -85,14 +87,10 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	result := TimeSeriesStats{Points: make([]TimeSeriesPoint, 0, expectedBuckets)}
-	for rows.Next() {
-		var p TimeSeriesPoint
-		var latency, overheadMs, providerLatencyMs, avgTTFTMs float64
-		var cacheHit, cacheMiss int
-		if err := rows.Scan(&p.Bucket, &p.Count, &p.Tokens, &cacheHit, &cacheMiss, &p.Errors, &latency, &overheadMs, &providerLatencyMs, &p.RateLimitHits, &avgTTFTMs); err != nil {
-			respondError(w, "failed to scan time series row", err, http.StatusInternalServerError)
-			return
-		}
+	var p TimeSeriesPoint
+	var latency, overheadMs, providerLatencyMs, avgTTFTMs float64
+	var cacheHit, cacheMiss int
+	if _, err := pgx.ForEachRow(rows, []any{&p.Bucket, &p.Count, &p.Tokens, &cacheHit, &cacheMiss, &p.Errors, &latency, &overheadMs, &providerLatencyMs, &p.RateLimitHits, &avgTTFTMs}, func() error {
 		p.Latency = latency
 		p.OverheadMs = overheadMs
 		p.ProviderLatencyMs = providerLatencyMs
@@ -100,8 +98,8 @@ func (h *StatsHandler) GetTimeSeries(w http.ResponseWriter, r *http.Request) {
 		p.TokensCacheHit = cacheHit
 		p.TokensCacheMiss = cacheMiss
 		result.Points = append(result.Points, p)
-	}
-	if err := rows.Err(); err != nil {
+		return nil
+	}); err != nil {
 		// Missing buckets are synthesized as zeros below, so an interrupted
 		// query must fail here rather than render as a quiet period.
 		respondError(w, "failed to read time series", err, http.StatusInternalServerError)
@@ -206,16 +204,12 @@ func (h *StatsHandler) GetProviderDistribution(w http.ResponseWriter, r *http.Re
 	}
 	var items []item
 	total := 0
-	for rows.Next() {
-		var i item
-		if err := rows.Scan(&i.Name, &i.Val); err != nil {
-			respondError(w, "failed to scan provider distribution row", err, http.StatusInternalServerError)
-			return
-		}
+	var i item
+	if _, err := pgx.ForEachRow(rows, []any{&i.Name, &i.Val}, func() error {
 		total += i.Val
 		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
+		return nil
+	}); err != nil {
 		respondError(w, "failed to read provider distribution", err, http.StatusInternalServerError)
 		return
 	}

--- a/internal/failover/failover_test.go
+++ b/internal/failover/failover_test.go
@@ -16,9 +16,14 @@ import (
 
 var testDB *db.DB
 
+// testDBURL is kept for tests that need a second pool with different
+// connection settings (see readfailure_test.go).
+var testDBURL string
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-	testDBURL, setupErr := db.SetupTestDB("failover")
+	var setupErr error
+	testDBURL, setupErr = db.SetupTestDB("failover")
 	if setupErr != nil {
 		log.Printf("failed to setup test DB: %v", setupErr)
 		os.Exit(1)

--- a/internal/failover/readfailure_test.go
+++ b/internal/failover/readfailure_test.go
@@ -1,0 +1,79 @@
+package failover
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/db"
+)
+
+// TestSyncAllModels_GroupTableReadFailure drives the two read-failure branches
+// of the sync with a deterministic seam: a repository over a one-connection
+// pool with a short statement_timeout, and an ACCESS EXCLUSIVE lock on
+// model_failover_groups held by another transaction. The first (unlocked) run
+// prepares the statements; under the lock the existing-group lookup in
+// upsertAutoGroup fails and is recorded, then the stale-group List fails and
+// the sync returns that error instead of reporting success.
+func TestSyncAllModels_GroupTableReadFailure(t *testing.T) {
+	ctx := context.Background()
+	u, err := url.Parse(testDBURL)
+	if err != nil {
+		t.Fatalf("parse test DB URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("statement_timeout", "250")
+	u.RawQuery = q.Encode()
+	slow, err := db.New(ctx, u.String(), 1, 1)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer slow.Close()
+	repo := NewRepository(slow.Pool())
+
+	base := "readfail-" + uuid.New().String()[:8]
+	var providerIDs []uuid.UUID
+	for i := range 2 {
+		pid, mid := uuid.New(), uuid.New()
+		providerIDs = append(providerIDs, pid)
+		if _, err := testDB.Pool().Exec(ctx, `
+			INSERT INTO providers (id, name, base_url, encrypted_key, key_nonce, key_salt, enabled, created_at)
+			VALUES ($1, $2, 'http://localhost:11434', 'dGVzdA==', 'dGVzdA==', 'dGVzdA==', true, now())`,
+			pid, base+"-p"+string(rune('a'+i))); err != nil {
+			t.Fatalf("insert provider: %v", err)
+		}
+		if _, err := testDB.Pool().Exec(ctx, `
+			INSERT INTO models (id, model_id, provider_id, enabled, created_at) VALUES ($1, $2, $3, true, now())`,
+			mid, base, pid); err != nil {
+			t.Fatalf("insert model: %v", err)
+		}
+	}
+	defer func() {
+		for _, pid := range providerIDs {
+			_, _ = testDB.Pool().Exec(ctx, "DELETE FROM providers WHERE id = $1", pid)
+		}
+		_, _ = testDB.Pool().Exec(ctx, "DELETE FROM model_failover_groups WHERE display_model = $1", base)
+	}()
+
+	if _, err := repo.SyncAllModels(ctx); err != nil {
+		t.Fatalf("warm-up sync: %v", err)
+	}
+	InvalidateFailoverCache()
+
+	holder, err := testDB.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer func() { _ = holder.Rollback(ctx) }()
+	if _, err := holder.Exec(ctx, "LOCK TABLE model_failover_groups IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+
+	_, err = repo.SyncAllModels(ctx)
+	if err == nil || !strings.Contains(err.Error(), "list failover groups") {
+		t.Fatalf("sync under lock: err = %v, want the group-list read failure", err)
+	}
+}

--- a/internal/failover/sync.go
+++ b/internal/failover/sync.go
@@ -2,10 +2,12 @@ package failover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 )
@@ -131,7 +133,10 @@ func (r *Repository) upsertAutoGroup(ctx context.Context, base string, currentID
 		entryEnabled[id.String()] = true
 	}
 
-	existing, _ = r.GetByModel(ctx, base)
+	existing, err = r.GetByModel(ctx, base)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, fmt.Errorf("lookup existing group: %w", err)
+	}
 	if existing != nil {
 		for uuidStr, enabled := range existing.EntryEnabled {
 			if _, stillPresent := entryEnabled[uuidStr]; stillPresent {
@@ -258,7 +263,10 @@ func (r *Repository) SyncAllModels(ctx context.Context) (*SyncResult, error) {
 		}
 	}
 
-	allGroups, _ := r.List(ctx)
+	allGroups, err := r.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list failover groups: %w", err)
+	}
 	for _, g := range allGroups {
 		if g.AutoCreated {
 			if _, ok := syncedBases[g.DisplayModel]; !ok {

--- a/internal/frontdesk/coverage_test.go
+++ b/internal/frontdesk/coverage_test.go
@@ -177,10 +177,7 @@ func TestServerSettingsEventsAndMemberMutations(t *testing.T) {
 
 // TestServerAccessorsAndHelpers covers the small exported accessors and helpers.
 func TestServerAccessorsAndHelpers(t *testing.T) {
-	srv, store := newTestServer(t)
-	if srv.SessionManager() == nil {
-		t.Error("SessionManager() returned nil")
-	}
+	_, store := newTestServer(t)
 	if store.DB() == nil {
 		t.Error("DB() returned nil")
 	}

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -449,16 +449,6 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.store.Close()
 }
 
-// SessionManager exposes the session manager for tests that need to mint or
-// inspect sessions directly.
-//
-// It used to claim it existed for "callers wiring background cleanup of expired
-// sessions". No such caller was ever written, and the cleanup that eventually
-// arrived (cmd/frontdesk) builds its own WebAuthnStore over the same database
-// instead, since it needs the store's cleanup method rather than the manager.
-// The comment is corrected rather than the accessor deleted: the tests use it.
-func (s *Server) SessionManager() *webauthn.SessionManager { return s.sessionMgr }
-
 func (s *Server) buildRouter(wa *adminauth.WebAuthnHandler, tp *adminauth.TotpHandler, oidc *adminauth.OIDCHandler, ui fs.FS) http.Handler {
 	r := chi.NewRouter()
 

--- a/internal/frontdesk/server_sessions_test.go
+++ b/internal/frontdesk/server_sessions_test.go
@@ -31,11 +31,11 @@ func TestFDSessions_ListMarksCurrent(t *testing.T) {
 	srv, _ := newTestServer(t)
 	ctx := context.Background()
 
-	here, err := srv.SessionManager().CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{UserAgent: "here", IP: "203.0.113.7"})
+	here, err := srv.sessionMgr.CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{UserAgent: "here", IP: "203.0.113.7"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := srv.SessionManager().CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{UserAgent: "phone"}); err != nil {
+	if _, err := srv.sessionMgr.CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{UserAgent: "phone"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +89,7 @@ func TestFDSessions_ListMarksCurrent(t *testing.T) {
 func TestFDSessions_RevokeByID(t *testing.T) {
 	srv, _ := newTestServer(t)
 	ctx := context.Background()
-	mgr := srv.SessionManager()
+	mgr := srv.sessionMgr
 
 	here, err := mgr.CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{UserAgent: "here"})
 	if err != nil {
@@ -141,7 +141,7 @@ func TestFDSessions_RevokeByID(t *testing.T) {
 func TestFDSessions_RevokeOthers(t *testing.T) {
 	srv, _ := newTestServer(t)
 	ctx := context.Background()
-	mgr := srv.SessionManager()
+	mgr := srv.sessionMgr
 
 	here, err := mgr.CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{})
 	if err != nil {

--- a/internal/frontdesk/sse_reauth_test.go
+++ b/internal/frontdesk/sse_reauth_test.go
@@ -172,7 +172,7 @@ func TestSSEClosesAfterSessionRevoked(t *testing.T) {
 		t.Run(carrier, func(t *testing.T) {
 			srv, _ := newTestServer(t)
 			ctx := context.Background()
-			token, err := srv.SessionManager().CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{})
+			token, err := srv.sessionMgr.CreateAuthToken(ctx, []byte("admin"), nil, webauthn.SessionMeta{})
 			if err != nil {
 				t.Fatalf("CreateAuthToken: %v", err)
 			}
@@ -188,7 +188,7 @@ func TestSSEClosesAfterSessionRevoked(t *testing.T) {
 			rec, done := startStream(t, srv, req)
 			awaitWrite(t, rec, "keep-alive on a live session")
 
-			if !srv.SessionManager().RevokeAuthToken(ctx, token) {
+			if !srv.sessionMgr.RevokeAuthToken(ctx, token) {
 				t.Fatal("RevokeAuthToken did not find the session")
 			}
 			awaitClosed(t, done, "after its session was revoked")

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -218,7 +218,7 @@ func scanModels(rows pgx.Rows) ([]*Model, error) {
 		}
 		models = append(models, &m)
 	}
-	return models, nil
+	return models, rows.Err()
 }
 
 // List returns all models, optionally filtered by provider ID.

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -167,19 +167,11 @@ func (i *ModelsDevInterleaved) UnmarshalJSON(data []byte) error {
 // Global models.dev cache instance.
 var modelsDevCache = &ModelsDevCache{}
 
-// LoadModelsDev fetches the models.dev API and builds the in-memory index.
-// Each call fetches fresh data from the remote API and replaces the cache.
-// It is safe to call concurrently: the write is protected by a mutex.
-//
-// This uses http.DefaultClient, which follows redirects without SSRF checks.
-// Production code must instead call LoadModelsDevWithClient with a client whose
-// transport is backed by a SafeDialer; this bare form serves tests that
-// exercise the real fetch and error paths.
-func LoadModelsDev(ctx context.Context) error {
-	return modelsDevCache.load(ctx, http.DefaultClient)
-}
-
-// LoadModelsDevWithClient is the testable version of LoadModelsDev.
+// LoadModelsDevWithClient fetches the models.dev API and builds the in-memory
+// index. Each call fetches fresh data from the remote API and replaces the
+// cache. It is safe to call concurrently: the write is protected by a mutex.
+// Callers supply the client so production can use a SafeDialer-backed
+// transport (models.dev redirects must not become an SSRF vector).
 func LoadModelsDevWithClient(ctx context.Context, client *http.Client) error {
 	return modelsDevCache.load(ctx, client)
 }

--- a/internal/provider/modelsdev_test.go
+++ b/internal/provider/modelsdev_test.go
@@ -752,7 +752,7 @@ func TestLoadModelsDev_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := LoadModelsDev(ctx); err == nil {
-		t.Error("expected error from LoadModelsDev with a cancelled context")
+	if err := LoadModelsDevWithClient(ctx, http.DefaultClient); err == nil {
+		t.Error("expected error from LoadModelsDevWithClient with a cancelled context")
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -211,6 +211,10 @@ func (r *Repository) List(ctx context.Context) ([]*Provider, error) {
 		}
 		providers = append(providers, p)
 	}
+	if err := rows.Err(); err != nil {
+		debuglog.Error("provider: list iteration failed", "error", err)
+		return nil, err
+	}
 
 	return providers, nil
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,9 +20,14 @@ import (
 
 var testDB *db.DB
 
+// testDBURL is kept for tests that need a second pool with different
+// connection settings (see readfailure_test.go).
+var testDBURL string
+
 func TestMain(m *testing.M) {
 	ctx := context.Background()
-	testDBURL, setupErr := db.SetupTestDB("provider")
+	var setupErr error
+	testDBURL, setupErr = db.SetupTestDB("provider")
 	if setupErr != nil {
 		log.Printf("failed to setup test DB: %v", setupErr)
 		os.Exit(1)

--- a/internal/provider/readfailure_test.go
+++ b/internal/provider/readfailure_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/db"
+)
+
+// TestList_ReadFailure covers the iteration-error branch of List with a
+// deterministic seam: a repository over a one-connection pool with a short
+// statement_timeout, and an ACCESS EXCLUSIVE lock on providers held by another
+// transaction. The first (unlocked) List prepares the statement; under the lock
+// the execute phase times out and surfaces from rows.Err().
+func TestList_ReadFailure(t *testing.T) {
+	ctx := context.Background()
+	u, err := url.Parse(testDBURL)
+	if err != nil {
+		t.Fatalf("parse test DB URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("statement_timeout", "250")
+	u.RawQuery = q.Encode()
+	slow, err := db.New(ctx, u.String(), 1, 1)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer slow.Close()
+	repo := NewRepository(slow.Pool())
+
+	if _, err := repo.List(ctx); err != nil {
+		t.Fatalf("warm-up List: %v", err)
+	}
+
+	holder, err := testDB.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer func() { _ = holder.Rollback(ctx) }()
+	if _, err := holder.Exec(ctx, "LOCK TABLE providers IN ACCESS EXCLUSIVE MODE"); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+
+	if _, err := repo.List(ctx); err == nil {
+		t.Fatal("List under lock: want read error, got nil")
+	}
+}

--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -169,7 +169,11 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 				maxWait = time.Duration(l.settings.GetInt(r.Context(), settingsKeyIPMaxWaitMs, defaultMaxWaitMs)) * time.Millisecond
 			}
 			if delay <= maxWait {
-				time.Sleep(delay)
+				if !waitOrCancel(r.Context(), delay) {
+					// Client left during the wait: give the budget back.
+					reservation.Cancel()
+					return
+				}
 				l.writeHeaders(w, entry.limiter, 0)
 				next.ServeHTTP(w, r)
 				return

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -982,3 +982,45 @@ func TestIPLimiter_ClientIP(t *testing.T) {
 		t.Errorf("ClientIP = %q, want 203.0.113.7", got)
 	}
 }
+
+// TestIPLimiter_BackpressureCancelledRequestReturnsBudget mirrors the key
+// limiter test for the IP stage: a client gone during the wait is not served
+// and gives its token back.
+func TestIPLimiter_BackpressureCancelledRequestReturnsBudget(t *testing.T) {
+	lim := NewIPLimiter(1, 1, nil, ipSettingsWithBackpressure(5000))
+	defer lim.Stop()
+
+	served := 0
+	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.WriteHeader(http.StatusOK)
+	}))
+	newReq := func(ctx context.Context) *http.Request {
+		req := httptest.NewRequestWithContext(ctx, "POST", "/api/totp/login", http.NoBody)
+		req.RemoteAddr = "1.2.3.4:1234"
+		return req
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, newReq(context.Background()))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", rr.Code)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	handler.ServeHTTP(httptest.NewRecorder(), newReq(ctx))
+	if served != 1 {
+		t.Fatalf("cancelled request reached the handler (served=%d)", served)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("cancelled request waited out the delay instead of returning")
+	}
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, newReq(context.Background()))
+	if rr.Code != http.StatusOK || served != 2 {
+		t.Fatalf("request after cancel: code=%d served=%d, want 200 and 2", rr.Code, served)
+	}
+}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -220,7 +220,14 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 				// under pressure, so an open throttle episode is left open (only a
 				// no-delay serve below closes it).
 				if delay <= maxWait {
-					time.Sleep(delay)
+					if !waitOrCancel(ctx, delay) {
+						// Client left during the wait: give the budget back.
+						reservation.Cancel()
+						if userRes != nil {
+							userRes.Cancel()
+						}
+						return
+					}
 					l.writeRateLimitHeaders(w, entry.limiter, 0)
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
@@ -377,5 +384,19 @@ func (l *Limiter) cleanup() {
 			entry.throttle.endIfThrottled(entry.throttleCtx(key), entry.lastUsed, "idle")
 			delete(l.limiters, key)
 		}
+	}
+}
+
+// waitOrCancel sleeps for delay unless ctx ends first. It reports false when
+// the context ended, so callers can return the reserved budget instead of
+// holding it for a client that has already gone.
+func waitOrCancel(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1451,3 +1451,66 @@ func TestGetLimiter_FleetDivisorDividesPerKeyOverride(t *testing.T) {
 		t.Errorf("per-key override not divided: rps=%v burst=%d, want 10/10", e.rps, e.burst)
 	}
 }
+
+// TestWaitOrCancel pins the backpressure wait primitive: it returns true once
+// the delay elapses and false as soon as the context ends, without waiting
+// out the delay.
+func TestWaitOrCancel(t *testing.T) {
+	if !waitOrCancel(context.Background(), time.Millisecond) {
+		t.Error("elapsed delay: want true")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if waitOrCancel(ctx, time.Hour) {
+		t.Error("cancelled context: want false")
+	}
+	if time.Since(start) > time.Second {
+		t.Error("cancelled context: returned only after the delay")
+	}
+}
+
+// TestMiddleware_BackpressureCancelledRequestReturnsBudget covers a client that
+// disconnects while queued in the backpressure window: the handler never runs
+// and the reserved token goes back, so the next caller is served immediately
+// instead of inheriting the dead request's wait.
+func TestMiddleware_BackpressureCancelledRequestReturnsBudget(t *testing.T) {
+	lim, repo := newTestLimiter()
+	defer lim.Stop()
+	repo.set("rate_limit_enabled", "true")
+	repo.set(settingsKeyRPS, "1") // one token per second: the wait is long enough to cancel into
+	repo.set(settingsKeyBurst, "1")
+	repo.set(settingsKeyMaxWaitMs, "5000")
+
+	served := 0
+	handler := lim.Middleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, requestWithKey("key-cancel"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rr.Code)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := requestWithKey("key-cancel").WithContext(context.WithValue(ctx, ctxkeys.VirtualKeyHashKey, "key-cancel"))
+	start := time.Now()
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if served != 1 {
+		t.Fatalf("cancelled request reached the handler (served=%d)", served)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("cancelled request waited out the delay instead of returning")
+	}
+
+	// The cancelled request's token is back: this one waits ~1s at most, well
+	// inside max_wait, and is served rather than queued behind two reservations.
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, requestWithKey("key-cancel"))
+	if rr.Code != http.StatusOK || served != 2 {
+		t.Fatalf("request after cancel: code=%d served=%d, want 200 and 2", rr.Code, served)
+	}
+}

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1514,3 +1514,52 @@ func TestMiddleware_BackpressureCancelledRequestReturnsBudget(t *testing.T) {
 		t.Fatalf("request after cancel: code=%d served=%d, want 200 and 2", rr.Code, served)
 	}
 }
+
+// TestMiddleware_BackpressureCancelledRequestReturnsUserBudget is the two-stage
+// variant: a cancelled request in the backpressure window returns both the
+// per-key and the user-aggregate reservation.
+func TestMiddleware_BackpressureCancelledRequestReturnsUserBudget(t *testing.T) {
+	lim, repo := newTestLimiter()
+	defer lim.Stop()
+	repo.set("rate_limit_enabled", "true")
+	repo.set(settingsKeyRPS, "1000")
+	repo.set(settingsKeyBurst, "1000")
+	repo.set(settingsKeyMaxWaitMs, "5000")
+
+	served := 0
+	handler := lim.Middleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served++
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// User stage: one token per second, burst 1. The per-key stage is generous,
+	// so the wait comes from the user reservation.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, ownedRPSReq("key-u", "uid-cancel", 1, 1))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rr.Code)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	userRPS, userBurst := 1.0, 1
+	ctx = context.WithValue(ctx, ctxkeys.VirtualKeyHashKey, "key-u")
+	ctx = context.WithValue(ctx, ctxkeys.VirtualKeyOwnerIDKey, "uid-cancel")
+	ctx = context.WithValue(ctx, ctxkeys.UserRateLimitRPSKey, &userRPS)
+	ctx = context.WithValue(ctx, ctxkeys.UserRateLimitBurstKey, &userBurst)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody).WithContext(ctx)
+	start := time.Now()
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if served != 1 {
+		t.Fatalf("cancelled request reached the handler (served=%d)", served)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("cancelled request waited out the delay instead of returning")
+	}
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, ownedRPSReq("key-u", "uid-cancel", 1, 1))
+	if rr.Code != http.StatusOK || served != 2 {
+		t.Fatalf("request after cancel: code=%d served=%d, want 200 and 2", rr.Code, served)
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -236,15 +236,10 @@ func (r *Repository) unsubscribe(id uint64) {
 	for i, sub := range r.subscriptions {
 		if sub.id == id {
 			r.subscriptions = append(r.subscriptions[:i], r.subscriptions[i+1:]...)
-			// Drain and close in a goroutine in case a publisher is
-			// currently blocked on this channel.
-			go func(c chan ChangeEvent) {
-				// Drain any remaining events from the channel before closing.
-				//nolint:revive,gosec // intentional: empty block for channel drain
-				for range c {
-				}
-				close(c)
-			}(sub.ch)
+			// Closing under the write lock is safe: notifyChange sends while
+			// holding the read lock, so no publisher can be mid-send here, and
+			// a buffered event stays readable by the subscriber after close.
+			close(sub.ch)
 			return
 		}
 	}
@@ -263,28 +258,22 @@ func (r *Repository) RegisterOnChange(fn func(key, value string)) {
 // It is non-blocking: subscriber channels that are full are skipped, and
 // callbacks are invoked in goroutines.
 func (r *Repository) notifyChange(key, value string) {
+	change := ChangeEvent{Key: key, Value: value}
+	// Sends are non-blocking, so holding the read lock across them costs
+	// nothing and guarantees unsubscribe (which closes under the write lock)
+	// never races a send on a closed channel.
 	r.changeMu.RLock()
-	subs := make([]subscription, len(r.subscriptions))
-	copy(subs, r.subscriptions)
+	for _, sub := range r.subscriptions {
+		select {
+		case sub.ch <- change:
+		default:
+			// Subscriber is too slow; skip to avoid blocking the writer.
+		}
+	}
 	callbacks := make([]func(key, value string), len(r.onChangeCallbacks))
 	copy(callbacks, r.onChangeCallbacks)
 	r.changeMu.RUnlock()
 
-	change := ChangeEvent{Key: key, Value: value}
-	for _, sub := range subs {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					debuglog.Warn("settings: failed to send change event, channel closed", "recover", r)
-				}
-			}()
-			select {
-			case sub.ch <- change:
-			default:
-				// Subscriber is too slow; skip to avoid blocking the writer.
-			}
-		}()
-	}
 	for _, fn := range callbacks {
 		go fn(key, value)
 	}
@@ -629,7 +618,7 @@ func (r *Repository) GetAll(ctx context.Context) (map[string]string, error) {
 		}
 		result[key] = value
 	}
-	return result, nil
+	return result, rows.Err()
 }
 
 // GetBool retrieves a setting and parses it as a boolean.

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1796,3 +1796,35 @@ func TestUnsubscribeClosesEvents(t *testing.T) {
 		t.Fatalf("Set after unsubscribe failed: %v", err)
 	}
 }
+
+// TestNotifyChangeSkipsSlowSubscriber pins the non-blocking publish: a
+// subscriber that never reads fills its buffer, further writes are dropped for
+// it rather than stalling the writer, and the writer keeps working.
+func TestNotifyChangeSkipsSlowSubscriber(t *testing.T) {
+	r := NewRepository(testPool)
+	ctx := context.Background()
+	clearSettings(t)
+
+	sub := r.Subscribe()
+	defer sub.Unsubscribe()
+
+	const writes = 20 // buffer is 16
+	for i := range writes {
+		if err := r.Set(ctx, "slow_key", fmt.Sprint(i)); err != nil {
+			t.Fatalf("Set %d failed: %v", i, err)
+		}
+	}
+	got := 0
+	for {
+		select {
+		case <-sub.Events():
+			got++
+			continue
+		default:
+		}
+		break
+	}
+	if got != 16 {
+		t.Errorf("slow subscriber received %d events, want exactly the 16 buffered", got)
+	}
+}

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1759,3 +1759,40 @@ func TestFailedWriteStillEvictsOnBothSides(t *testing.T) {
 		}
 	})
 }
+
+// TestUnsubscribeClosesEvents pins the teardown contract: after Unsubscribe the
+// Events channel is closed, so a `for range sub.Events()` consumer terminates.
+// A buffered event delivered before the unsubscribe is still readable first.
+func TestUnsubscribeClosesEvents(t *testing.T) {
+	r := NewRepository(testPool)
+	ctx := context.Background()
+	clearSettings(t)
+
+	sub := r.Subscribe()
+	if err := r.Set(ctx, "close_key", "v"); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+	sub.Unsubscribe()
+
+	select {
+	case ev, ok := <-sub.Events():
+		if !ok || ev.Key != "close_key" {
+			t.Fatalf("first receive = (%v, %v), want the buffered event", ev, ok)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("buffered event was lost on unsubscribe")
+	}
+	select {
+	case _, ok := <-sub.Events():
+		if ok {
+			t.Fatal("received a second event, want closed channel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Events() never closed after Unsubscribe")
+	}
+
+	// A write after unsubscribe must not panic on the closed channel.
+	if err := r.Set(ctx, "close_key", "again"); err != nil {
+		t.Fatalf("Set after unsubscribe failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the confirmed findings from a Codex whole-backend audit (27 of 28 verified real; the one skipped is the deliberately open `/traefik/config`, documented in code), plus two follow-ups Codex raised when reviewing this diff.

### Behaviour changes

- **settings subscriptions**: `Unsubscribe` closes the channel synchronously and `notifyChange` sends under the read lock, so the close can never race a send. The previous drain goroutine ranged over the channel before closing it and never terminated, so every unsubscribe leaked a goroutine and `Events()` never closed.
- **backup restore**: `pg_restore` now runs with `--single-transaction`, so a failed restore cannot leave the live database half dropped. The upload path checks `tmpFile.Close()` and rejects the upload on failure.
- **failover**: `GetByModel` errors are no longer treated as "not found" before an upsert (API create and auto-group sync), which could overwrite an existing group's configuration. `SyncAllModels` fails on a `List` error instead of skipping stale-group cleanup and reporting success.
- **discovery**: a model-list failure during failover sync is recorded in `result.Errors` and the run publishes a warning event instead of a success.
- **rows.Err()** is checked after every iteration in model, provider, settings, applogs, logs, stats, providers and failover queries. Per-row scan failures return 500 instead of silently dropping rows from a response that claims success.
- **app logs**: error responses carry a 500 status instead of a JSON error body under HTTP 200. Count-query failures keep the cached counts rather than publishing zeros for the rest of the TTL.
- **admin auth**: TOTP and recovery-code storage failures answer 500 without charging the login throttles, for both admin and user login. Previously a database error looked like a wrong code and counted toward lockout.
- **rate limiting**: backpressure waits are cancellable by the request context and return the reserved tokens when the client disconnects.
- **settings API**: post-commit `GetAll` failures are 500, not an empty 200.
- Removed test-only production accessors `Server.SessionManager` and `LoadModelsDev`; tests use the field and `LoadModelsDevWithClient` directly.

### Tests

The row-reading loops use `pgx.ForEachRow`/`pgx.AppendRows`, one error exit per query. Read failures are proven deterministically: a one-connection pool with `statement_timeout=250ms` runs the query once to prepare it, another transaction takes `ACCESS EXCLUSIVE` on the table, and the second run times out in the execute phase, which pgx surfaces from `rows.Err()`. Changed-line coverage 97.2% (local gate); the only uncovered lines are the upload copy/close failure, which `ParseMultipartForm` buffering makes unreachable.

New: settings `Unsubscribe` closes `Events()` and keeps the buffered event; `waitOrCancel` and both limiters return budget on a cancelled request; TOTP storage errors are 500 without throttle charge (admin and user login); discovery warning on sync-input errors.

Updated: three app-log tests that pinned the old 200-with-error-body behaviour now expect 500. The frontend HTTP layer throws on any non-2xx and never read that body, so nothing consumed the old shape.

### Review

Second opinion from a different model family: Codex (GPT-5.6 Terra) reviewed this diff and found two real gaps, both fixed in this PR (a sibling 200-with-error write in the same handler, and the discovery errors not surfacing as a warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
