### PR TITLE
refactor(web): split the five near-limit size-ratchet functions

### DIFF
--- a/web/src/components/TotpRecoveryCodes.tsx
+++ b/web/src/components/TotpRecoveryCodes.tsx
@@ -1,0 +1,90 @@
+import { useTranslation } from "react-i18next";
+import { Check, Download } from "@/lib/icons";
+import { CopyButton } from "./CopyButton";
+
+/**
+ * One-time reveal of freshly minted TOTP recovery codes, shared by the admin
+ * TOTP panel (Settings) and the self-service Security page so the two stay
+ * word-for-word and pixel-for-pixel identical. `onSaved` is the caller's
+ * acknowledgement that the codes have been stored somewhere safe.
+ */
+export function TotpRecoveryCodes({
+	codes,
+	onSaved,
+	testIdPrefix,
+}: {
+	codes: string[];
+	onSaved: () => void;
+	testIdPrefix?: string;
+}) {
+	const { t } = useTranslation();
+
+	const handleDownload = () => {
+		const blob = new Blob([`${codes.join("\n")}\n`], {
+			type: "text/plain",
+		});
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = "model-hotel-totp-recovery-codes.txt";
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		URL.revokeObjectURL(url);
+	};
+
+	const testId = (name: string) =>
+		testIdPrefix ? { "data-testid": `${testIdPrefix}-${name}` } : {};
+
+	return (
+		<div className="space-y-4">
+			<div className="ui-callout ui-callout-warning">
+				<p className="font-medium">{t("settings.totp.recoveryCodesWarning")}</p>
+			</div>
+			<div>
+				<div className="flex items-center justify-between mb-2">
+					<h3 className="text-sm font-medium text-(--text-primary)">
+						{t("settings.totp.recoveryCodes")}
+					</h3>
+					<CopyButton
+						text={codes.join("\n")}
+						size={16}
+						title={t("settings.totp.copyAll")}
+						toastType="success"
+					/>
+				</div>
+				<div className="p-3 bg-(--surface-elevated) rounded-[var(--radius-card,0.375rem)] border border-(--border-default)">
+					<div className="font-mono text-sm space-y-1">
+						{codes.map((code) => (
+							<div key={code} className="text-(--text-primary) break-all">
+								{code}
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				<button
+					type="button"
+					onClick={handleDownload}
+					className="ui-btn ui-btn-secondary"
+					aria-label={t("settings.totp.downloadCodesAriaLabel")}
+					{...testId("download-codes")}
+				>
+					<Download size={16} />
+					{t("settings.totp.downloadCodes")}
+				</button>
+				<button
+					type="button"
+					onClick={onSaved}
+					className="ui-btn ui-btn-primary"
+					aria-label={t("settings.totp.savedAriaLabel")}
+					{...testId("saved-codes")}
+				>
+					<Check size={16} />
+					{t("settings.totp.saved")}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/web/src/pages/Arena/__tests__/useArenaRunner.test.ts
+++ b/web/src/pages/Arena/__tests__/useArenaRunner.test.ts
@@ -317,8 +317,8 @@ describe("useArenaRunner", () => {
 
 		it("defers (does not error) an unrecognised slot while models load", async () => {
 			// While the chat list is still loading we can't classify the model, so
-			// the pending response is cleared for retry rather than permanently
-			// failed, and nothing is dispatched.
+			// the pending response is left untouched for a retry rather than
+			// permanently failed, and nothing is dispatched.
 			let hit = false;
 			server.use(
 				http.post("/api/chat/arena", () => {

--- a/web/src/pages/Arena/streamModel.ts
+++ b/web/src/pages/Arena/streamModel.ts
@@ -1,0 +1,244 @@
+import type { TFunction } from "i18next";
+import { produce } from "immer";
+import { API_BASE, getAuthHeaders } from "../../api/client";
+import type { GenerationParams } from "../../api/types";
+import { hasAnyParam } from "../../utils/params";
+import { readSSEStream, type StreamChunk } from "../../utils/sse";
+import { fetchWithRetry } from "../../utils/stagger";
+import { extractThinking, sanitizeDelta } from "../../utils/thinking";
+import type { ArenaResponse } from "./types";
+import type { ArenaRunnerDeps } from "./useArenaRunner";
+
+/** What one arena stream needs from the runner hook: mount-gated setters plus the mode and abort registries. */
+export interface ArenaStreamContext
+	extends Pick<
+		ArenaRunnerDeps,
+		"setRounds" | "setPhase" | "setRunningModels" | "arenaModeRef" | "toast"
+	> {
+	t: TFunction;
+	abortMapRef: React.RefObject<Map<string, AbortController>>;
+	mountedRef: React.RefObject<boolean>;
+}
+
+export interface ArenaStreamArgs {
+	model: string;
+	personaPrompt: string;
+	userPrompt: string;
+	roundIdx: number;
+	slotKey: "A" | "B";
+	matchupIdx: number;
+	slotParams?: GenerationParams;
+	abortCtrl: AbortController;
+}
+
+/**
+ * Streams one model's answer into its matchup slot: POSTs the arena chat
+ * request, folds SSE deltas (content, reasoning, usage) into the round state,
+ * stamps the slot done with metrics or an error, and finally clears the model
+ * from the running set, flipping the phase when it was the last one. The
+ * caller registers `abortCtrl` in `abortMapRef` before calling.
+ */
+export async function streamArenaResponse(
+	ctx: ArenaStreamContext,
+	args: ArenaStreamArgs,
+): Promise<void> {
+	const {
+		t,
+		toast,
+		setRounds,
+		setPhase,
+		setRunningModels,
+		arenaModeRef,
+		abortMapRef,
+		mountedRef,
+	} = ctx;
+	const {
+		model,
+		personaPrompt,
+		userPrompt,
+		roundIdx,
+		slotKey,
+		matchupIdx,
+		slotParams,
+		abortCtrl,
+	} = args;
+	const startTime = performance.now();
+	let promptTokens = 0;
+	let completionTokens = 0;
+
+	const chatMessages: Array<{ role: string; content: string }> = [];
+	if (personaPrompt.trim()) {
+		chatMessages.push({ role: "system", content: personaPrompt.trim() });
+	}
+	chatMessages.push({ role: "user", content: userPrompt });
+
+	try {
+		const resp = await fetchWithRetry(
+			`${API_BASE}/api/chat/arena`,
+			{
+				method: "POST",
+				headers: getAuthHeaders(),
+				body: JSON.stringify({
+					model,
+					stream: true,
+					messages: chatMessages,
+					...(slotParams && hasAnyParam(slotParams) ? slotParams : {}),
+				}),
+				signal: abortCtrl.signal,
+			},
+			{
+				maxRetries: 2,
+				onRetry: (
+					attempt: number,
+					delayMs: number,
+					status?: number | string,
+				) => {
+					toast(
+						t("hooks.useArenaRunner.retry", {
+							model,
+							status: status || t("hooks.useArenaRunner.networkError"),
+							attempt,
+							delay: (delayMs / 1000).toFixed(1),
+						}),
+						"info",
+					);
+				},
+			},
+		);
+
+		if (!resp.ok) {
+			const text = await resp.text();
+			throw new Error(`Arena failed: ${resp.status} ${text}`);
+		}
+
+		const reader = resp.body?.getReader();
+		if (!reader) throw new Error("No readable stream");
+
+		const completion = await readSSEStream<StreamChunk>({
+			reader,
+			signal: abortCtrl.signal,
+			onChunk(chunk) {
+				const delta = chunk.choices?.[0]?.delta?.content;
+				if (delta) {
+					const clean = sanitizeDelta(delta);
+					setRounds(
+						produce((draft) => {
+							const mu = draft[roundIdx]?.matchups[matchupIdx];
+							if (mu) {
+								const respKey = slotKey === "A" ? "responseA" : "responseB";
+								const resp = mu[respKey] as ArenaResponse;
+								const newRaw = resp.rawContent + clean;
+								const extracted = extractThinking(newRaw);
+								const nextContent = extracted.content;
+								const nextThinking = extracted.thinking || resp.thinkingContent;
+								mu[respKey] = {
+									...resp,
+									rawContent: newRaw,
+									content: nextContent,
+									thinkingContent: nextThinking,
+								};
+							}
+						}),
+					);
+				}
+				const thinkingDelta =
+					chunk.choices?.[0]?.delta?.reasoning_content ??
+					chunk.choices?.[0]?.delta?.reasoning;
+				if (thinkingDelta) {
+					setRounds(
+						produce((draft) => {
+							if (draft[roundIdx]?.matchups[matchupIdx]) {
+								const mu = draft[roundIdx].matchups[matchupIdx];
+								const respKey = slotKey === "A" ? "responseA" : "responseB";
+								mu[respKey] = {
+									...(mu[respKey] as ArenaResponse),
+									thinkingContent:
+										(mu[respKey]?.thinkingContent ?? "") + thinkingDelta,
+								};
+							}
+						}),
+					);
+				}
+				if (chunk.usage) {
+					promptTokens = chunk.usage.prompt_tokens ?? 0;
+					completionTokens = chunk.usage.completion_tokens ?? 0;
+				}
+			},
+		});
+
+		const durationMs = performance.now() - startTime;
+		const tokensPerSecond =
+			completionTokens > 0 && durationMs > 0
+				? completionTokens / (durationMs / 1000)
+				: null;
+
+		const truncationError: string | null =
+			!completion.sawDone && !completion.aborted
+				? completion.idleTimeout
+					? t("chat.stream.stalledTimeout")
+					: t("chat.stream.cutoffIncomplete")
+				: null;
+
+		setRounds(
+			produce((draft) => {
+				if (draft[roundIdx]?.matchups[matchupIdx]) {
+					const mu = draft[roundIdx].matchups[matchupIdx];
+					const respKey = slotKey === "A" ? "responseA" : "responseB";
+					mu[respKey] = {
+						...(mu[respKey] as ArenaResponse),
+						done: true,
+						error: truncationError,
+						metrics: {
+							tokensPerSecond,
+							durationMs: Math.round(durationMs),
+							promptTokens,
+							completionTokens,
+						},
+					};
+				}
+			}),
+		);
+	} catch (err) {
+		const msg =
+			err instanceof Error ? err.message : t("chat.stream.unknownError");
+		const errorDurationMs = Math.round(performance.now() - startTime);
+		setRounds(
+			produce((draft) => {
+				if (draft[roundIdx]?.matchups[matchupIdx]) {
+					const mu = draft[roundIdx].matchups[matchupIdx];
+					const respKey = slotKey === "A" ? "responseA" : "responseB";
+					mu[respKey] = {
+						...(mu[respKey] as ArenaResponse),
+						done: true,
+						error: msg,
+						metrics: {
+							tokensPerSecond:
+								completionTokens > 0 && errorDurationMs > 0
+									? completionTokens / (errorDurationMs / 1000)
+									: null,
+							durationMs: errorDurationMs,
+							promptTokens,
+							completionTokens,
+						},
+					};
+				}
+			}),
+		);
+		if (mountedRef.current) {
+			toast(
+				t("hooks.useArenaRunner.generationError", { model, error: msg }),
+				"error",
+			);
+		}
+	} finally {
+		setRunningModels((prev) => {
+			const next = new Set(prev);
+			next.delete(model);
+			if (next.size === 0 && !abortCtrl.signal.aborted) {
+				setPhase(arenaModeRef.current === "compare" ? "finished" : "voting");
+			}
+			return next;
+		});
+		abortMapRef.current.delete(model);
+	}
+}

--- a/web/src/pages/Arena/useArenaRunner.ts
+++ b/web/src/pages/Arena/useArenaRunner.ts
@@ -1,16 +1,12 @@
 import { produce } from "immer";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { API_BASE, getAuthHeaders } from "../../api/client";
 import type { GenerationParams } from "../../api/types";
 import type { ArenaSubMode } from "../../context/SidebarModeContext";
 import type { useToast } from "../../context/ToastContext";
 import { proxyModelID } from "../../utils/model";
-import { hasAnyParam } from "../../utils/params";
-import { readSSEStream, type StreamChunk } from "../../utils/sse";
-import { fetchWithRetry } from "../../utils/stagger";
-import { extractThinking, sanitizeDelta } from "../../utils/thinking";
-import type { ArenaResponse, BracketRound } from "./types";
+import { streamArenaResponse } from "./streamModel";
+import type { BracketRound } from "./types";
 import {
 	collectSlots,
 	initMatchupResponses,
@@ -69,7 +65,6 @@ export interface ArenaRunner {
 	abortMapRef: React.RefObject<Map<string, AbortController>>;
 }
 
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this hook
 export function useArenaRunner(deps: ArenaRunnerDeps): ArenaRunner {
 	const {
 		arenaModeRef,
@@ -198,194 +193,28 @@ export function useArenaRunner(deps: ArenaRunnerDeps): ArenaRunner {
 			const abortCtrl = new AbortController();
 			abortMapRef.current.set(model, abortCtrl);
 
-			const run = async () => {
-				const startTime = performance.now();
-				let promptTokens = 0;
-				let completionTokens = 0;
-
-				const chatMessages: Array<{ role: string; content: string }> = [];
-				if (personaPrompt.trim()) {
-					chatMessages.push({ role: "system", content: personaPrompt.trim() });
-				}
-				chatMessages.push({ role: "user", content: userPrompt });
-
-				try {
-					const resp = await fetchWithRetry(
-						`${API_BASE}/api/chat/arena`,
-						{
-							method: "POST",
-							headers: getAuthHeaders(),
-							body: JSON.stringify({
-								model,
-								stream: true,
-								messages: chatMessages,
-								...(slotParams && hasAnyParam(slotParams) ? slotParams : {}),
-							}),
-							signal: abortCtrl.signal,
-						},
-						{
-							maxRetries: 2,
-							onRetry: (
-								attempt: number,
-								delayMs: number,
-								status?: number | string,
-							) => {
-								toast(
-									t("hooks.useArenaRunner.retry", {
-										model,
-										status: status || t("hooks.useArenaRunner.networkError"),
-										attempt,
-										delay: (delayMs / 1000).toFixed(1),
-									}),
-									"info",
-								);
-							},
-						},
-					);
-
-					if (!resp.ok) {
-						const text = await resp.text();
-						throw new Error(`Arena failed: ${resp.status} ${text}`);
-					}
-
-					const reader = resp.body?.getReader();
-					if (!reader) throw new Error("No readable stream");
-
-					const completion = await readSSEStream<StreamChunk>({
-						reader,
-						signal: abortCtrl.signal,
-						onChunk(chunk) {
-							const delta = chunk.choices?.[0]?.delta?.content;
-							if (delta) {
-								const clean = sanitizeDelta(delta);
-								setRounds(
-									produce((draft) => {
-										const mu = draft[roundIdx]?.matchups[matchupIdx];
-										if (mu) {
-											const respKey =
-												slotKey === "A" ? "responseA" : "responseB";
-											const resp = mu[respKey] as ArenaResponse;
-											const newRaw = resp.rawContent + clean;
-											const extracted = extractThinking(newRaw);
-											const nextContent = extracted.content;
-											const nextThinking =
-												extracted.thinking || resp.thinkingContent;
-											mu[respKey] = {
-												...resp,
-												rawContent: newRaw,
-												content: nextContent,
-												thinkingContent: nextThinking,
-											};
-										}
-									}),
-								);
-							}
-							const thinkingDelta =
-								chunk.choices?.[0]?.delta?.reasoning_content ??
-								chunk.choices?.[0]?.delta?.reasoning;
-							if (thinkingDelta) {
-								setRounds(
-									produce((draft) => {
-										if (draft[roundIdx]?.matchups[matchupIdx]) {
-											const mu = draft[roundIdx].matchups[matchupIdx];
-											const respKey =
-												slotKey === "A" ? "responseA" : "responseB";
-											mu[respKey] = {
-												...(mu[respKey] as ArenaResponse),
-												thinkingContent:
-													(mu[respKey]?.thinkingContent ?? "") + thinkingDelta,
-											};
-										}
-									}),
-								);
-							}
-							if (chunk.usage) {
-								promptTokens = chunk.usage.prompt_tokens ?? 0;
-								completionTokens = chunk.usage.completion_tokens ?? 0;
-							}
-						},
-					});
-
-					const durationMs = performance.now() - startTime;
-					const tokensPerSecond =
-						completionTokens > 0 && durationMs > 0
-							? completionTokens / (durationMs / 1000)
-							: null;
-
-					const truncationError: string | null =
-						!completion.sawDone && !completion.aborted
-							? completion.idleTimeout
-								? t("chat.stream.stalledTimeout")
-								: t("chat.stream.cutoffIncomplete")
-							: null;
-
-					setRounds(
-						produce((draft) => {
-							if (draft[roundIdx]?.matchups[matchupIdx]) {
-								const mu = draft[roundIdx].matchups[matchupIdx];
-								const respKey = slotKey === "A" ? "responseA" : "responseB";
-								mu[respKey] = {
-									...(mu[respKey] as ArenaResponse),
-									done: true,
-									error: truncationError,
-									metrics: {
-										tokensPerSecond,
-										durationMs: Math.round(durationMs),
-										promptTokens,
-										completionTokens,
-									},
-								};
-							}
-						}),
-					);
-				} catch (err) {
-					const msg =
-						err instanceof Error ? err.message : t("chat.stream.unknownError");
-					const errorDurationMs = Math.round(performance.now() - startTime);
-					setRounds(
-						produce((draft) => {
-							if (draft[roundIdx]?.matchups[matchupIdx]) {
-								const mu = draft[roundIdx].matchups[matchupIdx];
-								const respKey = slotKey === "A" ? "responseA" : "responseB";
-								mu[respKey] = {
-									...(mu[respKey] as ArenaResponse),
-									done: true,
-									error: msg,
-									metrics: {
-										tokensPerSecond:
-											completionTokens > 0 && errorDurationMs > 0
-												? completionTokens / (errorDurationMs / 1000)
-												: null,
-										durationMs: errorDurationMs,
-										promptTokens,
-										completionTokens,
-									},
-								};
-							}
-						}),
-					);
-					if (mountedRef.current) {
-						toast(
-							t("hooks.useArenaRunner.generationError", { model, error: msg }),
-							"error",
-						);
-					}
-				} finally {
-					setRunningModels((prev) => {
-						const next = new Set(prev);
-						next.delete(model);
-						if (next.size === 0 && !abortCtrl.signal.aborted) {
-							setPhase(
-								arenaModeRef.current === "compare" ? "finished" : "voting",
-							);
-						}
-						return next;
-					});
-					abortMapRef.current.delete(model);
-				}
-			};
-
-			run();
+			void streamArenaResponse(
+				{
+					t,
+					toast,
+					setRounds,
+					setPhase,
+					setRunningModels,
+					arenaModeRef,
+					abortMapRef,
+					mountedRef,
+				},
+				{
+					model,
+					personaPrompt,
+					userPrompt,
+					roundIdx,
+					slotKey,
+					matchupIdx,
+					slotParams,
+					abortCtrl,
+				},
+			);
 		},
 		[
 			t,

--- a/web/src/pages/Arena/useArenaRunner.ts
+++ b/web/src/pages/Arena/useArenaRunner.ts
@@ -89,7 +89,8 @@ export function useArenaRunner(deps: ArenaRunnerDeps): ArenaRunner {
 	// React state: a late setState throws under jsdom teardown ("window is not
 	// defined") and leaks work in production. Flip a mounted flag on unmount,
 	// abort every in-flight request, and gate the setters through it so the
-	// streaming body below never dispatches into a dead tree.
+	// streaming body in streamModel.ts, which receives them on its context,
+	// never dispatches into a dead tree.
 	const mountedRef = useRef(true);
 	useEffect(() => {
 		// abortMapRef.current is stable for the component's lifetime (the Map is

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,15 +4,12 @@ import {
 	Activity,
 	AlertTriangle,
 	ArrowUpRight,
-	Bot,
 	Clock,
 	Gauge as GaugeIcon,
 	Hash,
 	LayoutDashboard,
-	PlugZap,
 	RefreshCw,
 	ShieldAlert,
-	Target,
 	Timer,
 } from "@/lib/icons";
 import { api } from "../api/client";
@@ -20,12 +17,12 @@ import { FilterDropdown } from "../components/FilterDropdown";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { PageHeader } from "../components/PageHeader";
 import { useIdentity } from "../context/IdentityContext";
-import { formatCompact, formatTokens, formatWithCommas } from "../utils/format";
+import { formatCompact, formatTokens } from "../utils/format";
 import { Gauge } from "./Dashboard/Gauge";
 import { GaugeModal } from "./Dashboard/GaugeModal";
 import { ProviderDoughnut } from "./Dashboard/ProviderDoughnut";
 import { ProviderLatencyPanel } from "./Dashboard/ProviderLatencyPanel";
-import { StatCard } from "./Dashboard/StatCard";
+import { StatCardsRow } from "./Dashboard/StatCardsRow";
 import { TimeSeriesChart } from "./Dashboard/TimeSeriesChart";
 import { MetricToggle, RangeToggle } from "./Dashboard/ToggleGroup";
 import { TokenSplitBar } from "./Dashboard/TokenSplitBar";
@@ -36,7 +33,6 @@ import { ModelDetailModal } from "./Models/ModelDetailModal";
 /* =====================================================
    DASHBOARD
    ===================================================== */
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this page
 export function Dashboard() {
 	const { t } = useTranslation();
 	// Owner filter is admin-only: non-admins are already server-scoped to
@@ -312,88 +308,22 @@ export function Dashboard() {
 					</div>
 				}
 			/>
-			{/* Stat cards. The provider/model pills count what the proxy can serve
-			    right now: enabled providers, and models that are enabled AND whose
-			    provider is enabled (the /v1/models rule the Models page title uses).
-			    That subsumes the excludeDeleted pre-filter in useDashboard, which
-			    still matters for the other queries riding the same flag. */}
-
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
-				<StatCard
-					label={t("dashboard.stats.totalProviders")}
-					value={providers?.filter((p) => p.enabled).length ?? 0}
-					icon={PlugZap}
-					accent={accents.providers}
-					loading={providersLoading}
-				/>
-				<StatCard
-					label={t("dashboard.stats.totalModels")}
-					value={
-						models?.filter((m) => m.enabled && m.provider_enabled).length ?? 0
-					}
-					icon={Bot}
-					accent={accents.models}
-					loading={modelsLoading}
-				/>
-				<StatCard
-					label={t("dashboard.chart.requestsOver", { range: rangeLabel })}
-					value={
-						globalRange === "1h"
-							? stats?.requests_last_1h || 0
-							: globalRange === "24h"
-								? stats?.total_requests_last_24h || 0
-								: stats?.total_requests_last_7d || 0
-					}
-					icon={Activity}
-					accent={accents.requests}
-					formatter={formatWithCommas}
-					onClick={() => setRequestsModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewRequestHistory")}
-				/>
-				<StatCard
-					label={t("dashboard.chart.errorRateOver", { range: rangeLabel })}
-					value={(stats?.error_rate || 0) * 100}
-					decimals={1}
-					suffix="%"
-					icon={AlertTriangle}
-					accent={accents.errors}
-					onClick={() => setErrorModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewErrorRateHistory")}
-				/>
-				<StatCard
-					label={t("dashboard.chart.avgDurationOver", { range: rangeLabel })}
-					value={(stats?.avg_latency_ms || 0) / 1000}
-					decimals={1}
-					suffix="s"
-					icon={Clock}
-					accent={accents.latency}
-					onClick={() => setLatencyModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewDurationHistory")}
-				/>
-				<StatCard
-					label={
-						globalMetric === "tokens"
-							? t("dashboard.stats.totalTokens", { range: rangeLabel })
-							: t("dashboard.stats.avgTokensPerReq")
-					}
-					value={
-						globalMetric === "tokens"
-							? totalTokens
-							: stats?.avg_tokens_per_request || 0
-					}
-					decimals={0}
-					suffix={
-						globalMetric === "tokens"
-							? ""
-							: t("dashboard.label.requestsPerQuery")
-					}
-					icon={globalMetric === "tokens" ? Hash : Target}
-					accent={accents.tokens}
-					formatter={globalMetric === "tokens" ? formatCompact : undefined}
-					onClick={() => setTokensModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewTokenHistory")}
-				/>
-			</div>
+			<StatCardsRow
+				globalRange={globalRange}
+				globalMetric={globalMetric}
+				rangeLabel={rangeLabel}
+				totalTokens={totalTokens}
+				accents={accents}
+				stats={stats}
+				models={models}
+				providers={providers}
+				modelsLoading={modelsLoading}
+				providersLoading={providersLoading}
+				setRequestsModalOpen={setRequestsModalOpen}
+				setErrorModalOpen={setErrorModalOpen}
+				setLatencyModalOpen={setLatencyModalOpen}
+				setTokensModalOpen={setTokensModalOpen}
+			/>
 
 			{/* Time-series charts row - selected metric renders first */}
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/web/src/pages/Dashboard/StatCardsRow.tsx
+++ b/web/src/pages/Dashboard/StatCardsRow.tsx
@@ -1,0 +1,137 @@
+import { useTranslation } from "react-i18next";
+import {
+	Activity,
+	AlertTriangle,
+	Bot,
+	Clock,
+	Hash,
+	PlugZap,
+	Target,
+} from "@/lib/icons";
+import { formatCompact, formatWithCommas } from "../../utils/format";
+import { StatCard } from "./StatCard";
+import type { UseDashboardReturn } from "./useDashboard";
+
+type StatCardsRowProps = Pick<
+	UseDashboardReturn,
+	| "globalRange"
+	| "globalMetric"
+	| "rangeLabel"
+	| "totalTokens"
+	| "accents"
+	| "stats"
+	| "models"
+	| "providers"
+	| "modelsLoading"
+	| "providersLoading"
+	| "setRequestsModalOpen"
+	| "setErrorModalOpen"
+	| "setLatencyModalOpen"
+	| "setTokensModalOpen"
+>;
+
+/** The six headline tiles under the dashboard header. */
+export function StatCardsRow({
+	globalRange,
+	globalMetric,
+	rangeLabel,
+	totalTokens,
+	accents,
+	stats,
+	models,
+	providers,
+	modelsLoading,
+	providersLoading,
+	setRequestsModalOpen,
+	setErrorModalOpen,
+	setLatencyModalOpen,
+	setTokensModalOpen,
+}: StatCardsRowProps) {
+	const { t } = useTranslation();
+	return (
+		<>
+			{/* Stat cards. The provider/model pills count what the proxy can serve
+		    right now: enabled providers, and models that are enabled AND whose
+		    provider is enabled (the /v1/models rule the Models page title uses).
+		    That subsumes the excludeDeleted pre-filter in useDashboard, which
+		    still matters for the other queries riding the same flag. */}
+
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+				<StatCard
+					label={t("dashboard.stats.totalProviders")}
+					value={providers?.filter((p) => p.enabled).length ?? 0}
+					icon={PlugZap}
+					accent={accents.providers}
+					loading={providersLoading}
+				/>
+				<StatCard
+					label={t("dashboard.stats.totalModels")}
+					value={
+						models?.filter((m) => m.enabled && m.provider_enabled).length ?? 0
+					}
+					icon={Bot}
+					accent={accents.models}
+					loading={modelsLoading}
+				/>
+				<StatCard
+					label={t("dashboard.chart.requestsOver", { range: rangeLabel })}
+					value={
+						globalRange === "1h"
+							? stats?.requests_last_1h || 0
+							: globalRange === "24h"
+								? stats?.total_requests_last_24h || 0
+								: stats?.total_requests_last_7d || 0
+					}
+					icon={Activity}
+					accent={accents.requests}
+					formatter={formatWithCommas}
+					onClick={() => setRequestsModalOpen(true)}
+					tooltip={t("dashboard.gauge.viewRequestHistory")}
+				/>
+				<StatCard
+					label={t("dashboard.chart.errorRateOver", { range: rangeLabel })}
+					value={(stats?.error_rate || 0) * 100}
+					decimals={1}
+					suffix="%"
+					icon={AlertTriangle}
+					accent={accents.errors}
+					onClick={() => setErrorModalOpen(true)}
+					tooltip={t("dashboard.gauge.viewErrorRateHistory")}
+				/>
+				<StatCard
+					label={t("dashboard.chart.avgDurationOver", { range: rangeLabel })}
+					value={(stats?.avg_latency_ms || 0) / 1000}
+					decimals={1}
+					suffix="s"
+					icon={Clock}
+					accent={accents.latency}
+					onClick={() => setLatencyModalOpen(true)}
+					tooltip={t("dashboard.gauge.viewDurationHistory")}
+				/>
+				<StatCard
+					label={
+						globalMetric === "tokens"
+							? t("dashboard.stats.totalTokens", { range: rangeLabel })
+							: t("dashboard.stats.avgTokensPerReq")
+					}
+					value={
+						globalMetric === "tokens"
+							? totalTokens
+							: stats?.avg_tokens_per_request || 0
+					}
+					decimals={0}
+					suffix={
+						globalMetric === "tokens"
+							? ""
+							: t("dashboard.label.requestsPerQuery")
+					}
+					icon={globalMetric === "tokens" ? Hash : Target}
+					accent={accents.tokens}
+					formatter={globalMetric === "tokens" ? formatCompact : undefined}
+					onClick={() => setTokensModalOpen(true)}
+					tooltip={t("dashboard.gauge.viewTokenHistory")}
+				/>
+			</div>
+		</>
+	);
+}

--- a/web/src/pages/Dashboard/StatCardsRow.tsx
+++ b/web/src/pages/Dashboard/StatCardsRow.tsx
@@ -48,90 +48,85 @@ export function StatCardsRow({
 	setTokensModalOpen,
 }: StatCardsRowProps) {
 	const { t } = useTranslation();
+	// The provider/model pills count what the proxy can serve right now:
+	// enabled providers, and models that are enabled AND whose provider is
+	// enabled (the /v1/models rule the Models page title uses). That subsumes
+	// the excludeDeleted pre-filter in useDashboard, which still matters for
+	// the other queries riding the same flag.
 	return (
-		<>
-			{/* Stat cards. The provider/model pills count what the proxy can serve
-		    right now: enabled providers, and models that are enabled AND whose
-		    provider is enabled (the /v1/models rule the Models page title uses).
-		    That subsumes the excludeDeleted pre-filter in useDashboard, which
-		    still matters for the other queries riding the same flag. */}
-
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
-				<StatCard
-					label={t("dashboard.stats.totalProviders")}
-					value={providers?.filter((p) => p.enabled).length ?? 0}
-					icon={PlugZap}
-					accent={accents.providers}
-					loading={providersLoading}
-				/>
-				<StatCard
-					label={t("dashboard.stats.totalModels")}
-					value={
-						models?.filter((m) => m.enabled && m.provider_enabled).length ?? 0
-					}
-					icon={Bot}
-					accent={accents.models}
-					loading={modelsLoading}
-				/>
-				<StatCard
-					label={t("dashboard.chart.requestsOver", { range: rangeLabel })}
-					value={
-						globalRange === "1h"
-							? stats?.requests_last_1h || 0
-							: globalRange === "24h"
-								? stats?.total_requests_last_24h || 0
-								: stats?.total_requests_last_7d || 0
-					}
-					icon={Activity}
-					accent={accents.requests}
-					formatter={formatWithCommas}
-					onClick={() => setRequestsModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewRequestHistory")}
-				/>
-				<StatCard
-					label={t("dashboard.chart.errorRateOver", { range: rangeLabel })}
-					value={(stats?.error_rate || 0) * 100}
-					decimals={1}
-					suffix="%"
-					icon={AlertTriangle}
-					accent={accents.errors}
-					onClick={() => setErrorModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewErrorRateHistory")}
-				/>
-				<StatCard
-					label={t("dashboard.chart.avgDurationOver", { range: rangeLabel })}
-					value={(stats?.avg_latency_ms || 0) / 1000}
-					decimals={1}
-					suffix="s"
-					icon={Clock}
-					accent={accents.latency}
-					onClick={() => setLatencyModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewDurationHistory")}
-				/>
-				<StatCard
-					label={
-						globalMetric === "tokens"
-							? t("dashboard.stats.totalTokens", { range: rangeLabel })
-							: t("dashboard.stats.avgTokensPerReq")
-					}
-					value={
-						globalMetric === "tokens"
-							? totalTokens
-							: stats?.avg_tokens_per_request || 0
-					}
-					decimals={0}
-					suffix={
-						globalMetric === "tokens"
-							? ""
-							: t("dashboard.label.requestsPerQuery")
-					}
-					icon={globalMetric === "tokens" ? Hash : Target}
-					accent={accents.tokens}
-					formatter={globalMetric === "tokens" ? formatCompact : undefined}
-					onClick={() => setTokensModalOpen(true)}
-					tooltip={t("dashboard.gauge.viewTokenHistory")}
-				/>
-			</div>
-		</>
+		<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+			<StatCard
+				label={t("dashboard.stats.totalProviders")}
+				value={providers?.filter((p) => p.enabled).length ?? 0}
+				icon={PlugZap}
+				accent={accents.providers}
+				loading={providersLoading}
+			/>
+			<StatCard
+				label={t("dashboard.stats.totalModels")}
+				value={
+					models?.filter((m) => m.enabled && m.provider_enabled).length ?? 0
+				}
+				icon={Bot}
+				accent={accents.models}
+				loading={modelsLoading}
+			/>
+			<StatCard
+				label={t("dashboard.chart.requestsOver", { range: rangeLabel })}
+				value={
+					globalRange === "1h"
+						? stats?.requests_last_1h || 0
+						: globalRange === "24h"
+							? stats?.total_requests_last_24h || 0
+							: stats?.total_requests_last_7d || 0
+				}
+				icon={Activity}
+				accent={accents.requests}
+				formatter={formatWithCommas}
+				onClick={() => setRequestsModalOpen(true)}
+				tooltip={t("dashboard.gauge.viewRequestHistory")}
+			/>
+			<StatCard
+				label={t("dashboard.chart.errorRateOver", { range: rangeLabel })}
+				value={(stats?.error_rate || 0) * 100}
+				decimals={1}
+				suffix="%"
+				icon={AlertTriangle}
+				accent={accents.errors}
+				onClick={() => setErrorModalOpen(true)}
+				tooltip={t("dashboard.gauge.viewErrorRateHistory")}
+			/>
+			<StatCard
+				label={t("dashboard.chart.avgDurationOver", { range: rangeLabel })}
+				value={(stats?.avg_latency_ms || 0) / 1000}
+				decimals={1}
+				suffix="s"
+				icon={Clock}
+				accent={accents.latency}
+				onClick={() => setLatencyModalOpen(true)}
+				tooltip={t("dashboard.gauge.viewDurationHistory")}
+			/>
+			<StatCard
+				label={
+					globalMetric === "tokens"
+						? t("dashboard.stats.totalTokens", { range: rangeLabel })
+						: t("dashboard.stats.avgTokensPerReq")
+				}
+				value={
+					globalMetric === "tokens"
+						? totalTokens
+						: stats?.avg_tokens_per_request || 0
+				}
+				decimals={0}
+				suffix={
+					globalMetric === "tokens" ? "" : t("dashboard.label.requestsPerQuery")
+				}
+				icon={globalMetric === "tokens" ? Hash : Target}
+				accent={accents.tokens}
+				formatter={globalMetric === "tokens" ? formatCompact : undefined}
+				onClick={() => setTokensModalOpen(true)}
+				tooltip={t("dashboard.gauge.viewTokenHistory")}
+			/>
+		</div>
 	);
 }

--- a/web/src/pages/Dashboard/useDashboard.ts
+++ b/web/src/pages/Dashboard/useDashboard.ts
@@ -11,13 +11,11 @@ import type {
 	TimeSeriesStats,
 } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
-import {
-	useLocalStorage,
-	useLocalStorageValue,
-} from "../../hooks/useLocalStorage";
+import { useLocalStorageValue } from "../../hooks/useLocalStorage";
 import { proxyModelID } from "../../utils/model";
 import { bucketLabel } from "./bucketLabel";
 import type { Range } from "./types";
+import { useDashboardRanges } from "./useDashboardRanges";
 
 /** Synthetic virtual_key_name values the backend meters under its own routes
  * (admin chat/arena and internal model requests) plus the reserved names users
@@ -184,120 +182,41 @@ export interface UseDashboardReturn {
 	};
 }
 
-const VALID_RANGES: ReadonlySet<Range> = new Set(["1h", "24h", "1w"]);
-const VALID_METRICS: ReadonlySet<MetricType> = new Set(["tokens", "requests"]);
-
 // toApiPeriod maps the frontend Range value to the backend period query param.
 // "1w" is shown in the UI but the backend expects "7d".
 const toApiPeriod = (r: Range): string => (r === "1w" ? "7d" : r);
-const deserializeRange = (stored: string, fallback: Range): Range =>
-	VALID_RANGES.has(stored as Range) ? (stored as Range) : fallback;
-const deserializeMetric = (stored: string, fallback: MetricType): MetricType =>
-	VALID_METRICS.has(stored as MetricType) ? (stored as MetricType) : fallback;
 
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this hook
 export function useDashboard(): UseDashboardReturn {
-	// Global state with localStorage persistence
-	const [globalRange, setGlobalRange] = useLocalStorage<Range>(
-		"dashboardRange",
-		"24h",
-		{ deserialize: deserializeRange },
-	);
-	const [globalMetric, setGlobalMetric] = useLocalStorage<MetricType>(
-		"dashboardMetric",
-		"tokens",
-		{ deserialize: deserializeMetric },
-	);
+	const {
+		globalRange,
+		setGlobalRange,
+		globalMetric,
+		setGlobalMetric,
+		requestsChartRange,
+		setRequestsChartRange,
+		tokensChartRange,
+		setTokensChartRange,
+		doughnutRange,
+		setDoughnutRange,
+		doughnutMetric,
+		setDoughnutMetric,
+		tokenRange,
+		setTokenRange,
+		modelsRange,
+		setModelsRange,
+		modelsMetric,
+		setModelsMetric,
+		latencyRange,
+		setLatencyRange,
+		virtualKeysRange,
+		setVirtualKeysRange,
+		virtualKeysMetric,
+		setVirtualKeysMetric,
+	} = useDashboardRanges();
 	const [excludeDeleted, setExcludeDeleted] = useState(false);
 	// Admin-only owner filter; rides every stats query like excludeDeleted.
 	const [ownerUserID, setOwnerUserID] = useState("");
 	const scoped = { ownerUserID: ownerUserID || undefined };
-
-	// Per-section local states: persisted in localStorage, synced from global
-	// header toggles when those change.
-	const [requestsChartRange, setRequestsChartRange] = useLocalStorage<Range>(
-		"dashboard.requestsChartRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [tokensChartRange, setTokensChartRange] = useLocalStorage<Range>(
-		"dashboard.tokensChartRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [doughnutRange, setDoughnutRange] = useLocalStorage<Range>(
-		"dashboard.doughnutRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [doughnutMetric, setDoughnutMetric] = useLocalStorage<MetricType>(
-		"dashboard.doughnutMetric",
-		globalMetric,
-		{ deserialize: deserializeMetric },
-	);
-	const [tokenRange, setTokenRange] = useLocalStorage<Range>(
-		"dashboard.tokenRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [modelsRange, setModelsRange] = useLocalStorage<Range>(
-		"dashboard.modelsRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [modelsMetric, setModelsMetric] = useLocalStorage<MetricType>(
-		"dashboard.modelsMetric",
-		globalMetric,
-		{ deserialize: deserializeMetric },
-	);
-	const [latencyRange, setLatencyRange] = useLocalStorage<Range>(
-		"dashboard.latencyRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [virtualKeysRange, setVirtualKeysRange] = useLocalStorage<Range>(
-		"dashboard.virtualKeysRange",
-		globalRange,
-		{ deserialize: deserializeRange },
-	);
-	const [virtualKeysMetric, setVirtualKeysMetric] = useLocalStorage<MetricType>(
-		"dashboard.virtualKeysMetric",
-		globalMetric,
-		{ deserialize: deserializeMetric },
-	);
-
-	// Sync locals when global header toggles change
-	const prevGlobalRangeRef = useRef(globalRange);
-	const prevGlobalMetricRef = useRef(globalMetric);
-	useEffect(() => {
-		if (prevGlobalRangeRef.current !== globalRange) {
-			prevGlobalRangeRef.current = globalRange;
-			setRequestsChartRange(globalRange);
-			setTokensChartRange(globalRange);
-			setDoughnutRange(globalRange);
-			setTokenRange(globalRange);
-			setModelsRange(globalRange);
-			setLatencyRange(globalRange);
-			setVirtualKeysRange(globalRange);
-		}
-	}, [
-		globalRange,
-		setRequestsChartRange,
-		setTokensChartRange,
-		setDoughnutRange,
-		setTokenRange,
-		setModelsRange,
-		setLatencyRange,
-		setVirtualKeysRange,
-	]);
-	useEffect(() => {
-		if (prevGlobalMetricRef.current !== globalMetric) {
-			prevGlobalMetricRef.current = globalMetric;
-			setDoughnutMetric(globalMetric);
-			setModelsMetric(globalMetric);
-			setVirtualKeysMetric(globalMetric);
-		}
-	}, [globalMetric, setDoughnutMetric, setModelsMetric, setVirtualKeysMetric]);
 
 	// Modal states
 	const [overheadModalOpen, setOverheadModalOpen] = useState(false);

--- a/web/src/pages/Dashboard/useDashboardRanges.ts
+++ b/web/src/pages/Dashboard/useDashboardRanges.ts
@@ -1,0 +1,143 @@
+import { useEffect, useRef } from "react";
+import type { MetricType } from "../../api/types";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
+import type { Range } from "./types";
+
+const VALID_RANGES: ReadonlySet<Range> = new Set(["1h", "24h", "1w"]);
+const VALID_METRICS: ReadonlySet<MetricType> = new Set(["tokens", "requests"]);
+
+const deserializeRange = (stored: string, fallback: Range): Range =>
+	VALID_RANGES.has(stored as Range) ? (stored as Range) : fallback;
+const deserializeMetric = (stored: string, fallback: MetricType): MetricType =>
+	VALID_METRICS.has(stored as MetricType) ? (stored as MetricType) : fallback;
+
+/**
+ * The dashboard's time-range and metric selections: a global pair driven by
+ * the page header plus one persisted pair per section. Sections follow the
+ * header whenever it changes and otherwise keep whatever the user picked.
+ */
+export function useDashboardRanges() {
+	// Global header toggles, persisted.
+	const [globalRange, setGlobalRange] = useLocalStorage<Range>(
+		"dashboardRange",
+		"24h",
+		{ deserialize: deserializeRange },
+	);
+	const [globalMetric, setGlobalMetric] = useLocalStorage<MetricType>(
+		"dashboardMetric",
+		"tokens",
+		{ deserialize: deserializeMetric },
+	);
+	// Per-section local states: persisted in localStorage, synced from global
+	// header toggles when those change.
+	const [requestsChartRange, setRequestsChartRange] = useLocalStorage<Range>(
+		"dashboard.requestsChartRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [tokensChartRange, setTokensChartRange] = useLocalStorage<Range>(
+		"dashboard.tokensChartRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [doughnutRange, setDoughnutRange] = useLocalStorage<Range>(
+		"dashboard.doughnutRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [doughnutMetric, setDoughnutMetric] = useLocalStorage<MetricType>(
+		"dashboard.doughnutMetric",
+		globalMetric,
+		{ deserialize: deserializeMetric },
+	);
+	const [tokenRange, setTokenRange] = useLocalStorage<Range>(
+		"dashboard.tokenRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [modelsRange, setModelsRange] = useLocalStorage<Range>(
+		"dashboard.modelsRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [modelsMetric, setModelsMetric] = useLocalStorage<MetricType>(
+		"dashboard.modelsMetric",
+		globalMetric,
+		{ deserialize: deserializeMetric },
+	);
+	const [latencyRange, setLatencyRange] = useLocalStorage<Range>(
+		"dashboard.latencyRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [virtualKeysRange, setVirtualKeysRange] = useLocalStorage<Range>(
+		"dashboard.virtualKeysRange",
+		globalRange,
+		{ deserialize: deserializeRange },
+	);
+	const [virtualKeysMetric, setVirtualKeysMetric] = useLocalStorage<MetricType>(
+		"dashboard.virtualKeysMetric",
+		globalMetric,
+		{ deserialize: deserializeMetric },
+	);
+
+	// Sync locals when global header toggles change
+	const prevGlobalRangeRef = useRef(globalRange);
+	const prevGlobalMetricRef = useRef(globalMetric);
+	useEffect(() => {
+		if (prevGlobalRangeRef.current !== globalRange) {
+			prevGlobalRangeRef.current = globalRange;
+			setRequestsChartRange(globalRange);
+			setTokensChartRange(globalRange);
+			setDoughnutRange(globalRange);
+			setTokenRange(globalRange);
+			setModelsRange(globalRange);
+			setLatencyRange(globalRange);
+			setVirtualKeysRange(globalRange);
+		}
+	}, [
+		globalRange,
+		setRequestsChartRange,
+		setTokensChartRange,
+		setDoughnutRange,
+		setTokenRange,
+		setModelsRange,
+		setLatencyRange,
+		setVirtualKeysRange,
+	]);
+	useEffect(() => {
+		if (prevGlobalMetricRef.current !== globalMetric) {
+			prevGlobalMetricRef.current = globalMetric;
+			setDoughnutMetric(globalMetric);
+			setModelsMetric(globalMetric);
+			setVirtualKeysMetric(globalMetric);
+		}
+	}, [globalMetric, setDoughnutMetric, setModelsMetric, setVirtualKeysMetric]);
+
+	return {
+		globalRange,
+		setGlobalRange,
+		globalMetric,
+		setGlobalMetric,
+		requestsChartRange,
+		setRequestsChartRange,
+		tokensChartRange,
+		setTokensChartRange,
+		doughnutRange,
+		setDoughnutRange,
+		doughnutMetric,
+		setDoughnutMetric,
+		tokenRange,
+		setTokenRange,
+		modelsRange,
+		setModelsRange,
+		modelsMetric,
+		setModelsMetric,
+		latencyRange,
+		setLatencyRange,
+		virtualKeysRange,
+		setVirtualKeysRange,
+		virtualKeysMetric,
+		setVirtualKeysMetric,
+	};
+}

--- a/web/src/pages/Dashboard/useDashboardRanges.ts
+++ b/web/src/pages/Dashboard/useDashboardRanges.ts
@@ -13,8 +13,9 @@ const deserializeMetric = (stored: string, fallback: MetricType): MetricType =>
 
 /**
  * The dashboard's time-range and metric selections: a global pair driven by
- * the page header plus one persisted pair per section. Sections follow the
- * header whenever it changes and otherwise keep whatever the user picked.
+ * the page header plus a persisted range per section, and a metric for the
+ * sections that have one. Sections follow the header whenever it changes and
+ * otherwise keep whatever the user picked.
  */
 export function useDashboardRanges() {
 	// Global header toggles, persisted.

--- a/web/src/pages/Security/index.tsx
+++ b/web/src/pages/Security/index.tsx
@@ -2,10 +2,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, Copy, Download, ShieldCheck, X } from "@/lib/icons";
+import { Copy, ShieldCheck, X } from "@/lib/icons";
 import { ApiError, api, clearAuth } from "../../api/client";
-import { CopyButton } from "../../components/CopyButton";
 import { PageHeader } from "../../components/PageHeader";
+import { TotpRecoveryCodes } from "../../components/TotpRecoveryCodes";
 import { useToast } from "../../context/ToastContext";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatDate } from "../../utils/format";
@@ -19,7 +19,6 @@ import { isBreachedPasswordError } from "../../utils/passwordPolicy";
  * session the caller already holds. Reuses the settings.totp.* strings so the
  * two panels stay word-for-word consistent across locales.
  */
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this page
 export function Security() {
 	const { t } = useTranslation();
 	const { toast } = useToast();
@@ -137,20 +136,6 @@ export function Security() {
 		else toast(t("common.failedToCopy"), "error");
 	};
 
-	const handleDownloadCodes = () => {
-		const blob = new Blob([`${recoveryCodes.join("\n")}\n`], {
-			type: "text/plain",
-		});
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement("a");
-		a.href = url;
-		a.download = "model-hotel-totp-recovery-codes.txt";
-		document.body.appendChild(a);
-		a.click();
-		a.remove();
-		URL.revokeObjectURL(url);
-	};
-
 	const passwordMutation = useMutation({
 		mutationFn: () => api.userTotp.changePassword(currentPassword, newPassword),
 		onSuccess: () => {
@@ -203,57 +188,11 @@ export function Security() {
 	let body: React.ReactNode;
 	if (showRecovery && recoveryCodes.length > 0) {
 		body = (
-			<div className="space-y-4">
-				<div className="ui-callout ui-callout-warning">
-					<p className="font-medium">
-						{t("settings.totp.recoveryCodesWarning")}
-					</p>
-				</div>
-				<div>
-					<div className="flex items-center justify-between mb-2">
-						<h3 className="text-sm font-medium text-(--text-primary)">
-							{t("settings.totp.recoveryCodes")}
-						</h3>
-						<CopyButton
-							text={recoveryCodes.join("\n")}
-							size={16}
-							title={t("settings.totp.copyAll")}
-							toastType="success"
-						/>
-					</div>
-					<div className="p-3 bg-(--surface-elevated) rounded-[var(--radius-card,0.375rem)] border border-(--border-default)">
-						<div className="font-mono text-sm space-y-1">
-							{recoveryCodes.map((code) => (
-								<div key={code} className="text-(--text-primary) break-all">
-									{code}
-								</div>
-							))}
-						</div>
-					</div>
-				</div>
-				<div className="flex flex-wrap gap-2">
-					<button
-						type="button"
-						onClick={handleDownloadCodes}
-						className="ui-btn ui-btn-secondary"
-						aria-label={t("settings.totp.downloadCodesAriaLabel")}
-						data-testid="security-download-codes"
-					>
-						<Download size={16} />
-						{t("settings.totp.downloadCodes")}
-					</button>
-					<button
-						type="button"
-						onClick={handleSavedRecoveryCodes}
-						className="ui-btn ui-btn-primary"
-						aria-label={t("settings.totp.savedAriaLabel")}
-						data-testid="security-saved-codes"
-					>
-						<Check size={16} />
-						{t("settings.totp.saved")}
-					</button>
-				</div>
-			</div>
+			<TotpRecoveryCodes
+				codes={recoveryCodes}
+				onSaved={handleSavedRecoveryCodes}
+				testIdPrefix="security"
+			/>
 		);
 	} else if (enrollUri) {
 		body = (

--- a/web/src/pages/Settings/AlertsSettings.tsx
+++ b/web/src/pages/Settings/AlertsSettings.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Bell, ChevronDown, ChevronRight, RefreshCw } from "@/lib/icons";
+import { Bell, ChevronDown, ChevronRight } from "@/lib/icons";
 import { ApiError, api } from "../../api/client";
 import { ResetButton } from "../../components/ResetButton";
 import { SettingsSection } from "../../components/SettingsSection";
@@ -11,26 +11,14 @@ import { useToast } from "../../context/ToastContext";
 import { AlertEventPicker } from "./AlertEventPicker";
 import { AlertSnippets } from "./AlertSnippets";
 import { AlertsWizard } from "./alerts/AlertsWizard";
-import { stripApiHead } from "./alerts/apiText";
+import { AppriseStatus } from "./alerts/AppriseStatus";
+import { REASON_CODES, stripApiHead } from "./alerts/apiText";
 import { DestinationList } from "./alerts/DestinationList";
 import { SETTING_DEFAULTS } from "./defaults";
 import {
 	invalidateAlertReads,
 	useSettingsMutations,
 } from "./useSettingsMutations";
-
-// The stable failure codes the alert endpoints report: /api/alert/test with a
-// 502 and the reachability probe in AlertStatus.reason. Anything outside this
-// set falls back to a generic error, so no server internals reach the screen.
-const REASON_CODES = new Set([
-	"not_configured",
-	"invalid_url",
-	"unreachable",
-	"unhealthy",
-	"apprise_reject",
-	"deliver_failed",
-	"undecryptable",
-]);
 
 interface AlertsSettingsProps {
 	collapsed: boolean;
@@ -39,7 +27,6 @@ interface AlertsSettingsProps {
 	managed?: boolean;
 }
 
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function AlertsSettings({
 	collapsed,
 	onToggle,
@@ -264,31 +251,6 @@ export function AlertsSettings({
 					),
 				);
 
-	const status = statusQuery.data;
-	const statusDotColor =
-		status?.reachable && status.healthy
-			? "var(--success-text)"
-			: status?.reachable
-				? "var(--warning-text)"
-				: "var(--error-text)";
-	const statusText =
-		status?.reachable && status.healthy
-			? t("settings.alerts.status.reachable")
-			: status?.reachable
-				? t("settings.alerts.status.issues")
-				: t("settings.alerts.status.unreachable");
-	// The reason code is the translated, actionable half of the probe result; the
-	// detail is raw server text (English, sometimes an HTTP status). The note
-	// therefore carries the reason and keeps the detail as the tooltip, where an
-	// operator who wants the literal answer can still find it.
-	const statusReason =
-		status &&
-		(!status.reachable || !status.healthy) &&
-		status.reason &&
-		REASON_CODES.has(status.reason)
-			? t(`settings.alerts.reason.${status.reason}`)
-			: "";
-
 	return (
 		<SettingsSection
 			icon={Bell}
@@ -424,59 +386,7 @@ export function AlertsSettings({
 							<p className="text-sm font-medium text-(--text-secondary)">
 								{t("settings.alerts.destinations.title")}
 							</p>
-							{apiUrl !== "" && (
-								<div
-									className="flex items-center gap-2 text-xs"
-									data-testid="alert-status"
-								>
-									{statusQuery.isFetching ? (
-										<span className="inline-flex items-center gap-1.5 text-(--text-muted)">
-											<RefreshCw size={12} className="animate-spin" />
-											{t("settings.alerts.status.checking")}
-										</span>
-									) : statusQuery.isError ? (
-										<span className="inline-flex items-center gap-1.5 text-(--text-secondary)">
-											<span
-												className="inline-block w-2 h-2 rounded-full"
-												style={{ background: "var(--error-text)" }}
-												aria-hidden="true"
-											/>
-											{t("settings.alerts.status.checkFailed")}
-										</span>
-									) : status ? (
-										<>
-											<span
-												className="inline-flex items-center gap-1.5 text-(--text-secondary)"
-												title={status.detail}
-											>
-												<span
-													className="inline-block w-2 h-2 rounded-full"
-													style={{ background: statusDotColor }}
-													aria-hidden="true"
-												/>
-												{statusText}
-											</span>
-											{statusReason !== "" && (
-												<span
-													className="text-(--text-secondary)"
-													data-testid="alert-status-note"
-												>
-													{statusReason}
-												</span>
-											)}
-										</>
-									) : null}
-									<button
-										type="button"
-										className="ui-link-accent inline-flex items-center gap-1"
-										onClick={() => statusQuery.refetch()}
-										data-testid="alert-status-recheck"
-									>
-										<RefreshCw size={11} />
-										{t("settings.alerts.status.recheck")}
-									</button>
-								</div>
-							)}
+							{apiUrl !== "" && <AppriseStatus statusQuery={statusQuery} />}
 						</div>
 						<p className="text-xs text-(--text-muted)">
 							{t("settings.alerts.destinations.note")}

--- a/web/src/pages/Settings/TotpSettings.tsx
+++ b/web/src/pages/Settings/TotpSettings.tsx
@@ -2,9 +2,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, Copy, Download, X } from "@/lib/icons";
+import { Copy, X } from "@/lib/icons";
 import { api } from "../../api/client";
-import { CopyButton } from "../../components/CopyButton";
+import { TotpRecoveryCodes } from "../../components/TotpRecoveryCodes";
 import { useToast } from "../../context/ToastContext";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { formatDate } from "../../utils/format";
@@ -133,20 +133,6 @@ export function TotpPanel() {
 		else toast(t("common.failedToCopy"), "error");
 	};
 
-	const handleDownloadCodes = () => {
-		const blob = new Blob([`${recoveryCodes.join("\n")}\n`], {
-			type: "text/plain",
-		});
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement("a");
-		a.href = url;
-		a.download = "model-hotel-totp-recovery-codes.txt";
-		document.body.appendChild(a);
-		a.click();
-		a.remove();
-		URL.revokeObjectURL(url);
-	};
-
 	const handleSavedRecoveryCodes = () => {
 		setRecoveryCodes([]);
 		setShowRecovery(false);
@@ -156,55 +142,10 @@ export function TotpPanel() {
 	// Recovery codes reveal view: shown once after a successful verify.
 	if (showRecovery && recoveryCodes.length > 0) {
 		return (
-			<div className="space-y-4">
-				<div className="ui-callout ui-callout-warning">
-					<p className="font-medium">
-						{t("settings.totp.recoveryCodesWarning")}
-					</p>
-				</div>
-				<div>
-					<div className="flex items-center justify-between mb-2">
-						<h3 className="text-sm font-medium text-(--text-primary)">
-							{t("settings.totp.recoveryCodes")}
-						</h3>
-						<CopyButton
-							text={recoveryCodes.join("\n")}
-							size={16}
-							title={t("settings.totp.copyAll")}
-							toastType="success"
-						/>
-					</div>
-					<div className="p-3 bg-(--surface-elevated) rounded-[var(--radius-card,0.375rem)] border border-(--border-default)">
-						<div className="font-mono text-sm space-y-1">
-							{recoveryCodes.map((code) => (
-								<div key={code} className="text-(--text-primary) break-all">
-									{code}
-								</div>
-							))}
-						</div>
-					</div>
-				</div>
-				<div className="flex flex-wrap gap-2">
-					<button
-						type="button"
-						onClick={handleDownloadCodes}
-						className="ui-btn ui-btn-secondary"
-						aria-label={t("settings.totp.downloadCodesAriaLabel")}
-					>
-						<Download size={16} />
-						{t("settings.totp.downloadCodes")}
-					</button>
-					<button
-						type="button"
-						onClick={handleSavedRecoveryCodes}
-						className="ui-btn ui-btn-primary"
-						aria-label={t("settings.totp.savedAriaLabel")}
-					>
-						<Check size={16} />
-						{t("settings.totp.saved")}
-					</button>
-				</div>
-			</div>
+			<TotpRecoveryCodes
+				codes={recoveryCodes}
+				onSaved={handleSavedRecoveryCodes}
+			/>
 		);
 	}
 

--- a/web/src/pages/Settings/alerts/AppriseStatus.tsx
+++ b/web/src/pages/Settings/alerts/AppriseStatus.tsx
@@ -1,10 +1,8 @@
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "@/lib/icons";
-import type { api } from "../../../api/client";
+import type { AlertStatus } from "../../../api/types";
 import { REASON_CODES } from "./apiText";
-
-type AlertStatus = Awaited<ReturnType<typeof api.alert.status>>;
 
 /**
  * Whether apprise-api can be reached: a dot, a word, an optional reason, and a

--- a/web/src/pages/Settings/alerts/AppriseStatus.tsx
+++ b/web/src/pages/Settings/alerts/AppriseStatus.tsx
@@ -1,0 +1,94 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { RefreshCw } from "@/lib/icons";
+import type { api } from "../../../api/client";
+import { REASON_CODES } from "./apiText";
+
+type AlertStatus = Awaited<ReturnType<typeof api.alert.status>>;
+
+/**
+ * Whether apprise-api can be reached: a dot, a word, an optional reason, and a
+ * recheck link. Sits beside the destination list it qualifies.
+ */
+export function AppriseStatus({
+	statusQuery,
+}: {
+	statusQuery: UseQueryResult<AlertStatus>;
+}) {
+	const { t } = useTranslation();
+	const status = statusQuery.data;
+	const statusDotColor =
+		status?.reachable && status.healthy
+			? "var(--success-text)"
+			: status?.reachable
+				? "var(--warning-text)"
+				: "var(--error-text)";
+	const statusText =
+		status?.reachable && status.healthy
+			? t("settings.alerts.status.reachable")
+			: status?.reachable
+				? t("settings.alerts.status.issues")
+				: t("settings.alerts.status.unreachable");
+	// The reason code is the translated, actionable half of the probe result; the
+	// detail is raw server text (English, sometimes an HTTP status). The note
+	// therefore carries the reason and keeps the detail as the tooltip, where an
+	// operator who wants the literal answer can still find it.
+	const statusReason =
+		status &&
+		(!status.reachable || !status.healthy) &&
+		status.reason &&
+		REASON_CODES.has(status.reason)
+			? t(`settings.alerts.reason.${status.reason}`)
+			: "";
+
+	return (
+		<div className="flex items-center gap-2 text-xs" data-testid="alert-status">
+			{statusQuery.isFetching ? (
+				<span className="inline-flex items-center gap-1.5 text-(--text-muted)">
+					<RefreshCw size={12} className="animate-spin" />
+					{t("settings.alerts.status.checking")}
+				</span>
+			) : statusQuery.isError ? (
+				<span className="inline-flex items-center gap-1.5 text-(--text-secondary)">
+					<span
+						className="inline-block w-2 h-2 rounded-full"
+						style={{ background: "var(--error-text)" }}
+						aria-hidden="true"
+					/>
+					{t("settings.alerts.status.checkFailed")}
+				</span>
+			) : status ? (
+				<>
+					<span
+						className="inline-flex items-center gap-1.5 text-(--text-secondary)"
+						title={status.detail}
+					>
+						<span
+							className="inline-block w-2 h-2 rounded-full"
+							style={{ background: statusDotColor }}
+							aria-hidden="true"
+						/>
+						{statusText}
+					</span>
+					{statusReason !== "" && (
+						<span
+							className="text-(--text-secondary)"
+							data-testid="alert-status-note"
+						>
+							{statusReason}
+						</span>
+					)}
+				</>
+			) : null}
+			<button
+				type="button"
+				className="ui-link-accent inline-flex items-center gap-1"
+				onClick={() => statusQuery.refetch()}
+				data-testid="alert-status-recheck"
+			>
+				<RefreshCw size={11} />
+				{t("settings.alerts.status.recheck")}
+			</button>
+		</div>
+	);
+}

--- a/web/src/pages/Settings/alerts/apiText.ts
+++ b/web/src/pages/Settings/alerts/apiText.ts
@@ -13,8 +13,9 @@ export function stripApiHead(message: string, prefix: string): string {
 }
 
 // The stable failure codes the alert endpoints report: /api/alert/test with a
-// 502 and the reachability probe in AlertStatus.reason. Anything outside this
-// set falls back to a generic error, so no server internals reach the screen.
+// 502 and the reachability probe in AlertStatus.reason. Only codes in this set
+// get a translated reason: a test error outside it shows the generic message,
+// and a probe reason outside it shows no reason note at all.
 export const REASON_CODES = new Set([
 	"not_configured",
 	"invalid_url",

--- a/web/src/pages/Settings/alerts/apiText.ts
+++ b/web/src/pages/Settings/alerts/apiText.ts
@@ -11,3 +11,16 @@ export function stripApiHead(message: string, prefix: string): string {
 	const status = /^\d+ /.exec(rest);
 	return status === null ? message : rest.slice(status[0].length);
 }
+
+// The stable failure codes the alert endpoints report: /api/alert/test with a
+// 502 and the reachability probe in AlertStatus.reason. Anything outside this
+// set falls back to a generic error, so no server internals reach the screen.
+export const REASON_CODES = new Set([
+	"not_configured",
+	"invalid_url",
+	"unreachable",
+	"unhealthy",
+	"apprise_reject",
+	"deliver_failed",
+	"undecryptable",
+]);


### PR DESCRIPTION
PR A of the size-ratchet cleanup planned after #928 and #929. Five of the eleven `max-lines-per-function` suppressions sat within 40 lines of the 500-line limit; each loses one self-contained section instead of a widened limit.

Stacked on #929 (branch base); merge that first.

| Function | Was | Moved out |
|---|---|---|
| `Security` | 501 | recovery-codes reveal, now shared `components/TotpRecoveryCodes.tsx`; the admin `TotpSettings` panel had a byte-identical copy and uses it too |
| `useArenaRunner` | 503 | the per-model streaming body, now `Arena/streamModel.ts` (`streamArenaResponse(ctx, args)`), taking the mount-gated setters as a context object |
| `useDashboard` | 520 | global and per-section range/metric state plus the header sync effects, now `Dashboard/useDashboardRanges.ts`; also pulls the file back from 788 of the 800-line file ceiling |
| `AlertsSettings` | 528 | the apprise reachability indicator, now `Settings/alerts/AppriseStatus.tsx`; `REASON_CODES` moved to `alerts/apiText.ts` beside the helpers it serves |
| `Dashboard` | 537 | the six stat tiles, now `Dashboard/StatCardsRow.tsx` with props typed as `Pick<UseDashboardReturn, ...>` |

No behaviour change. Props are typed from the parent hook's return types; no new state.

## Verification

- `pnpm lint`, `pnpm exec tsc -b`, Biome, `make size-check` clean.
- Vitest for `pages/Dashboard`, `pages/Settings`, `pages/Security`, `pages/Arena` and the page-level suites: 1816 tests pass. Existing page tests render the moved JSX, so no new tests were needed.

Six suppressions remain (DataStorageSettings, UserModal, KeyDetailModal, DatabaseBackupSettings, Arena, Chat) for PRs B and C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
