### PR TITLE
fix(db): provider names are unique in the form routing uses

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"embed"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -78,6 +79,12 @@ func main() {
 
 	database, err := db.New(ctx, cfg.DatabaseURL, cfg.DBMaxConns, cfg.DBMinConns)
 	if err != nil {
+		// A migration that refuses is a schema the database would not take, not
+		// a database this process could not reach, and the two need different
+		// things from the operator. The refusal's own message says what to fix.
+		if errors.Is(err, db.ErrMigrations) {
+			debuglog.Fatal("startup: database migration refused", "error", err)
+		}
 		debuglog.Fatal("startup: failed to connect to database", "error", err)
 	}
 	defer database.Close()

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -94,6 +94,14 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := enforceSourceGenFence(ctx, tx, sourceGen); err != nil {
 		return applyOutcome{}, err
 	}
+	// After the fence, so a push a newer generation already superseded stays the
+	// quiet stale outcome instead of being reported as a bad envelope. Still
+	// ahead of every write, and a check on the envelope as a whole: two providers
+	// whose names are one name once normalized would fight over one routing id,
+	// and nothing about the member's own rows changes the answer.
+	if err := validateSyncedProviderNames(env.Config.Providers); err != nil {
+		return applyOutcome{}, err
+	}
 	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}

--- a/internal/api/configsync_apply_upserts.go
+++ b/internal/api/configsync_apply_upserts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/hugalafutro/model-hotel/internal/db"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 	"github.com/hugalafutro/model-hotel/internal/user"
@@ -92,6 +93,26 @@ func validateSyncedProvider(p ExportProvider) error {
 	return nil
 }
 
