### PR TITLE
refactor(web): split the three modal and settings size-ratchet functions

### DIFF
--- a/web/src/pages/Settings/DataStorageSettings.tsx
+++ b/web/src/pages/Settings/DataStorageSettings.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../utils/duration";
 import { clearProviderCache, getProviderCacheCount } from "./constants";
 import { PurgeLogsControl } from "./PurgeLogsControl";
+import { usePurgeState } from "./purgeState";
 import { useSettingsMutations } from "./useSettingsMutations";
 
 interface DataStorageSettingsProps {
@@ -90,17 +91,22 @@ export function DataStorageSettings({
 		setArenaHistoryLimit,
 	} = useStorage();
 
+	const requestsPurge = usePurgeState();
+	const appLogsPurge = usePurgeState();
+
 	const purgeMutation = useMutation({
 		mutationFn: (olderThan: string) => api.logs.purge(olderThan),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["logs"] });
 			toast(t("settings.common.requestsDeleted"), "success");
+			requestsPurge.settled(true);
 		},
 		onError: (err: Error) => {
 			toast(
 				t("settings.common.failedToDeleteRequests", { message: err.message }),
 				"error",
 			);
+			requestsPurge.settled(false);
 		},
 	});
 
@@ -109,12 +115,14 @@ export function DataStorageSettings({
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["appLogs"] });
 			toast(t("settings.common.logsDeleted"), "success");
+			appLogsPurge.settled(true);
 		},
 		onError: (err: Error) => {
 			toast(
 				t("settings.common.failedToDeleteAppLogs", { message: err.message }),
 				"error",
 			);
+			appLogsPurge.settled(false);
 		},
 	});
 
