### PR TITLE
chore: enable nolintlint and drop dead nolint directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ __pycache__/
 
 # Catalog drift reporter (local-only for now; unignore + wire into CI once proven)
 /tools/refresh-catalogs/
+
+# Local agent tooling (skills, lockfile); never published
+/.agents/
+/skills-lock.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,18 @@ linters:
     - nilerr       # Checks for returning nil even if err != nil
     - bodyclose    # HTTP response body must be closed
     - forbidigo    # Ban t.Skip: tests must pass or fail (see settings below)
+    - nolintlint   # Every //nolint must name a linter, carry a reason, and actually suppress something
 
   settings:
     errcheck:
       check-type-assertions: false
+
+    nolintlint:
+      # A directive that suppresses nothing is dead weight: either the linter
+      # is not enabled or the config already excludes it for that path.
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
 
     forbidigo:
       # The test database and every required tool (pg_dump, pg_restore, docker)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,20 +145,6 @@ linters:
           - revive
         text: "unused-parameter|package-comments"
 
-      # gosec's taint rules (G704 SSRF, G705 XSS, G118 context lifetime) are
-      # not deterministic: the same tree reports a finding, nothing, or an
-      # unused directive depending on analysis order between runs. A gosec
-      # //nolint that is unused on one run still suppresses a real report on
-      # the next, so nolintlint's unused check is waived for gosec. The
-      # message carries no rule id, so the waiver covers every gosec rule:
-      # a dead gosec directive for a deterministic rule goes unreported, the
-      # price of a lint that never flaps. The explanation and specific-linter
-      # requirements still apply. The text is a substring of nolintlint's
-      # own wording (golangci-lint 2.13); re-check it after an upgrade.
-      - linters:
-          - nolintlint
-        text: 'is unused for linter "gosec"'
-
 formatters:
   enable:
     - gci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,6 +145,16 @@ linters:
           - revive
         text: "unused-parameter|package-comments"
 
+      # gosec's taint rules (G704 SSRF, G705 XSS, G118 context lifetime) are
+      # not deterministic: the same tree reports a finding, nothing, or an
+      # unused directive depending on analysis order between runs. A gosec
+      # //nolint that is unused on one run still suppresses a real report on
+      # the next, so nolintlint's unused check is waived for gosec only; the
+      # explanation and specific-linter requirements still apply.
+      - linters:
+          - nolintlint
+        text: 'is unused for linter "gosec"'
+
 formatters:
   enable:
     - gci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,8 +149,12 @@ linters:
       # not deterministic: the same tree reports a finding, nothing, or an
       # unused directive depending on analysis order between runs. A gosec
       # //nolint that is unused on one run still suppresses a real report on
-      # the next, so nolintlint's unused check is waived for gosec only; the
-      # explanation and specific-linter requirements still apply.
+      # the next, so nolintlint's unused check is waived for gosec. The
+      # message carries no rule id, so the waiver covers every gosec rule:
+      # a dead gosec directive for a deterministic rule goes unreported, the
+      # price of a lint that never flaps. The explanation and specific-linter
+      # requirements still apply. The text is a substring of nolintlint's
+      # own wording (golangci-lint 2.13); re-check it after an upgrade.
       - linters:
           - nolintlint
         text: 'is unused for linter "gosec"'

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -52,12 +52,12 @@ func TestMain(m *testing.M) {
 	cmdTestDB, err = db.New(ctx, cmdTestDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer cmdTestDB.Close()
 
 	util.CloseDockerClient()
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/server/spa.go
+++ b/cmd/server/spa.go
@@ -71,5 +71,6 @@ func (h *SPAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
+	//nolint:gosec // content-type set to text/html; template output is sanitized
 	_, _ = w.Write(h.indexHTML)
 }

--- a/cmd/server/spa.go
+++ b/cmd/server/spa.go
@@ -71,6 +71,5 @@ func (h *SPAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	//nolint:gosec // content-type set to text/html; template output is sanitized
 	_, _ = w.Write(h.indexHTML)
 }

--- a/cmd/server/spa.go
+++ b/cmd/server/spa.go
@@ -71,6 +71,6 @@ func (h *SPAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
-	//nolint:gosec // content-type set to text/html; template output is sanitized
+	// #nosec G705 -- content-type set to text/html; template output is sanitized
 	_, _ = w.Write(h.indexHTML)
 }

--- a/cmd/server/spa_test.go
+++ b/cmd/server/spa_test.go
@@ -144,7 +144,7 @@ func TestSPAHandler_ConstructedDirectly_WithFileServer(t *testing.T) {
 	customFS := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("// custom file server")) //nolint:errcheck // test only
+		w.Write([]byte("// custom file server"))
 	})
 
 	h := &SPAHandler{

--- a/internal/admin/token_test.go
+++ b/internal/admin/token_test.go
@@ -33,7 +33,6 @@ func TestNewCreatesHashedToken(t *testing.T) {
 	}
 
 	tokenPath := filepath.Join(tmpDir, "admin-token")
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
@@ -149,7 +148,6 @@ func TestLegacyPlaintextMigration(t *testing.T) {
 		t.Error("Legacy token should still validate after migration")
 	}
 
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read migrated token file: %v", err)
@@ -192,7 +190,7 @@ func TestExistingHashTokenNotMigrated(t *testing.T) {
 		t.Error("Existing hash token should not be treated as new")
 	}
 
-	data, err := os.ReadFile(tokenPath) //nolint:gosec // test-only: controlled test path
+	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
 	}
@@ -215,7 +213,6 @@ func TestRegenerationByDeletingFile(t *testing.T) {
 	oldToken := mgr1.Token()
 
 	tokenPath := filepath.Join(tmpDir, "admin-token")
-	//nolint:gosec // test-only: cleanup before test
 	_ = os.Remove(tokenPath)
 
 	mgr2, isNew, err := New(tmpDir, "")
@@ -267,7 +264,7 @@ func TestNewWithExplicitToken(t *testing.T) {
 
 	// Verify the file stores the hash, not the plaintext
 	tokenPath := filepath.Join(tmpDir, "admin-token")
-	data, err := os.ReadFile(tokenPath) //nolint:gosec // test-only: controlled test path
+	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
 	}
@@ -315,7 +312,7 @@ func TestNewCreatesTokenWithSha256Prefix(t *testing.T) {
 	}
 
 	tokenPath := filepath.Join(tmpDir, "admin-token")
-	data, err := os.ReadFile(tokenPath) //nolint:gosec // test-only: controlled test path
+	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
 	}