+// validateSyncedProviderNames refuses an envelope carrying two providers whose
+// names are the same one once spaces become hyphens. That is the form routing
+// uses (provider.NormalizeName), so such a pair fights over one routing id and
+// one provider cache slot, and the unique index migration 082 installs would
+// refuse the second row anyway. This is the envelope-wide half of the provider
+// validation, so it runs over the whole list once, ahead of the writes, rather
+// than per row inside them.
+func validateSyncedProviderNames(providers []ExportProvider) error {
+	seen := make(map[string]string, len(providers))
+	for _, p := range providers {
+		normalized := provider.NormalizeName(p.Name)
+		if first, ok := seen[normalized]; ok {
+			return fmt.Errorf("%w: providers %q and %q are one name once spaces become hyphens, which is the form routing uses",
+				errInvalidSyncedProvider, first, p.Name)
+		}
+		seen[normalized] = p.Name
+	}
+	return nil
+}
+
 func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider, validateURL func(string) error) error {
 	for _, p := range providers {
 		if err := validateSyncedProvider(p); err != nil {
@@ -129,6 +150,17 @@ func upsertProviders(ctx context.Context, tx pgx.Tx, providers []ExportProvider,
 				updated_at = now()`,
 			p.Name, p.BaseURL, providerTypeForImport(p), p.EncryptedKey, p.KeyNonce, p.KeySalt, p.MaskedKey, p.Enabled, p.AutodiscoveryEnabled, p.ScheduledDisableOn, p.MaxInFlight)
 		if err != nil {
+			// The normalized-name index (migration 082) rejecting a name the envelope
+			// carries means this member holds a provider the envelope does not whose
+			// name differs from it only in spaces and hyphens. The declarative delete
+			// that would remove it runs after this upsert, so the insert meets it. Same
+			// refusal class as the field checks above: the envelope carries what the
+			// interactive API would reject, so a 400, not a 500. Named rather than any
+			// 23505, so the explanation cannot end up on another index's failure.
+			if db.IsUniqueViolationOn(err, "providers_name_normalized_unique") {
+				return fmt.Errorf("%w: provider %q is one name with a provider on this member once spaces become hyphens",
+					errInvalidSyncedProvider, p.Name)
+			}
 			return err
 		}
 	}

--- a/internal/api/configsync_provider_twins_test.go
+++ b/internal/api/configsync_provider_twins_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// An envelope carrying two providers whose names are one name once spaces
+// become hyphens is refused whole, with the same 400 every other envelope-content
+// refusal answers with. Writing it would leave the member with two rows fighting
+// over one routing id, which is exactly what the normalized-name index forbids.
+func TestConfigSync_RefusesProvidersCollidingAfterNormalization(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	seedProvider(t, "twin a", "sk-secret", configSyncMasterKey)
+	seedProvider(t, "twin b", "sk-secret", configSyncMasterKey)
+
+	env := doExport(t, r)
+	if len(env.Config.Providers) != 2 {
+		t.Fatalf("export carries %d providers, want 2", len(env.Config.Providers))
+	}
+	for i := range env.Config.Providers {
+		if env.Config.Providers[i].Name == "twin b" {
+			env.Config.Providers[i].Name = "twin-a"
+		}
+	}
+
+	rec := doImport(t, r, env, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("import status = %d, want 400; body %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, errInvalidSyncedProvider.Error()) {
+		t.Errorf("refusal %q does not carry %q", body, errInvalidSyncedProvider.Error())
+	}
+	for _, want := range []string{"twin a", "twin-a"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("refusal %q does not name %q", body, want)
+		}
+	}
+	if got := providerNames(t); len(got) != 2 || !got["twin a"] || !got["twin b"] {
+		t.Errorf("a refused envelope changed the provider set: %v", got)
+	}
+}
+
+// validateSyncedProviderNames is the envelope-wide half of the provider
+// validation, so it runs over the list rather than a row, and it wraps the
+// sentinel the import handler maps to a 400.
+func TestValidateSyncedProviderNames(t *testing.T) {
+	ok := []ExportProvider{{Name: "alpha"}, {Name: "beta gamma"}, {Name: "beta-gamma-2"}}
+	if err := validateSyncedProviderNames(ok); err != nil {
+		t.Fatalf("distinct names refused: %v", err)
+	}
+	err := validateSyncedProviderNames([]ExportProvider{{Name: "alpha"}, {Name: "a b"}, {Name: "a-b"}})
+	if err == nil || !errors.Is(err, errInvalidSyncedProvider) {
+		t.Fatalf("colliding names not refused with the sentinel: %v", err)
+	}
+	for _, want := range []string{"a b", "a-b"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// The collision the envelope cannot see: a provider this member has and the
+// envelope does not, whose name is a twin of one the envelope carries. The
+// declarative delete that would remove it runs after the upsert, so the insert
+// hits the normalized-name index. That is still the envelope carrying what the
+// interactive API would refuse, so it is the same 400, not a 500.
+func TestConfigSync_RefusesTwinOfALocalProviderAsBadRequest(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	seedProvider(t, "twin-a", "sk-secret", configSyncMasterKey)
+	seedProvider(t, "keep", "sk-secret", configSyncMasterKey)
+
+	env := doExport(t, r)
+	if _, err := apiTestDB.Pool().Exec(t.Context(),
+		`UPDATE providers SET name = 'twin a' WHERE name = 'twin-a'`); err != nil {
+		t.Fatalf("rename the local row: %v", err)
+	}
+
+	rec := doImport(t, r, env, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("import status = %d, want 400; body %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, errInvalidSyncedProvider.Error()) {
+		t.Errorf("refusal %q does not carry %q", body, errInvalidSyncedProvider.Error())
+	}
+	// The phrase the in-transaction branch uses, so this pins the constraint
+	// path rather than the envelope-wide check that runs before the transaction.
+	if !strings.Contains(body, `"twin-a" is one name with a provider on this member`) {
+		t.Errorf("refusal %q is not the one the normalized-name index produces", body)
+	}
+	if got := providerNames(t); len(got) != 2 || !got["keep"] || !got["twin a"] {
+		t.Errorf("a refused envelope changed the provider set: %v", got)
+	}
+}
+
+// The commit fence answers before the envelope's content is judged. A push a
+// newer generation already superseded is the quiet stale outcome even when it
+// carries names that would otherwise be refused, so Front Desk sees a skip for a
+// push the fence exists to ignore rather than a failed member.
+func TestConfigSync_StaleEnvelopeWithCollidingNamesIsStale(t *testing.T) {
+	cleanConfigTables(t)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	seedProvider(t, "twin a", "sk-secret", configSyncMasterKey)
+
+	env := doExport(t, r)
+	if resp, rec := doImportGen(t, r, env, new(int64(7))); rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+		t.Fatalf("gen=7 import: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
+	}
+
+	// "twin-a" is one name with the member's "twin a" once normalized, so this
+	// envelope would be refused with a 400 if the fence did not answer first.
+	resp, rec := doImportGen(t, r, withExtraProvider(env, "twin-a"), new(int64(6)))
+	if rec.Code != http.StatusOK || resp.Applied || !resp.Stale {
+		t.Fatalf("stale import with colliding names: code=%d applied=%v stale=%v, want 200 not-applied stale; body %s",
+			rec.Code, resp.Applied, resp.Stale, rec.Body.String())
+	}
+	if got := providerNames(t); len(got) != 1 || !got["twin a"] {
+		t.Errorf("a stale envelope changed the provider set: %v", got)
+	}
+}

--- a/internal/api/handler_provider_name_twins_test.go
+++ b/internal/api/handler_provider_name_twins_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// createTwinProvider posts a provider and returns the recorder, so a test can
+// assert on either the created row or the refusal.
+func createTwinProvider(t *testing.T, r chi.Router, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"name":` + strconv.Quote(name) + `,"base_url":"https://api.example.com/v1","api_key":"sk-twin"}`
+	req := httptest.NewRequest(http.MethodPost, "/providers", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// renameTwinProvider puts a new name onto an existing provider.
+func renameTwinProvider(t *testing.T, r chi.Router, id, name string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := `{"name":` + strconv.Quote(name) + `}`
+	req := httptest.NewRequest(http.MethodPut, "/providers/"+id, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// createdProviderID reads the id out of a 201 response.
+func createdProviderID(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	return resp.ID
+}
+
+// Two names that differ only by a space where the other has a hyphen are one
+// name as far as routing is concerned, so the create path refuses the second,
+// and the refusal says why rather than claiming an exact duplicate.
+func TestCreateProvider_RefusesNormalizedTwin(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	createdProviderID(t, createTwinProvider(t, r, "twin a"))
+
+	rec := createTwinProvider(t, r, "twin-a")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("creating the twin returned %d, want 409; body %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "spaces and hyphens") {
+		t.Errorf("refusal %q does not explain that spaces and hyphens are the same name", body)
+	}
+}
+
+// The same rule on the rename path: a provider cannot take a name that is
+// another provider's up to the normalization.
+func TestUpdateProvider_RefusesNormalizedTwinOfAnotherProvider(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	createdProviderID(t, createTwinProvider(t, r, "twin a"))
+	otherID := createdProviderID(t, createTwinProvider(t, r, "other"))
+
+	rec := renameTwinProvider(t, r, otherID, "twin-a")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("renaming onto the twin returned %d, want 409; body %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "spaces and hyphens") {
+		t.Errorf("refusal %q does not explain that spaces and hyphens are the same name", body)
+	}
+}
+
+// A provider renaming itself to its own twin spelling is not a conflict: the
+// row that would collide is the row being renamed, and the normalized name it
+// routes under does not change.
+func TestUpdateProvider_AllowsOwnNormalizedTwinSpelling(t *testing.T) {
+	_, r := newTestHandlerWithRouter(t)
+
+	id := createdProviderID(t, createTwinProvider(t, r, "twin a"))
+
+	rec := renameTwinProvider(t, r, id, "twin-a")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("renaming a provider to its own twin spelling returned %d, want 200; body %s", rec.Code, rec.Body.String())
+	}
+	var stored string
+	if err := apiTestDB.Pool().QueryRow(t.Context(), `SELECT name FROM providers WHERE id = $1`, id).Scan(&stored); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if stored != "twin-a" {
+		t.Errorf("stored name = %q, want %q", stored, "twin-a")
+	}
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -89,7 +89,7 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.providerNameTaken(r.Context(), req.Name, uuid.Nil) {
-		http.Error(w, "a provider with this name already exists", http.StatusConflict)
+		http.Error(w, providerNameConflictMsg, http.StatusConflict)
 		return
 	}
 
@@ -123,7 +123,7 @@ func (h *Handler) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	p, err := h.providerRepo.Create(r.Context(), req, encCiphertext, encNonce, encSalt)
 	if err != nil {
 		if db.IsUniqueViolation(err) {
-			http.Error(w, "a provider with this name already exists", http.StatusConflict)
+			http.Error(w, providerNameConflictMsg, http.StatusConflict)
 			return
 		}
 		respondError(w, fmt.Sprintf("failed to create provider %q", req.Name), err, http.StatusInternalServerError)
@@ -411,7 +411,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Name != nil && h.providerNameTaken(r.Context(), *req.Name, id) {
-		http.Error(w, "a provider with this name already exists", http.StatusConflict)
+		http.Error(w, providerNameConflictMsg, http.StatusConflict)
 		return
 	}
 
@@ -447,7 +447,7 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 	p, err := h.providerRepo.Update(r.Context(), id, req, encryptedKey, keyNonce, keySalt)
 	if err != nil {
 		if db.IsUniqueViolation(err) {
-			http.Error(w, "a provider with this name already exists", http.StatusConflict)
+			http.Error(w, providerNameConflictMsg, http.StatusConflict)
 			return
 		}
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -598,10 +598,19 @@ func providerTypeAllowsEmptyKey(providerType string) bool {
 	return providerType == "opencode-zen" || providerType == "custom" || provider.IsLocalServerType(providerType)
 }
 
+// providerNameConflictMsg is the 409 both provider writes answer with, on the
+// application-level check and on the constraint that backs it. It spells out
+// the comparison because it is not the obvious one: names are unique in the
+// form routing uses (provider.NormalizeName maps spaces to hyphens), so a name
+// that reads as free in the dashboard can still be taken.
+const providerNameConflictMsg = "a provider with this name already exists: names are compared the way routing compares them, with spaces and hyphens treated alike"
+
 // providerNameTaken is the application-level duplicate-name check both writes
-// run before the DB unique constraint sees the row. excludeID is the provider
-// being renamed, so a rename to its own name is not a conflict; pass uuid.Nil
-// on create. A lookup failure looks like "no duplicate" and leaves the
+// run before the DB unique constraint sees the row. GetByName falls back to the
+// normalized form, so this catches a name that is another provider's up to
+// spaces and hyphens as well as an exact one. excludeID is the provider being
+// renamed, so taking its own name, in either spelling, is not a conflict; pass
+// uuid.Nil on create. A lookup failure looks like "no duplicate" and leaves the
 // constraint as the backstop, so it is logged: a flaky database must not
 // quietly admit duplicates.
 func (h *Handler) providerNameTaken(ctx context.Context, name string, excludeID uuid.UUID) bool {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,6 +4,7 @@ package db
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"time"
@@ -60,6 +61,12 @@ type DB struct {
 	pool *pgxpool.Pool
 }
 
+// ErrMigrations marks a New that reached the database and then would not take
+// its schema. A migration can refuse on purpose (082 refuses an install whose
+// provider names collide once normalized), and that has to read as a schema
+// refusal rather than as a database the process could not reach.
+var ErrMigrations = errors.New("failed to run migrations")
+
 // New creates a new DB instance, runs migrations, and returns the database connection.
 func New(ctx context.Context, databaseURL string, maxConns, minConns int32) (*DB, error) {
 	config, err := pgxpool.ParseConfig(databaseURL)
@@ -86,7 +93,7 @@ func New(ctx context.Context, databaseURL string, maxConns, minConns int32) (*DB
 
 	if err := db.runMigrations(ctx); err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("failed to run migrations: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrMigrations, err)
 	}
 
 	return db, nil

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -496,6 +496,11 @@ func TestRunMigrations_ReadDirError(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "failed to read migrations directory") {
 		t.Errorf("error = %q, want substring %q", got, "failed to read migrations directory")
 	}
+	// The caller logs a schema the database refused differently from a database
+	// it could not reach, so the two have to be distinguishable.
+	if !errors.Is(err, ErrMigrations) {
+		t.Errorf("error %v is not an ErrMigrations", err)
+	}
 }
 
 // TestRunMigrations_DirEntry tests that directory entries are skipped.

--- a/internal/db/migration_provider_name_normalized_test.go
+++ b/internal/db/migration_provider_name_normalized_test.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"context"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+const providerNameNormalizedMigration = "migrations/082_provider_name_normalized_unique.sql"
+
+// Migration 082 makes provider names unique in the form routing actually uses,
+// where a space and a hyphen are the same character. Its three behaviours are
+// asserted in one test because they share a seeded state: the migration refuses
+// an install that already holds a colliding pair (naming both rows so the
+// operator knows which to rename), applies once the collision is gone, and
+// leaves behind an index that stops the next twin at the database.
+//
+// The migration is replayed directly, because runMigrations has already applied
+// it to the shared test database; the index it installs has to come off first or
+// the colliding pair could not be seeded at all. That drop is on the database
+// every test in this package shares, so this test must not run in parallel with
+// one that writes providers: it holds the index off until its cleanup restores
+// it.
+func TestProviderNameNormalizedMigrationRefusesCollisions(t *testing.T) {
+	ctx := context.Background()
+	b, err := fs.ReadFile(embeddedMigrations, providerNameNormalizedMigration)
+	if err != nil {
+		t.Fatalf("read %s: %v", providerNameNormalizedMigration, err)
+	}
+	sql := string(b)
+
+	if _, err := testPool.Exec(ctx, `DROP INDEX IF EXISTS providers_name_normalized_unique`); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM providers WHERE name LIKE 'twin%'`)
+		// Leave the shared database with the index the migration installs, and
+		// prove the replay is harmless while doing so.
+		if _, err := testPool.Exec(context.Background(), sql); err != nil {
+			t.Errorf("restore migration: %v", err)
+		}
+	})
+
+	for _, name := range []string{"twin a", "twin-a"} {
+		if _, err := testPool.Exec(ctx,
+			`INSERT INTO providers (name, base_url, provider_type) VALUES ($1, 'https://twin.example.test/v1', 'custom')`,
+			name); err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+	}
+
+	_, err = testPool.Exec(ctx, sql)
+	if err == nil {
+		t.Fatal("the migration applied over a colliding pair; it must refuse")
+	}
+	// The operator has to pick which name survives, so the message names both,
+	// and it has to carry the remedy itself: the Go driver renders a server
+	// error as severity, message and SQLSTATE only, so the HINT never reaches
+	// the startup log.
+	for _, want := range []string{"twin a", "twin-a", "rename one provider in each group"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q does not carry %q", err.Error(), want)
+		}
+	}
+
+	if _, err := testPool.Exec(ctx, `DELETE FROM providers WHERE name = 'twin a'`); err != nil {
+		t.Fatalf("resolve the collision: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, sql); err != nil {
+		t.Fatalf("the migration must apply once the collision is gone: %v", err)
+	}
+
+	_, err = testPool.Exec(ctx,
+		`INSERT INTO providers (name, base_url, provider_type) VALUES ('twin a', 'https://twin.example.test/v1', 'custom')`)
+	if !IsUniqueViolationOn(err, "providers_name_normalized_unique") {
+		t.Fatalf("inserting a normalized twin returned %v, want a 23505", err)
+	}
+}

--- a/internal/db/migrations/082_provider_name_normalized_unique.sql
+++ b/internal/db/migrations/082_provider_name_normalized_unique.sql
@@ -1,0 +1,40 @@
+-- Provider names have been unique on the raw string since migration 023, but
+-- that is not the form the gateway routes on. provider.NormalizeName maps every
+-- space to a hyphen, and the normalized name is what "<provider>/<model>"
+-- routing ids carry, what the provider cache keys on, and what GetByName falls
+-- back to when the raw lookup misses. So "a b" and "a-b" pass the raw
+-- constraint, produce the same routing id, share one cache slot, and resolve to
+-- whichever row the fallback query returns first.
+--
+-- The unique index closes that: names are unique in the normalized form too.
+-- The raw constraint stays, because ON CONFLICT (name) in the config-sync
+-- import keys on it.
+--
+-- An install that already holds a colliding pair refuses to start rather than
+-- being repaired here. It is already misrouting, and either name is load
+-- bearing: renaming one changes the routing id every client and every custom
+-- failover group entry names it by, so the operator picks which one survives.
+DO $$
+DECLARE
+    collisions text;
+BEGIN
+    SELECT string_agg(g.names, '; ' ORDER BY g.names) INTO collisions
+    FROM (
+        SELECT string_agg(quote_literal(name), ', ' ORDER BY name) AS names
+        FROM providers
+        GROUP BY REPLACE(name, ' ', '-')
+        HAVING count(*) > 1
+    ) g;
+
+    IF collisions IS NOT NULL THEN
+        -- The remedy belongs in the message, not only in the HINT: the Go driver
+        -- renders a server error as severity, message and SQLSTATE alone, so a
+        -- HINT reaches an operator running psql and nobody else.
+        RAISE EXCEPTION 'provider names collide once spaces become hyphens, which is the form routing uses; rename one provider in each group so the names differ by more than a space, then restart. Groups: %', collisions
+            USING HINT = 'rename one provider in each group so the names differ by more than a space, then restart';
+    END IF;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS providers_name_normalized_unique
+        ON providers ((REPLACE(name, ' ', '-')));
+END
+$$;

--- a/internal/db/pgerr.go
+++ b/internal/db/pgerr.go
@@ -14,6 +14,18 @@ func IsUniqueViolation(err error) bool {
 	return pgCode(err, "23505")
 }
 
+// IsUniqueViolationOn reports whether err is a unique violation raised by one
+// named constraint or index. A table can carry several, so a caller that
+// explains the failure in its own words has to know which one fired: reading
+// every 23505 as the interesting one starts lying the day another unique column
+// is added.
+func IsUniqueViolationOn(err error, constraint string) bool {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+		return pgErr.Code == "23505" && pgErr.ConstraintName == constraint
+	}
+	return false
+}
+
 // IsForeignKeyViolation reports whether err is a PostgreSQL foreign-key
 // violation (SQLSTATE 23503). Callers use it to turn a reference to a row that
 // has since been deleted into a 400/404 instead of a 500.

--- a/internal/db/pgerr_test.go
+++ b/internal/db/pgerr_test.go
@@ -82,3 +82,34 @@ func TestIsForeignKeyViolation(t *testing.T) {
 		})
 	}
 }
+
+// IsUniqueViolationOn is the narrow variant: the same 23505, but only from the
+// constraint the caller names, so a message about one index cannot be attached
+// to another index's failure.
+func TestIsUniqueViolationOn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		constraint string
+		want       bool
+	}{
+		{"nil_error", nil, "providers_name_normalized_unique", false},
+		{"matching_constraint", &pgconn.PgError{Code: "23505", ConstraintName: "providers_name_normalized_unique"}, "providers_name_normalized_unique", true},
+		{"other_constraint", &pgconn.PgError{Code: "23505", ConstraintName: "providers_name_unique"}, "providers_name_normalized_unique", false},
+		{"no_constraint_name", &pgconn.PgError{Code: "23505"}, "providers_name_normalized_unique", false},
+		{"other_sqlstate", &pgconn.PgError{Code: "23503", ConstraintName: "providers_name_normalized_unique"}, "providers_name_normalized_unique", false},
+		{"wrapped", fmt.Errorf("wrap: %w", &pgconn.PgError{Code: "23505", ConstraintName: "providers_name_normalized_unique"}), "providers_name_normalized_unique", true},
+		{"non_pg_error", errors.New("some other error"), "providers_name_normalized_unique", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsUniqueViolationOn(tt.err, tt.constraint); got != tt.want {
+				t.Errorf("IsUniqueViolationOn(%v, %q) = %v, want %v", tt.err, tt.constraint, got, tt.want)
+			}
+		})
+	}
+}

--- a/web/src/pages/Providers/AddProviderModal.tsx
+++ b/web/src/pages/Providers/AddProviderModal.tsx
@@ -68,10 +68,14 @@ function generateProviderName(
 		providerTypeTranslationKeys[type] || "providers.add.providerFallback",
 	);
 	if (!providers) return baseName;
-	const existingNames = new Set(providers.map((p) => p.name));
-	if (!existingNames.has(baseName)) return baseName;
+	// Names are taken in the form routing uses, where a space and a hyphen are
+	// the same character, so a suggestion has to dodge both spellings or the
+	// create it proposes comes back a 409.
+	const routingForm = (name: string) => name.replaceAll(" ", "-");
+	const existingNames = new Set(providers.map((p) => routingForm(p.name)));
+	if (!existingNames.has(routingForm(baseName))) return baseName;
 	let n = 2;
-	while (existingNames.has(`${baseName} ${n}`)) n++;
+	while (existingNames.has(routingForm(`${baseName} ${n}`))) n++;
 	return `${baseName} ${n}`;
 }
 

--- a/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
@@ -1027,6 +1027,35 @@ describe("AddProviderModal", () => {
 			selectTypeSync("openai");
 			expect(nameInput).toHaveValue("OpenAI 3");
 		});
+
+		// The backend takes a name in the form routing uses, where a space and a
+		// hyphen are the same character, so "OpenAI-2" already occupies the name
+		// "OpenAI 2" would ask for.
+		it("skips a suggestion whose hyphenated spelling is taken", () => {
+			const existingProviders = ["OpenAI", "OpenAI-2"].map((name, i) => ({
+				name,
+				base_url: "https://api.openai.com/v1",
+				provider_type: "openai",
+				id: `p${i + 1}`,
+				masked_key: "sk_••••",
+				enabled: true,
+				autodiscovery_enabled: true,
+				scheduled_disable_on: null,
+				max_in_flight: null,
+				last_discovered_at: null,
+				last_used_at: null,
+				created_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+				model_count: 0,
+				total_tokens: 0,
+			}));
+			renderWithProviders(
+				<AddProviderModal {...defaultProps} providers={existingProviders} />,
+			);
+			const nameInput = screen.getByLabelText("Name");
+			selectTypeSync("openai");
+			expect(nameInput).toHaveValue("OpenAI 3");
+		});
 	});
 
 	describe("handleProviderTypeChange with custom", () => {

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -95,7 +95,7 @@ This is invisible to the client: ordinary Chat Completions in and out, streaming
 **Model Routing:**
 
 - `hotel/<model>` - Failover routing (tries all providers that offer the model, with automatic failover on 5xx and optionally on 429)
-- `<provider>/<model>` - Direct routing to a specific named provider (no failover)
+- `<provider>/<model>` - Direct routing to a specific named provider (no failover). The provider name is carried in the form routing uses, with every space replaced by a hyphen: a provider named `my provider` is addressed as `my-provider/<model>`
 
 **Streaming Response Format:**
 ```
@@ -299,10 +299,22 @@ The plaintext API key is never returned; `masked_key` is a display-only preview.
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
-| `name` | string | Yes | 1-100 characters, unique |
+| `name` | string | Yes | 1-100 characters, unique in the routing form (see below) |
 | `base_url` | string | Yes | 1-500 characters, must use HTTPS unless `ALLOW_HTTP_PROVIDERS=true` |
 | `provider_type` | string | No | One of the known types (see [Model Discovery](Model-Discovery#provider-type)). Omitted, it is derived from the vendor hostname |
 | `api_key` | string | No | 1-500 characters (required for most providers, optional for Ollama, KoboldCPP, LMStudio, OpenCode Zen, custom) |
+
+**Names are unique in the form routing uses.** A `<provider>/<model>` id replaces
+every space in the provider name with a hyphen, so `my provider` and
+`my-provider` are one name: creating the second, or renaming a provider onto it,
+returns `409`. Renaming a provider to its own other spelling is allowed, since
+the name it routes under does not change. An install that already holds such a
+pair, from before the rule existed, refuses to start until one of them is
+renamed, because either name may be the one clients use. The dashboard is down
+at that point, so the rename happens in the database (the startup message names
+the pair): `docker compose exec db psql -U modelhotel -d modelhotel -c "UPDATE
+providers SET name = 'my provider 2' WHERE name = 'my-provider'"`, then start
+again. Restoring a backup taken before the rule is the usual way to reach this.
 
 **Self-hosted providers must name their type.** Omitting `provider_type` derives it
 from the hostname only, so `http://box:11434` becomes a generic OpenAI-compatible

--- a/wiki/Failover-and-Hotel-Routing.md
+++ b/wiki/Failover-and-Hotel-Routing.md
@@ -272,6 +272,8 @@ The prefix itself is matched **case-sensitively**: `hotel/` routes through a gro
 
 Three conditions all answer **404**, each with its own reason in the error body: no group exists for that name (`model not found: hotel/<name>`), the group's master toggle is off (`failover group disabled`), or the group has no entries at all (`no entries in failover group`). A group that exists and is enabled but whose every entry was filtered out answers with the no-available-provider error instead, which carries the reason each candidate was skipped.
 
+The other form, `<provider>/<model>`, names one provider directly and carries the provider's name in the form routing uses: every space becomes a hyphen, so a provider named `my provider` is addressed as `my-provider/<model>`. Provider names are unique in that form, so an id names exactly one provider.
+
 ### Model Name Resolution
 
 **Exact Base Name Matching:**

--- a/wiki/High-Availability.md
+++ b/wiki/High-Availability.md
@@ -391,7 +391,9 @@ What makes this safe to leave running:
 - **What the dashboard would refuse, sync refuses.** A member applies an envelope
   with the load-bearing checks its own admin API applies on the way in: provider
   `base_url` shape (the same address rules), provider name length and
-  printability, the disable date's format, the per-provider `max_in_flight`
+  printability, provider names that are one name once spaces become hyphens
+  (the form routing uses, so such a pair would fight over one routing id), the
+  disable date's format, the per-provider `max_in_flight`
   ceiling (1 to 10000, or null: a value below one would read as no ceiling at
   all), settings minimums and URL-typed settings, per-key and per-user rate
   limits, and password hash format. An envelope that fails any of them is
@@ -400,7 +402,11 @@ What makes this safe to leave running:
   configsync: refusing to apply an invalid provider: provider "x": max_in_flight
   must be ...`), in the sync result, in the failure event and in the readiness
   check, cut to one line of 240 characters; the member's own log carries the
-  full text.
+  full text. The name rule has one refusal an operator has to clear by hand:
+  when the primary renames `a b` to `a-b`, a member still holding the old row
+  refuses every push, because the delete that would remove it runs after the
+  provider write, so rename or delete that stale row on the member and the next
+  push converges.
 - **Newer config always wins.** Each push carries a monotonic source generation,
   and a member refuses any import older than the one it has already applied, so
   repointing the primary while an earlier push is still in flight can never strand a


### PR DESCRIPTION
## What

Provider names were unique on the raw string only (migration 023), while routing ids (`<provider>/<model>` with spaces mapped to hyphens), the provider cache and `GetByName`'s fallback all use the normalized form. `"a b"` and `"a-b"` could coexist, share one cache slot and route to whichever row came back first. Found by the Codex audit during the simplification pass (#941), agreed as the first follow-up.

## Changes

- Migration `082_provider_name_normalized_unique`: unique index on `REPLACE(name, ' ', '-')`. An install already holding a colliding pair refuses to start with a message naming the pair and the remedy (rename one in the database, restart). Chosen over a silent rename because either name may be the one clients route by.
- Admin API: create and rename answer 409 for a normalized twin with a message that states the rule (the check itself already went through the normalized lookup; only the DB backstop and the wording were missing). Renaming a provider to its own other spelling stays allowed.
- Config-sync import: an envelope carrying a colliding pair is refused before the transaction (after the stale-source fence, so a superseded push stays a quiet `Stale`), and a twin of a local provider absent from the export is reported as a refused import rather than a 500.
- `db.IsUniqueViolationOn` names the constraint it expects, so the twin message cannot start lying when another unique column appears.
- Startup log distinguishes a refused migration from a database connection failure.
- Dashboard: the suggested provider name compares the way the backend does, so it never proposes a name the create would refuse.
- Wiki: the rule and its remedy in API-Reference, Failover-and-Hotel-Routing and High-Availability.

## Verification

- Tests: migration refusal names both raw names and applies cleanly once one is gone; the index rejects a twin with 23505 on the named index; handler tests for create, rename and own-spelling rename; config-sync pre-flight, stale-fence ordering and local-twin refusal; dashboard name generator.
- `make lint` 0 issues, vet, gofmt, gci, size gate, i18n check; suites of `internal/db`, `internal/api`, `cmd/server`, `cmd/frontdesk`, Providers vitest.
- Two Opus review rounds (nine findings fixed in round 1, two nits in round 2).
- Dev stack rebuilt from the branch: migration 082 applied, creating `Twin Smoke` then `Twin-Smoke` answers 409 with the new message, admin API answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