@@ -190,6 +198,7 @@ export function DataStorageSettings({
 							<div className="flex items-center gap-2 flex-wrap">
 								<PurgeLogsControl
 									mutation={purgeMutation}
+									state={requestsPurge}
 									labels={{
 										button: t("settings.logging.deleteRequests"),
 										tooltip: t("settings.logging.deleteRequests.tooltip"),
@@ -213,6 +222,7 @@ export function DataStorageSettings({
 
 								<PurgeLogsControl
 									mutation={purgeAppLogsMutation}
+									state={appLogsPurge}
 									labels={{
 										button: t("settings.logging.deleteAppLogs"),
 										tooltip: t("settings.logging.deleteAppLogs.tooltip"),

--- a/web/src/pages/Settings/DataStorageSettings.tsx
+++ b/web/src/pages/Settings/DataStorageSettings.tsx
@@ -20,6 +20,7 @@ import {
 	minutesToGoDuration,
 } from "../../utils/duration";
 import { clearProviderCache, getProviderCacheCount } from "./constants";
+import { PurgeLogsControl } from "./PurgeLogsControl";
 import { useSettingsMutations } from "./useSettingsMutations";
 
 interface DataStorageSettingsProps {
@@ -29,7 +30,6 @@ interface DataStorageSettingsProps {
 	managed?: boolean;
 }
 
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function DataStorageSettings({
 	collapsed,
 	onToggle,
@@ -41,10 +41,6 @@ export function DataStorageSettings({
 	const queryClient = useQueryClient();
 	const { settings, updateMutation, resetSettingMutation } =
 		useSettingsMutations();
-	const [confirmDelete, setConfirmDelete] = useState(false);
-	const [deleteSelection, setDeleteSelection] = useState("");
-	const [confirmDeleteAppLogs, setConfirmDeleteAppLogs] = useState(false);
-	const [appLogsDeleteSelection, setAppLogsDeleteSelection] = useState("");
 
 	const [quotaDisabled, setQuotaDisabled] = useState(() => {
 		try {
@@ -99,15 +95,12 @@ export function DataStorageSettings({
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["logs"] });
 			toast(t("settings.common.requestsDeleted"), "success");
-			setConfirmDelete(false);
-			setDeleteSelection("");
 		},
 		onError: (err: Error) => {
 			toast(
 				t("settings.common.failedToDeleteRequests", { message: err.message }),
 				"error",
 			);
-			setConfirmDelete(false);
 		},
 	});
 
@@ -116,15 +109,12 @@ export function DataStorageSettings({
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["appLogs"] });
 			toast(t("settings.common.logsDeleted"), "success");
-			setConfirmDeleteAppLogs(false);
-			setAppLogsDeleteSelection("");
 		},
 		onError: (err: Error) => {
 			toast(
 				t("settings.common.failedToDeleteAppLogs", { message: err.message }),
 				"error",
 			);
-			setConfirmDeleteAppLogs(false);
 		},
 	});
 
@@ -135,12 +125,6 @@ export function DataStorageSettings({
 	// The slider is in days; the backend stores a Go duration in hours.
 	const logRetentionDays = logRetentionToDays(logRetention);
 	const staleTimeoutMinutes = goDurationToMinutes(staleRequestTimeout);
-
-	// The dropdown values (1d/1w/1m/all) are exactly the tokens the backend's
-	// purge endpoints accept, so pass the selection through and only guard the
-	// empty "select a range" placeholder.
-	const getDeleteOlderThan = (selection: string): string =>
-		["1d", "1w", "1m", "all"].includes(selection) ? selection : "";
 
 	return (
 		<SettingsSection
@@ -204,126 +188,52 @@ export function DataStorageSettings({
 							/>
 
 							<div className="flex items-center gap-2 flex-wrap">
-								{!confirmDelete ? (
-									<button
-										type="button"
-										onClick={() => setConfirmDelete(true)}
-										className="ui-btn ui-btn-danger"
-										title={t("settings.logging.deleteRequests.tooltip")}
-									>
-										{t("settings.logging.deleteRequests")}
-									</button>
-								) : (
-									<>
-										<select
-											value={deleteSelection}
-											onChange={(e) => setDeleteSelection(e.target.value)}
-											className="ui-input px-3 py-1.5 text-xs"
-										>
-											<option value="">
-												{t("settings.logging.deleteRequests.selectRange")}
-											</option>
-											<option value="1d">
-												{t("settings.logging.deleteRequests.olderThan1d")}
-											</option>
-											<option value="1w">
-												{t("settings.logging.deleteRequests.olderThan1w")}
-											</option>
-											<option value="1m">
-												{t("settings.logging.deleteRequests.olderThan1m")}
-											</option>
-											<option value="all">
-												{t("settings.logging.deleteRequests.allLogs")}
-											</option>
-										</select>
-										<button
-											type="button"
-											disabled={!deleteSelection || purgeMutation.isPending}
-											onClick={() => {
-												const olderThan = getDeleteOlderThan(deleteSelection);
-												if (olderThan) purgeMutation.mutate(olderThan);
-											}}
-											className="ui-btn ui-btn-danger"
-										>
-											{t("settings.logging.deleteRequests.confirm")}
-										</button>
-										<button
-											type="button"
-											onClick={() => {
-												setConfirmDelete(false);
-												setDeleteSelection("");
-											}}
-											className="ui-btn ui-btn-secondary"
-										>
-											{t("settings.logging.deleteRequests.cancel")}
-										</button>
-									</>
-								)}
+								<PurgeLogsControl
+									mutation={purgeMutation}
+									labels={{
+										button: t("settings.logging.deleteRequests"),
+										tooltip: t("settings.logging.deleteRequests.tooltip"),
+										selectRange: t(
+											"settings.logging.deleteRequests.selectRange",
+										),
+										olderThan1d: t(
+											"settings.logging.deleteRequests.olderThan1d",
+										),
+										olderThan1w: t(
+											"settings.logging.deleteRequests.olderThan1w",
+										),
+										olderThan1m: t(
+											"settings.logging.deleteRequests.olderThan1m",
+										),
+										allLogs: t("settings.logging.deleteRequests.allLogs"),
+										confirm: t("settings.logging.deleteRequests.confirm"),
+										cancel: t("settings.logging.deleteRequests.cancel"),
+									}}
+								/>
 
-								{!confirmDeleteAppLogs ? (
-									<button
-										type="button"
-										onClick={() => setConfirmDeleteAppLogs(true)}
-										className="ui-btn ui-btn-danger"
-										title={t("settings.logging.deleteAppLogs.tooltip")}
-									>
-										{t("settings.logging.deleteAppLogs")}
-									</button>
-								) : (
-									<>
-										<select
-											value={appLogsDeleteSelection}
-											onChange={(e) =>
-												setAppLogsDeleteSelection(e.target.value)
-											}
-											className="ui-input px-3 py-1.5 text-xs"
-										>
-											<option value="">
-												{t("settings.logging.deleteAppLogs.selectRange")}
-											</option>
-											<option value="1d">
-												{t("settings.logging.deleteAppLogs.olderThan1d")}
-											</option>
-											<option value="1w">
-												{t("settings.logging.deleteAppLogs.olderThan1w")}
-											</option>
-											<option value="1m">
-												{t("settings.logging.deleteAppLogs.olderThan1m")}
-											</option>
-											<option value="all">
-												{t("settings.logging.deleteAppLogs.allLogs")}
-											</option>
-										</select>
-										<button
-											type="button"
-											disabled={
-												!appLogsDeleteSelection ||
-												purgeAppLogsMutation.isPending
-											}
-											onClick={() => {
-												const olderThan = getDeleteOlderThan(
-													appLogsDeleteSelection,
-												);
-												if (olderThan) purgeAppLogsMutation.mutate(olderThan);
-											}}
-											className="ui-btn ui-btn-danger"
-										>
-											{purgeAppLogsMutation.isPending
-												? t("settings.logging.deleteAppLogs.deleting")
-												: t("settings.logging.deleteAppLogs.confirm")}
-										</button>
-										<button
-											type="button"
-											onClick={() => {
-												setConfirmDeleteAppLogs(false);
-												setAppLogsDeleteSelection("");
-											}}
-											className="ui-btn ui-btn-secondary"
-										>
-											{t("settings.logging.deleteAppLogs.cancel")}
-										</button>
-									</>
-								)}
+								<PurgeLogsControl
+									mutation={purgeAppLogsMutation}
+									labels={{
+										button: t("settings.logging.deleteAppLogs"),
+										tooltip: t("settings.logging.deleteAppLogs.tooltip"),
+										selectRange: t(
+											"settings.logging.deleteAppLogs.selectRange",
+										),
+										olderThan1d: t(
+											"settings.logging.deleteAppLogs.olderThan1d",
+										),
+										olderThan1w: t(
+											"settings.logging.deleteAppLogs.olderThan1w",
+										),
+										olderThan1m: t(
+											"settings.logging.deleteAppLogs.olderThan1m",
+										),
+										allLogs: t("settings.logging.deleteAppLogs.allLogs"),
+										confirm: t("settings.logging.deleteAppLogs.confirm"),
+										cancel: t("settings.logging.deleteAppLogs.cancel"),
+										deleting: t("settings.logging.deleteAppLogs.deleting"),
+									}}
+								/>
 							</div>
 						</SettingsGroup>
 

--- a/web/src/pages/Settings/PurgeLogsControl.tsx
+++ b/web/src/pages/Settings/PurgeLogsControl.tsx
@@ -31,7 +31,8 @@ export function PurgeLogsControl({
 }: {
 	labels: PurgeLogsLabels;
 	mutation: UseMutationResult<unknown, Error, string>;
-	state: PurgeState;
+	/** Settling stays with the card that owns the mutation. */
+	state: Omit<PurgeState, "settled">;
 }) {
 	const { confirming, selection } = state;
 

--- a/web/src/pages/Settings/PurgeLogsControl.tsx
+++ b/web/src/pages/Settings/PurgeLogsControl.tsx
@@ -1,0 +1,96 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+import { useState } from "react";
+
+export interface PurgeLogsLabels {
+	button: string;
+	tooltip: string;
+	selectRange: string;
+	olderThan1d: string;
+	olderThan1w: string;
+	olderThan1m: string;
+	allLogs: string;
+	confirm: string;
+	cancel: string;
+	/** Shown on the confirm button while the purge runs; falls back to `confirm`. */
+	deleting?: string;
+}
+
+/**
+ * The two-step "delete older than" control shared by the request-log and
+ * app-log purges: a danger button that expands into a range select plus
+ * confirm and cancel. The dropdown values (1d/1w/1m/all) are exactly the
+ * tokens the backend's purge endpoints accept, so the selection is passed
+ * through and only the empty "select a range" placeholder is guarded.
+ */
+export function PurgeLogsControl({
+	labels,
+	mutation,
+}: {
+	labels: PurgeLogsLabels;
+	mutation: UseMutationResult<unknown, Error, string>;
+}) {
+	const [confirming, setConfirming] = useState(false);
+	const [selection, setSelection] = useState("");
+
+	if (!confirming) {
+		return (
+			<button
+				type="button"
+				onClick={() => setConfirming(true)}
+				className="ui-btn ui-btn-danger"
+				title={labels.tooltip}
+			>
+				{labels.button}
+			</button>
+		);
+	}
+
+	const olderThan = ["1d", "1w", "1m", "all"].includes(selection)
+		? selection
+		: "";
+
+	return (
+		<>
+			<select
+				value={selection}
+				onChange={(e) => setSelection(e.target.value)}
+				className="ui-input px-3 py-1.5 text-xs"
+			>
+				<option value="">{labels.selectRange}</option>
+				<option value="1d">{labels.olderThan1d}</option>
+				<option value="1w">{labels.olderThan1w}</option>
+				<option value="1m">{labels.olderThan1m}</option>
+				<option value="all">{labels.allLogs}</option>
+			</select>
+			<button
+				type="button"
+				disabled={!selection || mutation.isPending}
+				onClick={() => {
+					if (!olderThan) return;
+					mutation.mutate(olderThan, {
+						onSuccess: () => {
+							setConfirming(false);
+							setSelection("");
+						},
+						onError: () => setConfirming(false),
+					});
+				}}
+				className="ui-btn ui-btn-danger"
+			>
+				{mutation.isPending
+					? (labels.deleting ?? labels.confirm)
+					: labels.confirm}
+			</button>
+			<button
+				type="button"
+				onClick={() => {
+					setConfirming(false);
+					setSelection("");
+				}}
+				className="ui-btn ui-btn-secondary"
+			>
+				{labels.cancel}
+			</button>
+		</>
+	);
+}

--- a/web/src/pages/Settings/PurgeLogsControl.tsx
+++ b/web/src/pages/Settings/PurgeLogsControl.tsx
@@ -1,5 +1,5 @@
 import type { UseMutationResult } from "@tanstack/react-query";
-import { useState } from "react";
+import type { PurgeState } from "./purgeState";
 
 export interface PurgeLogsLabels {
 	button: string;
@@ -20,39 +20,26 @@ export interface PurgeLogsLabels {
  * app-log purges: a danger button that expands into a range select plus
  * confirm and cancel. The dropdown values (1d/1w/1m/all) are exactly the
  * tokens the backend's purge endpoints accept, so the selection is passed
- * through and only the empty "select a range" placeholder is guarded.
+ * through and only the empty "select a range" placeholder is guarded. The
+ * confirm and range state comes from the parent's usePurgeState so it survives
+ * the section remount that a managed-mode flip causes.
  */
 export function PurgeLogsControl({
 	labels,
 	mutation,
+	state,
 }: {
 	labels: PurgeLogsLabels;
 	mutation: UseMutationResult<unknown, Error, string>;
+	state: PurgeState;
 }) {
-	const [confirming, setConfirming] = useState(false);
-	const [selection, setSelection] = useState("");
-
-	// The mutation lives in the parent and outlives this component: the settings
-	// section remounts its children when managed mode flips, so a purge started
-	// before the flip settles after it. Close on settle by watching the
-	// mutation's submittedAt during render rather than through per-call
-	// callbacks, which would land on the discarded instance and leave a reopened
-	// control actionable. A purge already in flight at mount counts as unseen;
-	// one already settled at mount does not.
-	const [settledSeen, setSettledSeen] = useState(() =>
-		mutation.isPending ? 0 : mutation.submittedAt,
-	);
-	if (!mutation.isPending && mutation.submittedAt !== settledSeen) {
-		setSettledSeen(mutation.submittedAt);
-		setConfirming(false);
-		if (mutation.isSuccess) setSelection("");
-	}
+	const { confirming, selection } = state;
 
 	if (!confirming) {
 		return (
 			<button
 				type="button"
-				onClick={() => setConfirming(true)}
+				onClick={state.open}
 				className="ui-btn ui-btn-danger"
 				title={labels.tooltip}
 			>
@@ -69,7 +56,7 @@ export function PurgeLogsControl({
 		<>
 			<select
 				value={selection}
-				onChange={(e) => setSelection(e.target.value)}
+				onChange={(e) => state.select(e.target.value)}
 				className="ui-input px-3 py-1.5 text-xs"
 			>
 				<option value="">{labels.selectRange}</option>
@@ -92,10 +79,7 @@ export function PurgeLogsControl({
 			</button>
 			<button
 				type="button"
-				onClick={() => {
-					setConfirming(false);
-					setSelection("");
-				}}
+				onClick={state.cancel}
 				className="ui-btn ui-btn-secondary"
 			>
 				{labels.cancel}

--- a/web/src/pages/Settings/PurgeLogsControl.tsx
+++ b/web/src/pages/Settings/PurgeLogsControl.tsx
@@ -32,6 +32,22 @@ export function PurgeLogsControl({
 	const [confirming, setConfirming] = useState(false);
 	const [selection, setSelection] = useState("");
 
+	// The mutation lives in the parent and outlives this component: the settings
+	// section remounts its children when managed mode flips, so a purge started
+	// before the flip settles after it. Close on settle by watching the
+	// mutation's submittedAt during render rather than through per-call
+	// callbacks, which would land on the discarded instance and leave a reopened
+	// control actionable. A purge already in flight at mount counts as unseen;
+	// one already settled at mount does not.
+	const [settledSeen, setSettledSeen] = useState(() =>
+		mutation.isPending ? 0 : mutation.submittedAt,
+	);
+	if (!mutation.isPending && mutation.submittedAt !== settledSeen) {
+		setSettledSeen(mutation.submittedAt);
+		setConfirming(false);
+		if (mutation.isSuccess) setSelection("");
+	}
+
 	if (!confirming) {
 		return (
 			<button
@@ -66,14 +82,7 @@ export function PurgeLogsControl({
 				type="button"
 				disabled={!selection || mutation.isPending}
 				onClick={() => {
-					if (!olderThan) return;
-					mutation.mutate(olderThan, {
-						onSuccess: () => {
-							setConfirming(false);
-							setSelection("");
-						},
-						onError: () => setConfirming(false),
-					});
+					if (olderThan) mutation.mutate(olderThan);
 				}}
 				className="ui-btn ui-btn-danger"
 			>

--- a/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
@@ -971,6 +971,42 @@ describe("Delete Request Logs", () => {
 		).toBeInTheDocument();
 	});
 
+	it("closes a purge confirmation reopened after a managed-mode remount", async () => {
+		// The purge mutation lives in the parent; the section remounts its
+		// children when managed flips, so a purge started before the flip
+		// settles against a fresh control that may have been reopened meanwhile.
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		server.use(
+			http.delete("/api/logs/purge", async () => {
+				await gate;
+				return HttpResponse.json({ deleted: 1 });
+			}),
+		);
+		const user = userEvent.setup();
+		const { rerender } = renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		await user.selectOptions(screen.getByRole("combobox"), "1d");
+		await user.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+		rerender(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} managed />,
+		);
+		rerender(<DataStorageSettings collapsed={false} onToggle={onToggle} />);
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		expect(screen.getByRole("combobox")).toBeInTheDocument();
+
+		release();
+		await waitFor(() => {
+			expect(screen.getByText(/requests deleted/i)).toBeInTheDocument();
+		});
+		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+	});
+
 	it("calls purgeMutation when selection made and confirmed", async () => {
 		const user = userEvent.setup();
 		renderWithProviders(

--- a/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
@@ -971,7 +971,7 @@ describe("Delete Request Logs", () => {
 		).toBeInTheDocument();
 	});
 
-	it("closes a purge confirmation reopened after a managed-mode remount", async () => {
+	it("closes a purge confirmation that outlived a managed-mode remount", async () => {
 		// The purge mutation lives in the parent; the section remounts its
 		// children when managed flips, so a purge started before the flip
 		// settles against a fresh control that may have been reopened meanwhile.
@@ -997,14 +997,52 @@ describe("Delete Request Logs", () => {
 			<DataStorageSettings collapsed={false} onToggle={onToggle} managed />,
 		);
 		rerender(<DataStorageSettings collapsed={false} onToggle={onToggle} />);
-		await user.click(screen.getByRole("button", { name: /delete requests/i }));
-		expect(screen.getByRole("combobox")).toBeInTheDocument();
+		// The confirmation is card state, so it survives the remount still open.
+		expect(screen.getByRole("combobox")).toHaveValue("1d");
 
 		release();
 		await waitFor(() => {
 			expect(screen.getByText(/requests deleted/i)).toBeInTheDocument();
 		});
-		expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+		});
+	});
+
+	it("keeps the chosen range when a purge fails after a managed-mode remount", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		server.use(
+			http.delete("/api/logs/purge", async () => {
+				await gate;
+				return HttpResponse.json({ error: "boom" }, { status: 500 });
+			}),
+		);
+		const user = userEvent.setup();
+		const { rerender } = renderWithProviders(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} />,
+		);
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		await user.selectOptions(screen.getByRole("combobox"), "1d");
+		await user.click(screen.getByRole("button", { name: /confirm delete/i }));
+
+		rerender(
+			<DataStorageSettings collapsed={false} onToggle={onToggle} managed />,
+		);
+		rerender(<DataStorageSettings collapsed={false} onToggle={onToggle} />);
+		release();
+		await waitFor(() => {
+			expect(screen.getByText(/failed to delete/i)).toBeInTheDocument();
+		});
+		// A failed purge closes the confirmation but keeps the range, so reopening
+		// shows the same choice instead of the placeholder.
+		await waitFor(() => {
+			expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+		});
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		expect(screen.getByRole("combobox")).toHaveValue("1d");
 	});
 
 	it("calls purgeMutation when selection made and confirmed", async () => {

--- a/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
+++ b/web/src/pages/Settings/__tests__/DataStorageSettings.test.tsx
@@ -972,9 +972,9 @@ describe("Delete Request Logs", () => {
 	});
 
 	it("closes a purge confirmation that outlived a managed-mode remount", async () => {
-		// The purge mutation lives in the parent; the section remounts its
-		// children when managed flips, so a purge started before the flip
-		// settles against a fresh control that may have been reopened meanwhile.
+		// The section remounts its children when managed flips. The confirm and
+		// range state is card state, so a purge started before the flip settles
+		// against the same open confirmation it started from.
 		let release!: () => void;
 		const gate = new Promise<void>((resolve) => {
 			release = resolve;
@@ -1007,6 +1007,9 @@ describe("Delete Request Logs", () => {
 		await waitFor(() => {
 			expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
 		});
+		// Success also clears the range, so reopening shows the placeholder.
+		await user.click(screen.getByRole("button", { name: /delete requests/i }));
+		expect(screen.getByRole("combobox")).toHaveValue("");
 	});
 
 	it("keeps the chosen range when a purge fails after a managed-mode remount", async () => {

--- a/web/src/pages/Settings/purgeState.ts
+++ b/web/src/pages/Settings/purgeState.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+
+export interface PurgeState {
+	confirming: boolean;
+	selection: string;
+	open: () => void;
+	select: (value: string) => void;
+	cancel: () => void;
+	/** Mutation-level settle: closes the confirmation, clears the range on success only. */
+	settled: (success: boolean) => void;
+}
+
+/**
+ * Confirm and range state for one PurgeLogsControl, owned by the settings
+ * card rather than the control. The card's mutation outlives the control
+ * (SettingsSection remounts its children when managed mode flips), so the
+ * state and the settle reset have to live where the mutation does or a purge
+ * that settles after a remount would leave a reopened control actionable.
+ */
+export function usePurgeState(): PurgeState {
+	const [confirming, setConfirming] = useState(false);
+	const [selection, setSelection] = useState("");
+	return {
+		confirming,
+		selection,
+		open: () => setConfirming(true),
+		select: setSelection,
+		cancel: () => {
+			setConfirming(false);
+			setSelection("");
+		},
+		settled: (success) => {
+			setConfirming(false);
+			if (success) setSelection("");
+		},
+	};
+}

--- a/web/src/pages/Users/UserModal.tsx
+++ b/web/src/pages/Users/UserModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import type { DashboardUser } from "../../api/types";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { Modal } from "../../components/Modal";
@@ -16,6 +17,7 @@ export function UserModal({
 	onClose: () => void;
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
 }) {
+	const { t } = useTranslation();
 	const {
 		username,
 		setUsername,
@@ -59,7 +61,6 @@ export function UserModal({
 		chooseProviderMode,
 		toggleProvider,
 		toggleGrant,
-		t,
 	} = useUserForm({ user, onClose, onToast });
 
 	return (

--- a/web/src/pages/Users/UserModal.tsx
+++ b/web/src/pages/Users/UserModal.tsx
@@ -1,24 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
-import { api } from "../../api/client";
-import type { DashboardUser, UserUpsertRequest } from "../../api/types";
+import type { DashboardUser } from "../../api/types";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { Modal } from "../../components/Modal";
 import { Toggle } from "../../components/Toggle";
-import { useIdentity } from "../../context/IdentityContext";
-import { isBreachedPasswordError } from "../../utils/passwordPolicy";
+import { useUserForm } from "./useUserForm";
 
-/** Duck-typed ApiError body (robust across module boundaries, like App.tsx). */
-function errMessage(err: unknown, fallback: string): string {
-	if (err && typeof err === "object" && "message" in err) {
-		const m = (err as { message?: unknown }).message;
-		if (typeof m === "string" && m) return m;
-	}
-	return fallback;
-}
-
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function UserModal({
 	user,
 	managed = false,
@@ -31,202 +16,51 @@ export function UserModal({
 	onClose: () => void;
 	onToast: (msg: string, type: "success" | "error" | "info") => void;
 }) {
-	const { t } = useTranslation();
-	const queryClient = useQueryClient();
-	const { me } = useIdentity();
-	const isEdit = user !== null;
-	const isSelf = isEdit && me?.username === user.username;
-
-	const [username, setUsername] = useState(user?.username ?? "");
-	const [displayName, setDisplayName] = useState(user?.display_name ?? "");
-	const [email, setEmail] = useState(user?.email ?? "");
-	const [password, setPassword] = useState("");
-	const [role, setRole] = useState<"admin" | "user">(user?.role ?? "user");
-	const [grants, setGrants] = useState<string[]>(user?.grants ?? []);
-	const [enabled, setEnabled] = useState(user?.enabled ?? true);
-	const [limitRps, setLimitRps] = useState(
-		user?.rate_limit_rps?.toString() ?? "",
-	);
-	const [limitBurst, setLimitBurst] = useState(
-		user?.rate_limit_burst?.toString() ?? "",
-	);
-	const [limitTpm, setLimitTpm] = useState(
-		user?.rate_limit_tpm?.toString() ?? "",
-	);
-	// A stored cap is an explicit array; null/absent means "every provider".
-	// On create neither mode is preselected: capping a new account has to be a
-	// deliberate choice, since existing accounts were grandfathered uncapped.
-	const [providerMode, setProviderMode] = useState<"all" | "selected" | null>(
-		user ? (user.allowed_providers ? "selected" : "all") : null,
-	);
-	const [selectedProviders, setSelectedProviders] = useState<string[]>(
-		user?.allowed_providers ?? [],
-	);
-	const [providerError, setProviderError] = useState<
-		"required" | "empty" | null
-	>(null);
-	const [error, setError] = useState<string | null>(null);
-	const [confirmDelete, setConfirmDelete] = useState(false);
-	const [confirmTotpReset, setConfirmTotpReset] = useState(false);
-	const [resetValue, setResetValue] = useState("");
-
-	// The checkbox list renders from the backend catalog, so a new grant kind
-	// appears here without a frontend release.
-	const { data: catalog } = useQuery({
-		queryKey: ["user-grants"],
-		queryFn: () => api.users.grants(),
-		staleTime: Number.POSITIVE_INFINITY,
-	});
-	const allGrants = catalog?.grants ?? [];
-
-	const { data: providers } = useQuery({
-		queryKey: ["providers"],
-		queryFn: () => api.providers.list(),
-	});
-	const sortedProviders = (providers ?? [])
-		.slice()
-		.sort((a, b) => a.name.localeCompare(b.name));
-
-	// True while an edit leaves the stored cap exactly as it was found. Such a
-	// save OMITS allowed_providers, which the API reads as "preserve" (see
-	// UpdateUser: an absent key copies the stored value forward). That is the
-	// only way to edit a user whose stored cap is an empty array, which is a
-	// reachable state -- pruning the last capped provider empties it -- and one
-	// the control cannot re-state without widening the account.
-	const storedCap = user?.allowed_providers ?? null;
-	const capUnchanged =
-		isEdit &&
-		providerMode === (storedCap ? "selected" : "all") &&
-		(providerMode === "all" ||
-			(selectedProviders.length === (storedCap?.length ?? 0) &&
-				selectedProviders.every((id) => storedCap?.includes(id))));
-
-	const invalidate = () =>
-		queryClient.invalidateQueries({ queryKey: ["users"] });
-
-	// A breached-password rejection comes back as a stable English 400 string;
-	// swap it for localized copy while leaving every other server error (e.g. a
-	// duplicate username) to surface its own message verbatim.
-	const passwordSaveError = (err: unknown): string =>
-		isBreachedPasswordError(err)
-			? t("users.validation.passwordBreached")
-			: errMessage(err, t("users.toast.saveFailed"));
-
-	const buildRequest = (): UserUpsertRequest => ({
-		username: username.trim(),
-		display_name: displayName.trim(),
-		email: email.trim() ? email.trim() : null,
+	const {
+		username,
+		setUsername,
+		displayName,
+		setDisplayName,
+		email,
+		setEmail,
+		password,
+		setPassword,
 		role,
-		grants: role === "admin" ? [] : grants,
-		rate_limit_rps: limitRps !== "" ? parseFloat(limitRps) : null,
-		rate_limit_burst: limitBurst !== "" ? parseInt(limitBurst, 10) : null,
-		rate_limit_tpm: limitTpm !== "" ? parseInt(limitTpm, 10) : null,
-		// Omitted when untouched (preserve), explicit null clears the cap.
-		// handleSave guarantees a mode was picked before anything is sent.
-		...(capUnchanged
-			? {}
-			: {
-					allowed_providers: providerMode === "all" ? null : selectedProviders,
-				}),
-		...(isEdit ? { enabled } : { password }),
-	});
-
-	const saveMutation = useMutation({
-		mutationFn: () =>
-			isEdit
-				? api.users.update(user.id, buildRequest())
-				: api.users.create(buildRequest()),
-		onSuccess: () => {
-			invalidate();
-			onToast(
-				isEdit ? t("users.toast.updated") : t("users.toast.created"),
-				"success",
-			);
-			onClose();
-		},
-		onError: (err) => setError(passwordSaveError(err)),
-	});
-
-	const deleteMutation = useMutation({
-		mutationFn: () => api.users.remove(user?.id ?? ""),
-		onSuccess: () => {
-			invalidate();
-			onToast(t("users.toast.deleted"), "success");
-			onClose();
-		},
-		onError: (err) => {
-			setConfirmDelete(false);
-			setError(errMessage(err, t("users.toast.deleteFailed")));
-		},
-	});
-
-	const resetMutation = useMutation({
-		mutationFn: () => api.users.setPassword(user?.id ?? "", resetValue),
-		onSuccess: () => {
-			setResetValue("");
-			onToast(t("users.toast.passwordReset"), "success");
-		},
-		onError: (err) => setError(passwordSaveError(err)),
-	});
-
-	const totpResetMutation = useMutation({
-		mutationFn: () => api.users.resetTotp(user?.id ?? ""),
-		onSuccess: () => {
-			setConfirmTotpReset(false);
-			invalidate();
-			onToast(t("users.toast.totpReset"), "success");
-		},
-		onError: (err) => {
-			setConfirmTotpReset(false);
-			setError(errMessage(err, t("users.toast.saveFailed")));
-		},
-	});
-
-	const handleSave = () => {
-		setError(null);
-		setProviderError(null);
-		if (!username.trim()) {
-			setError(t("users.validation.usernameRequired"));
-			return;
-		}
-		if (!isEdit && password.length < 8) {
-			setError(t("users.validation.passwordShort"));
-			return;
-		}
-		// Skipped when the cap is untouched: that save omits the field entirely,
-		// so a stored empty array stays stored instead of blocking every edit.
-		if (!capUnchanged) {
-			if (providerMode === null) {
-				setProviderError("required");
-				return;
-			}
-			// The API rejects an empty array, so never let one leave the form.
-			if (providerMode === "selected" && selectedProviders.length === 0) {
-				setProviderError("empty");
-				return;
-			}
-		}
-		saveMutation.mutate();
-	};
-
-	// Both provider controls clear the validation message as soon as the admin
-	// acts on it, so a stale complaint never outlives the thing it complained about.
-	const chooseProviderMode = (mode: "all" | "selected") => {
-		setProviderError(null);
-		setProviderMode(mode);
-	};
-
-	const toggleProvider = (id: string) => {
-		setProviderError(null);
-		setSelectedProviders((prev) =>
-			prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
-		);
-	};
-
-	const toggleGrant = (g: string) =>
-		setGrants((prev) =>
-			prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
-		);
+		setRole,
+		grants,
+		enabled,
+		setEnabled,
+		limitRps,
+		setLimitRps,
+		limitBurst,
+		setLimitBurst,
+		limitTpm,
+		setLimitTpm,
+		providerMode,
+		selectedProviders,
+		providerError,
+		error,
+		setError,
+		confirmDelete,
+		setConfirmDelete,
+		confirmTotpReset,
+		setConfirmTotpReset,
+		resetValue,
+		setResetValue,
+		isEdit,
+		isSelf,
+		allGrants,
+		sortedProviders,
+		saveMutation,
+		deleteMutation,
+		resetMutation,
+		totpResetMutation,
+		handleSave,
+		chooseProviderMode,
+		toggleProvider,
+		toggleGrant,
+		t,
+	} = useUserForm({ user, onClose, onToast });
 
 	return (
 		<Modal
@@ -582,7 +416,7 @@ export function UserModal({
 							</p>
 						</div>
 
-						{user.totp_enabled && (
+						{user?.totp_enabled && (
 							<div>
 								<button
 									type="button"

--- a/web/src/pages/Users/useUserForm.ts
+++ b/web/src/pages/Users/useUserForm.ts
@@ -16,9 +16,9 @@ function errMessage(err: unknown, fallback: string): string {
 }
 
 /**
- * Form state, validation and the four mutations behind UserModal. `user` null
- * means create mode. Everything the modal renders comes back in one bag so the
- * component is markup only.
+ * Form state, save validation and the four mutations behind UserModal. `user`
+ * null means create mode. The modal keeps only the reset-password length check
+ * that gates its own button.
  */
 export function useUserForm({
 	user,
@@ -269,6 +269,5 @@ export function useUserForm({
 		chooseProviderMode,
 		toggleProvider,
 		toggleGrant,
-		t,
 	};
 }

--- a/web/src/pages/Users/useUserForm.ts
+++ b/web/src/pages/Users/useUserForm.ts
@@ -1,0 +1,274 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../../api/client";
+import type { DashboardUser, UserUpsertRequest } from "../../api/types";
+import { useIdentity } from "../../context/IdentityContext";
+import { isBreachedPasswordError } from "../../utils/passwordPolicy";
+
+/** Duck-typed ApiError body (robust across module boundaries, like App.tsx). */
+function errMessage(err: unknown, fallback: string): string {
+	if (err && typeof err === "object" && "message" in err) {
+		const m = (err as { message?: unknown }).message;
+		if (typeof m === "string" && m) return m;
+	}
+	return fallback;
+}
+
+/**
+ * Form state, validation and the four mutations behind UserModal. `user` null
+ * means create mode. Everything the modal renders comes back in one bag so the
+ * component is markup only.
+ */
+export function useUserForm({
+	user,
+	onClose,
+	onToast,
+}: {
+	user: DashboardUser | null;
+	onClose: () => void;
+	onToast: (msg: string, type: "success" | "error" | "info") => void;
+}) {
+	const { t } = useTranslation();
+	const queryClient = useQueryClient();
+	const { me } = useIdentity();
+	const isEdit = user !== null;
+	const isSelf = isEdit && me?.username === user.username;
+
+	const [username, setUsername] = useState(user?.username ?? "");
+	const [displayName, setDisplayName] = useState(user?.display_name ?? "");
+	const [email, setEmail] = useState(user?.email ?? "");
+	const [password, setPassword] = useState("");
+	const [role, setRole] = useState<"admin" | "user">(user?.role ?? "user");
+	const [grants, setGrants] = useState<string[]>(user?.grants ?? []);
+	const [enabled, setEnabled] = useState(user?.enabled ?? true);
+	const [limitRps, setLimitRps] = useState(
+		user?.rate_limit_rps?.toString() ?? "",
+	);
+	const [limitBurst, setLimitBurst] = useState(
+		user?.rate_limit_burst?.toString() ?? "",
+	);
+	const [limitTpm, setLimitTpm] = useState(
+		user?.rate_limit_tpm?.toString() ?? "",
+	);
+	// A stored cap is an explicit array; null/absent means "every provider".
+	// On create neither mode is preselected: capping a new account has to be a
+	// deliberate choice, since existing accounts were grandfathered uncapped.
+	const [providerMode, setProviderMode] = useState<"all" | "selected" | null>(
+		user ? (user.allowed_providers ? "selected" : "all") : null,
+	);
+	const [selectedProviders, setSelectedProviders] = useState<string[]>(
+		user?.allowed_providers ?? [],
+	);
+	const [providerError, setProviderError] = useState<
+		"required" | "empty" | null
+	>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [confirmDelete, setConfirmDelete] = useState(false);
+	const [confirmTotpReset, setConfirmTotpReset] = useState(false);
+	const [resetValue, setResetValue] = useState("");
+
+	// The checkbox list renders from the backend catalog, so a new grant kind
+	// appears here without a frontend release.
+	const { data: catalog } = useQuery({
+		queryKey: ["user-grants"],
+		queryFn: () => api.users.grants(),
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	const allGrants = catalog?.grants ?? [];
+
+	const { data: providers } = useQuery({
+		queryKey: ["providers"],
+		queryFn: () => api.providers.list(),
+	});
+	const sortedProviders = (providers ?? [])
+		.slice()
+		.sort((a, b) => a.name.localeCompare(b.name));
+
+	// True while an edit leaves the stored cap exactly as it was found. Such a
+	// save OMITS allowed_providers, which the API reads as "preserve" (see
+	// UpdateUser: an absent key copies the stored value forward). That is the
+	// only way to edit a user whose stored cap is an empty array, which is a
+	// reachable state -- pruning the last capped provider empties it -- and one
+	// the control cannot re-state without widening the account.
+	const storedCap = user?.allowed_providers ?? null;
+	const capUnchanged =
+		isEdit &&
+		providerMode === (storedCap ? "selected" : "all") &&
+		(providerMode === "all" ||
+			(selectedProviders.length === (storedCap?.length ?? 0) &&
+				selectedProviders.every((id) => storedCap?.includes(id))));
+
+	const invalidate = () =>
+		queryClient.invalidateQueries({ queryKey: ["users"] });
+
+	// A breached-password rejection comes back as a stable English 400 string;
+	// swap it for localized copy while leaving every other server error (e.g. a
+	// duplicate username) to surface its own message verbatim.
+	const passwordSaveError = (err: unknown): string =>
+		isBreachedPasswordError(err)
+			? t("users.validation.passwordBreached")
+			: errMessage(err, t("users.toast.saveFailed"));
+
+	const buildRequest = (): UserUpsertRequest => ({
+		username: username.trim(),
+		display_name: displayName.trim(),
+		email: email.trim() ? email.trim() : null,
+		role,
+		grants: role === "admin" ? [] : grants,
+		rate_limit_rps: limitRps !== "" ? parseFloat(limitRps) : null,
+		rate_limit_burst: limitBurst !== "" ? parseInt(limitBurst, 10) : null,
+		rate_limit_tpm: limitTpm !== "" ? parseInt(limitTpm, 10) : null,
+		// Omitted when untouched (preserve), explicit null clears the cap.
+		// handleSave guarantees a mode was picked before anything is sent.
+		...(capUnchanged
+			? {}
+			: {
+					allowed_providers: providerMode === "all" ? null : selectedProviders,
+				}),
+		...(isEdit ? { enabled } : { password }),
+	});
+
+	const saveMutation = useMutation({
+		mutationFn: () =>
+			isEdit
+				? api.users.update(user.id, buildRequest())
+				: api.users.create(buildRequest()),
+		onSuccess: () => {
+			invalidate();
+			onToast(
+				isEdit ? t("users.toast.updated") : t("users.toast.created"),
+				"success",
+			);
+			onClose();
+		},
+		onError: (err) => setError(passwordSaveError(err)),
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: () => api.users.remove(user?.id ?? ""),
+		onSuccess: () => {
+			invalidate();
+			onToast(t("users.toast.deleted"), "success");
+			onClose();
+		},
+		onError: (err) => {
+			setConfirmDelete(false);
+			setError(errMessage(err, t("users.toast.deleteFailed")));
+		},
+	});
+
+	const resetMutation = useMutation({
+		mutationFn: () => api.users.setPassword(user?.id ?? "", resetValue),
+		onSuccess: () => {
+			setResetValue("");
+			onToast(t("users.toast.passwordReset"), "success");
+		},
+		onError: (err) => setError(passwordSaveError(err)),
+	});
+
+	const totpResetMutation = useMutation({
+		mutationFn: () => api.users.resetTotp(user?.id ?? ""),
+		onSuccess: () => {
+			setConfirmTotpReset(false);
+			invalidate();
+			onToast(t("users.toast.totpReset"), "success");
+		},
+		onError: (err) => {
+			setConfirmTotpReset(false);
+			setError(errMessage(err, t("users.toast.saveFailed")));
+		},
+	});
+
+	const handleSave = () => {
+		setError(null);
+		setProviderError(null);
+		if (!username.trim()) {
+			setError(t("users.validation.usernameRequired"));
+			return;
+		}
+		if (!isEdit && password.length < 8) {
+			setError(t("users.validation.passwordShort"));
+			return;
+		}
+		// Skipped when the cap is untouched: that save omits the field entirely,
+		// so a stored empty array stays stored instead of blocking every edit.
+		if (!capUnchanged) {
+			if (providerMode === null) {
+				setProviderError("required");
+				return;
+			}
+			// The API rejects an empty array, so never let one leave the form.
+			if (providerMode === "selected" && selectedProviders.length === 0) {
+				setProviderError("empty");
+				return;
+			}
+		}
+		saveMutation.mutate();
+	};
+
+	// Both provider controls clear the validation message as soon as the admin
+	// acts on it, so a stale complaint never outlives the thing it complained about.
+	const chooseProviderMode = (mode: "all" | "selected") => {
+		setProviderError(null);
+		setProviderMode(mode);
+	};
+
+	const toggleProvider = (id: string) => {
+		setProviderError(null);
+		setSelectedProviders((prev) =>
+			prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+		);
+	};
+
+	const toggleGrant = (g: string) =>
+		setGrants((prev) =>
+			prev.includes(g) ? prev.filter((x) => x !== g) : [...prev, g],
+		);
+
+	return {
+		username,
+		setUsername,
+		displayName,
+		setDisplayName,
+		email,
+		setEmail,
+		password,
+		setPassword,
+		role,
+		setRole,
+		grants,
+		enabled,
+		setEnabled,
+		limitRps,
+		setLimitRps,
+		limitBurst,
+		setLimitBurst,
+		limitTpm,
+		setLimitTpm,
+		providerMode,
+		selectedProviders,
+		providerError,
+		error,
+		setError,
+		confirmDelete,
+		setConfirmDelete,
+		confirmTotpReset,
+		setConfirmTotpReset,
+		resetValue,
+		setResetValue,
+		isEdit,
+		isSelf,
+		allGrants,
+		sortedProviders,
+		saveMutation,
+		deleteMutation,
+		resetMutation,
+		totpResetMutation,
+		handleSave,
+		chooseProviderMode,
+		toggleProvider,
+		toggleGrant,
+		t,
+	};
+}

--- a/web/src/pages/VirtualKeys/KeyDetailModal.tsx
+++ b/web/src/pages/VirtualKeys/KeyDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
 	BrainSlashIcon,
 	CalendarPlus,
@@ -56,6 +57,7 @@ export function KeyDetailModal({
 	// hidden, since local changes are replaced on the next config sync.
 	managed?: boolean;
 }) {
+	const { t } = useTranslation();
 	const {
 		editing,
 		editName,
@@ -88,7 +90,6 @@ export function KeyDetailModal({
 		startEditing,
 		hasChanges,
 		handleClose,
-		t,
 		isAdmin,
 		providers,
 		users,

--- a/web/src/pages/VirtualKeys/KeyDetailModal.tsx
+++ b/web/src/pages/VirtualKeys/KeyDetailModal.tsx
@@ -1,6 +1,3 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
 import {
 	BrainSlashIcon,
 	CalendarPlus,
@@ -15,7 +12,6 @@ import {
 	UserRound,
 	Zap,
 } from "@/lib/icons";
-import { api } from "../../api/client";
 import type { VirtualKey } from "../../api/types";
 import { ConfirmDeleteButton } from "../../components/ConfirmDeleteButton";
 import { CopyablePill } from "../../components/CopyablePill";
@@ -23,8 +19,8 @@ import { InfoHint } from "../../components/InfoHint";
 import { DetailItem } from "../../components/LogDetailItem";
 import { Modal } from "../../components/Modal";
 import { Toggle } from "../../components/Toggle";
-import { useIdentity } from "../../context/IdentityContext";
 import { formatNumber } from "../../utils/format";
+import { useKeyEdit } from "./useKeyEdit";
 
 function SectionHeader({
 	icon: Icon,
@@ -47,7 +43,6 @@ function SectionHeader({
 	);
 }
 
-// eslint-disable-next-line max-lines-per-function -- size ratchet: split this component
 export function KeyDetailModal({
 	vk,
 	onClose,
@@ -61,260 +56,43 @@ export function KeyDetailModal({
 	// hidden, since local changes are replaced on the next config sync.
 	managed?: boolean;
 }) {
-	const queryClient = useQueryClient();
-	const { t } = useTranslation();
-	const { isAdmin, me } = useIdentity();
-	const [editing, setEditing] = useState(false);
-	const [editName, setEditName] = useState(vk.name);
-	const [editOwnerId, setEditOwnerId] = useState(vk.owner_user_id ?? "");
-	const [editRps, setEditRps] = useState(vk.rate_limit_rps?.toString() ?? "");
-	const [editBurst, setEditBurst] = useState(
-		vk.rate_limit_burst?.toString() ?? "",
-	);
-	const [editTpm, setEditTpm] = useState(vk.rate_limit_tpm?.toString() ?? "");
-	const [excludedProviders, setExcludedProviders] = useState<string[]>([]);
-	const [originalExcluded, setOriginalExcluded] = useState<string[]>([]);
-	const [providerError, setProviderError] = useState("");
-	const [editStripReasoning, setEditStripReasoning] = useState(
-		vk.strip_reasoning,
-	);
-
-	const { data: providers } = useQuery({
-		queryKey: ["providers"],
-		queryFn: () => api.providers.list(),
-	});
-
-	// Roster for the owner select; admin-only, like the assignment itself.
-	const { data: users } = useQuery({
-		queryKey: ["users"],
-		queryFn: () => api.users.list(),
-		enabled: isAdmin,
-	});
-
-	const sortedProviders = (providers ?? [])
-		.slice()
-		.sort((a, b) => a.name.localeCompare(b.name));
-
-	// A virtual key can never name a provider outside its OWNER's account cap:
-	// the API resolves the write against that cap and the proxy intersects it
-	// again per request. Mirroring it here only saves the user a round trip into
-	// a rejection; it decides nothing.
-	const ownerAccount = editOwnerId
-		? (users ?? []).find((u) => u.id === editOwnerId)
-		: undefined;
-	const ownerCap = ownerAccount?.allowed_providers ?? null;
-	// Non-admins cannot reassign a key (the server writes it to them whatever the
-	// body says), so their own account cap is the one that will apply.
-	const cap = ownerCap ?? (isAdmin ? null : (me?.allowed_providers ?? null));
-	const capIsOtherOwner =
-		ownerCap !== null && ownerAccount?.username !== me?.username;
-	const capNoteId = "vk-detail-provider-cap-note";
-	const capNote = capIsOtherOwner
-		? t("virtualkeys.modal.form.providerOutsideOwnerAccess")
-		: t("virtualkeys.modal.form.providerOutsideAccountAccess");
-	const isOutsideCap = (id: string) => cap !== null && !cap.includes(id);
-	const outsideCapIds = sortedProviders
-		.map((p) => p.id)
-		.filter((id) => isOutsideCap(id));
-	// An out-of-cap provider is always excluded, on top of whatever the user
-	// picked. This is derived rather than seeded into excludedProviders so that
-	// providersChanged keeps tracking user intent alone (an untouched picker
-	// stays untouched) and so a cap that resolves after edit mode opened still
-	// applies.
-	const effectiveExcluded =
-		outsideCapIds.length > 0
-			? Array.from(new Set([...excludedProviders, ...outsideCapIds]))
-			: excludedProviders;
-
-	const toggleProvider = (providerId: string) => {
-		// Out-of-cap chips stay focusable (aria-disabled, not disabled) so their
-		// explanation is reachable, so the choke point on activating them is here.
-		if (isOutsideCap(providerId)) return;
-		setExcludedProviders((prev) =>
-			prev.includes(providerId)
-				? prev.filter((id) => id !== providerId)
-				: [...prev, providerId],
-		);
-	};
-
-	const resetProviders = () => setExcludedProviders([]);
-
-	const deleteMutation = useMutation({
-		mutationFn: () => api.virtualKeys.delete(vk.id),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["virtualKeys"] });
-			onToast(t("virtualkeys.deleted"), "success");
-			onClose();
-		},
-		onError: (err: Error) => {
-			onToast(t("virtualkeys.deleteFailed", { message: err.message }), "error");
-		},
-	});
-
-	const updateMutation = useMutation({
-		mutationFn: ({
-			name,
-			rate_limit_rps,
-			rate_limit_burst,
-			rate_limit_tpm,
-			allowed_providers,
-			strip_reasoning,
-			owner_user_id,
-		}: {
-			name: string;
-			rate_limit_rps?: number | null;
-			rate_limit_burst?: number | null;
-			rate_limit_tpm?: number | null;
-			allowed_providers?: string[] | null;
-			strip_reasoning?: boolean;
-			owner_user_id?: string | null;
-		}) =>
-			api.virtualKeys.update(vk.id, {
-				name,
-				rate_limit_rps,
-				rate_limit_burst,
-				rate_limit_tpm,
-				// Both are omitted-means-preserve on the API; keep them off the
-				// wire entirely rather than sending an explicit undefined.
-				...(allowed_providers !== undefined ? { allowed_providers } : {}),
-				strip_reasoning,
-				...(owner_user_id !== undefined ? { owner_user_id } : {}),
-			}),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["virtualKeys"] });
-			onToast(t("virtualkeys.modal.keyUpdated"), "success");
-			onClose();
-		},
-		onError: (err: Error) => {
-			onToast(
-				t("virtualkeys.modal.keyUpdateFailed", { message: err.message }),
-				"error",
-			);
-		},
-	});
-
-	const handleSave = () => {
-		if (!editName.trim()) return;
-		setProviderError("");
-		// An untouched picker OMITS allowed_providers rather than restating it.
-		// The API reads an absent field as "preserve the stored value" and, since
-		// the request claims nothing about provider access and keeps the key where
-		// it is, does not re-check it against the owner's cap. That is the only
-		// spelling that can edit a key whose owner's cap has since narrowed below
-		// its stored list, and the only one that does not quietly overwrite the
-		// operator's stored intent with the narrowed view this picker is showing.
-		//
-		// A REASSIGNMENT is the exception, and this condition must keep both of
-		// its halves in step with the server's (`req.allowedProvidersPresent ||
-		// !sameOwner(...)` in internal/api/virtualkeys.go). Handing the key to a
-		// different account re-validates the preserved list against the NEW
-		// owner's cap, so omitting the field there gets the stored list refused
-		// with no way back inside this modal: the out-of-cap chips are inert, and
-		// excluding the rest to force a change trips the empty-list guard below.
-		// Restating the narrowed list is also right on the merits, since moving a
-		// key into a narrower account is a deliberate claim, not an untouched
-		// field.
-		let allowedProviders: string[] | null | undefined;
-		if (providersChanged || ownerChanged) {
-			const allProviderIds = sortedProviders.map((p) => p.id);
-			allowedProviders =
-				effectiveExcluded.length > 0
-					? allProviderIds.filter((id) => !effectiveExcluded.includes(id))
-					: // User removed all exclusions → send null (no restriction)
-						null;
-			if (allowedProviders && allowedProviders.length === 0) {
-				setProviderError(t("virtualKeys.create.providerRequired"));
-				return;
-			}
-		}
-		updateMutation.mutate({
-			name: editName.trim(),
-			rate_limit_rps: editRps !== "" ? parseFloat(editRps) : null,
-			rate_limit_burst: editBurst !== "" ? parseInt(editBurst, 10) : null,
-			rate_limit_tpm: editTpm !== "" ? parseInt(editTpm, 10) : null,
-			...(allowedProviders !== undefined
-				? { allowed_providers: allowedProviders }
-				: {}),
-			strip_reasoning: editStripReasoning,
-			// Non-admins omit the field entirely; the server preserves the
-			// current owner (and would force self anyway).
-			...(isAdmin
-				? { owner_user_id: editOwnerId !== "" ? editOwnerId : null }
-				: {}),
-		});
-	};
-
-	const handleCancelEdit = () => {
-		setEditName(vk.name);
-		setEditOwnerId(vk.owner_user_id ?? "");
-		setEditRps(vk.rate_limit_rps?.toString() ?? "");
-		setEditBurst(vk.rate_limit_burst?.toString() ?? "");
-		setEditTpm(vk.rate_limit_tpm?.toString() ?? "");
-		setExcludedProviders([]);
-		setOriginalExcluded([]);
-		setEditStripReasoning(vk.strip_reasoning);
-		setEditing(false);
-	};
-
-	const startEditing = () => {
-		setEditName(vk.name);
-		setEditOwnerId(vk.owner_user_id ?? "");
-		setEditRps(vk.rate_limit_rps?.toString() ?? "");
-		setEditBurst(vk.rate_limit_burst?.toString() ?? "");
-		setEditTpm(vk.rate_limit_tpm?.toString() ?? "");
-		setEditStripReasoning(vk.strip_reasoning);
-		setProviderError("");
-		// Compute excluded providers from the VK's allowed_providers.
-		// If the key has restrictions but providers haven't loaded yet,
-		// we must not proceed — that would silently clear restrictions.
-		//
-		// The test is the LIST'S PRESENCE, not its length. An EMPTY list is a
-		// restriction (deny everything), and it is an ordinary state: deleting the
-		// last provider a key was scoped to prunes the stored list to `{}`. Length-
-		// gating it let a deny-all key fall to the else-branch below, which clears
-		// excludedProviders and paints every provider as allowed, so the first chip
-		// touched would widen the key.
-		if (vk.allowed_providers && !providers) {
-			return;
-		}
-		if (vk.allowed_providers && providers) {
-			const allIds = providers.map((p) => p.id);
-			const excluded = allIds.filter(
-				(id) => !vk.allowed_providers?.includes(id),
-			);
-			setExcludedProviders(excluded);
-			setOriginalExcluded(excluded);
-		} else {
-			setExcludedProviders([]);
-			setOriginalExcluded([]);
-		}
-		setEditing(true);
-	};
-
-	const providersChanged =
-		excludedProviders.length !== originalExcluded.length ||
-		excludedProviders.some((id) => !originalExcluded.includes(id));
-
-	// Moving a key to a different account re-opens the provider question even
-	// when the picker was not touched, because the cap that binds the write
-	// changes with it. handleSave uses this to stay in step with the server.
-	const ownerChanged = editOwnerId !== (vk.owner_user_id ?? "");
-
-	const hasChanges =
-		editName !== vk.name ||
-		ownerChanged ||
-		editRps !== (vk.rate_limit_rps?.toString() ?? "") ||
-		editBurst !== (vk.rate_limit_burst?.toString() ?? "") ||
-		editTpm !== (vk.rate_limit_tpm?.toString() ?? "") ||
-		providersChanged ||
-		editStripReasoning !== vk.strip_reasoning;
-
-	const handleClose = () => {
-		if (editing && hasChanges) {
-			if (!window.confirm(t("virtualkeys.modal.discardChanges"))) return;
-		}
-		onClose();
-	};
+	const {
+		editing,
+		editName,
+		setEditName,
+		editOwnerId,
+		setEditOwnerId,
+		editRps,
+		setEditRps,
+		editBurst,
+		setEditBurst,
+		editTpm,
+		setEditTpm,
+		excludedProviders,
+		providerError,
+		editStripReasoning,
+		setEditStripReasoning,
+		sortedProviders,
+		capIsOtherOwner,
+		capNoteId,
+		capNote,
+		isOutsideCap,
+		outsideCapIds,
+		effectiveExcluded,
+		toggleProvider,
+		resetProviders,
+		deleteMutation,
+		updateMutation,
+		handleSave,
+		handleCancelEdit,
+		startEditing,
+		hasChanges,
+		handleClose,
+		t,
+		isAdmin,
+		providers,
+		users,
+	} = useKeyEdit({ vk, onClose, onToast });
 
 	return (
 		<Modal

--- a/web/src/pages/VirtualKeys/useKeyEdit.ts
+++ b/web/src/pages/VirtualKeys/useKeyEdit.ts
@@ -305,7 +305,6 @@ export function useKeyEdit({
 		startEditing,
 		hasChanges,
 		handleClose,
-		t,
 		isAdmin,
 		providers,
 		users,

--- a/web/src/pages/VirtualKeys/useKeyEdit.ts
+++ b/web/src/pages/VirtualKeys/useKeyEdit.ts
@@ -1,0 +1,313 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "../../api/client";
+import type { VirtualKey } from "../../api/types";
+import { useIdentity } from "../../context/IdentityContext";
+
+/**
+ * Edit-mode state, the owner-cap derivation and the two mutations behind
+ * KeyDetailModal, returned as one bag so the component is markup only.
+ */
+export function useKeyEdit({
+	vk,
+	onClose,
+	onToast,
+}: {
+	vk: VirtualKey;
+	onClose: () => void;
+	onToast: (msg: string, type: "success" | "error" | "info") => void;
+}) {
+	const queryClient = useQueryClient();
+	const { t } = useTranslation();
+	const { isAdmin, me } = useIdentity();
+	const [editing, setEditing] = useState(false);
+	const [editName, setEditName] = useState(vk.name);
+	const [editOwnerId, setEditOwnerId] = useState(vk.owner_user_id ?? "");
+	const [editRps, setEditRps] = useState(vk.rate_limit_rps?.toString() ?? "");
+	const [editBurst, setEditBurst] = useState(
+		vk.rate_limit_burst?.toString() ?? "",
+	);
+	const [editTpm, setEditTpm] = useState(vk.rate_limit_tpm?.toString() ?? "");
+	const [excludedProviders, setExcludedProviders] = useState<string[]>([]);
+	const [originalExcluded, setOriginalExcluded] = useState<string[]>([]);
+	const [providerError, setProviderError] = useState("");
+	const [editStripReasoning, setEditStripReasoning] = useState(
+		vk.strip_reasoning,
+	);
+
+	const { data: providers } = useQuery({
+		queryKey: ["providers"],
+		queryFn: () => api.providers.list(),
+	});
+
+	// Roster for the owner select; admin-only, like the assignment itself.
+	const { data: users } = useQuery({
+		queryKey: ["users"],
+		queryFn: () => api.users.list(),
+		enabled: isAdmin,
+	});
+
+	const sortedProviders = (providers ?? [])
+		.slice()
+		.sort((a, b) => a.name.localeCompare(b.name));
+
+	// A virtual key can never name a provider outside its OWNER's account cap:
+	// the API resolves the write against that cap and the proxy intersects it
+	// again per request. Mirroring it here only saves the user a round trip into
+	// a rejection; it decides nothing.
+	const ownerAccount = editOwnerId
+		? (users ?? []).find((u) => u.id === editOwnerId)
+		: undefined;
+	const ownerCap = ownerAccount?.allowed_providers ?? null;
+	// Non-admins cannot reassign a key (the server writes it to them whatever the
+	// body says), so their own account cap is the one that will apply.
+	const cap = ownerCap ?? (isAdmin ? null : (me?.allowed_providers ?? null));
+	const capIsOtherOwner =
+		ownerCap !== null && ownerAccount?.username !== me?.username;
+	const capNoteId = "vk-detail-provider-cap-note";
+	const capNote = capIsOtherOwner
+		? t("virtualkeys.modal.form.providerOutsideOwnerAccess")
+		: t("virtualkeys.modal.form.providerOutsideAccountAccess");
+	const isOutsideCap = (id: string) => cap !== null && !cap.includes(id);
+	const outsideCapIds = sortedProviders
+		.map((p) => p.id)
+		.filter((id) => isOutsideCap(id));
+	// An out-of-cap provider is always excluded, on top of whatever the user
+	// picked. This is derived rather than seeded into excludedProviders so that
+	// providersChanged keeps tracking user intent alone (an untouched picker
+	// stays untouched) and so a cap that resolves after edit mode opened still
+	// applies.
+	const effectiveExcluded =
+		outsideCapIds.length > 0
+			? Array.from(new Set([...excludedProviders, ...outsideCapIds]))
+			: excludedProviders;
+
+	const toggleProvider = (providerId: string) => {
+		// Out-of-cap chips stay focusable (aria-disabled, not disabled) so their
+		// explanation is reachable, so the choke point on activating them is here.
+		if (isOutsideCap(providerId)) return;
+		setExcludedProviders((prev) =>
+			prev.includes(providerId)
+				? prev.filter((id) => id !== providerId)
+				: [...prev, providerId],
+		);
+	};
+
+	const resetProviders = () => setExcludedProviders([]);
+
+	const deleteMutation = useMutation({
+		mutationFn: () => api.virtualKeys.delete(vk.id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["virtualKeys"] });
+			onToast(t("virtualkeys.deleted"), "success");
+			onClose();
+		},
+		onError: (err: Error) => {
+			onToast(t("virtualkeys.deleteFailed", { message: err.message }), "error");
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: ({
+			name,
+			rate_limit_rps,
+			rate_limit_burst,
+			rate_limit_tpm,
+			allowed_providers,
+			strip_reasoning,
+			owner_user_id,
+		}: {
+			name: string;
+			rate_limit_rps?: number | null;
+			rate_limit_burst?: number | null;
+			rate_limit_tpm?: number | null;
+			allowed_providers?: string[] | null;
+			strip_reasoning?: boolean;
+			owner_user_id?: string | null;
+		}) =>
+			api.virtualKeys.update(vk.id, {
+				name,
+				rate_limit_rps,
+				rate_limit_burst,
+				rate_limit_tpm,
+				// Both are omitted-means-preserve on the API; keep them off the
+				// wire entirely rather than sending an explicit undefined.
+				...(allowed_providers !== undefined ? { allowed_providers } : {}),
+				strip_reasoning,
+				...(owner_user_id !== undefined ? { owner_user_id } : {}),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["virtualKeys"] });
+			onToast(t("virtualkeys.modal.keyUpdated"), "success");
+			onClose();
+		},
+		onError: (err: Error) => {
+			onToast(
+				t("virtualkeys.modal.keyUpdateFailed", { message: err.message }),
+				"error",
+			);
+		},
+	});
+
+	const handleSave = () => {
+		if (!editName.trim()) return;
+		setProviderError("");
+		// An untouched picker OMITS allowed_providers rather than restating it.
+		// The API reads an absent field as "preserve the stored value" and, since
+		// the request claims nothing about provider access and keeps the key where
+		// it is, does not re-check it against the owner's cap. That is the only
+		// spelling that can edit a key whose owner's cap has since narrowed below
+		// its stored list, and the only one that does not quietly overwrite the
+		// operator's stored intent with the narrowed view this picker is showing.
+		//
+		// A REASSIGNMENT is the exception, and this condition must keep both of
+		// its halves in step with the server's (`req.allowedProvidersPresent ||
+		// !sameOwner(...)` in internal/api/virtualkeys.go). Handing the key to a
+		// different account re-validates the preserved list against the NEW
+		// owner's cap, so omitting the field there gets the stored list refused
+		// with no way back inside this modal: the out-of-cap chips are inert, and
+		// excluding the rest to force a change trips the empty-list guard below.
+		// Restating the narrowed list is also right on the merits, since moving a
+		// key into a narrower account is a deliberate claim, not an untouched
+		// field.
+		let allowedProviders: string[] | null | undefined;
+		if (providersChanged || ownerChanged) {
+			const allProviderIds = sortedProviders.map((p) => p.id);
+			allowedProviders =
+				effectiveExcluded.length > 0
+					? allProviderIds.filter((id) => !effectiveExcluded.includes(id))
+					: // User removed all exclusions → send null (no restriction)
+						null;
+			if (allowedProviders && allowedProviders.length === 0) {
+				setProviderError(t("virtualKeys.create.providerRequired"));
+				return;
+			}
+		}
+		updateMutation.mutate({
+			name: editName.trim(),
+			rate_limit_rps: editRps !== "" ? parseFloat(editRps) : null,
+			rate_limit_burst: editBurst !== "" ? parseInt(editBurst, 10) : null,
+			rate_limit_tpm: editTpm !== "" ? parseInt(editTpm, 10) : null,
+			...(allowedProviders !== undefined
+				? { allowed_providers: allowedProviders }
+				: {}),
+			strip_reasoning: editStripReasoning,
+			// Non-admins omit the field entirely; the server preserves the
+			// current owner (and would force self anyway).
+			...(isAdmin
+				? { owner_user_id: editOwnerId !== "" ? editOwnerId : null }
+				: {}),
+		});
+	};
+
+	const handleCancelEdit = () => {
+		setEditName(vk.name);
+		setEditOwnerId(vk.owner_user_id ?? "");
+		setEditRps(vk.rate_limit_rps?.toString() ?? "");
+		setEditBurst(vk.rate_limit_burst?.toString() ?? "");
+		setEditTpm(vk.rate_limit_tpm?.toString() ?? "");
+		setExcludedProviders([]);
+		setOriginalExcluded([]);
+		setEditStripReasoning(vk.strip_reasoning);
+		setEditing(false);
+	};
+
+	const startEditing = () => {
+		setEditName(vk.name);
+		setEditOwnerId(vk.owner_user_id ?? "");
+		setEditRps(vk.rate_limit_rps?.toString() ?? "");
+		setEditBurst(vk.rate_limit_burst?.toString() ?? "");
+		setEditTpm(vk.rate_limit_tpm?.toString() ?? "");
+		setEditStripReasoning(vk.strip_reasoning);
+		setProviderError("");
+		// Compute excluded providers from the VK's allowed_providers.
+		// If the key has restrictions but providers haven't loaded yet,
+		// we must not proceed — that would silently clear restrictions.
+		//
+		// The test is the LIST'S PRESENCE, not its length. An EMPTY list is a
+		// restriction (deny everything), and it is an ordinary state: deleting the
+		// last provider a key was scoped to prunes the stored list to `{}`. Length-
+		// gating it let a deny-all key fall to the else-branch below, which clears
+		// excludedProviders and paints every provider as allowed, so the first chip
+		// touched would widen the key.
+		if (vk.allowed_providers && !providers) {
+			return;
+		}
+		if (vk.allowed_providers && providers) {
+			const allIds = providers.map((p) => p.id);
+			const excluded = allIds.filter(
+				(id) => !vk.allowed_providers?.includes(id),
+			);
+			setExcludedProviders(excluded);
+			setOriginalExcluded(excluded);
+		} else {
+			setExcludedProviders([]);
+			setOriginalExcluded([]);
+		}
+		setEditing(true);
+	};
+
+	const providersChanged =
+		excludedProviders.length !== originalExcluded.length ||
+		excludedProviders.some((id) => !originalExcluded.includes(id));
+
+	// Moving a key to a different account re-opens the provider question even
+	// when the picker was not touched, because the cap that binds the write
+	// changes with it. handleSave uses this to stay in step with the server.
+	const ownerChanged = editOwnerId !== (vk.owner_user_id ?? "");
+
+	const hasChanges =
+		editName !== vk.name ||
+		ownerChanged ||
+		editRps !== (vk.rate_limit_rps?.toString() ?? "") ||
+		editBurst !== (vk.rate_limit_burst?.toString() ?? "") ||
+		editTpm !== (vk.rate_limit_tpm?.toString() ?? "") ||
+		providersChanged ||
+		editStripReasoning !== vk.strip_reasoning;
+
+	const handleClose = () => {
+		if (editing && hasChanges) {
+			if (!window.confirm(t("virtualkeys.modal.discardChanges"))) return;
+		}
+		onClose();
+	};
+
+	return {
+		editing,
+		editName,
+		setEditName,
+		editOwnerId,
+		setEditOwnerId,
+		editRps,
+		setEditRps,
+		editBurst,
+		setEditBurst,
+		editTpm,
+		setEditTpm,
+		excludedProviders,
+		providerError,
+		editStripReasoning,
+		setEditStripReasoning,
+		sortedProviders,
+		capIsOtherOwner,
+		capNoteId,
+		capNote,
+		isOutsideCap,
+		outsideCapIds,
+		effectiveExcluded,
+		toggleProvider,
+		resetProviders,
+		deleteMutation,
+		updateMutation,
+		handleSave,
+		handleCancelEdit,
+		startEditing,
+		hasChanges,
+		handleClose,
+		t,
+		isAdmin,
+		providers,
+		users,
+	};
+}


### PR DESCRIPTION
PR B of the size-ratchet cleanup (after #928, #929, #930). Three more `max-lines-per-function` suppressions go, each by moving one section out.

| Function | Was | Moved out |
|---|---|---|
| `DataStorageSettings` | 553 | the request-log and app-log purge flows were two copies of the same button, range select, confirm and cancel; one `Settings/PurgeLogsControl.tsx` owns the confirm and selection state and renders twice with its labels and mutation. The parent keeps the toasts and cache invalidation; the per-call `mutate` callbacks reset the control on success and close it on error, exactly as the old mutation-level callbacks did. |
| `UserModal` | 564 | form state, validation and the four mutations, now `Users/useUserForm.ts` returned as one bag; the component is markup only |
| `KeyDetailModal` | 616 | edit state, owner-cap derivation and the two mutations, now `VirtualKeys/useKeyEdit.ts` the same way |

The plan's shared provider-cap picker between UserModal and KeyDetailModal was dropped: the two pickers have different semantics (an allow-list with all/selected modes versus an exclusion list intersected with the owner's cap) and only look alike.

One narrowing change in `UserModal`: `user.totp_enabled` became `user?.totp_enabled` inside the edit-only branch, because `isEdit` now comes from the hook and no longer narrows `user` for TypeScript. Same runtime behaviour.

## Verification

- `pnpm lint`, `pnpm exec tsc -b`, Biome, `make size-check` clean.
- Vitest for `pages/Users`, `pages/VirtualKeys` and the DataStorageSettings suite: 257 tests pass.

Three suppressions remain (DatabaseBackupSettings, Arena, Chat) for PR C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
