### PR TITLE
fix(discovery): one DiscoveryService per handler and per process

### DIFF
--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
-	"github.com/hugalafutro/model-hotel/internal/proxy"
 	"github.com/hugalafutro/model-hotel/internal/settings"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
@@ -58,7 +57,11 @@ type discoveryDeps struct {
 	providerRepo *provider.Repository
 	modelRepo    *model.Repository
 	failoverRepo *failover.Repository
-	dialer       *proxy.SafeDialer
+	// discovery is the process-wide DiscoveryService, shared with the API
+	// handler and the quota poll loop: one transport pool and one quota circuit
+	// breaker for the life of the process rather than one per run. It carries
+	// the SSRF-protected dial and redirect hooks the handler was built with.
+	discovery *provider.DiscoveryService
 	// settingsRepo carries the outstanding-claim alert's threshold and its
 	// persisted edge latch. Typed as the interface the API package already
 	// defines so this stays a dependency on the two reads and two writes the
@@ -115,13 +118,12 @@ func runDiscovery(deps discoveryDeps, source string) DiscoveryResult {
 		result.Errors = append(result.Errors, fmt.Sprintf("failed to list providers: %v", err))
 		return result
 	}
-	discoverySvc := provider.NewDiscoveryService(deps.dialer.DialContext, deps.dialer.CheckRedirect)
 	var scannedOK []uuid.UUID
 	for _, p := range providers {
 		if !p.Enabled {
 			continue
 		}
-		changed, ok := scanProvider(ctx, deps, discoverySvc, p, source, &result)
+		changed, ok := scanProvider(ctx, deps, deps.discovery, p, source, &result)
 		if changed {
 			changesRecorded = true
 		}

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -73,9 +73,16 @@ func testDiscoveryDeps(t *testing.T) discoveryDeps {
 		providerRepo: provider.NewRepository(pool),
 		modelRepo:    model.NewRepository(pool),
 		failoverRepo: failover.NewRepository(pool),
-		dialer:       proxy.NewSafeDialer([]string{"127.0.0.1"}, nil),
+		discovery:    newTestDiscoveryService(),
 		settingsRepo: settings.NewRepository(pool),
 	}
+}
+
+// newTestDiscoveryService mirrors the production wiring: one service carrying
+// the SafeDialer's hooks, shared by every run in the test's deps.
+func newTestDiscoveryService() *provider.DiscoveryService {
+	sd := proxy.NewSafeDialer([]string{"127.0.0.1"}, nil)
+	return provider.NewDiscoveryService(sd.DialContext, sd.CheckRedirect)
 }
 
 // wipeDiscoveryState clears the tables discovery writes to so tests don't
@@ -460,9 +467,8 @@ func TestScanProviderUnreachable(t *testing.T) {
 		t.Fatalf("failed to create provider: %v", err)
 	}
 
-	svc := provider.NewDiscoveryService(deps.dialer.DialContext, deps.dialer.CheckRedirect)
 	var result DiscoveryResult
-	changed, ok := scanProvider(ctx, deps, svc, p, "test", &result)
+	changed, ok := scanProvider(ctx, deps, deps.discovery, p, "test", &result)
 	if changed {
 		t.Error("expected no change row for a failed scan")
 	}
@@ -839,11 +845,9 @@ func TestRecordMissingModelsUntrustedWhenSuspect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("snapshot: %v", err)
 	}
-	svc := provider.NewDiscoveryService(deps.dialer.DialContext, deps.dialer.CheckRedirect)
-
 	cancelled, cancel := context.WithCancel(ctx)
 	cancel()