@@ -356,7 +353,6 @@ func TestSha256PrefixedFileReadAsHash(t *testing.T) {
 	}
 
 	// File should not be modified (not re-hashed)
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
@@ -395,7 +391,6 @@ func TestLegacyBare64HexFileStillWorks(t *testing.T) {
 	}
 
 	// File should not be modified (backward compat — keep as-is)
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
@@ -427,7 +422,6 @@ func TestValidateTokenWithPrefixedAndLegacyFormat(t *testing.T) {
 
 	// Read the file — should be sha256: prefixed now
 	tokenPath := filepath.Join(tmpDir, "admin-token")
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)
@@ -443,7 +437,6 @@ func TestValidateTokenWithPrefixedAndLegacyFormat(t *testing.T) {
 
 	// Now simulate a legacy bare hash file: write the hash without prefix
 	hashPart := string(data[len(sha256Prefix):])
-	//nolint:gosec // test-only path
 	if err := os.WriteFile(tokenPath, []byte(hashPart), 0o600); err != nil {
 		t.Fatalf("Failed to write legacy format: %v", err)
 	}
@@ -485,7 +478,6 @@ func TestPlaintextTokenGetsHashedAndRewrittenWithPrefix(t *testing.T) {
 		t.Error("Plaintext token file should not be treated as new")
 	}
 
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		t.Fatalf("Failed to read token file: %v", err)

--- a/internal/adminauth/harness_test.go
+++ b/internal/adminauth/harness_test.go
@@ -50,12 +50,12 @@ func TestMain(m *testing.M) {
 	apiTestDB, err = db.New(ctx, apiTestDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer apiTestDB.Close()
 
 	util.CloseDockerClient()
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // newChiRequest builds a JSON request + recorder. Copied from the api test

--- a/internal/alert/catalog_test.go
+++ b/internal/alert/catalog_test.go
@@ -120,7 +120,7 @@ func TestCatalogTypesAreEmitted(t *testing.T) {
 			if path == skipFile {
 				return nil
 			}
-			b, rerr := os.ReadFile(path) //nolint:gosec // fixed set of repo-relative paths, not user input
+			b, rerr := os.ReadFile(path)
 			if rerr != nil {
 				return rerr
 			}

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -240,8 +240,6 @@ func (h *Handler) GetAppLogs(w http.ResponseWriter, r *http.Request) {
 // getAppLogCounts returns cached unfiltered level and source counts.
 // The cache refreshes every appLogCountCacheTTL to avoid running GROUP BY
 // queries on every paginated history request (which polls every 2s in live mode).
-//
-//nolint:revive // result names not needed for internal API types
 func (h *Handler) getAppLogCounts(ctx context.Context) (map[string]int, map[string]int) {
 	appLogCountCache.RLock()
 	if time.Since(appLogCountCache.fetchedAt) < appLogCountCacheTTL && appLogCountCache.levelCounts != nil {

--- a/internal/api/backup_retention_test.go
+++ b/internal/api/backup_retention_test.go
@@ -634,7 +634,6 @@ func TestPrunePreview(t *testing.T) {
 			fmt.Sprintf("backup_%s_001_auto.dump", now.AddDate(0, -3, 0).Format("20060102_150405")),
 		}
 		for _, name := range names {
-			//nolint:gosec // test-only: permissive perms acceptable
 			if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -715,7 +714,6 @@ func TestApplyPrune(t *testing.T) {
 		// Create an old scheduler backup that falls outside retention periods.
 		oldTime := time.Now().AddDate(-2, 0, 0)
 		oldName := fmt.Sprintf("backup_%s_001_auto.dump", oldTime.Format("20060102_150405"))
-		//nolint:gosec // test-only: permissive perms acceptable
 		if err := os.WriteFile(filepath.Join(dir, oldName), []byte("old-backup"), 0o644); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/api/backup_scheduler_test.go
+++ b/internal/api/backup_scheduler_test.go
@@ -853,7 +853,6 @@ func TestRunScheduledBackup_RotationWithExistingBackups(t *testing.T) {
 
 	// Create an old backup file to test rotation after a new backup
 	oldName := fmt.Sprintf("backup_%s_001.dump", time.Now().AddDate(0, 0, -1).Format("20060102_150405"))
-	//nolint:gosec // test-only
 	if err := os.WriteFile(filepath.Join(dir, oldName), []byte("old"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -932,16 +931,13 @@ if [ -n "$OUTPUT_FILE" ]; then
 fi
 exit 0
 `
-	//nolint:gosec // test-only: script in temp dir
 	if err := os.WriteFile(mockPgDump, []byte(mockScript), 0o755); err != nil {
 		t.Fatalf("failed to write mock pg_dump: %v", err)
 	}
 
 	// Temporarily prepend the mock dir to PATH
 	originalPath := os.Getenv("PATH")
-	//nolint:errcheck // cleanup: restore PATH after test
 	defer os.Setenv("PATH", originalPath)
-	//nolint:errcheck // prepend mock dir to PATH
 	os.Setenv("PATH", tmpDir+":"+originalPath)
 
 	backupDir := t.TempDir()
@@ -965,7 +961,6 @@ exit 0
 	// Create some old scheduler backup files that should be pruned by rotation
 	// ("_auto" marks them as scheduler-created; manual backups are never pruned).
 	oldName := "backup_20240101_120000_001_auto.dump"
-	//nolint:gosec // test-only
 	if err := os.WriteFile(filepath.Join(backupDir, oldName), []byte("old backup data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -1032,15 +1027,12 @@ if [ -n "$OUTPUT_FILE" ]; then
 fi
 exit 0
 `
-	//nolint:gosec // test-only
 	if err := os.WriteFile(mockPgDump, []byte(mockScript), 0o755); err != nil {
 		t.Fatalf("failed to write mock pg_dump: %v", err)
 	}
 
 	originalPath := os.Getenv("PATH")
-	//nolint:errcheck // cleanup
 	defer os.Setenv("PATH", originalPath)
-	//nolint:errcheck // test-only: prepend mock dir to PATH
 	os.Setenv("PATH", tmpDir+":"+originalPath)
 
 	backupDir := t.TempDir()
@@ -1231,15 +1223,12 @@ if [ -n "$OUTPUT_FILE" ]; then
 fi
 exit 0
 `
-	//nolint:gosec // test-only
 	if err := os.WriteFile(mockPgDump, []byte(mockScript), 0o755); err != nil {
 		t.Fatalf("failed to write mock pg_dump: %v", err)
 	}
 
 	originalPath := os.Getenv("PATH")
-	//nolint:errcheck // cleanup
 	defer os.Setenv("PATH", originalPath)
-	//nolint:errcheck // test-only: prepend mock dir to PATH
 	os.Setenv("PATH", tmpDir+":"+originalPath)
 
 	backupDir := t.TempDir()
@@ -1251,7 +1240,6 @@ exit 0
 		"backup_20240115_090000_001_auto.dump", // old enough to be pruned
 	}
 	for _, name := range oldFiles {
-		//nolint:gosec // test-only
 		if err := os.WriteFile(filepath.Join(backupDir, name), []byte("old data"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -1333,15 +1321,12 @@ if [ -n "$OUTPUT_FILE" ]; then
 fi
 exit 0
 `
-	//nolint:gosec // test-only
 	if err := os.WriteFile(mockPgDump, []byte(mockScript), 0o755); err != nil {
 		t.Fatalf("failed to write mock pg_dump: %v", err)
 	}
 
 	originalPath := os.Getenv("PATH")
-	//nolint:errcheck // cleanup
 	defer os.Setenv("PATH", originalPath)
-	//nolint:errcheck // test-only: prepend mock dir to PATH
 	os.Setenv("PATH", tmpDir+":"+originalPath)
 
 	backupDir := t.TempDir()
@@ -1365,7 +1350,6 @@ exit 0
 
 	// Create an old scheduler backup with a valid filename (classified as prune)
 	oldName := "backup_20230101_120000_001_auto.dump"
-	//nolint:gosec // test-only
 	if err := os.WriteFile(filepath.Join(backupDir, oldName), []byte("old data"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/backup_sign_handler_test.go
+++ b/internal/api/backup_sign_handler_test.go
@@ -18,8 +18,6 @@ import (
 
 // setupSignedBackupRouter is setupBackupRouter with a signing key wired, so the
 // signature paths are exercised the way a configured deployment runs them.
-//
-//nolint:revive // unnamedResult: test helper, mirrors setupBackupRouter
 func setupSignedBackupRouter(t *testing.T, masterKey string) (chi.Router, string) {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/api/backup_sign_test.go
+++ b/internal/api/backup_sign_test.go
@@ -356,7 +356,7 @@ func TestVerifyBackupHandle_ChecksTheOpenInodeNotThePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open(path) //nolint:gosec // test-controlled temp path
+	f, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestVerifyBackupHandle_LeavesTheHandleAtTheStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open(path) //nolint:gosec // test-controlled temp path
+	f, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-//nolint:gosec,revive // test-only: error not critical, unnamedResult is test helper
 func setupBackupRouter(t *testing.T) (chi.Router, string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -58,13 +57,11 @@ func TestBackupHandler_ListBackups_WithFiles(t *testing.T) {
 
 	// Create fake backup files - names encode timestamps so sort is deterministic
 	for _, name := range []string{"backup_20250101_120000.dump", "backup_20250102_120000.dump"} {
-		//nolint:gosec // test-only: permissive perms acceptable
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 	// Create a non-dump file that should be ignored
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +95,6 @@ func TestBackupHandler_DownloadBackup(t *testing.T) {
 	r, dir := setupBackupRouter(t)
 
 	content := []byte("fake backup content")
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(filepath.Join(dir, "backup_test.dump"), content, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +155,6 @@ func TestBackupHandler_DownloadBackup_DoesNotHoldBackupMutex(t *testing.T) {
 	dir := t.TempDir()
 	h := NewBackupHandler("postgres://invalid:invalid@127.0.0.1:1/nonexistent", dir, &mockAdminAuth{}, nil)
 
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(filepath.Join(dir, "backup_test.dump"), []byte("payload"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +236,6 @@ func TestBackupHandler_DeleteBackup(t *testing.T) {
 	r, dir := setupBackupRouter(t)
 
 	path := filepath.Join(dir, "backup_delete.dump")
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +414,6 @@ func TestBackupHandler_DeleteBackup_RemoveError(t *testing.T) {
 	}
 
 	// Make directory read-only so os.Remove fails
-	//nolint:gosec // test-only: permissive to restrictive is fine
 	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +507,6 @@ func TestBackupHandler_ListBackups_SingleDumpFile(t *testing.T) {
 	// Create a .dump file (content is not a real pg_dump, but ListBackups
 	// only reads file info, not content).
 	dumpPath := filepath.Join(dir, "backup_valid.dump")
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(dumpPath, []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -773,7 +765,6 @@ func TestCreateBackup_Success(t *testing.T) {
 	// Verify the backup file actually exists on disk
 	backupPath := backupDir + "/" + resp.Filename
 	if _, err := exec.LookPath("stat"); err == nil {
-		//nolint:gosec // test-only subprocess
 		if _, err := exec.Command("stat", backupPath).CombinedOutput(); err != nil {
 			t.Errorf("backup file should exist at %s", backupPath)
 		}
@@ -923,7 +914,6 @@ func TestNewBackupHandler_AbsFallback_Subprocess(t *testing.T) {
 	}
 
 	// Delete the CWD while the subprocess is running
-	//nolint:gosec // test-only: removing test directory
 	if err := os.RemoveAll(tmpDir); err != nil {
 		t.Fatalf("cannot remove temp dir: %v", err)
 	}
@@ -969,22 +959,18 @@ fi
 # Exit successfully so the handler thinks backup worked
 exit 0
 `
-	//nolint:gosec // test-only: script in temp dir
 	if err := os.WriteFile(mockPgDump, []byte(mockScript), 0o755); err != nil {
 		t.Fatalf("failed to write mock pg_dump: %v", err)
 	}
 
 	// Temporarily modify PATH so exec.LookPath finds our mock first
 	originalPath := os.Getenv("PATH")
-	//nolint:errcheck // cleanup: restore PATH after test
 	defer os.Setenv("PATH", originalPath)
-	//nolint:errcheck // prepend mock dir to PATH
 	os.Setenv("PATH", tmpDir+":"+originalPath)
 
 	// Test case 1: DATABASE_URL with password
 	t.Run("with_password", func(t *testing.T) {
 		// Clear capture file
-		//nolint:errcheck,gosec // test-only: clearing capture file
 		os.WriteFile(captureFile, []byte{}, 0o644)
 
 		backupDir := t.TempDir()
@@ -1042,7 +1028,6 @@ exit 0
 	// Test case 2: DATABASE_URL without password
 	t.Run("without_password", func(t *testing.T) {
 		// Clear capture file
-		//nolint:errcheck,gosec // test-only: clearing capture file
 		os.WriteFile(captureFile, []byte{}, 0o644)
 
 		backupDir := t.TempDir()
@@ -1090,8 +1075,6 @@ exit 0
 
 // setupBackupRouterWithSettings creates a backup handler with a settingsRepo for tests
 // that need retention settings.
-//
-//nolint:revive // unnamedResult is test helper
 func setupBackupRouterWithSettings(t *testing.T, ss SettingsStore) (chi.Router, string) {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/api/discovery_confirm.go
+++ b/internal/api/discovery_confirm.go
@@ -160,7 +160,7 @@ func ConfirmMissingModels(ctx context.Context, svc *provider.DiscoveryService, p
 	}
 
 	for probe, delay := range confirmProbeDelays {
-		//nolint:gosec // jitter, not crypto
+		// jitter, not crypto
 		wait := delay + time.Duration(rand.Int64N(int64(confirmProbeJitter)))
 		debuglog.Info("discovery: models absent from listing, running confirmation probe",
 			"provider", prov.Name, "provider_id", prov.ID, "missing", missing,

--- a/internal/api/discovery_integration_test.go
+++ b/internal/api/discovery_integration_test.go
@@ -584,10 +584,10 @@ func TestDiscoverProviderModels_WithModelsDevCache(t *testing.T) {
 			break
 		}
 	}
-	if gpt4 == nil { //nolint:staticcheck // SA5011
+	if gpt4 == nil {
 		t.Fatal("gpt-4 model not found in response")
 	}
-	if gpt4.DisplayName != "GPT-4 Test" { //nolint:staticcheck // SA5011
+	if gpt4.DisplayName != "GPT-4 Test" {
 		t.Errorf("Expected display_name='GPT-4 Test' from models.dev enrichment, got %q", gpt4.DisplayName)
 	}
 	if gpt4.ContextLength == nil || *gpt4.ContextLength != 8192 {

--- a/internal/api/discovery_quota.go
+++ b/internal/api/discovery_quota.go
@@ -81,7 +81,7 @@ func (h *Handler) serveQuota(w http.ResponseWriter, r *http.Request, prov *provi
 		http.Error(w, "", http.StatusFailedDependency)
 	default:
 		w.Header().Set("Content-Type", "application/json")
-		//nolint:gosec // G705 false positive: provider quota JSON body, not HTML; Content-Type is application/json
+		// #nosec G705 -- provider quota JSON body, not HTML; Content-Type is application/json
 		_, _ = w.Write(snap.Payload)
 	}
 }

--- a/internal/api/failover_api_test.go
+++ b/internal/api/failover_api_test.go
@@ -52,12 +52,12 @@ func TestMain(m *testing.M) {
 	apiTestDB, err = db.New(ctx, apiTestDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer apiTestDB.Close()
 
 	util.CloseDockerClient()
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/api/handler_models_test.go
+++ b/internal/api/handler_models_test.go
@@ -280,7 +280,7 @@ func TestTestModel_VertexExpress(t *testing.T) {
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, network, target)
 		},
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only mock server
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	defer func() { h.testModelTransport = origTransport }()
 
@@ -365,7 +365,7 @@ func TestTestModel_AnthropicMessages(t *testing.T) {
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, network, target)
 		},
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only mock server
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	defer func() { h.testModelTransport = origTransport }()
 

--- a/internal/api/logscache_test.go
+++ b/internal/api/logscache_test.go
@@ -119,13 +119,13 @@ func TestLogsCacheSet_ExpiresInFuture(t *testing.T) {
 
 	// Check that expiry is in the future
 	entry := cache.entries["test"]
-	if entry == nil { //nolint:staticcheck // SA5011
+	if entry == nil {
 		t.Fatal("expected entry to exist")
 	}
-	if !entry.expiry.After(time.Now()) { //nolint:staticcheck // SA5011
+	if !entry.expiry.After(time.Now()) {
 		t.Error("expected expiry to be in the future")
 	}
-	if entry.expiry.After(time.Now().Add(2 * time.Second)) { //nolint:staticcheck // SA5011
+	if entry.expiry.After(time.Now().Add(2 * time.Second)) {
 		t.Error("expected expiry to be within TTL")
 	}
 }

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -653,14 +653,14 @@ func (h *Handler) doTestModelEgressRequest(ctx context.Context, client *http.Cli
 	if err != nil {
 		return nil, err
 	}
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+	// #nosec G704 -- provider URL is admin-configured, not arbitrary user input
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	util.SetProviderAuthHeaders(req, providerType, apiKey)
 	req.Header.Set("Content-Type", "application/json")
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+	// #nosec G704 -- provider URL is admin-configured, not arbitrary user input
 	resp, err := client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return resp, err

--- a/internal/api/system_integration_test.go
+++ b/internal/api/system_integration_test.go
@@ -66,18 +66,18 @@ func TestCollect_EmptySinceWithTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("collect with empty since failed: %v", err)
 	}
-	if stats == nil { //nolint:staticcheck // SA5011
+	if stats == nil {
 		t.Fatal("Expected non-nil stats")
 	}
 
 	// Verify AppStats structure
-	if stats.App.Goroutines <= 0 { //nolint:staticcheck // SA5011
+	if stats.App.Goroutines <= 0 {
 		t.Error("Expected goroutines > 0")
 	}
-	if stats.App.UptimeSeconds < 0 { //nolint:staticcheck // SA5011
+	if stats.App.UptimeSeconds < 0 {
 		t.Error("Expected uptime_seconds >= 0")
 	}
-	if stats.App.Procs <= 0 { //nolint:staticcheck // SA5011
+	if stats.App.Procs <= 0 {
 		t.Error("Expected procs > 0")
 	}
 }

--- a/internal/api/system_test.go
+++ b/internal/api/system_test.go
@@ -18,8 +18,6 @@ import (
 // value constructs a metrics.Value with the given kind and scalar.
 // The fields of metrics.Value are unexported, so we use unsafe to build
 // test values matching the internal layout: {kind ValueKind, scalar uint64}.
-//
-//nolint:gosec // test-only: unsafe for reflective struct access
 func value(kind metrics.ValueKind, scalar uint64) metrics.Value {
 	return *(*metrics.Value)(unsafe.Pointer(&struct {
 		kind   metrics.ValueKind

--- a/internal/api/virtualkeys.go
+++ b/internal/api/virtualkeys.go
@@ -187,12 +187,12 @@ func (h *Handler) providerNameByID(ctx context.Context) func(string) string {
 // undo a too-wide list this function let through.
 func (h *Handler) ownerProviderCap(ctx context.Context, ownerID *uuid.UUID) (*[]string, error) {
 	if ownerID == nil || h.userRepo == nil {
-		return nil, nil //nolint:nilnil // nil cap = unrestricted, not an error sentinel
+		return nil, nil // nil cap = unrestricted, not an error sentinel
 	}
 	u, err := h.userRepo.Get(ctx, *ownerID)
 	if err != nil {
 		if errors.Is(err, user.ErrNotFound) {
-			return nil, nil //nolint:nilnil // deleted owner; the FK rejects the write
+			return nil, nil // deleted owner; the FK rejects the write
 		}
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (h *Handler) ownerProviderCap(ctx context.Context, ownerID *uuid.UUID) (*[]
 		// A store that reports neither a row nor an error. The real repository
 		// returns ErrNotFound, but ownerUsername guards this too and an
 		// authorization input must not depend on which of the two it gets.
-		return nil, nil //nolint:nilnil // no row = no cap to enforce
+		return nil, nil // no row = no cap to enforce
 	}
 	return u.AllowedProviders, nil
 }
@@ -288,7 +288,7 @@ func resolveWriteOwner(id *user.Identity, requested *string) (*uuid.UUID, error)
 		return id.UserID, nil
 	}
 	if requested == nil || *requested == "" {
-		return nil, nil //nolint:nilnil // nil owner = unowned key, not an error sentinel
+		return nil, nil // nil owner = unowned key, not an error sentinel
 	}
 	uid, err := uuid.Parse(*requested)
 	if err != nil {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -187,7 +187,7 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			// reverse proxy this is the operator's real IP, not the proxy's.
 			RemoteAddr: clientip.From(r),
 		}
-		// record deliberately uses a background context so a
+		//nolint:gosec // G118: record deliberately uses a background context so a
 		// client disconnect can never drop the audit row; the request context is
 		// the wrong scope here.
 		rec.wg.Go(func() {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -187,7 +187,7 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			// reverse proxy this is the operator's real IP, not the proxy's.
 			RemoteAddr: clientip.From(r),
 		}
-		//nolint:gosec // G118: record deliberately uses a background context so a
+		// #nosec G118 -- record deliberately uses a background context so a
 		// client disconnect can never drop the audit row; the request context is
 		// the wrong scope here.
 		rec.wg.Go(func() {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -187,7 +187,7 @@ func (rec *Recorder) Middleware(next http.Handler) http.Handler {
 			// reverse proxy this is the operator's real IP, not the proxy's.
 			RemoteAddr: clientip.From(r),
 		}
-		//nolint:gosec // G118: record deliberately uses a background context so a
+		// record deliberately uses a background context so a
 		// client disconnect can never drop the audit row; the request context is
 		// the wrong scope here.
 		rec.wg.Go(func() {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -33,11 +33,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // newRecorder returns a Recorder over the package test DB with a clean

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -58,12 +58,12 @@ func TestMain(m *testing.M) {
 	testDB, err = New(ctx, testURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	testPool = testDB.Pool()
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 func TestNewInvalidURL(t *testing.T) {

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -125,7 +125,7 @@ func (b *Bus) Close() {
 func closeAndDrain(ch chan Event) {
 	close(ch)
 	go func() {
-		//nolint:revive,gosec // intentional: empty block for channel drain
+		//nolint:revive // intentional: empty block for channel drain
 		for range ch {
 		}
 	}()

--- a/internal/failover/failover_test.go
+++ b/internal/failover/failover_test.go
@@ -34,11 +34,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/frontdesk/authstore.go
+++ b/internal/frontdesk/authstore.go
@@ -301,8 +301,8 @@ func scanCredential(sc scanner) (*webauthn.CredentialRecord, error) {
 	}
 	// These columns are written from a byte and a uint32 respectively (see
 	// StoreCredential), so the stored values are always within range.
-	cred.FlagsByte = byte(flags & 0xff)             //nolint:gosec // value originates from a byte
-	cred.SignCount = uint32(signCount & 0xffffffff) //nolint:gosec // value originates from a uint32
+	cred.FlagsByte = byte(flags & 0xff)
+	cred.SignCount = uint32(signCount & 0xffffffff)
 	if parsed, err := uuid.Parse(aaguid); err == nil {
 		cred.AAGUID = parsed
 	}

--- a/internal/frontdesk/autosync_divergence_test.go
+++ b/internal/frontdesk/autosync_divergence_test.go
@@ -26,7 +26,7 @@ func TestAutoSync_MemberVersionUnreadableIsNotSkipped(t *testing.T) {
 	replica.dryDiff = driftDiff
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	enableAutoSync(t, store, pm.ID)
 	alignFleetVersions(t, srv, store, "dev")
 
@@ -171,7 +171,7 @@ func TestAutoSyncPrimaryExportUnreadable(t *testing.T) {
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
 	rm, _ := store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
-	store.CreateMember(t.Context(), "other", other.srv.URL, "otoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "other", other.srv.URL, "otoken")
 	enableAutoSync(t, store, pm.ID)
 	alignFleetVersions(t, srv, store, "dev") // else the version gate holds both members first
 
@@ -199,7 +199,7 @@ func TestAutoSyncReEnableConvergesDriftedReplica(t *testing.T) {
 	replica.dryDiff = driftDiff
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	if err := store.SetAutoSync(t.Context(), true, pm.ID); err != nil {
 		t.Fatalf("SetAutoSync: %v", err)
 	}

--- a/internal/frontdesk/autosync_incomplete_test.go
+++ b/internal/frontdesk/autosync_incomplete_test.go
@@ -384,7 +384,7 @@ func TestAutoSync_HealthyMemberIsSyncedOnceWhileAnotherIsIncomplete(t *testing.T
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
 	im, _ := store.CreateMember(t.Context(), "incomplete", incomplete.srv.URL, "itoken")
-	store.CreateMember(t.Context(), "healthy", healthy.srv.URL, "htoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "healthy", healthy.srv.URL, "htoken")
 	enableAutoSync(t, store, pm.ID)
 	alignFleetVersions(t, srv, store, "dev")
 

--- a/internal/frontdesk/autosync_test.go
+++ b/internal/frontdesk/autosync_test.go
@@ -336,7 +336,7 @@ func TestAutoSync_MemberWithADifferentConfigIsSynced(t *testing.T) {
 	replica.dryDiff = driftDiff
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	enableAutoSync(t, store, pm.ID)
 	alignFleetVersions(t, srv, store, "dev")
 
@@ -794,7 +794,7 @@ func TestAutoSyncDisabledIsNoop(t *testing.T) {
 	replica.dryDiff = driftDiff
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	// Designate a primary but leave auto-sync disabled.
 	if err := store.SetAutoSync(t.Context(), false, pm.ID); err != nil {
 		t.Fatalf("SetAutoSync: %v", err)
@@ -821,8 +821,8 @@ func TestAutoSyncNoChangeWhenHashUnchanged(t *testing.T) {
 	replica.dryDiff = driftDiff
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
-	enableAutoSync(t, store, pm.ID)                                       // last applied == current
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
+	enableAutoSync(t, store, pm.ID) // last applied == current
 	alignFleetVersions(t, srv, store, "dev")
 
 	if got := srv.autoSyncOnce(t.Context(), "hash-A"); got != "hash-A" {

--- a/internal/frontdesk/configsync_test.go
+++ b/internal/frontdesk/configsync_test.go
@@ -422,7 +422,7 @@ func TestConfigSyncTakesNoPreSyncBackup(t *testing.T) {
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
 	enableAutoSync(t, store, pm.ID)
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 	alignFleetVersions(t, srv, store, "dev")
 
 	rec := do(t, srv, http.MethodPost, "/api/config/sync", `{"primary_id":"`+pm.ID+`"}`, true)

--- a/internal/frontdesk/fleetstatus_test.go
+++ b/internal/frontdesk/fleetstatus_test.go
@@ -196,7 +196,7 @@ func TestFleetStatusEmptyPrimaryExport(t *testing.T) {
 	replica := newStubFleetMember(t, "rtoken")
 
 	pm, _ := store.CreateMember(t.Context(), "primary", primary.srv.URL, "ptoken")
-	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken") //nolint:errcheck // presence is the point
+	store.CreateMember(t.Context(), "replica", replica.srv.URL, "rtoken")
 
 	resp := fleetStatusByID(t, srv, pm.ID)
 	if resp.PrimaryReachable {

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -293,6 +293,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// The server's own lifetime, handed to detached request work. Cancelled by
 	// Shutdown and by nothing else, so a server that is never shut down simply
 	// never ends it.
+	//nolint:gosec // G118: the cancel func is stored on the server and called by Shutdown
 	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -293,7 +293,6 @@ func NewServer(cfg ServerConfig) *Server {
 	// The server's own lifetime, handed to detached request work. Cancelled by
 	// Shutdown and by nothing else, so a server that is never shut down simply
 	// never ends it.
-	//nolint:gosec // G118: the cancel func is stored on the server and called by Shutdown
 	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/frontdesk/server.go
+++ b/internal/frontdesk/server.go
@@ -293,7 +293,7 @@ func NewServer(cfg ServerConfig) *Server {
 	// The server's own lifetime, handed to detached request work. Cancelled by
 	// Shutdown and by nothing else, so a server that is never shut down simply
 	// never ends it.
-	//nolint:gosec // G118: the cancel func is stored on the server and called by Shutdown
+	// #nosec G118 -- the cancel func is stored on the server and called by Shutdown
 	s.shutdownCtx, s.shutdownCancel = context.WithCancel(context.Background())
 
 	// Bind the scrape-time member-fleet collector to this server's store and

--- a/internal/gemini/speech.go
+++ b/internal/gemini/speech.go
@@ -222,7 +222,7 @@ func wavFromPCM(pcm []byte, sampleRate int) []byte {
 	binary.LittleEndian.PutUint16(header[22:], channels)
 	binary.LittleEndian.PutUint32(header[24:], uint32(sampleRate))            //nolint:gosec // G115: a sample rate is small and positive
 	binary.LittleEndian.PutUint32(header[28:], uint32(sampleRate*blockAlign)) //nolint:gosec // G115: as above
-	binary.LittleEndian.PutUint16(header[32:], uint16(blockAlign))            //nolint:gosec // G115: 2
+	binary.LittleEndian.PutUint16(header[32:], uint16(blockAlign))
 	binary.LittleEndian.PutUint16(header[34:], bitsPerSample)
 	copy(header[36:], "data")
 	binary.LittleEndian.PutUint32(header[40:], uint32(len(pcm))) //nolint:gosec // G115: as the RIFF size above

--- a/internal/httpx/decodeguard_test.go
+++ b/internal/httpx/decodeguard_test.go
@@ -69,7 +69,7 @@ func TestNoUnboundedJSONDecode(t *testing.T) {
 		if filepath.Dir(abs) == selfDir {
 			return nil
 		}
-		src, err := os.ReadFile(path) //nolint:gosec // walking this repo's own source tree
+		src, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/internal/httpx/server_test.go
+++ b/internal/httpx/server_test.go
@@ -296,7 +296,7 @@ func TestBodyReadDeadlineBoundsAnUnreadBody(t *testing.T) {
 // context stayed alive, then answers 200 with "alive" or "cancelled".
 func outliveBudget(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	http.NewResponseController(w).Flush()
+	http.NewResponseController(w).Flush() // a recorder cannot flush; irrelevant here
 	deadline := time.Now().Add(3 * slowBudget)
 	for time.Now().Before(deadline) {
 		if r.Context().Err() != nil {

--- a/internal/httpx/server_test.go
+++ b/internal/httpx/server_test.go
@@ -296,7 +296,7 @@ func TestBodyReadDeadlineBoundsAnUnreadBody(t *testing.T) {
 // context stayed alive, then answers 200 with "alive" or "cancelled".
 func outliveBudget(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	http.NewResponseController(w).Flush() //nolint:errcheck // a recorder cannot flush; irrelevant here
+	http.NewResponseController(w).Flush()
 	deadline := time.Now().Add(3 * slowBudget)
 	for time.Now().Before(deadline) {
 		if r.Context().Err() != nil {

--- a/internal/model/model_db_test.go
+++ b/internal/model/model_db_test.go
@@ -27,12 +27,12 @@ func TestMain(m *testing.M) {
 	testDB, err := db.New(ctx, dbURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	testPool = testDB.Pool()
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // insertTestProvider inserts a provider row and returns its ID.

--- a/internal/paramrewrite/selfheal.go
+++ b/internal/paramrewrite/selfheal.go
@@ -77,7 +77,7 @@ func SelfHealChatCompletion(
 // postChatCompletion builds and sends a single POST with the given body,
 // applying caller-supplied headers.
 func postChatCompletion(ctx context.Context, client *http.Client, targetURL string, body []byte, applyHeaders func(*http.Request)) (*http.Response, error) {
-	// targetURL is admin-configured provider base, not user input
+	//nolint:gosec // targetURL is admin-configured provider base, not user input
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/paramrewrite/selfheal.go
+++ b/internal/paramrewrite/selfheal.go
@@ -77,7 +77,7 @@ func SelfHealChatCompletion(
 // postChatCompletion builds and sends a single POST with the given body,
 // applying caller-supplied headers.
 func postChatCompletion(ctx context.Context, client *http.Client, targetURL string, body []byte, applyHeaders func(*http.Request)) (*http.Response, error) {
-	//nolint:gosec // targetURL is admin-configured provider base, not user input
+	// targetURL is admin-configured provider base, not user input
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/paramrewrite/selfheal.go
+++ b/internal/paramrewrite/selfheal.go
@@ -77,7 +77,7 @@ func SelfHealChatCompletion(
 // postChatCompletion builds and sends a single POST with the given body,
 // applying caller-supplied headers.
 func postChatCompletion(ctx context.Context, client *http.Client, targetURL string, body []byte, applyHeaders func(*http.Request)) (*http.Response, error) {
-	//nolint:gosec // targetURL is admin-configured provider base, not user input
+	// #nosec G704 -- targetURL is admin-configured provider base, not user input
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/provider/anthropic_discovery_test.go
+++ b/internal/provider/anthropic_discovery_test.go
@@ -46,7 +46,6 @@ func TestAnthropicDiscoveryWithMockServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v1/models" {
 			w.Header().Set("Content-Type", "application/json")
-			//nolint:gosec // test-only: error handling not critical
 			w.Write([]byte(page1))
 			return
 		}
@@ -99,7 +98,6 @@ func TestAnthropicDiscoveryWithMockServer(t *testing.T) {
 
 	// Check capabilities parsed from API
 	var caps model.Capability
-	//nolint:gosec // test-only: error handling not critical
 	json.Unmarshal([]byte(m1.Capabilities), &caps)
 	if !caps.Vision {
 		t.Error("expected Vision=true for opus")
@@ -181,10 +179,8 @@ func TestAnthropicDiscoverypagination(t *testing.T) {
 		callCount++
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Query().Get("after_id") == "" {
-			//nolint:gosec // test-only: mock server response
 			w.Write([]byte(page1))
 		} else {
-			//nolint:gosec // test-only: mock server response
 			w.Write([]byte(page2))
 		}
 	}))
@@ -233,7 +229,6 @@ func TestAnthropicDiscoverynoCapabilities(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		//nolint:gosec // test-only: mock server response
 		w.Write([]byte(page1))
 	}))
 	defer server.Close()
@@ -273,7 +268,6 @@ func TestAnthropicDiscoverynoCapabilities(t *testing.T) {
 	}
 	// Capabilities should have defaults (streaming, tool_calling)
 	var caps model.Capability
-	//nolint:gosec // test-only
 	json.Unmarshal([]byte(m.Capabilities), &caps)
 	if !caps.Streaming {
 		t.Error("expected Streaming=true by default")

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -658,7 +658,7 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 			case <-time.After(backoff):
 			}
 		}
-		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+		// #nosec G704 -- provider URL is admin-configured, not arbitrary user input
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
 			// Same scrub as doDiscoveryRequest, for the same reason, and with a

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -658,7 +658,7 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 			case <-time.After(backoff):
 			}
 		}
-		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+		// provider URL is admin-configured, not arbitrary user input
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
 			// Same scrub as doDiscoveryRequest, for the same reason, and with a

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -658,7 +658,7 @@ func (d *DiscoveryService) doQuotaRequestWithRetry(ctx context.Context, req *htt
 			case <-time.After(backoff):
 			}
 		}
-		// provider URL is admin-configured, not arbitrary user input
+		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
 		resp, err := d.httpClient.Do(req)
 		if err != nil {
 			// Same scrub as doDiscoveryRequest, for the same reason, and with a

--- a/internal/provider/discovery_cohere_http_test.go
+++ b/internal/provider/discovery_cohere_http_test.go
@@ -56,7 +56,6 @@ func TestDiscoverCohere(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		//nolint:gosec // test-only
 		json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()

--- a/internal/provider/discovery_live_test.go
+++ b/internal/provider/discovery_live_test.go
@@ -61,7 +61,6 @@ func TestAnthropicDiscoveryLiveAPI(t *testing.T) {
 
 	for _, m := range models {
 		var caps model.Capability
-		//nolint:gosec // test-only
 		json.Unmarshal([]byte(m.Capabilities), &caps)
 		ctxLen := "<nil>"
 		if m.ContextLength != nil {

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -216,7 +216,6 @@ func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider 
 
 		// The OpenAI listing has no type; NormalizeModelClassification's name
 		// heuristics keep embedding/reranker models out of the chat picker.
-		//nolint:gocritic // model variable shadows import but context makes it clear
 		model := &model.Model{
 			ID:              uuid.New(),
 			ProviderID:      provider.ID,

--- a/internal/provider/discovery_lmstudio.go
+++ b/internal/provider/discovery_lmstudio.go
@@ -216,6 +216,7 @@ func (d *DiscoveryService) discoverLMStudioOpenAI(ctx context.Context, provider 
 
 		// The OpenAI listing has no type; NormalizeModelClassification's name
 		// heuristics keep embedding/reranker models out of the chat picker.
+		// model shadows the imported package for the rest of this block.
 		model := &model.Model{
 			ID:              uuid.New(),
 			ProviderID:      provider.ID,

--- a/internal/provider/modelsdev_cache_test.go
+++ b/internal/provider/modelsdev_cache_test.go
@@ -87,7 +87,6 @@ func (t *modelsDevTestTransport) RoundTrip(req *http.Request) (*http.Response, e
 	// Simple approach: if the request is for models.dev API, redirect to our test server
 	if req.URL.String() == modelsDevAPIURL {
 		// Create a new request to our test server
-		//nolint:gosec // test-only: test server URL
 		testReq, err := http.NewRequest(req.Method, t.url, req.Body)
 		if err != nil {
 			return nil, err

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -38,11 +38,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 func newTestRepo(t *testing.T) *Repository {

--- a/internal/proxy/anthropic_handler.go
+++ b/internal/proxy/anthropic_handler.go
@@ -103,6 +103,6 @@ func (h *Handler) readAnthropicBody(w http.ResponseWriter, r *http.Request) ([]b
 func writeAnthropicError(w http.ResponseWriter, message string, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	//nolint:gosec // G705 false positive: Anthropic JSON error body, not HTML; Content-Type is application/json
+	// #nosec G705 -- Anthropic JSON error body, not HTML; Content-Type is application/json
 	_, _ = w.Write(anthropic.BuildErrorResponseFromMessage(message, status))
 }

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -126,7 +126,7 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
-	//nolint:gosec // G705 false positive: Anthropic JSON response body, not HTML; Content-Type is application/json
+	// #nosec G705 -- Anthropic JSON response body, not HTML; Content-Type is application/json
 	_, _ = w.Write(body)
 	return outcomeServed
 }

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -89,7 +89,7 @@ func (a *anthropicResponseWriter) Write(p []byte) (int, error) {
 		// text/event-stream (never text/html), and the consumer is an API client,
 		// not a browser. CodeQL go/reflected-xss cannot trace the middleware header
 		// through this wrapper, so the alert is dismissed as a false positive.
-		//nolint:gosec // G705: see above — JSON/SSE API body, nosniff set globally, not HTML
+		// #nosec G705 -- see above — JSON/SSE API body, nosniff set globally, not HTML
 		return a.w.Write(p)
 	}
 	if a.streaming {
@@ -192,7 +192,7 @@ func (a *anthropicResponseWriter) handleStreamLine(line []byte) {
 		return
 	}
 	if len(out) > 0 {
-		//nolint:gosec // G705 false positive: Anthropic SSE event body, not HTML; Content-Type is text/event-stream
+		// #nosec G705 -- Anthropic SSE event body, not HTML; Content-Type is text/event-stream
 		_, _ = a.w.Write(out)
 		a.Flush()
 	}
@@ -213,7 +213,7 @@ func (a *anthropicResponseWriter) finishStream() {
 		debuglog.Warn("anthropic: thought signatures arrived after their tool_use block opened and could not be carried; the next turn will be refused", "count", n, "model", a.model)
 	}
 	if len(out) > 0 {
-		//nolint:gosec // G705 false positive: Anthropic SSE event body, not HTML; Content-Type is text/event-stream
+		// #nosec G705 -- Anthropic SSE event body, not HTML; Content-Type is text/event-stream
 		_, _ = a.w.Write(out)
 		a.Flush()
 	}
@@ -264,6 +264,6 @@ func (a *anthropicResponseWriter) Finalize() {
 
 	a.w.Header().Set("Content-Type", "application/json")
 	a.w.WriteHeader(a.status)
-	//nolint:gosec // G705 false positive: Anthropic JSON response body, not HTML; Content-Type is application/json
+	// #nosec G705 -- Anthropic JSON response body, not HTML; Content-Type is application/json
 	_, _ = a.w.Write(out)
 }

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -89,7 +89,6 @@ func (a *anthropicResponseWriter) Write(p []byte) (int, error) {
 		// text/event-stream (never text/html), and the consumer is an API client,
 		// not a browser. CodeQL go/reflected-xss cannot trace the middleware header
 		// through this wrapper, so the alert is dismissed as a false positive.
-		//nolint:gosec // G705: see above — JSON/SSE API body, nosniff set globally, not HTML
 		return a.w.Write(p)
 	}
 	if a.streaming {

--- a/internal/proxy/anthropic_writer.go
+++ b/internal/proxy/anthropic_writer.go
@@ -89,6 +89,7 @@ func (a *anthropicResponseWriter) Write(p []byte) (int, error) {
 		// text/event-stream (never text/html), and the consumer is an API client,
 		// not a browser. CodeQL go/reflected-xss cannot trace the middleware header
 		// through this wrapper, so the alert is dismissed as a false positive.
+		//nolint:gosec // G705: see above — JSON/SSE API body, nosniff set globally, not HTML
 		return a.w.Write(p)
 	}
 	if a.streaming {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -397,7 +397,7 @@ func (h *Handler) ProxyKeyMiddleware(next http.Handler) http.Handler {
 		debuglog.Debug("proxy: virtual key auth", "key", vk.Name, "strip_reasoning", vk.StripReasoning)
 		// Fire-and-forget touch with a timeout so the goroutine cannot
 		// outlive the server if the DB is slow.
-		//nolint:gosec // intentional: periodic cache refresh is not request-scoped
+		// #nosec G118 -- intentional: periodic cache refresh is not request-scoped
 		go func(hash string) {
 			defer func() {
 				if r := recover(); r != nil {

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -24,7 +24,6 @@ func extractStreamingUsage(data string) *Usage {
 	for scanner.Scan() {
 		line := scanner.Text()
 		var payload string
-		//nolint:gocritic // if-else chain is clearer than switch for SSE prefix matching
 		if after, ok := strings.CutPrefix(line, "data: "); ok {
 			payload = after
 		} else if strings.HasPrefix(line, "data:") && len(line) > 5 {

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -24,6 +24,7 @@ func extractStreamingUsage(data string) *Usage {
 	for scanner.Scan() {
 		line := scanner.Text()
 		var payload string
+		// if-else chain reads clearer than a switch for SSE prefix matching
 		if after, ok := strings.CutPrefix(line, "data: "); ok {
 			payload = after
 		} else if strings.HasPrefix(line, "data:") && len(line) > 5 {

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -315,7 +315,7 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		client.CheckRedirect = h.safeDialer.CheckRedirect
 	}
 
-	//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+	// #nosec G704 -- provider URL is admin-configured, not arbitrary user input
 	resp, err := client.Do(req)
 	if err != nil {
 		// A connection that never landed, a DNS failure or an expired deadline

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -365,7 +365,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	}
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(resp.StatusCode)
-	//nolint:gosec // G705 false positive: provider JSON body, not HTML; Content-Type is application/json
+	// #nosec G705 -- provider JSON body, not HTML; Content-Type is application/json
 	if _, writeErr := w.Write(body); writeErr != nil {
 		debuglog.Warn("proxy: client write failed during passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", writeErr)
 	}

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -249,6 +249,7 @@ func (h *Handler) issueParamRetry(
 		retryCheckRedirect = h.safeDialer.CheckRedirect
 	}
 	retryClient := &http.Client{Transport: h.upstreamTransport, CheckRedirect: retryCheckRedirect}
+	// retryResp.Body is returned to the caller, which consumes and closes it
 	retryResp, retryErr := retryClient.Do(retryReq)
 	*dialMs += retryDial.take()
 	if retryErr == nil && st.responsesAttempt {

--- a/internal/proxy/param_retry.go
+++ b/internal/proxy/param_retry.go
@@ -249,7 +249,6 @@ func (h *Handler) issueParamRetry(
 		retryCheckRedirect = h.safeDialer.CheckRedirect
 	}
 	retryClient := &http.Client{Transport: h.upstreamTransport, CheckRedirect: retryCheckRedirect}
-	//nolint:bodyclose // retryResp.Body is returned to the caller, which consumes and closes it
 	retryResp, retryErr := retryClient.Do(retryReq)
 	*dialMs += retryDial.take()
 	if retryErr == nil && st.responsesAttempt {

--- a/internal/proxy/probe_error_frame_test.go
+++ b/internal/proxy/probe_error_frame_test.go
@@ -544,7 +544,7 @@ func TestProbeErrorFrame_NeverLogsTheProviderCredential(t *testing.T) {
 		run  func(t *testing.T, h *Handler, st *requestState, cand modelCandidate)
 	}{
 		{"sequential", func(_ *testing.T, h *Handler, st *requestState, cand modelCandidate) {
-			resp, err := srv.Client().Get(srv.URL) //nolint:noctx // test server, no context needed
+			resp, err := srv.Client().Get(srv.URL)
 			if err != nil {
 				t.Fatalf("get: %v", err)
 			}

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -475,7 +475,6 @@ func (h *Handler) beginAttempt(failoverCtx context.Context, st *requestState, ca
 // fire-and-forget goroutine with its own timeout, so the request path is
 // never blocked by a slow DB write.
 func (h *Handler) touchProviderLastUsed(pid uuid.UUID) {
-	//nolint:gosec // intentional: failover goroutine needs independent lifecycle
 	go func(pid uuid.UUID) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -475,6 +475,7 @@ func (h *Handler) beginAttempt(failoverCtx context.Context, st *requestState, ca
 // fire-and-forget goroutine with its own timeout, so the request path is
 // never blocked by a slow DB write.
 func (h *Handler) touchProviderLastUsed(pid uuid.UUID) {
+	//nolint:gosec // intentional: failover goroutine needs independent lifecycle
 	go func(pid uuid.UUID) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -475,7 +475,7 @@ func (h *Handler) beginAttempt(failoverCtx context.Context, st *requestState, ca
 // fire-and-forget goroutine with its own timeout, so the request path is
 // never blocked by a slow DB write.
 func (h *Handler) touchProviderLastUsed(pid uuid.UUID) {
-	//nolint:gosec // intentional: failover goroutine needs independent lifecycle
+	// #nosec G118 -- intentional: failover goroutine needs independent lifecycle
 	go func(pid uuid.UUID) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -697,7 +697,7 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 			}
 			tryReq.Body = body
 		}
-		//nolint:gosec // provider URL is admin-configured, not arbitrary user input
+		// #nosec G704 -- provider URL is admin-configured, not arbitrary user input
 		resp, err = upstreamClient.Do(tryReq)
 		*dialMs += dialTimer.take()
 		st.timings.dialMs += *dialMs

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -42,11 +42,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // newIntegrationHandler creates a Handler with a real settings.Repository

--- a/internal/proxy/stream_sink.go
+++ b/internal/proxy/stream_sink.go
@@ -40,7 +40,7 @@ func newStreamSink(w http.ResponseWriter) *streamSink {
 // NOT flush — callers flush explicitly so the existing flush points stay
 // byte-for-byte where they were.
 func (s *streamSink) write(p []byte) error {
-	//nolint:gosec // G705 false positive: SSE frame to a text/event-stream response, not HTML
+	// #nosec G705 -- SSE frame to a text/event-stream response, not HTML
 	n, err := s.w.Write(p)
 	s.bytesWritten += int64(n)
 	return err

--- a/internal/proxy/stream_sink.go
+++ b/internal/proxy/stream_sink.go
@@ -40,6 +40,7 @@ func newStreamSink(w http.ResponseWriter) *streamSink {
 // NOT flush — callers flush explicitly so the existing flush points stay
 // byte-for-byte where they were.
 func (s *streamSink) write(p []byte) error {
+	//nolint:gosec // G705 false positive: SSE frame to a text/event-stream response, not HTML
 	n, err := s.w.Write(p)
 	s.bytesWritten += int64(n)
 	return err

--- a/internal/proxy/stream_sink.go
+++ b/internal/proxy/stream_sink.go
@@ -40,7 +40,6 @@ func newStreamSink(w http.ResponseWriter) *streamSink {
 // NOT flush — callers flush explicitly so the existing flush points stay
 // byte-for-byte where they were.
 func (s *streamSink) write(p []byte) error {
-	//nolint:gosec // G705 false positive: SSE frame to a text/event-stream response, not HTML
 	n, err := s.w.Write(p)
 	s.bytesWritten += int64(n)
 	return err

--- a/internal/proxy/upstream_error_forward.go
+++ b/internal/proxy/upstream_error_forward.go
@@ -132,7 +132,7 @@ func (h *Handler) forwardUpstreamError(w http.ResponseWriter, st *requestState, 
 		// provider-authored free text.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(resp.StatusCode)
-		//nolint:gosec // G705 false positive: provider JSON error body, not HTML; Content-Type is application/json
+		// #nosec G705 -- provider JSON error body, not HTML; Content-Type is application/json
 		_, _ = w.Write(masker.mask(body))
 	case json.Valid(body):
 		// A non-2xx whose JSON body carries no error object. OpenCode Zen and

--- a/internal/pwned/pwned.go
+++ b/internal/pwned/pwned.go
@@ -57,7 +57,7 @@ func (c *Checker) Breached(ctx context.Context, password string) (bool, int, err
 	// storage: only the 5-char prefix below is ever sent and the password is
 	// never persisted as this hash. The gosec/CodeQL weak-hash warnings key on
 	// the word "password" reaching sha1 and cannot see that distinction.
-	sum := sha1.Sum([]byte(password)) //nolint:gosec // codeql[go/weak-sensitive-data-hashing] -- G401 SHA-1 is the HIBP k-anonymity wire contract, not a security primitive
+	sum := sha1.Sum([]byte(password)) //nolint:gosec // codeql[go/weak-sensitive-data-hashing] -- HIBP k-anonymity wire contract, not a security primitive
 	hash := strings.ToUpper(hex.EncodeToString(sum[:]))
 	prefix, suffix := hash[:5], hash[5:]
 

--- a/internal/pwned/pwned.go
+++ b/internal/pwned/pwned.go
@@ -57,7 +57,7 @@ func (c *Checker) Breached(ctx context.Context, password string) (bool, int, err
 	// storage: only the 5-char prefix below is ever sent and the password is
 	// never persisted as this hash. The gosec/CodeQL weak-hash warnings key on
 	// the word "password" reaching sha1 and cannot see that distinction.
-	sum := sha1.Sum([]byte(password)) //nolint:gosec // codeql[go/weak-sensitive-data-hashing] -- HIBP k-anonymity wire contract, not a security primitive
+	sum := sha1.Sum([]byte(password)) //nolint:gosec // codeql[go/weak-sensitive-data-hashing] -- G401 SHA-1 is the HIBP k-anonymity wire contract, not a security primitive
 	hash := strings.ToUpper(hex.EncodeToString(sum[:]))
 	prefix, suffix := hash[:5], hash[5:]
 

--- a/internal/quota/repository_test.go
+++ b/internal/quota/repository_test.go
@@ -30,12 +30,12 @@ func TestMain(m *testing.M) {
 	testDB, err := db.New(ctx, dbURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	testPool = testDB.Pool()
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // insertTestProvider inserts a provider row and returns its ID.

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -29,11 +29,11 @@ func TestMain(m *testing.M) {
 	testDB, err := db.New(ctx, testURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	testPool = testDB.Pool()
 	defer testDB.Close()
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 func clearSettings(t *testing.T) {

--- a/internal/totp/totp_test.go
+++ b/internal/totp/totp_test.go
@@ -34,11 +34,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // newTestRepo returns a Repository backed by the per-package test DB, with a

--- a/internal/user/user_test.go
+++ b/internal/user/user_test.go
@@ -30,11 +30,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/util/docker_wrapper_compose_test.go
+++ b/internal/util/docker_wrapper_compose_test.go
@@ -28,7 +28,6 @@ func TestListComposeContainers(t *testing.T) {
 		if r.URL.Path == "/containers/json" && r.URL.Query().Get("all") == "true" {
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(containers)
-			//nolint:gosec // test-only: error handling not critical
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/util/docker_wrapper_stats_test.go
+++ b/internal/util/docker_wrapper_stats_test.go
@@ -14,7 +14,6 @@ func TestGetContainerStats(t *testing.T) {
 
 	// Use the production dockerStatsResponse type directly
 	var statsResp dockerStatsResponse
-	//nolint:gosec // test-only: error handling not critical
 	json.Unmarshal([]byte(`{
 		"cpu_stats": {
 			"cpu_usage": {"total_usage": 500, "percpu_usage": [250, 250]},
@@ -52,7 +51,6 @@ func TestGetContainerStats(t *testing.T) {
 		if r.URL.Path != "/containers/abc123def4567/stats" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		//nolint:gosec // test-only: error handling not critical
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(statsResp)
 	}))

--- a/internal/util/docker_wrapper_test.go
+++ b/internal/util/docker_wrapper_test.go
@@ -92,13 +92,11 @@ func TestGetOwnContainerID_CgroupV1(t *testing.T) {
 11:cpu:/docker/abc123def4567890
 10:blkio:/docker/abc123def4567890`
 	cgroupFile := tmpDir + "/cgroup"
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0o644); err != nil {
 		t.Fatalf("failed to write temp cgroup file: %v", err)
 	}
 
 	// Read the file manually to verify the logic (since we can't override the path)
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(cgroupFile)
 	if err != nil {
 		t.Fatalf("failed to read temp file: %v", err)
@@ -136,12 +134,10 @@ func TestGetOwnContainerID_CgroupV2(t *testing.T) {
 	tmpDir := t.TempDir()
 	cgroupContent := `0::/abc123def4567890`
 	cgroupFile := tmpDir + "/cgroup"
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(cgroupFile, []byte(cgroupContent), 0o644); err != nil {
 		t.Fatalf("failed to write temp cgroup file: %v", err)
 	}
 
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(cgroupFile)
 	if err != nil {
 		t.Fatalf("failed to read temp file: %v", err)
@@ -175,12 +171,10 @@ func TestGetOwnContainerID_CgroupV2(t *testing.T) {
 func TestGetOwnContainerID_Empty(t *testing.T) {
 	tmpDir := t.TempDir()
 	cgroupFile := tmpDir + "/cgroup"
-	//nolint:gosec // test-only: permissive perms acceptable
 	if err := os.WriteFile(cgroupFile, []byte(""), 0o644); err != nil {
 		t.Fatalf("failed to write temp cgroup file: %v", err)
 	}
 
-	//nolint:gosec // test-only: controlled test path
 	data, err := os.ReadFile(cgroupFile)
 	if err != nil {
 		t.Fatalf("failed to read temp file: %v", err)

--- a/internal/virtualkey/virtualkey_test.go
+++ b/internal/virtualkey/virtualkey_test.go
@@ -32,11 +32,11 @@ func TestMain(m *testing.M) {
 	testDB, err = db.New(ctx, testDBURL, 25, 5)
 	if err != nil {
 		log.Printf("failed to initialize test DB: %v", err)
-		os.Exit(1) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+		os.Exit(1)
 	}
 	defer testDB.Close()
 
-	os.Exit(m.Run()) //nolint:gocritic // test-only: os.Exit in TestMain is intentional
+	os.Exit(m.Run())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Enables `nolintlint` in `.golangci.yml` (`allow-unused`, `require-explanation`, `require-specific`) and removes the 132 `//nolint` directives it proved dead, across 59 files. Go nolint count drops from 207 to 74. Every survivor names a linter, carries a reason, and suppresses a real finding.

What was dead:
- 5 directives for linters that are not enabled (`nilnil` in `virtualkeys.go`, `noctx` in a proxy test). Their reasons stay as plain comments where they document intent.
- 26 `os.Exit in TestMain` gocritic pairs across 13 packages, 9 `SA5011` staticcheck hints in tests, and ~85 test-file gosec/errcheck/revive hints already covered by the `_test.go` path exclusions.
- A handful of prod hints whose rule never fires (`G404` is globally excluded, masked `G115` casts, `importShadow` and `unnamedResult` are excluded gocritic checks).

Two multi-linter directives are trimmed to the linter that still fires rather than removed.

## gosec taint rules are not deterministic

Three cache-clean runs of the same tree gave three different answers for the taint rules (`G704` SSRF, `G705` XSS, `G118` context lifetime): a finding, nothing, or an "unused directive". A `//nolint:gosec` on those sites therefore flaps under `allow-unused`. The 21 taint sites now use gosec's own `// #nosec G70x -- reason` marker instead: nolintlint never sees it, and it is scoped to the named rule (verified under golangci-lint 2.13: a wrong id lets the finding through, the right one suppresses it). No waiver in `.golangci.yml`, so a dead gosec directive for a deterministic rule stays reportable.

Verified stable: four consecutive cache-clean runs at the pre-push scope, all `0 issues`.

Review rounds: Codex `review --base master` (clean), Opus reviewer (6 findings, 5 applied: dropped intent comments kept as plain comments, waiver scope), Codex `exec` on gpt-5.6-terra (2 findings, both applied: `#nosec` over the global waiver, name G401 in the pwned reason).

## Also

`.gitignore` now covers `/.agents/` and `/skills-lock.json` (local agent tooling, never published).

## Test plan

- [x] `golangci-lint run ./...` clean, three cache-clean repeats at hook scope
- [x] `go test ./cmd/... ./internal/...` 40 packages pass
- [x] `make build`, `go vet`, `make size-check`
- [x] Only `//nolint` lines and their orphaned `//` doc separators changed in Go files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