-	disabled, trusted := recordMissingModels(cancelled, deps, svc, p, nil, snapshot)
+	disabled, trusted := recordMissingModels(cancelled, deps, deps.discovery, p, nil, snapshot)
 
 	if trusted {
 		t.Error("a suspect scan reported trusted=true")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -387,7 +387,10 @@ func main() {
 		providerRepo: providerRepo,
 		modelRepo:    modelRepo,
 		failoverRepo: failoverRepo,
-		dialer:       sd,
+		// The handler owns the process's one discovery service, built from the
+		// same SafeDialer hooks it was given; sharing it here is what keeps the
+		// transport pool and the quota circuit breaker alive between runs.
+		discovery:    apiHandler.DiscoveryService(),
 		settingsRepo: settingsRepo,
 	}
 
@@ -457,6 +460,11 @@ func main() {
 	// Release goroutine-leaking resources before draining HTTP connections.
 	proxyHandler.Close()
 	apiHandler.StopBackupScheduler()
+	// Close only drops the shared service's idle pooled connections; a request
+	// the discovery runs or the quota poll loop still hold keeps its own
+	// connection until it returns. Both loops stop on the deferred root cancel,
+	// which runs after this block.
+	discDeps.discovery.Close()
 	util.CloseDockerClient()
 
 	// End every open /api/events SSE stream. Each one is an in-flight request

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -164,7 +164,12 @@ type Handler struct {
 	// than package-level, so two handlers built concurrently neither race nor
 	// couple to whichever was constructed last. Nil falls back to the package
 	// default.
-	newDiscovery   func() *provider.DiscoveryService
+	newDiscovery func() *provider.DiscoveryService
+	// discovery is the one service that factory ever produces, built on first
+	// use. One per handler keeps the transport's idle-connection pool and the
+	// quota circuit breaker's failure counts alive across calls.
+	discovery      *provider.DiscoveryService
+	discoveryOnce  sync.Once
 	circuitBreaker CircuitBreakerControl
 	capLedger      *provider.CapLedger
 	audit          *audit.Recorder   // nil until SetAudit (audit trail of admin actions)

--- a/internal/api/discovery.go
+++ b/internal/api/discovery.go
@@ -29,15 +29,35 @@ var newDiscoveryService = func() *provider.DiscoveryService {
 	return provider.NewDiscoveryService(nil, nil)
 }
 
-// discoveryService returns this handler's DiscoveryService. Every caller inside
-// the package goes through it rather than the package variable, so a handler's
-// SSRF-protected dial and redirect hooks cannot be swapped out from under it by
-// another handler's construction.
+// discoveryService returns this handler's DiscoveryService, built on first use
+// and never again. Every caller inside the package goes through it rather than
+// the package variable, so a handler's SSRF-protected dial and redirect hooks
+// cannot be swapped out from under it by another handler's construction.
+//
+// One instance per handler is what makes the service's state mean anything: a
+// new one per call would hand back a fresh transport whose idle-connection pool
+// is discarded after a single use, and a fresh quota circuit breaker whose
+// failure counts restart from zero, so consecutive failures across polls could
+// never reach the threshold that opens it.
+//
+// Built lazily rather than in NewHandler so a test that installs its own
+// factory before the first call still gets its fake.
 func (h *Handler) discoveryService() *provider.DiscoveryService {
-	if h.newDiscovery != nil {
-		return h.newDiscovery()
-	}
-	return newDiscoveryService()
+	h.discoveryOnce.Do(func() {
+		if h.newDiscovery != nil {
+			h.discovery = h.newDiscovery()
+			return
+		}
+		h.discovery = newDiscoveryService()
+	})
+	return h.discovery
+}
+
+// DiscoveryService exposes that one instance to the server binary, so the
+// background discovery run and the quota poll loop share the handler's service
+// rather than each building one of their own.
+func (h *Handler) DiscoveryService() *provider.DiscoveryService {
+	return h.discoveryService()
 }
 
 // Injectable variables for test overrides.

--- a/internal/api/discovery_lifecycle_test.go
+++ b/internal/api/discovery_lifecycle_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/hugalafutro/model-hotel/internal/provider"
+)
+
+// TestDiscoveryService_BuiltOnce pins the whole point of the lifecycle change:
+// the handler builds one DiscoveryService and hands the same one to every
+// caller. A fresh service per call throws away the transport's idle-connection
+// pool and resets the quota circuit breaker, so the breaker could never reach
+// its threshold in a running process.
+func TestDiscoveryService_BuiltOnce(t *testing.T) {
+	h := newTestHandler(t)
+
+	var built atomic.Int64
+	h.newDiscovery = func() *provider.DiscoveryService {
+		built.Add(1)
+		return provider.NewDiscoveryServiceWithHTTPClient(&http.Client{})
+	}
+
+	first := h.discoveryService()
+	for range 3 {
+		if got := h.discoveryService(); got != first {
+			t.Fatal("discoveryService() must return the same instance every time")
+		}
+	}
+	// Request paths go through the same accessor, so a served pass must not
+	// build another one either.
+	h.PollQuotasOnce(context.Background())
+	h.PollQuotasOnce(context.Background())
+	if got := h.DiscoveryService(); got != first {
+		t.Fatal("the exported accessor must return the same instance")
+	}
+
+	if got := built.Load(); got != 1 {
+		t.Fatalf("got %d constructions, want exactly 1", got)
+	}
+}
+
+// failingQuotaHandler returns a handler with one enabled quota-capable provider
+// whose upstream always refuses, plus the counter of upstream attempts made.
+// The error is deliberately not a network error: a transient one is retried, so
+// the count would stop reading as one attempt per pass.
+func failingQuotaHandler(t *testing.T, name string) (*Handler, uuid.UUID, *atomic.Int64) {
+	t.Helper()
+	h := newTestHandler(t)
+	id := insertQuotaPollProvider(t, h.dbPool.Pool(), name, "https://api.nano-gpt.com/v1", true)
+
+	attempts := &atomic.Int64{}
+	h.newDiscovery = func() *provider.DiscoveryService {
+		ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
+			Transport: &mockTransport{roundTripFunc: func(_ *http.Request) (*http.Response, error) {
+				attempts.Add(1)
+				return nil, errors.New("upstream refused the quota fetch")
+			}},
+		})
+		ds.SetRetryBaseDelay(time.Millisecond)
+		return ds
+	}
+	return h, id, attempts
+}
+
+// TestPollQuotasOnce_BreakerOpensAcrossPasses is the production symptom the
+// single service fixes: consecutive quota failures only add up while the
+// breaker state survives the pass. Five failing passes reach the threshold, so
+// the sixth is short-circuited without touching the upstream at all.
+func TestPollQuotasOnce_BreakerOpensAcrossPasses(t *testing.T) {
+	h, _, attempts := failingQuotaHandler(t, "nanogpt-breaker")
+
+	for range 5 {
+		h.PollQuotasOnce(context.Background())
+	}
+	opened := attempts.Load()
+	if opened != 5 {
+		t.Fatalf("got %d upstream attempts over 5 passes, want 5 (one per pass)", opened)
+	}
+
+	h.PollQuotasOnce(context.Background())
+
+	if got := attempts.Load(); got != opened {
+		t.Fatalf("the sixth pass must be short-circuited by the open breaker, got %d attempts (was %d)", got, opened)
+	}
+}
+
+// TestPollQuotasOnce_PrunesBreakersOfRemovedProviders verifies each pass hands
+// its provider list to the breaker map. A deleted provider's circuit state
+// would otherwise be retained for the life of the process, and would still be
+// open if the same id ever came back.
+func TestPollQuotasOnce_PrunesBreakersOfRemovedProviders(t *testing.T) {
+	h, id, attempts := failingQuotaHandler(t, "nanogpt-prune")
+
+	for range 5 {
+		h.PollQuotasOnce(context.Background())
+	}
+	opened := attempts.Load()
+
+	// The provider goes away, and a pass with it gone prunes its entry.
+	deleteProvider(t, h.dbPool.Pool(), id)
+	h.PollQuotasOnce(context.Background())
+
+	// Same id back again: with the entry pruned the upstream is tried afresh,
+	// with it retained the still-open circuit would refuse to call at all.
+	restoreProvider(t, h.dbPool.Pool(), id, "nanogpt-prune-again", "https://api.nano-gpt.com/v1")
+	h.PollQuotasOnce(context.Background())
+
+	if got := attempts.Load(); got != opened+1 {
+		t.Fatalf("got %d upstream attempts, want %d: a pruned breaker must not short-circuit a provider that came back", got, opened+1)
+	}
+}
+
+func deleteProvider(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), `DELETE FROM providers WHERE id = $1`, id); err != nil {
+		t.Fatalf("delete provider: %v", err)
+	}
+}
+
+func restoreProvider(t *testing.T, pool *pgxpool.Pool, id uuid.UUID, name, baseURL string) {
+	t.Helper()
+	ek, kn, ks := encryptTestKey(t, "test-api-key", testMasterKey)
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO providers (id, name, base_url, encrypted_key, key_nonce, key_salt, enabled, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, true, now(), now())`,
+		id, name, baseURL, ek, kn, ks)
+	if err != nil {
+		t.Fatalf("restore provider: %v", err)
+	}
+}

--- a/internal/api/discovery_quota.go
+++ b/internal/api/discovery_quota.go
@@ -166,6 +166,7 @@ func (h *Handler) RefreshAllQuotas(w http.ResponseWriter, r *http.Request) {
 		provCancel()
 		results = append(results, result)
 	}
+	pruneQuotaBreakersFor(discovery, providers)
 
 	writeJSON(w, map[string]any{
 		"results":   results,

--- a/internal/api/quota_snapshot.go
+++ b/internal/api/quota_snapshot.go
@@ -144,6 +144,8 @@ func (h *Handler) PollQuotasOnce(ctx context.Context) {
 		h.pollQuotaForProvider(ctx, disc, prov, kind)
 	}
 
+	pruneQuotaBreakersFor(disc, providers)
+
 	h.RefreshQuotaAdvice(ctx)
 }
 
@@ -480,4 +482,19 @@ func buildQuotaAdvice(
 		delete(recovered, id)
 	}
 	return advice, recovered
+}
+
+// pruneQuotaBreakersFor drops the quota circuit state of every provider not in
+// providers. The service outlives a pass, which is what lets its breaker count
+// failures across polls; the same longevity would keep a deleted provider's
+// circuit state for the rest of the process without this. providers is the
+// list the pass read at its start, so a provider created during the pass whose
+// circuit a concurrent single-provider poll touched loses that one failure
+// count; the cost is one extra upstream call, not worth a second listing.
+func pruneQuotaBreakersFor(disc *provider.DiscoveryService, providers []*provider.Provider) {
+	live := make(map[string]bool, len(providers))
+	for _, prov := range providers {
+		live[prov.ID.String()] = true
+	}
+	disc.PruneQuotaBreakers(func(providerID string) bool { return live[providerID] })
 }

--- a/internal/api/quota_snapshot_test.go
+++ b/internal/api/quota_snapshot_test.go
@@ -153,9 +153,18 @@ func insertQuotaPollProvider(t *testing.T, pool *pgxpool.Pool, name, baseURL str
 // nanoGPTPollDiscovery returns a discovery service whose /usage endpoint reports
 // a fresh dailyInputTokens.used value, and 404s everything else.
 func nanoGPTPollDiscovery(used int64) *provider.DiscoveryService {
+	return countingNanoGPTPollDiscovery(used, &atomic.Int64{})
+}
+
+// countingNanoGPTPollDiscovery is nanoGPTPollDiscovery with a tally of the
+// /usage calls it serves. A handler builds its discovery service once and keeps
+// it, so a test that needs to know how many polls actually went upstream counts
+// them here rather than counting factory calls.
+func countingNanoGPTPollDiscovery(used int64, usageCalls *atomic.Int64) *provider.DiscoveryService {
 	ds := provider.NewDiscoveryServiceWithHTTPClient(&http.Client{
 		Transport: &mockTransport{roundTripFunc: func(req *http.Request) (*http.Response, error) {
 			if strings.HasSuffix(req.URL.Path, "/usage") {
+				usageCalls.Add(1)
 				body := `{"active":true,"provider":"nanogpt","dailyInputTokens":{"used":` +
 					strconv.FormatInt(used, 10) + `,"limit":100}}`
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
@@ -1045,27 +1054,26 @@ func exhaustedZaiCodingDiscovery(resetsAt time.Time) *provider.DiscoveryService 
 }
 
 // TestNudgeQuotaPoll_DebouncesRepeatOpens verifies a flapping circuit cannot
-// turn into a poll storm against the provider it just gave up on. The discovery
-// service is built on the caller's goroutine before the poll is spawned, so the
-// factory count is a synchronous readout of how many nudges were admitted.
+// turn into a poll storm against the provider it just gave up on. Admitted
+// nudges are counted at the upstream call: the handler keeps one discovery
+// service for its lifetime, so how many times the factory ran says nothing
+// about how many nudges got through. The debounce rejects synchronously,
+// before the poll goroutine is spawned, so the second reading needs no wait.
 func TestNudgeQuotaPoll_DebouncesRepeatOpens(t *testing.T) {
 	h := newTestHandler(t)
 	id := insertQuotaPollProvider(t, h.dbPool.Pool(), "nanogpt-nudge-debounce", "https://api.nano-gpt.com/v1", true)
 
-	var admitted atomic.Int64
-	h.newDiscovery = func() *provider.DiscoveryService {
-		admitted.Add(1)
-		return nanoGPTPollDiscovery(7)
-	}
+	var polled atomic.Int64
+	h.newDiscovery = func() *provider.DiscoveryService { return countingNanoGPTPollDiscovery(7, &polled) }
 
 	h.NudgeQuotaPoll(id)
 	waitForQuotaSnapshot(t, h, id, "usage")
-	if got := admitted.Load(); got != 1 {
+	if got := polled.Load(); got != 1 {
 		t.Fatalf("first nudge: got %d polls, want 1", got)
 	}
 
 	h.NudgeQuotaPoll(id)
-	if got := admitted.Load(); got != 1 {
+	if got := polled.Load(); got != 1 {
 		t.Fatalf("a second open inside the debounce window must not poll again, got %d polls", got)
 	}
 }

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -70,6 +70,35 @@ func (d *DiscoveryService) SetRetryBaseDelay(dur time.Duration) {
 	d.retryBaseDelay = dur
 }
 
+// Close releases the idle connections the discovery client is holding. One
+// service serves every discovery run and quota poll for the life of the
+// process, so its pool is drained here at shutdown rather than after a pass.
+// Safe to call repeatedly.
+func (d *DiscoveryService) Close() {
+	if d.httpClient != nil {
+		d.httpClient.CloseIdleConnections()
+	}
+}
+
+// PruneQuotaBreakers drops the circuit state of every provider live does not
+// claim. The service outlives any single poll pass, which is what makes the
+// breaker's failure counts add up across polls, and equally what would keep a
+// deleted provider's entry in the map for the rest of the process lifetime.
+// A nil predicate keeps everything: a caller with no provider list to compare
+// against must never be read as "nothing is live".
+func (d *DiscoveryService) PruneQuotaBreakers(live func(providerID string) bool) {
+	if live == nil {
+		return
+	}
+	d.quotaBreaker.Range(func(key, _ any) bool {
+		id, ok := key.(string)
+		if !ok || !live(id) {
+			d.quotaBreaker.Delete(key)
+		}
+		return true
+	})
+}
+
 // maxDiscoveryRetries bounds attempts for a single discovery HTTP call.
 const maxDiscoveryRetries = 3
 

--- a/internal/provider/discovery_lifecycle_test.go
+++ b/internal/provider/discovery_lifecycle_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestPruneQuotaBreakers_DropsRemovedKeepsLive covers the map hygiene a
+// long-lived service needs: one instance now serves every poll pass for the
+// life of the process, so a provider deleted from the database would otherwise
+// keep its circuit state forever.
+func TestPruneQuotaBreakers_DropsRemovedKeepsLive(t *testing.T) {
+	d := NewDiscoveryService(nil, nil)
+	kept := d.getOrCreateCircuit("live-provider")
+	d.getOrCreateCircuit("removed-provider")
+
+	live := map[string]bool{"live-provider": true}
+	d.PruneQuotaBreakers(func(id string) bool { return live[id] })
+
+	if _, ok := d.quotaBreaker.Load("removed-provider"); ok {
+		t.Error("a provider outside the live set must lose its circuit state")
+	}
+	got, ok := d.quotaBreaker.Load("live-provider")
+	if !ok {
+		t.Fatal("a live provider must keep its circuit state")
+	}
+	if got != kept {
+		t.Error("a live provider's circuit must be the same state, not a fresh one")
+	}
+}
+
+// TestPruneQuotaBreakers_NilPredicateKeepsEverything pins the fail-safe: a
+// caller with no provider list must not be read as "no provider is live".
+func TestPruneQuotaBreakers_NilPredicateKeepsEverything(t *testing.T) {
+	d := NewDiscoveryService(nil, nil)
+	d.getOrCreateCircuit("some-provider")
+
+	d.PruneQuotaBreakers(nil)
+
+	if _, ok := d.quotaBreaker.Load("some-provider"); !ok {
+		t.Error("a nil predicate must leave the breaker map alone")
+	}
+}
+
+// TestClose_Idempotent verifies shutdown can call Close more than once, and
+// that a service built with a nil HTTP client does not panic on it.
+func TestClose_Idempotent(t *testing.T) {
+	d := NewDiscoveryService(nil, nil)
+	d.Close()
+	d.Close()
+
+	NewDiscoveryServiceWithHTTPClient(nil).Close()
+	NewDiscoveryServiceWithHTTPClient(&http.Client{}).Close()
+}

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -1479,6 +1479,10 @@ These are exposed via:
 - `POST /api/providers/refresh-quotas` - refreshes usage/balance for all supported providers
 
 Quota/balance fetches use a circuit breaker with 5 consecutive failure threshold and 5-minute cooldown.
+The gateway keeps one discovery service for the life of the process, so this state persists across
+polls: five failures spread over five separate poll passes open the circuit exactly as five failures
+inside one pass would, and the counter only resets on a successful fetch, a restart, or the provider
+being deleted.
 
 ---
 


### PR DESCRIPTION
## What

`Handler.discoveryService()` built a new `provider.DiscoveryService` on every call, and `cmd/server` built another per discovery run. Each construction made a fresh `http.Transport` (its pool discarded after one use) and a fresh quota circuit breaker, so consecutive quota failures never reached the threshold across polls and the breaker was inert in production. Found by the Codex audit during the simplification pass (#941), agreed as the second follow-up.

## Changes

- `internal/api`: one service per handler, built lazily and exactly once from the handler's own factory (its SSRF dial and redirect hooks), so the existing test injection point keeps working unchanged.
- `cmd/server`: one service built at startup and shared by the discovery loop and the quota poller; `Close()` drops its idle pooled connections at shutdown (the loops stop on the deferred root cancel, which the third follow-up reorders).
- `DiscoveryService.PruneQuotaBreakers` and `Close`; both quota passes (the poller and the manual refresh) prune the breaker map to the providers that still exist, so a deleted provider's circuit state does not stay for the life of the process. A provider created mid-pass whose circuit a concurrent single-provider poll touched can lose one failure count; that costs one upstream call and is noted at the helper.
- Wiki: Model-Discovery says the breaker state persists across polls.

## Verification

- Tests: one construction per handler across calls and requests; five failures across separate calls open the circuit; prune keeps live providers and drops removed ones; Close is idempotent.
- `make lint` 0 issues, vet, gofmt, gci, size gate; suites of `internal/provider`, `internal/api`, `cmd/server`.
- Two Opus review rounds (three findings in round 1, fixed).
- Dev stack rebuilt from the branch: refresh-quotas 200 (5 refreshed), a live OpenRouter discovery run 200, quota read 200, no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
