### PR TITLE
fix(server): own the app-log purge and order shutdown

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -119,6 +119,20 @@ ADMIN_TOKEN=
                 #     Only enable if you trust the deployment environment.
                 # - /var/run/docker.sock:/var/run/docker.sock:ro
             restart: unless-stopped
+            # Model Hotel winds down in stages on SIGTERM. Worst case, in order:
+            # 10s HTTP drain (open SSE tabs and proxied streams are ended first, so
+            # this is usually quick) + 35s background join (the 30s ceiling of the
+            # scheduled-disable sweep, which deliberately finishes the statement it
+            # has already started, plus a 5s margin; the retention and stale-log
+            # sweeps have no ceiling and the join cancels them instead of waiting)
+            # + 10s audit drain (one record's 5s insert plus the 5s retention prune
+            # it piggybacks) + 5s app-log writer stop + 5s OTLP flush = 65s. The
+            # closes around them (the event bus, the proxy handler, discovery, the
+            # docker client, the rate limiters and the database pool) carry no budget
+            # of their own, so this is a ceiling with headroom over the 65s, not the
+            # sum. Docker's default grace is 10s, which would SIGKILL partway through
+            # the drain and take the audit rows and the last log lines with it.
+            stop_grace_period: 75s
             depends_on:
                 db:
                     condition: service_healthy

--- a/README.md
+++ b/README.md
@@ -378,6 +378,20 @@ ADMIN_TOKEN=
                 #     Only enable if you trust the deployment environment.
                 # - /var/run/docker.sock:/var/run/docker.sock:ro
             restart: unless-stopped
+            # Model Hotel winds down in stages on SIGTERM. Worst case, in order:
+            # 10s HTTP drain (open SSE tabs and proxied streams are ended first, so
+            # this is usually quick) + 35s background join (the 30s ceiling of the
+            # scheduled-disable sweep, which deliberately finishes the statement it
+            # has already started, plus a 5s margin; the retention and stale-log
+            # sweeps have no ceiling and the join cancels them instead of waiting)
+            # + 10s audit drain (one record's 5s insert plus the 5s retention prune
+            # it piggybacks) + 5s app-log writer stop + 5s OTLP flush = 65s. The
+            # closes around them (the event bus, the proxy handler, discovery, the
+            # docker client, the rate limiters and the database pool) carry no budget
+            # of their own, so this is a ceiling with headroom over the 65s, not the
+            # sum. Docker's default grace is 10s, which would SIGKILL partway through
+            # the drain and take the audit rows and the last log lines with it.
+            stop_grace_period: 75s
             depends_on:
                 db:
                     condition: service_healthy

--- a/cmd/server/background.go
+++ b/cmd/server/background.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -21,6 +23,125 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/settings"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
+
+// backgroundJoinBudget is what shutdown gives the join: the sweep ceiling plus
+// a margin. Every loop selects on the root context, but the passes they run
+// deliberately do not — logRetentionPass, staleLogCleanupPass and
+// sweepScheduledDisables all issue their statements on the group's drain
+// context — so a pass already running when the cancel lands ignores it and
+// finishes the statement it started. Of those three only the sweep carries a
+// ceiling of its own (sweepScheduledDisableTimeout), and this budget is derived
+// from it so the sweep is waited out rather than cut a tick short; the margin
+// covers the tick that started it plus the loop wiring around it. The other two
+// carry no ceiling, so the budget does not wait for them, it ENDS them: Wait
+// cancels the drain context on its way out, and a DELETE or UPDATE still
+// running at that point is cancelled, not awaited. A loop still running when
+// the budget expires is named in the log and shutdown proceeds rather than
+// hanging.
+const backgroundJoinBudget = sweepScheduledDisableTimeout + 5*time.Second
+
+// backgroundGroup tracks the process-lifetime loops so shutdown can cancel the
+// root context and then join them before anything they read is released. A
+// loop started with a bare `go` is invisible here, so it would keep running
+// against a pool the shutdown path is closing.
+type backgroundGroup struct {
+	wg sync.WaitGroup
+	// mu guards running, which is read from Wait on the shutdown goroutine
+	// while the loops themselves are removing their own names.
+	mu      sync.Mutex
+	running map[string]bool
+	// joined closes when every member has returned. Created on the first Wait
+	// and reused, because a Wait that times out leaves its joiner parked in
+	// wg.Wait and a fresh one per call would accumulate them.
+	joinOnce sync.Once
+	joined   chan struct{}
+	// drainCtx is what the detached maintenance passes run their statements on,
+	// created on first use and guarded by mu. Wait cancels it.
+	drainCtx    context.Context
+	drainCancel context.CancelFunc
+}
+
+// drainContext returns the context a maintenance pass runs its statements on
+// when it deliberately outlives the loop that called it. It keeps parent's
+// values but not its cancellation, so at runtime a pass that has begun finishes
+// its statement however long the database takes, exactly as it does with no
+// shutdown in sight. Wait is what ends it: a pass stalled on the database is
+// cancelled when the join budget expires, so it cannot outlast the join and
+// write into a pool this shutdown is about to close.
+func (g *backgroundGroup) drainContext(parent context.Context) context.Context {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.initDrain(parent)
+	return g.drainCtx
+}
+
+// initDrain creates the drain context on first use. Callers hold mu.
+func (g *backgroundGroup) initDrain(parent context.Context) {
+	if g.drainCtx == nil {
+		g.drainCtx, g.drainCancel = context.WithCancel(context.WithoutCancel(parent))
+	}
+}
+
+// Go starts f as a named member of the group.
+func (g *backgroundGroup) Go(name string, f func()) {
+	g.mu.Lock()
+	if g.running == nil {
+		g.running = make(map[string]bool)
+	}
+	g.running[name] = true
+	g.mu.Unlock()
+
+	g.wg.Go(func() {
+		defer func() {
+			g.mu.Lock()
+			delete(g.running, name)
+			g.mu.Unlock()
+		}()
+		f()
+	})
+}
+
+// Wait joins every member and returns nil, or gives up after budget and returns
+// the names still running, sorted. The caller logs them: a loop that outlives
+// its cancellation is an operational fact worth seeing, not a reason to block
+// the process from exiting.
+//
+// The joiner is started once and its channel reused, so a Wait that gives up
+// does not leave one goroutine parked in wg.Wait per call.
+func (g *backgroundGroup) Wait(budget time.Duration) []string {
+	g.mu.Lock()
+	g.initDrain(context.Background())
+	cancelDrain := g.drainCancel
+	g.mu.Unlock()
+	// The detached passes end here and not before. While the server is up they
+	// run unbounded, which is what keeps a slow sweep from dropping work. This
+	// is a cut, not a ceiling: a pass still running when the budget expires is
+	// cancelled here rather than awaited, so its statement is rolled back and
+	// the pool it holds is released before the close below it. Cancelled on both
+	// paths, since a join that returned nil has already seen every member out
+	// and there is nothing left to end.
+	defer cancelDrain()
+
+	g.joinOnce.Do(func() {
+		g.joined = make(chan struct{})
+		go func() {
+			g.wg.Wait()
+			close(g.joined)
+		}()
+	})
+	joined := g.joined
+
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-joined:
+		return nil
+	case <-timer.C:
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		return slices.Sorted(maps.Keys(g.running))
+	}
+}
 
 // settingsIntervalLoop runs tick on a timer whose period comes from a setting,
 // and reacts to changes of that setting immediately via sub rather than waiting
@@ -112,13 +233,20 @@ func settingsIntervalLoop(ctx context.Context, sub *settings.Subscription, readI
 	}
 }
 
-// every runs f on a ticker of period d until ctx is done.
+// every runs f on a ticker of period d until ctx is done. A tick that lands
+// together with the cancellation starts nothing: select picks at random between
+// two ready cases, so without this check a pass could begin AFTER shutdown has
+// cancelled ctx, and the join budget would already be counting down against a
+// ceiling that had not started yet.
 func every(ctx context.Context, d time.Duration, f func()) {
 	ticker := time.NewTicker(d)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
+			if ctx.Err() != nil {
+				return
+			}
 			f()
 		case <-ctx.Done():
 			return
@@ -183,23 +311,27 @@ func quotaPollLoop(ctx context.Context, settingsRepo *settings.Repository, pollO
 //     catches in-process orphans (e.g. a panic skips the final
 //     updateRequestLog). The timeout is generous to avoid killing
 //     legitimate long-running streaming requests.
-func staleLogCleanupLoop(ctx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
+func staleLogCleanupLoop(ctx, drainCtx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
 	every(ctx, 5*time.Minute, func() {
-		staleLogCleanupPass(pool, settingsRepo, serverStartTime)
+		staleLogCleanupPass(drainCtx, pool, settingsRepo, serverStartTime)
 	})
 }
 
 // staleLogCleanupPass runs one stale-log sweep; a stale_request_timeout of 0
 // disables the age-based check for this cycle.
-func staleLogCleanupPass(pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
-	staleTimeout := settingsRepo.GetDuration(context.Background(), "stale_request_timeout", 30*time.Minute)
+//
+// drainCtx is the group's drain context rather than the loop's, so a sweep
+// already under way when the server is asked to stop still finishes its UPDATE.
+// The shutdown join is what ends it if the database has stalled.
+func staleLogCleanupPass(drainCtx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository, serverStartTime time.Time) {
+	staleTimeout := settingsRepo.GetDuration(drainCtx, "stale_request_timeout", 30*time.Minute)
 	if staleTimeout <= 0 {
 		return
 	}
 	// The age cutoff is computed here, like the server-start cutoff beside it,
 	// rather than handed to Postgres as an interval string to parse back.
 	cutoff := time.Now().Add(-staleTimeout)
-	tag, err := pool.Exec(context.Background(), `
+	tag, err := pool.Exec(drainCtx, `
 		UPDATE request_logs
 		SET state = 'failed', error_kind = 'internal', error_message = 'request interrupted (stale)'
 		WHERE state IN ('pending', 'streaming')
@@ -220,9 +352,9 @@ func staleLogCleanupPass(pool *pgxpool.Pool, settingsRepo *settings.Repository, 
 
 // logRetentionLoop hourly deletes request_logs and app_logs rows older than
 // the log_retention setting; a disabled or unparseable value skips the cycle.
-func logRetentionLoop(ctx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository) {
+func logRetentionLoop(ctx, drainCtx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository) {
 	every(ctx, time.Hour, func() {
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(drainCtx, pool, settingsRepo)
 	})
 }
 
@@ -274,8 +406,15 @@ var retentionWarned struct {
 // a value the sweep cannot read skips too, but says so once, because a
 // retention setting that silently never fires is a failure the operator cannot
 // see from the dashboard.
-func logRetentionPass(pool *pgxpool.Pool, settingsRepo *settings.Repository) {
-	retention := settingsRepo.GetWithDefault(context.Background(), "log_retention", "")
+//
+// drainCtx carries no deadline of its own. The first sweep after retention is
+// enabled, or the first after an outage, deletes a whole backlog and takes as
+// long as it takes; a ceiling here would cancel that DELETE, roll it back and
+// leave the pass failing identically every hour while both tables grew. The
+// shutdown join is the only thing that ends it, which is what keeps a stalled
+// database from outliving the join.
+func logRetentionPass(drainCtx context.Context, pool *pgxpool.Pool, settingsRepo *settings.Repository) {
+	retention := settingsRepo.GetWithDefault(drainCtx, "log_retention", "")
 	window, enabled, err := parseLogRetention(retention)
 	if err != nil {
 		retentionWarned.Lock()
@@ -292,7 +431,7 @@ func logRetentionPass(pool *pgxpool.Pool, settingsRepo *settings.Repository) {
 	}
 	cutoff := time.Now().Add(-window)
 	for _, table := range []string{"request_logs", "app_logs"} {
-		tag, err := pool.Exec(context.Background(),
+		tag, err := pool.Exec(drainCtx,
 			`DELETE FROM `+table+` WHERE created_at < $1`, cutoff)
 		if err != nil {
 			debuglog.Error("retention: delete of old entries failed", "table", table, "error", err)
@@ -303,7 +442,14 @@ func logRetentionPass(pool *pgxpool.Pool, settingsRepo *settings.Repository) {
 }
 
 // sweepScheduledDisableTimeout bounds a sweep that outlives its caller's
-// context, so shutdown still terminates promptly.
+// context. A sweep that has begun deliberately ignores the cancellation (see
+// sweepScheduledDisables), so this ceiling is the only thing that ends it, and
+// it is the one ceiling backgroundJoinBudget is derived from: the join waits the
+// sweep out instead of naming it and letting the pool close on the UPDATE it has
+// already committed. The other two detached passes have no ceiling and are not
+// waited out at all, they are cancelled when the budget expires. The work here
+// is one UPDATE over tens of rows plus a failover sync over every enabled model,
+// which on a large fleet is the part that needs the room.
 const sweepScheduledDisableTimeout = 30 * time.Second
 
 // sweepScheduledDisables fires every due scheduled disable and returns how many
@@ -313,15 +459,20 @@ const sweepScheduledDisableTimeout = 30 * time.Second
 // per provider tells the operator what happened.
 //
 // A sweep that has begun finishes even while the server is shutting down, which
-// is why the caller's cancellation is dropped here the way api.UpdateProvider
-// drops the request's. The UPDATE clears scheduled_disable_on as it fires, so
-// the disable is only ever due once: a cancellation landing between that commit
-// and the drained rows would lose the operator's event permanently — no later
-// sweep can re-derive it — and leave the failover groups carrying models of a
-// provider that is already off. scheduledDisableLoop keeps selecting on the
-// original context, so the loop itself still exits at once.
-func sweepScheduledDisables(ctx context.Context, providerRepo *provider.Repository, failoverRepo *failover.Repository) int {
-	sweepCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sweepScheduledDisableTimeout)
+// is why drainCtx is the group's drain context and not the loop's. The UPDATE
+// clears scheduled_disable_on as it fires, so the disable is only ever due once:
+// a cancellation landing between that commit and the sync would leave the
+// failover groups carrying models of a provider that is already off, and no
+// later sweep re-derives them. That committed UPDATE and the sync behind it are
+// what the detachment protects. It does not protect the event: shutdown closes
+// the event bus before it joins this loop, so a sweep firing during shutdown
+// publishes into a closed bus and the operator's notification is lost however
+// long the join waits. Accepted, because the disable itself is persisted and the
+// dashboard shows the provider as disabled on the next start.
+// scheduledDisableLoop keeps selecting on the original context, so the loop
+// itself still exits at once.
+func sweepScheduledDisables(drainCtx context.Context, providerRepo *provider.Repository, failoverRepo *failover.Repository) int {
+	sweepCtx, cancel := context.WithTimeout(drainCtx, sweepScheduledDisableTimeout)
 	defer cancel()
 
 	disabled, err := providerRepo.DisableDueScheduled(sweepCtx)
@@ -338,7 +489,9 @@ func sweepScheduledDisables(ctx context.Context, providerRepo *provider.Reposito
 		})
 	}
 	if _, err := failoverRepo.SyncAllModels(sweepCtx); err != nil {
-		debuglog.Info("scheduled disable: failover sync failed", "error", err)
+		// A permanent desync: the providers are off and no later sweep
+		// re-derives the groups they are still listed in.
+		debuglog.Error("scheduled disable: failover sync failed", "error", err)
 	}
 	return len(disabled)
 }
@@ -347,8 +500,8 @@ func sweepScheduledDisables(ctx context.Context, providerRepo *provider.Reposito
 // that straddled midnight must still fire the disable) and then on every tick.
 // A one-minute tick keeps "as soon as the date flips" honest at negligible cost:
 // the sweep is a single UPDATE on a table of tens of rows.
-func scheduledDisableLoop(ctx context.Context, providerRepo *provider.Repository, failoverRepo *failover.Repository, tick time.Duration) {
-	sweep := func() { sweepScheduledDisables(ctx, providerRepo, failoverRepo) }
+func scheduledDisableLoop(ctx, drainCtx context.Context, providerRepo *provider.Repository, failoverRepo *failover.Repository, tick time.Duration) {
+	sweep := func() { sweepScheduledDisables(drainCtx, providerRepo, failoverRepo) }
 	sweep()
 	every(ctx, tick, sweep)
 }

--- a/cmd/server/background_test.go
+++ b/cmd/server/background_test.go
@@ -247,7 +247,7 @@ func TestStaleLogCleanupPass(t *testing.T) {
 			t.Fatalf("set failed: %v", err)
 		}
 		defer func() { _ = settingsRepo.Set(ctx, "stale_request_timeout", "30m") }()
-		staleLogCleanupPass(pool, settingsRepo, time.Now())
+		staleLogCleanupPass(ctx, pool, settingsRepo, time.Now())
 	})
 
 	t.Run("marks_stale_rows", func(t *testing.T) {
@@ -261,7 +261,7 @@ func TestStaleLogCleanupPass(t *testing.T) {
 		ch := events.DefaultBus.Subscribe()
 		defer events.DefaultBus.Unsubscribe(ch)
 
-		staleLogCleanupPass(pool, settingsRepo, time.Now())
+		staleLogCleanupPass(ctx, pool, settingsRepo, time.Now())
 
 		var state string
 		if err := pool.QueryRow(ctx, `SELECT state FROM request_logs`).Scan(&state); err != nil {
@@ -275,7 +275,7 @@ func TestStaleLogCleanupPass(t *testing.T) {
 
 	t.Run("db_error_only_logs", func(t *testing.T) {
 		broken := closedTestPool(t)
-		staleLogCleanupPass(broken.Pool(), settingsRepo, time.Now())
+		staleLogCleanupPass(ctx, broken.Pool(), settingsRepo, time.Now())
 	})
 }
 
@@ -296,7 +296,7 @@ func TestLogRetentionPass(t *testing.T) {
 
 	t.Run("unset_skips", func(t *testing.T) {
 		setRetention("")
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 	})
 
 	t.Run("unrecognised_skips", func(t *testing.T) {
@@ -308,7 +308,7 @@ func TestLogRetentionPass(t *testing.T) {
 			t.Fatalf("insert failed: %v", err)
 		}
 		setRetention("0")
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 		var n int
 		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
 			t.Fatalf("count failed: %v", err)
@@ -321,7 +321,7 @@ func TestLogRetentionPass(t *testing.T) {
 	t.Run("deletes_old_rows", func(t *testing.T) {
 		// The 10-day-old row from the previous subtest is older than 1 week.
 		setRetention("1w")
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 		var n int
 		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
 			t.Fatalf("count failed: %v", err)
@@ -349,7 +349,7 @@ func TestLogRetentionPass(t *testing.T) {
 			t.Fatalf("insert failed: %v", err)
 		}
 		setRetention("48h")
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 		for _, table := range []string{"request_logs", "app_logs"} {
 			var n int
 			if err := pool.QueryRow(ctx, `SELECT count(*) FROM `+table).Scan(&n); err != nil {
@@ -373,8 +373,8 @@ func TestLogRetentionPass(t *testing.T) {
 		debuglog.SetHandler(slog.NewTextHandler(&logs, nil))
 		defer debuglog.SetHandler(debuglog.StdoutHandler())
 		setRetention("soon")
-		logRetentionPass(pool, settingsRepo)
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 		var n int
 		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
 			t.Fatalf("count failed: %v", err)
@@ -399,7 +399,7 @@ func TestLogRetentionPass(t *testing.T) {
 		debuglog.SetHandler(slog.NewTextHandler(&logs, nil))
 		defer debuglog.SetHandler(debuglog.StdoutHandler())
 		setRetention("0s")
-		logRetentionPass(pool, settingsRepo)
+		logRetentionPass(ctx, pool, settingsRepo)
 		var n int
 		if err := pool.QueryRow(ctx, `SELECT count(*) FROM request_logs`).Scan(&n); err != nil {
 			t.Fatalf("count failed: %v", err)
@@ -415,13 +415,13 @@ func TestLogRetentionPass(t *testing.T) {
 	t.Run("other_retention_windows", func(t *testing.T) {
 		for _, v := range []string{"1h", "24h", "720h"} {
 			setRetention(v)
-			logRetentionPass(pool, settingsRepo)
+			logRetentionPass(ctx, pool, settingsRepo)
 		}
 	})
 
 	t.Run("db_error_only_logs", func(t *testing.T) {
 		setRetention("24h")
-		logRetentionPass(closedTestPool(t).Pool(), settingsRepo)
+		logRetentionPass(ctx, closedTestPool(t).Pool(), settingsRepo)
 	})
 }
 
@@ -797,7 +797,7 @@ func TestStaleLogCleanupLoopStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		staleLogCleanupLoop(ctx, cmdTestDB.Pool(), newTestSettingsRepo(), time.Now())
+		staleLogCleanupLoop(ctx, context.Background(), cmdTestDB.Pool(), newTestSettingsRepo(), time.Now())
 		close(done)
 	}()
 	cancel()
@@ -815,7 +815,7 @@ func TestLogRetentionLoopStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		logRetentionLoop(ctx, cmdTestDB.Pool(), newTestSettingsRepo())
+		logRetentionLoop(ctx, context.Background(), cmdTestDB.Pool(), newTestSettingsRepo())
 		close(done)
 	}()
 	cancel()
@@ -985,11 +985,12 @@ func TestSweepScheduledDisables_NothingDue(t *testing.T) {
 	assertNoScheduledDisableEvent(t, ch)
 }
 
-// TestSweepScheduledDisables_CompletesOnCancelledContext pins the shutdown
-// behaviour: the sweep drops its caller's cancellation, because the UPDATE
-// clears the schedule as it fires and a sweep abandoned midway would strand the
-// disable with no event and no way for a later sweep to notice.
-func TestSweepScheduledDisables_CompletesOnCancelledContext(t *testing.T) {
+// TestScheduledDisableLoop_SweepsOnACancelledLoopContext pins the shutdown
+// behaviour: the sweep runs on the group's drain context rather than the loop's,
+// so a sweep the shutdown cancel lands on still fires. The UPDATE clears the
+// schedule as it fires, and a sweep abandoned midway would strand the disable
+// with no event and no way for a later sweep to notice.
+func TestScheduledDisableLoop_SweepsOnACancelledLoopContext(t *testing.T) {
 	if cmdTestDB == nil {
 		t.Fatal("test DB unavailable")
 	}
@@ -1003,9 +1004,11 @@ func TestSweepScheduledDisables_CompletesOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if n := sweepScheduledDisables(ctx, provider.NewRepository(pool), failover.NewRepository(pool)); n != 1 {
-		t.Fatalf("disabled %d providers under a cancelled context, want 1", n)
-	}
+	// The loop sweeps once before its first tick and then returns at once on
+	// the cancelled context, so what runs here is exactly that sweep, on a
+	// loop context that is already dead. An hour-long tick rules out a second.
+	scheduledDisableLoop(ctx, context.Background(), provider.NewRepository(pool), failover.NewRepository(pool), time.Hour)
+
 	assertProviderState(t, due, "cancelled-ctx", false, false)
 	if fired := collectScheduledDisableEvents(t, ch, 1); fired["sched-cancelled-ctx"] != due.String() {
 		t.Errorf("event carries provider_id %q, want %s", fired["sched-cancelled-ctx"], due)
@@ -1044,7 +1047,7 @@ func TestScheduledDisableLoop_SweepsAtStartup(t *testing.T) {
 	go func() {
 		// An hour-long tick guarantees the disable below is the startup
 		// sweep's doing rather than a tick's.
-		scheduledDisableLoop(ctx, provider.NewRepository(pool), failover.NewRepository(pool), time.Hour)
+		scheduledDisableLoop(ctx, context.Background(), provider.NewRepository(pool), failover.NewRepository(pool), time.Hour)
 		close(done)
 	}()
 
@@ -1085,7 +1088,7 @@ func TestScheduledDisableLoop_SweepsOnTick(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
-		scheduledDisableLoop(ctx, provider.NewRepository(pool), failover.NewRepository(pool), 10*time.Millisecond)
+		scheduledDisableLoop(ctx, context.Background(), provider.NewRepository(pool), failover.NewRepository(pool), 10*time.Millisecond)
 		close(done)
 	}()
 
@@ -1114,5 +1117,192 @@ func TestScheduledDisableLoop_SweepsOnTick(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("scheduled disable loop did not stop on context cancellation")
+	}
+}
+
+// Shutdown cancels the root context, joins the background loops, and only then
+// releases what they read. This pins that order: the probe standing in for the
+// database must not have closed while a registered loop is still running. A
+// loop started with a bare `go` was invisible to the join, so the deferred
+// database close could run underneath it.
+func TestBackgroundGroup_JoinsLoopsBeforeResourcesClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var g backgroundGroup
+
+	var dbClosed atomic.Bool
+	observed := make(chan bool, 1)
+	g.Go("fake-loop", func() {
+		<-ctx.Done()
+		// A loop's last act still reads the pool, the way the retention sweep
+		// does. If the join did not cover it, the close would land here.
+		time.Sleep(20 * time.Millisecond)
+		observed <- dbClosed.Load()
+	})
+
+	cancel()
+	if stuck := g.Wait(5 * time.Second); stuck != nil {
+		t.Fatalf("Wait reported %v still running, want none", stuck)
+	}
+	dbClosed.Store(true)
+
+	if <-observed {
+		t.Fatal("a loop was still running against a closed database: the join returned before it did")
+	}
+}
+
+// The join is bounded: a loop that does not honour its cancellation delays the
+// exit by the budget and is named, instead of hanging the process forever. The
+// loops that did stop are not named.
+func TestBackgroundGroup_WaitNamesALoopThatIgnoresCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var g backgroundGroup
+
+	release := make(chan struct{})
+	g.Go("well-behaved", func() { <-ctx.Done() })
+	g.Go("ignores-ctx", func() { <-release })
+
+	cancel()
+	start := time.Now()
+	stuck := g.Wait(200 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	// One joiner however often Wait gives up: a fresh goroutine per call would
+	// park in wg.Wait and stay there.
+	joiner := g.joined
+	if again := g.Wait(10 * time.Millisecond); !slices.Equal(again, stuck) {
+		t.Fatalf("second Wait returned %v, want the same %v", again, stuck)
+	}
+	if g.joined != joiner {
+		t.Fatal("Wait started a second joiner goroutine instead of reusing the first")
+	}
+
+	close(release)
+	if left := g.Wait(5 * time.Second); left != nil {
+		t.Fatalf("loops still running after release: %v", left)
+	}
+
+	if !slices.Equal(stuck, []string{"ignores-ctx"}) {
+		t.Fatalf("Wait returned %v, want [ignores-ctx]", stuck)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Wait took %s: an uncooperative loop must delay shutdown, not hang it", elapsed)
+	}
+}
+
+// A tick landing together with the shutdown cancel starts nothing. select picks
+// at random between two ready cases, so without the guard a maintenance pass
+// could begin AFTER the cancel and hold a ceiling the join budget had already
+// started counting down against. Repeated because one run only samples that
+// coin once: without the guard, two hundred of them never all come up
+// "cancelled".
+func TestEveryStartsNoPassAfterTheCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	for range 200 {
+		every(ctx, time.Nanosecond, func() { calls++ })
+	}
+	if calls != 0 {
+		t.Fatalf("f ran %d times under a cancelled context: a maintenance pass began after shutdown did", calls)
+	}
+}
+
+// The passes that detached from the root context are bounded by the join and by
+// nothing else: while the server is up they run for as long as the database
+// takes, and Wait's budget expiring is what cancels them.
+func TestBackgroundGroup_WaitCancelsTheDrainContext(t *testing.T) {
+	var g backgroundGroup
+	root, cancelRoot := context.WithCancel(context.Background())
+	drainCtx := g.drainContext(root)
+
+	cancelRoot()
+	if drainCtx.Err() != nil {
+		t.Fatal("the root cancellation ended the drain context: a pass already running would lose the statement it started")
+	}
+
+	release := make(chan struct{})
+	defer close(release)
+	g.Go("ignores-ctx", func() { <-release })
+
+	if stuck := g.Wait(50 * time.Millisecond); !slices.Equal(stuck, []string{"ignores-ctx"}) {
+		t.Fatalf("Wait returned %v, want [ignores-ctx]", stuck)
+	}
+	if drainCtx.Err() == nil {
+		t.Fatal("the join budget expired without cancelling the drain context: a pass stalled on the database would outlive the join and write into a closing pool")
+	}
+}
+
+// The same property at the group: a member that ignores the cancellation and
+// runs to a ceiling of its own is joined, not named, when the budget covers it.
+func TestBackgroundGroup_WaitJoinsAMemberThatIgnoresCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var g backgroundGroup
+
+	const memberCeiling = 100 * time.Millisecond
+	g.Go("detached-pass", func() {
+		// context.WithoutCancel + a deadline, the way sweepScheduledDisables
+		// runs: the cancel below is not what ends this.
+		passCtx, passCancel := context.WithTimeout(context.WithoutCancel(ctx), memberCeiling)
+		defer passCancel()
+		<-passCtx.Done()
+	})
+
+	cancel()
+	start := time.Now()
+	if stuck := g.Wait(5 * time.Second); stuck != nil {
+		t.Fatalf("Wait reported %v still running, want none: a budget above the member's ceiling must join it", stuck)
+	}
+	if elapsed := time.Since(start); elapsed < memberCeiling {
+		t.Fatalf("Wait returned after %s, before the member's %s ceiling: it did not wait the detached pass out", elapsed, memberCeiling)
+	}
+}
+
+// A maintenance pass runs its statements on the group's drain context and
+// carries no ceiling of its own: the first sweep after retention is enabled has
+// a whole backlog to delete, and a deadline there would cancel the DELETE, roll
+// it back and leave the pass failing identically every hour. What bounds it is
+// the shutdown join cancelling that context. Here the table is locked out from
+// under the sweep so the DELETE blocks, and the cancellation is the only thing
+// that can end it.
+//
+// The cancel stands in for the join budget expiring and fires in milliseconds,
+// so the ACCESS EXCLUSIVE lock is held for that long rather than for the length
+// of a real budget: the api suite shares this database and this table.
+func TestLogRetentionPassEndsWhenTheDrainContextIsCancelled(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Fatal("test DB unavailable")
+	}
+	ctx := context.Background()
+	pool := cmdTestDB.Pool()
+	settingsRepo := newTestSettingsRepo()
+	if err := settingsRepo.Set(ctx, "log_retention", "1w"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	t.Cleanup(func() { _ = settingsRepo.Set(ctx, "log_retention", "") })
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin failed: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `LOCK TABLE app_logs IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("lock failed: %v", err)
+	}
+
+	const joinExpiry = 100 * time.Millisecond
+	drainCtx, cancelDrain := context.WithCancel(context.Background())
+	defer cancelDrain()
+	time.AfterFunc(joinExpiry, cancelDrain)
+
+	start := time.Now()
+	logRetentionPass(drainCtx, pool, settingsRepo)
+	elapsed := time.Since(start)
+
+	if elapsed < joinExpiry {
+		t.Fatalf("pass returned after %s, before the %s cancel: the DELETE never waited on the lock, so nothing was proved", elapsed, joinExpiry)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("pass took %s: a statement on the drain context must end when the join cancels it, or shutdown closes the pool underneath it", elapsed)
 	}
 }

--- a/cmd/server/discovery.go
+++ b/cmd/server/discovery.go
@@ -106,12 +106,16 @@ func publishDiscoveryEvent(source string, result DiscoveryResult) {
 // records confirmed-missing models, and re-syncs failover groups afterwards.
 // source labels the trigger ("startup"/"scheduled") in events and the
 // discovery change feed.
-func runDiscovery(deps discoveryDeps, source string) DiscoveryResult {
+//
+// ctx is the caller's, and every scan and write below hangs off it: a run
+// started by the scheduler carries the server's root context, so shutdown's
+// cancel ends a scan in flight instead of leaving it writing into a pool the
+// shutdown path is about to close.
+func runDiscovery(ctx context.Context, deps discoveryDeps, source string) DiscoveryResult {
 	result := DiscoveryResult{}
 	// Set when any background-discovery change row is recorded, so we can
 	// publish a single live-update event for the Models nav badge.
 	changesRecorded := false
-	ctx := context.Background()
 	providers, err := deps.providerRepo.List(ctx)
 	if err != nil {
 		debuglog.Error("discovery: failed to list providers", "error", err)
@@ -475,12 +479,16 @@ func anyRecentlyDiscovered(providers []*provider.Provider, now time.Time, window
 // maybeStartupDiscovery launches the initial discovery run in the background,
 // unless discovery_on_startup is off or any provider was already discovered
 // within startupDiscoveryWindow (a restart loop must not hammer providers).
-func maybeStartupDiscovery(deps discoveryDeps, settingsRepo *settings.Repository) {
-	if !settingsRepo.GetBool(context.Background(), "discovery_on_startup", true) {
+// The run carries ctx, so a shutdown during startup ends it, and it runs as a
+// member of group so shutdown joins it: started with a bare `go` it would be
+// the one lifetime producer still scanning, upserting and logging while the
+// discovery service, the app-log writer and the pool are being closed.
+func maybeStartupDiscovery(ctx context.Context, group *backgroundGroup, deps discoveryDeps, settingsRepo *settings.Repository) {
+	if !settingsRepo.GetBool(ctx, "discovery_on_startup", true) {
 		return
 	}
 	recentlyDiscovered := false
-	providers, err := deps.providerRepo.List(context.Background())
+	providers, err := deps.providerRepo.List(ctx)
 	if err == nil {
 		recentlyDiscovered = anyRecentlyDiscovered(providers, time.Now(), startupDiscoveryWindow)
 	}
@@ -488,8 +496,7 @@ func maybeStartupDiscovery(deps discoveryDeps, settingsRepo *settings.Repository
 		debuglog.Info("discovery: skipping startup — last discovery within 5 minutes")
 		return
 	}
-	go func() {
-		result := runDiscovery(deps, "startup")
-		publishDiscoveryEvent("Startup", result)
-	}()
+	group.Go("startup-discovery", func() {
+		publishDiscoveryEvent("Startup", runDiscovery(ctx, deps, "startup"))
+	})
 }

--- a/cmd/server/discovery_test.go
+++ b/cmd/server/discovery_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -139,7 +141,7 @@ func TestRunDiscoveryNoProviders(t *testing.T) {
 	}
 	wipeDiscoveryState(t)
 
-	result := runDiscovery(testDiscoveryDeps(t), "test")
+	result := runDiscovery(context.Background(), testDiscoveryDeps(t), "test")
 	if result.ProvidersScanned != 0 || result.ProvidersFailed != 0 || result.ModelsDiscovered != 0 {
 		t.Errorf("expected empty result, got %+v", result)
 	}
@@ -180,7 +182,7 @@ func TestRunDiscoveryPrunesChangeJournal(t *testing.T) {
 		}
 	}
 
-	runDiscovery(testDiscoveryDeps(t), "test")
+	runDiscovery(context.Background(), testDiscoveryDeps(t), "test")
 
 	rows, err := pool.Query(ctx, `SELECT diff->'added'->0->>'model_id' FROM discovery_changes`)
 	if err != nil {
@@ -246,7 +248,7 @@ func TestRunDiscoveryAlertsOnUnaddressedClaims(t *testing.T) {
 	ch := events.DefaultBus.Subscribe()
 	defer events.DefaultBus.Unsubscribe(ch)
 
-	runDiscovery(testDiscoveryDeps(t), "test")
+	runDiscovery(context.Background(), testDiscoveryDeps(t), "test")
 
 	ev := waitForEvent(t, ch, api.EventTypeClaimsOutstanding)
 	if got := ev.Metadata["claim_count"]; got != 1 {
@@ -284,7 +286,7 @@ func TestRunDiscoveryClaimAlertFailureDoesNotFailRun(t *testing.T) {
 	ch := events.DefaultBus.Subscribe()
 	defer events.DefaultBus.Unsubscribe(ch)
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	waitForEvent(t, ch, api.EventTypeClaimsOutstanding)
 	if len(result.Errors) != 0 {
@@ -304,9 +306,66 @@ func TestRunDiscoveryListError(t *testing.T) {
 	deps.pool = broken.Pool()
 	deps.providerRepo = provider.NewRepository(broken.Pool())
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 	if len(result.Errors) == 0 {
 		t.Fatal("expected a list-providers error")
+	}
+}
+
+// A scheduled run carries the server's root context, so shutdown's cancel has
+// to end a scan already in flight instead of leaving it writing into a pool
+// that is about to close. The mock provider cancels the root while the gateway
+// is waiting on its response: the upstream request is aborted and the provider
+// is counted as failed, rather than the scan running to completion.
+func TestRunDiscoveryCancelledRootEndsScanInFlight(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Fatal("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var reached atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Store(true)
+		// The shutdown signal, arriving while this scan waits upstream.
+		cancel()
+		// Hold the response. The client's abort closes the connection, which
+		// ends this wait and leaves the scan with a failed request; a scan that
+		// did not honour the cancellation waits the ceiling out and is served a
+		// perfectly good listing, which is what the assertions below rule out.
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data":   []map[string]any{{"id": "cancel-test-model", "object": "model", "owned_by": "tester"}},
+		})
+	}))
+	defer srv.Close()
+
+	deps := testDiscoveryDeps(t)
+	if _, err := deps.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "cmdserver-discovery-cancel-test",
+		BaseURL: srv.URL + "/v1",
+	}, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	result := runDiscovery(ctx, deps, "test")
+
+	if !reached.Load() {
+		t.Fatal("the provider was never scanned, so nothing was cancelled in flight")
+	}
+	if result.ProvidersFailed != 1 {
+		t.Fatalf("providers failed = %d (%v), want 1: a cancelled root must end the scan", result.ProvidersFailed, result.Errors)
+	}
+	if result.ModelsDiscovered != 0 {
+		t.Fatalf("models discovered = %d, want 0: the cancelled scan returned a listing anyway", result.ModelsDiscovered)
 	}
 }
 
@@ -385,7 +444,7 @@ func TestRunDiscoveryHappyPath(t *testing.T) {
 	ch := events.DefaultBus.Subscribe()
 	defer events.DefaultBus.Unsubscribe(ch)
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ProvidersScanned != 2 {
 		t.Errorf("expected 2 providers scanned, got %d", result.ProvidersScanned)
@@ -514,7 +573,8 @@ func TestMaybeStartupDiscovery(t *testing.T) {
 		defer func() { _ = settingsRepo.Set(ctx, "discovery_on_startup", "true") }()
 		// Must return without launching discovery; nothing observable to
 		// assert beyond not panicking and not touching providers.
-		maybeStartupDiscovery(deps, settingsRepo)
+		var group backgroundGroup
+		maybeStartupDiscovery(context.Background(), &group, deps, settingsRepo)
 	})
 
 	t.Run("skips_recently_discovered", func(t *testing.T) {
@@ -529,7 +589,8 @@ func TestMaybeStartupDiscovery(t *testing.T) {
 		touchLastDiscovered(ctx, deps.pool, p)
 		// Recently-discovered guard fires: no background run is launched, so
 		// the unreachable provider is never scanned again.
-		maybeStartupDiscovery(deps, settingsRepo)
+		var group backgroundGroup
+		maybeStartupDiscovery(context.Background(), &group, deps, settingsRepo)
 	})
 
 	t.Run("runs_in_background", func(t *testing.T) {
@@ -537,7 +598,8 @@ func TestMaybeStartupDiscovery(t *testing.T) {
 		ch := events.DefaultBus.Subscribe()
 		defer events.DefaultBus.Unsubscribe(ch)
 
-		maybeStartupDiscovery(deps, settingsRepo)
+		var group backgroundGroup
+		maybeStartupDiscovery(context.Background(), &group, deps, settingsRepo)
 
 		// Zero providers: the background run completes immediately with a
 		// success event.
@@ -546,6 +608,63 @@ func TestMaybeStartupDiscovery(t *testing.T) {
 			t.Errorf("expected success severity, got %q", ev.Severity)
 		}
 	})
+}
+
+// TestMaybeStartupDiscoveryIsJoinedByTheGroup pins the startup run to the
+// background group. Started with a bare `go` it is the one lifetime producer
+// shutdown cannot see, so it keeps scanning, upserting and logging while the
+// discovery service, the app-log writer and the pool are being closed. The
+// provider here holds its listing open until released, so the run is
+// demonstrably still in flight when the group is asked who is running.
+func TestMaybeStartupDiscoveryIsJoinedByTheGroup(t *testing.T) {
+	if cmdTestDB == nil {
+		t.Fatal("test DB unavailable")
+	}
+	wipeDiscoveryState(t)
+
+	release := make(chan struct{})
+	scanning := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(scanning) })
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data":   []map[string]any{{"id": "startup-join-model", "object": "model", "owned_by": "tester"}},
+		})
+	}))
+	defer srv.Close()
+
+	deps := testDiscoveryDeps(t)
+	settingsRepo := newTestSettingsRepo()
+	if _, err := deps.providerRepo.Create(context.Background(), provider.CreateProviderRequest{
+		Name:    "cmdserver-startup-join-test",
+		BaseURL: srv.URL + "/v1",
+	}, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+
+	var group backgroundGroup
+	maybeStartupDiscovery(context.Background(), &group, deps, settingsRepo)
+
+	select {
+	case <-scanning:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the provider was never scanned, so no run was in flight to join")
+	}
+	if stuck := group.Wait(50 * time.Millisecond); len(stuck) != 1 || stuck[0] != "startup-discovery" {
+		t.Fatalf("group members still running = %v, want [startup-discovery]: the run is not registered with the group", stuck)
+	}
+
+	close(release)
+	if stuck := group.Wait(10 * time.Second); len(stuck) != 0 {
+		t.Fatalf("group members still running = %v, want none: the run was not joined", stuck)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -631,7 +750,7 @@ func TestRunDiscoveryPrunesRetiredModels(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = deps.settingsRepo.Set(context.Background(), "model_prune_days", "7") })
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ModelsPruned != 1 {
 		t.Errorf("ModelsPruned = %d, want 1 (errors: %v)", result.ModelsPruned, result.Errors)
@@ -674,7 +793,7 @@ func TestRunDiscoveryPrunesWithShortHorizon(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = deps.settingsRepo.Set(context.Background(), "model_prune_days", "7") })
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ModelsPruned != 1 {
 		t.Errorf("ModelsPruned = %d, want 1 (errors: %v)", result.ModelsPruned, result.Errors)
@@ -703,7 +822,7 @@ func TestRunDiscoveryPruneOffKeepsRows(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = deps.settingsRepo.Set(context.Background(), "model_prune_days", "7") })
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ModelsPruned != 0 || !modelExists(t, old) {
 		t.Errorf("prune ran with model_prune_days=0: pruned=%d exists=%v", result.ModelsPruned, modelExists(t, old))
@@ -729,7 +848,7 @@ func TestRunDiscoveryPruneSkipsFailedProvider(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = deps.settingsRepo.Set(context.Background(), "model_prune_days", "7") })
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ProvidersFailed != 1 {
 		t.Fatalf("ProvidersFailed = %d, want 1 (the test needs one failing scan)", result.ProvidersFailed)
@@ -767,7 +886,7 @@ func TestRunDiscoveryPruneSkipsProviderWithUpsertFailure(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = deps.settingsRepo.Set(context.Background(), "model_prune_days", "7") })
 
-	result := runDiscovery(deps, "test")
+	result := runDiscovery(context.Background(), deps, "test")
 
 	if result.ProvidersFailed != 0 {
 		t.Fatalf("ProvidersFailed = %d, want 0 (the listing itself succeeds)", result.ProvidersFailed)
@@ -804,7 +923,7 @@ func TestRunDiscoveryPruneRejectsUnusableHorizon(t *testing.T) {
 				t.Fatalf("set: %v", err)
 			}
 
-			result := runDiscovery(deps, "test")
+			result := runDiscovery(context.Background(), deps, "test")
 
 			if result.ModelsPruned != 0 {
 				t.Errorf("ModelsPruned = %d, want 0 for model_prune_days=%q", result.ModelsPruned, value)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,8 +67,15 @@ func main() {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
+	// The root context of every background loop. Shutdown cancels it explicitly
+	// before joining them, so the deferred cancel here is only the safety net
+	// for the early-exit paths above the shutdown block.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Every process-lifetime loop starts on this group, so shutdown can join
+	// them after the cancel and before the resources they read are released.
+	var background backgroundGroup
 
 	// Initialize the admin manager before the DB connection: it only needs the
 	// data directory and env token, no database.
@@ -189,7 +196,7 @@ func main() {
 	// serving. Runs for the app lifetime (ctx), reading config live so toggles
 	// apply without a restart.
 	alertDispatcher := alert.New(alert.NewSettingsConfigProvider(settingsRepo, cfg.MasterKey), nil)
-	go alertDispatcher.Run(ctx)
+	background.Go("alert-dispatcher", func() { alertDispatcher.Run(ctx) })
 
 	// Prometheus metrics at the conventional /metrics path (root, no IP rate
 	// limiter so scrapers are not throttled). Authenticated via METRICS_TOKEN or
@@ -237,7 +244,7 @@ func main() {
 	})
 	apiHandler.SetAudit(auditRecorder)
 
-	go webauthn.SessionCleanupLoop(ctx, webauthnRepo, time.Hour)
+	background.Go("webauthn-session-cleanup", func() { webauthn.SessionCleanupLoop(ctx, webauthnRepo, time.Hour) })
 
 	// TOTP (RFC 6238) second-factor. Always constructed so the public status
 	// and login endpoints are mounted; enforcement is driven by the cached
@@ -348,7 +355,12 @@ func main() {
 	// is where the BackupHandler is constructed and wired as h.backupScheduler.
 	// Started earlier it silently no-ops on a nil scheduler, so no automatic
 	// (GFS) backups run whatever backup_enabled is set to.
-	apiHandler.StartBackupScheduler(context.Background())
+	//
+	// On the root context and in the group like every other lifetime loop: a
+	// scheduled backup logs and reads the settings store as it runs, so the
+	// shutdown path has to be able to cancel it and then wait for it rather
+	// than close the pool under it.
+	background.Go("backup-scheduler", func() { <-apiHandler.StartBackupScheduler(ctx) })
 
 	// Admin chat routes: an admin-authenticated proxy for the Chat/Arena UI,
 	// with the streaming-aware timeout (as on /v1) and per-IP rate limiting.
@@ -413,7 +425,7 @@ func main() {
 	}
 
 	// Startup: run initial discovery for all enabled providers (if enabled).
-	maybeStartupDiscovery(discDeps, settingsRepo)
+	maybeStartupDiscovery(ctx, &background, discDeps, settingsRepo)
 
 	warmCaches(discDeps, settingsRepo)
 	initKeyCacheTTL(settingsRepo)
@@ -421,14 +433,27 @@ func main() {
 	// Background maintenance loops (see background.go). The discovery scheduler
 	// sleeps a full interval before its first run so it doesn't bypass the
 	// discovery_on_startup setting handled by maybeStartupDiscovery above.
-	go discoverySchedulerLoop(ctx, settingsRepo, func(source string) DiscoveryResult {
-		return runDiscovery(discDeps, source)
+	background.Go("discovery-scheduler", func() {
+		discoverySchedulerLoop(ctx, settingsRepo, func(source string) DiscoveryResult {
+			return runDiscovery(ctx, discDeps, source)
+		})
 	})
-	go staleLogCleanupLoop(ctx, database.Pool(), settingsRepo, serverStartTime)
-	go proxy.PhraseStalenessLoop(ctx, database.Pool())
-	go logRetentionLoop(ctx, database.Pool(), settingsRepo)
-	go quotaPollLoop(ctx, settingsRepo, apiHandler.PollQuotasOnce, apiHandler.DisableQuotaAdvice, time.Minute)
-	go scheduledDisableLoop(ctx, providerRepo, failoverRepo, time.Minute)
+	// The context the detached maintenance passes run their statements on: the
+	// root's values without its cancellation, so a pass that has begun still
+	// finishes what it started when the signal lands, and the join below is the
+	// only thing that ends it.
+	drainCtx := background.drainContext(ctx)
+	background.Go("stale-log-cleanup", func() {
+		staleLogCleanupLoop(ctx, drainCtx, database.Pool(), settingsRepo, serverStartTime)
+	})
+	background.Go("phrase-staleness", func() { proxy.PhraseStalenessLoop(ctx, database.Pool()) })
+	background.Go("log-retention", func() { logRetentionLoop(ctx, drainCtx, database.Pool(), settingsRepo) })
+	background.Go("quota-poll", func() {
+		quotaPollLoop(ctx, settingsRepo, apiHandler.PollQuotasOnce, apiHandler.DisableQuotaAdvice, time.Minute)
+	})
+	background.Go("scheduled-disable", func() {
+		scheduledDisableLoop(ctx, drainCtx, providerRepo, failoverRepo, time.Minute)
+	})
 
 	// Listener posture (header/idle timeouts, per-request body deadline) is
 	// decided once in httpx.NewServer, shared with Front Desk.
@@ -457,37 +482,104 @@ func main() {
 
 	debuglog.Info("server: shutting down gracefully")
 
-	// Release goroutine-leaking resources before draining HTTP connections.
-	proxyHandler.Close()
-	apiHandler.StopBackupScheduler()
-	// Close only drops the shared service's idle pooled connections; a request
-	// the discovery runs or the quota poll loop still hold keeps its own
-	// connection until it returns. Both loops stop on the deferred root cancel,
-	// which runs after this block.
-	discDeps.discovery.Close()
-	util.CloseDockerClient()
+	// The whole block below is budgeted so a container stop can complete it.
+	// Worst case, in order: 10s HTTP drain + 35s background join
+	// (backgroundJoinBudget: the 30s scheduled-disable sweep ceiling plus a 5s
+	// margin, the one detached pass the join actually waits out; the retention
+	// and stale-log passes carry no ceiling and are cancelled by the join rather
+	// than awaited) + 10s audit drain (one record's 5s insert plus the 5s
+	// retention prune it piggybacks, both inside the same WaitGroup member) + 5s
+	// app-log writer stop + 5s OTLP flush = 65s. The closes around them (the
+	// event bus, the proxy handler, discovery, the docker client, the rate
+	// limiters and the database pool) carry no budget of their own, so
+	// stop_grace_period in docker-compose.yml is 75s: a ceiling with headroom
+	// over the 65s, not the sum. Docker's 10s default would SIGKILL the process
+	// partway through the drain instead.
+
+	// Cancel the root context first: every background loop selects on it, so
+	// this is what starts them unwinding while the drain below runs.
+	cancel()
 
 	// End every open /api/events SSE stream. Each one is an in-flight request
 	// that server.Shutdown would otherwise wait on until the deadline, so one
 	// open dashboard tab costs a restart the full 10s.
 	events.DefaultBus.Close()
 
-	// Flush pending app log DB writes before closing the database.
-	api.StopAppLogWriter()
+	// Ahead of the drain, because closing the handler is what tells the streams
+	// it supervises to wind up: each one watches h.shutdown and ends with a
+	// well-formed error frame inside shutdownStreamGrace. Called after
+	// server.Shutdown instead, no stream ever gets the signal, so the drain
+	// burns its whole deadline and the streams die with the process. It aborts
+	// nothing on its own: it closes that signal channel and the idle upstream
+	// connections.
+	proxyHandler.Close()
 
-	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 10*time.Second)
+	// Stop accepting and drain the HTTP requests still in flight, before the
+	// join rather than after it: the listener has to come down first, or a join
+	// that spends its budget leaves the gateway taking new requests for that
+	// long after the signal. On a budget of its own, because ctx is cancelled
+	// by now and a shutdown context derived from it would give the drain no
+	// time at all.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		debuglog.Error("server: error during shutdown", "error", err)
 	}
 
-	// The server has stopped accepting requests, so no new audit goroutines can
-	// spawn; drain the ones already in flight before the deferred database.Close
-	// so their inserts are not lost.
+	// Join the background loops before touching a resource they hold. They have
+	// been unwinding since the cancel above, and the drain may have absorbed
+	// part of the budget on the way: on a busy gateway it takes its whole
+	// deadline, on an idle one server.Shutdown returns as soon as the last
+	// request finishes and the join starts from a standing start. So the budget
+	// has to cover the scheduled-disable sweep in full (see
+	// backgroundJoinBudget), not merely the remainder of one. The retention and
+	// stale-log passes are a different case: they carry no ceiling, so what the
+	// budget gives them is not a wait but an end. Bounded either way: a loop that
+	// has not returned when it expires is named in the log rather than hanging
+	// the process, and the drain context those passes run on is cancelled with
+	// it, cutting whatever statement is still open.
+	if stuck := background.Wait(backgroundJoinBudget); len(stuck) > 0 {
+		debuglog.Warn("server: background loops still running at shutdown", "loops", strings.Join(stuck, ","))
+	}
+
+	// Drain the audit goroutines already in flight before the database closes,
+	// so their inserts are not lost. When the drain above returned nil the
+	// server has stopped serving, so no new ones can spawn and this is a clean
+	// join. When it returned a deadline error the handlers it gave up on are
+	// still live, and a record spawning now Adds to the same WaitGroup this is
+	// waiting on: an Add that lifts the counter off zero concurrently with Wait
+	// is the documented misuse, so what a handler that outlived the drain costs
+	// is a panic on the way out rather than one missing row. The drain deadline
+	// is therefore the thing that keeps this honest, not this wait. Each record
+	// is bounded by its own 5s insert deadline plus the 5s retention prune it
+	// piggybacks, which is the 10s this stage is budgeted at.
 	auditRecorder.Wait()
 
 	debuglog.Info("server: stopped")
+
+	// Nothing is serving any more, so the pooled connections and clients can
+	// go. The backup scheduler was cancelled with the other loops above, and
+	// joined with them unless the join named it as still running; this only
+	// clears the handler's own cancel bookkeeping either way.
+	apiHandler.StopBackupScheduler()
+	discDeps.discovery.Close()
+	util.CloseDockerClient()
+
+	// As late as the writer can go and still have a pool to flush into: the
+	// background loops (backup scheduler included) are joined, the HTTP surface
+	// is drained, and the proxy, discovery and docker closes above have said
+	// what they log. It is not a proof that nothing can log again. A loop the
+	// join just named, or a handler the drain gave up on, is still a producer,
+	// and what it writes from here on still reaches stderr and the ring buffer;
+	// what it no longer reaches is app_logs, because the stopped writer refuses
+	// it and counts it as a drop, reported on stderr once per report interval
+	// rather than lost silently. So
+	// flush what the writer is holding now, before the OTLP exporter below and
+	// before the deferred database close that flush needs. One 5s deadline
+	// covers the whole stop, and whatever the queue still holds when it expires
+	// is counted as dropped rather than flushed past the grace period.
+	api.StopAppLogWriter()
 
 	// Flush and close the OTLP log exporter (if enabled) last, so the shutdown
 	// records above are exported too. Fresh context: the HTTP drain may have
@@ -499,4 +591,10 @@ func main() {
 			debuglog.Error("otel: OTLP log exporter shutdown failed", "error", err)
 		}
 	}
+
+	// The database closes last, on the defer registered right after db.New.
+	// Deferred calls run LIFO after this line, so the rate limiters stop first
+	// and the pool goes after them; nothing above reaches a closed pool. The
+	// deferred root cancel that follows it is a no-op, cancel having already run
+	// at the top of this block.
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,20 @@ services:
             #     Only enable if you trust the deployment environment.
             # - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: unless-stopped
+        # Model Hotel winds down in stages on SIGTERM. Worst case, in order:
+        # 10s HTTP drain (open SSE tabs and proxied streams are ended first, so
+        # this is usually quick) + 35s background join (the 30s ceiling of the
+        # scheduled-disable sweep, which deliberately finishes the statement it
+        # has already started, plus a 5s margin; the retention and stale-log
+        # sweeps have no ceiling and the join cancels them instead of waiting)
+        # + 10s audit drain (one record's 5s insert plus the 5s retention prune
+        # it piggybacks) + 5s app-log writer stop + 5s OTLP flush = 65s. The
+        # closes around them (the event bus, the proxy handler, discovery, the
+        # docker client, the rate limiters and the database pool) carry no budget
+        # of their own, so this is a ceiling with headroom over the 65s, not the
+        # sum. Docker's default grace is 10s, which would SIGKILL partway through
+        # the drain and take the audit rows and the last log lines with it.
+        stop_grace_period: 75s
         depends_on:
             db:
                 condition: service_healthy

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -79,7 +79,9 @@ type SettingsStore interface {
 
 // BackupScheduler defines the interface for the periodic backup scheduler.
 type BackupScheduler interface {
-	StartScheduler(ctx context.Context)
+	// StartScheduler returns a channel closed when the scheduler goroutine has
+	// exited, so the process owner can join it during shutdown.
+	StartScheduler(ctx context.Context) <-chan struct{}
 	StopScheduler()
 }
 
@@ -332,12 +334,16 @@ func (h *Handler) SetQuotaAdvisor(a *QuotaAdvisor) {
 // StartBackupScheduler starts the periodic backup scheduler if backup_enabled is true.
 // Call this only after Register, which constructs the BackupHandler and assigns it as
 // h.backupScheduler; calling earlier leaves the scheduler nil and no backups ever run.
-func (h *Handler) StartBackupScheduler(ctx context.Context) {
+// The returned channel closes when the scheduler goroutine has exited, so shutdown can
+// join it; it is already closed when there was no scheduler to start.
+func (h *Handler) StartBackupScheduler(ctx context.Context) <-chan struct{} {
 	if h.backupScheduler == nil {
 		debuglog.Warn("backup: StartBackupScheduler called before the scheduler was wired; no automatic backups will run")
-		return
+		stopped := make(chan struct{})
+		close(stopped)
+		return stopped
 	}
-	h.backupScheduler.StartScheduler(ctx)
+	return h.backupScheduler.StartScheduler(ctx)
 }
 
 // StopBackupScheduler stops the periodic backup scheduler.

--- a/internal/api/applog_drops_test.go
+++ b/internal/api/applog_drops_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -47,6 +49,16 @@ func closedTestPool(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
+// armed fills in the lifetime pieces newDBLogWriter would have created, so a
+// test can build a writer as a literal (no run goroutine, a pool of its own)
+// and still drive send, flush and stop against it. Without them stop would
+// close a nil channel and every flush would derive from a nil context.
+func armed(w *dbLogWriter) *dbLogWriter {
+	w.stopping = make(chan struct{})
+	w.life, w.endLife = context.WithCancel(context.Background())
+	return w
+}
+
 // A batch the database refused used to vanish with `_ = err`: up to 50 entries
 // gone from the App Logs history with no evidence anywhere, which reads exactly
 // like the gateway never having logged at all.
@@ -56,7 +68,7 @@ func TestDBLogWriter_ReportsEntriesItCouldNotPersist(t *testing.T) {
 	// Built as a literal rather than through newDBLogWriter: flush needs only
 	// the pool and the reporter, and this way the capture destination is set
 	// before anything could read it, with no run goroutine in the picture.
-	w := &dbLogWriter{pool: closedTestPool(t), drops: &logDropReporter{dst: &out, interval: time.Hour}}
+	w := armed(&dbLogWriter{pool: closedTestPool(t), drops: &logDropReporter{dst: &out, interval: time.Hour}})
 
 	w.flush([]AppLogEntry{
 		{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: "first"},
@@ -109,6 +121,30 @@ func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
 	if !strings.Contains(tail, "applog: 7 entries dropped") {
 		t.Errorf("the 7 suppressed entries were never accounted for: %q", tail)
 	}
+
+	// A drop that lands after the final report has no later notice to be
+	// carried into: writes racing a shutdown reach the reporter after stop has
+	// already said its piece, and throttling them there is silence.
+	before := out.String()
+	r.drop(1, "after the final report")
+	late := strings.TrimPrefix(out.String(), before)
+	if !strings.Contains(late, "applog: 1 entries dropped") {
+		t.Errorf("a drop after the final report was swallowed by the throttle: %q", late)
+	}
+
+	// One notice, not one per entry. reportPending rearms the throttle rather
+	// than lifting it, so the drops behind that first late one aggregate the
+	// way they always did: a writer stopped while the log path is still busy
+	// costs a line per interval, not a line per entry.
+	said := out.String()
+	r.drop(1, "and another")
+	r.drop(1, "and another")
+	if out.String() != said {
+		t.Errorf("the throttle did not come back after the final report: %q", strings.TrimPrefix(out.String(), said))
+	}
+	if r.pending != 2 {
+		t.Errorf("pending = %d, want 2: the throttled late drops were not kept on the count", r.pending)
+	}
 }
 
 // And the tail reaches stderr through the shutdown path that actually runs:
@@ -117,21 +153,21 @@ func TestLogDropReporter_ThrottlesWithoutLosingTheCount(t *testing.T) {
 func TestDBLogWriter_StopReportsTheSuppressedTail(t *testing.T) {
 	t.Parallel()
 	var out syncBuffer
-	w := &dbLogWriter{
+	w := armed(&dbLogWriter{
 		pool:          closedTestPool(t),
-		ch:            make(chan AppLogEntry, 16),
+		ch:            make(chan logMsg, 16),
 		done:          make(chan struct{}),
 		flushInterval: 10 * time.Millisecond,
 		sendTimeout:   time.Second,
 		drops:         &logDropReporter{dst: &out, interval: time.Hour},
-	}
+	})
 	go w.run()
 
 	entry := func(m string) AppLogEntry {
 		return AppLogEntry{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "test", Message: m}
 	}
 	// First failing flush: reported immediately, and it starts the interval.
-	w.ch <- entry("one")
+	w.ch <- logMsg{entry: entry("one")}
 	deadline := time.Now().Add(5 * time.Second)
 	for out.String() == "" && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
@@ -143,7 +179,7 @@ func TestDBLogWriter_StopReportsTheSuppressedTail(t *testing.T) {
 
 	// Second one is inside the interval, so it is suppressed and must survive
 	// only on the pending count.
-	w.ch <- entry("two")
+	w.ch <- logMsg{entry: entry("two")}
 	w.stop()
 
 	tail := strings.TrimPrefix(out.String(), firstNotice)
@@ -157,12 +193,12 @@ func TestDBLogWriter_StopReportsTheSuppressedTail(t *testing.T) {
 func TestDBLogWriter_ReportsAnEntryTheQueueCouldNotTake(t *testing.T) {
 	t.Parallel()
 	var out syncBuffer
-	w := &dbLogWriter{
-		ch:          make(chan AppLogEntry, 1),
+	w := armed(&dbLogWriter{
+		ch:          make(chan logMsg, 1),
 		sendTimeout: 50 * time.Millisecond,
 		drops:       &logDropReporter{dst: &out, interval: time.Hour},
-	}
-	w.ch <- AppLogEntry{Message: "occupies the queue"} // nothing drains it
+	})
+	w.ch <- logMsg{entry: AppLogEntry{Message: "occupies the queue"}} // nothing drains it
 
 	w.write(AppLogEntry{Level: "info", Source: "test", Message: "dropped-entry-text"})
 
@@ -215,11 +251,394 @@ func TestLogDropReporter_NilIsInert(t *testing.T) {
 	noDst.reportPending()
 
 	for _, w := range []*dbLogWriter{
-		{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond},
-		{ch: make(chan AppLogEntry, 1), sendTimeout: 10 * time.Millisecond, drops: noDst},
+		armed(&dbLogWriter{ch: make(chan logMsg, 1), sendTimeout: 10 * time.Millisecond}),
+		armed(&dbLogWriter{ch: make(chan logMsg, 1), sendTimeout: 10 * time.Millisecond, drops: noDst}),
 	} {
-		w.ch <- AppLogEntry{Message: "occupies the queue"}
+		w.ch <- logMsg{entry: AppLogEntry{Message: "occupies the queue"}}
 		w.write(AppLogEntry{Level: "info", Source: "test", Message: "discarded"})
 		w.flush([]AppLogEntry{{Level: "info", Source: "test", Message: "discarded"}})
+	}
+}
+
+// stop puts one deadline over the whole final drain. When it expires, whatever
+// is still queued is dropped in a single counted notice instead of being
+// flushed a batch at a time with a deadline each: a queue holding
+// dbLogChannelSize entries against a stalled database would otherwise take a
+// hundred of those in a row, and the process would be killed with the database
+// pool still open.
+func TestDBLogWriter_StopDropsWhatTheDeadlineDoesNotCover(t *testing.T) {
+	t.Parallel()
+	const queued = 20
+	var out syncBuffer
+	w := armed(&dbLogWriter{
+		ch:   make(chan logMsg, queued),
+		done: make(chan struct{}),
+		// Long enough that only the stop path can move these entries.
+		flushInterval: time.Hour,
+		sendTimeout:   time.Second,
+		drops:         &logDropReporter{dst: &out, interval: time.Hour},
+	})
+	go w.run()
+
+	for i := range queued {
+		w.ch <- logMsg{entry: AppLogEntry{Level: "info", Source: "test", Message: fmt.Sprintf("queued %d", i)}}
+	}
+	// Stands in for the stop deadline expiring, which is what stop's own timer
+	// does to this context.
+	w.endLife()
+
+	stopped := make(chan struct{})
+	go func() {
+		w.stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not return: the final drain is not bounded by its deadline")
+	}
+
+	got := out.String()
+	if want := fmt.Sprintf("%d entries dropped", queued); !strings.Contains(got, want) {
+		t.Errorf("notice = %q, want one saying %q: the undrained tail has to be accounted, not silently lost", got, want)
+	}
+	if n := strings.Count(got, "\n"); n != 1 {
+		t.Errorf("got %d notices in %q, want exactly one for the whole undrained tail", n, got)
+	}
+}
+
+// One cause, one notice. The drain writes more than one batch, and a database
+// that refuses them is a single incident: reported per batch it reads as
+// several, and the operator has to add the counts up by hand to learn how big
+// the hole in the history is. Discriminating because the pool here fails every
+// Exec, so the drain does hand batches over and does get them back refused, and
+// because the reporter throttles nothing (interval 0), so every notice the drain
+// produces is visible.
+//
+// drainTail is driven directly rather than through run: run flushes on its own
+// as soon as a batch fills, so a test that fed the queue and then stopped the
+// writer would be racing it for the first fifty entries.
+func TestDBLogWriter_DrainReportsTheRefusedTailAsOneNotice(t *testing.T) {
+	t.Parallel()
+	const queued = dbLogBatchSize + 10
+	var out syncBuffer
+	w := armed(&dbLogWriter{
+		pool:  closedTestPool(t),
+		ch:    make(chan logMsg, queued),
+		drops: &logDropReporter{dst: &out},
+	})
+
+	for i := range queued {
+		w.ch <- logMsg{entry: AppLogEntry{Level: "info", Source: "test", Message: fmt.Sprintf("queued %d", i)}}
+	}
+	w.drainTail(nil)
+
+	got := out.String()
+	if want := fmt.Sprintf("%d entries dropped", queued); !strings.Contains(got, want) {
+		t.Errorf("notice = %q, want one saying %q: the whole refused drain is one hole, counted once", got, want)
+	}
+	if n := strings.Count(got, "\n"); n != 1 {
+		t.Errorf("got %d notices in %q, want exactly one for the whole refused drain", n, got)
+	}
+}
+
+// A second stop waits for the first one's drain rather than returning on the
+// closed flag. Returning early would tell its caller the writer is finished
+// while batches are still going into a pool the caller is about to close.
+func TestDBLogWriter_SecondStopWaitsForTheFirstDrain(t *testing.T) {
+	t.Parallel()
+	w := armed(&dbLogWriter{
+		ch:            make(chan logMsg, 1),
+		done:          make(chan struct{}),
+		flushInterval: time.Hour,
+		sendTimeout:   time.Second,
+		drops:         &logDropReporter{interval: time.Hour},
+	})
+	// The state a first caller leaves behind while its drain is still running:
+	// the queue is retired but done has not been closed yet.
+	w.mu.Lock()
+	w.closed = true
+	w.mu.Unlock()
+
+	returned := make(chan struct{})
+	go func() {
+		w.stop()
+		close(returned)
+	}()
+	select {
+	case <-returned:
+		t.Fatal("second stop returned while the first caller's drain was still writing")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(w.done) // the first caller's drain finishes
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second stop did not return once the drain had finished")
+	}
+}
+
+// liveTestPool returns an open pool against the test database.
+func liveTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	if apiTestDBURL == "" {
+		t.Fatal("apiTestDBURL not set: test database required")
+	}
+	pool, err := pgxpool.New(context.Background(), apiTestDBURL)
+	if err != nil {
+		t.Fatalf("failed to create pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// countAppLogs reports how many rows the given source has.
+func countAppLogs(t *testing.T, pool *pgxpool.Pool, source string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM app_logs WHERE source = $1`, source).Scan(&n); err != nil {
+		t.Fatalf("count rows for %s: %v", source, err)
+	}
+	return n
+}
+
+// testEntry builds an entry attributed to source.
+func testEntry(source, message string) AppLogEntry {
+	return AppLogEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Level:     "info",
+		Source:    source,
+		Message:   message,
+	}
+}
+
+// Shutdown used to close the queue under the producers and rely on a recover in
+// write to absorb the "send on closed channel" that followed, which is a panic
+// caught after the fact, not synchronisation: whether it fired at all depended
+// on the schedule. Writers racing stop must simply never panic.
+func TestDBLogWriter_ConcurrentWriteDuringStopNeverPanics(t *testing.T) {
+	pool := liveTestPool(t)
+	const source = "stop-race-test"
+	if _, err := pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source); err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source)
+	})
+
+	w := newDBLogWriter(pool, 10*time.Millisecond)
+
+	// The other half of the guarantee, on the racing path this time: a send
+	// that answered nil while the close was already under way is a row, not a
+	// maybe. Only send reports that, which is why the writers call it directly;
+	// write is send plus the drop accounting.
+	var mu sync.Mutex
+	var accepted []string
+	// Every writer reports its first accepted send, so stop lands on a queue
+	// that already holds entries rather than possibly ahead of all of them.
+	running := make(chan struct{}, 8)
+	var writers sync.WaitGroup
+	for g := range 8 {
+		writers.Go(func() {
+			var mine []string
+			for i := range 50 {
+				msg := fmt.Sprintf("g%d-%d", g, i)
+				timer := time.NewTimer(w.sendTimeout)
+				err := w.send(logMsg{entry: testEntry(source, msg)}, timer.C)
+				timer.Stop()
+				if err == nil {
+					mine = append(mine, msg)
+				}
+				if i == 0 {
+					running <- struct{}{}
+				}
+			}
+			mu.Lock()
+			accepted = append(accepted, mine...)
+			mu.Unlock()
+		})
+	}
+	for range 8 {
+		<-running
+	}
+	// Stop while the writers above are still going: the whole point is that the
+	// close lands in the middle of concurrent sends.
+	w.stop()
+	writers.Wait()
+
+	// A write after stop is a drop, not a panic, and not a resurrected queue.
+	w.write(testEntry(source, "after stop"))
+
+	persisted := appLogMessages(t, pool, source)
+	if len(accepted) == 0 {
+		t.Fatal("no send was accepted, so the race never happened and nothing is being proved")
+	}
+	for _, msg := range accepted {
+		if !persisted[msg] {
+			t.Fatalf("%q was accepted by the writer but never reached the database: a send that returned nil must be a row", msg)
+		}
+	}
+	if persisted["after stop"] {
+		t.Fatal("an entry written after stop reached the database")
+	}
+}
+
+// appLogMessages reports which messages the given source has rows for.
+func appLogMessages(t *testing.T, pool *pgxpool.Pool, source string) map[string]bool {
+	t.Helper()
+	rows, err := pool.Query(context.Background(),
+		`SELECT message FROM app_logs WHERE source = $1`, source)
+	if err != nil {
+		t.Fatalf("read rows for %s: %v", source, err)
+	}
+	defer rows.Close()
+	seen := map[string]bool{}
+	for rows.Next() {
+		var msg string
+		if err := rows.Scan(&msg); err != nil {
+			t.Fatalf("scan row for %s: %v", source, err)
+		}
+		seen[msg] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate rows for %s: %v", source, err)
+	}
+	return seen
+}
+
+// The hot log path is bounded by sendTimeout and nothing else. RWMutex parks a
+// new reader behind a waiting writer, so a sender that took the read lock
+// before consulting the closed state would be held for the whole of another
+// sender's send whenever stop was queued between them, with its own deadline
+// not yet in the select.
+func TestDBLogWriter_WriteStaysBoundedWhileStopWaits(t *testing.T) {
+	const sendTimeout = 50 * time.Millisecond
+	w := armed(&dbLogWriter{
+		ch:          make(chan logMsg, 1),
+		done:        make(chan struct{}),
+		sendTimeout: sendTimeout,
+		drops:       &logDropReporter{dst: &syncBuffer{}, interval: time.Hour},
+	})
+	// No run goroutine: stop only has to get past the senders, and the queue
+	// stays full so a sender that reaches the send blocks in it.
+	close(w.done)
+	w.ch <- logMsg{}
+
+	// A sender that holds the read lock for two seconds.
+	const hold = 2 * time.Second
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		_ = w.send(logMsg{entry: testEntry("bound-test", "holder")}, time.After(hold))
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// stop now queues for the write lock behind that sender.
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		w.stop()
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	w.write(testEntry("bound-test", "measured"))
+	elapsed := time.Since(start)
+
+	<-sent
+	<-stopped
+	if elapsed > 10*sendTimeout {
+		t.Fatalf("write took %s with stop waiting, want at most its own %s send timeout", elapsed, sendTimeout)
+	}
+}
+
+// The other half of the same guarantee: an entry whose write returned before
+// stop was called reaches the database, so shutdown is a flush and not a
+// truncation.
+func TestDBLogWriter_StopPersistsEverythingWrittenBefore(t *testing.T) {
+	pool := liveTestPool(t)
+	const source = "stop-flush-test"
+	if _, err := pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source); err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source)
+	})
+
+	// An interval long enough that nothing flushes on the ticker: only stop can
+	// have written these rows.
+	w := newDBLogWriter(pool, time.Hour)
+	const want = 20
+	for i := range want {
+		w.write(testEntry(source, fmt.Sprintf("entry %d", i)))
+	}
+	w.stop()
+
+	if got := countAppLogs(t, pool, source); got != want {
+		t.Fatalf("rows after stop = %d, want %d: entries written before stop were lost", got, want)
+	}
+}
+
+// The barrier is what lets a purge own the rows: everything queued before it
+// has to be in the database by the time it returns.
+func TestDBLogWriter_FlushBarrierDrainsQueuedEntries(t *testing.T) {
+	pool := liveTestPool(t)
+	const source = "barrier-test"
+	if _, err := pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source); err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM app_logs WHERE source = $1`, source)
+	})
+
+	// A ticker that will not fire during the test, so the barrier is the only
+	// thing that can have flushed the queue.
+	w := newDBLogWriter(pool, time.Hour)
+	defer w.stop()
+	for i := range 5 {
+		w.write(testEntry(source, fmt.Sprintf("queued %d", i)))
+	}
+
+	if err := w.flushBarrier(appLogFlushBarrierTimeout); err != nil {
+		t.Fatalf("flushBarrier: %v", err)
+	}
+	if got := countAppLogs(t, pool, source); got != 5 {
+		t.Fatalf("rows after barrier = %d, want 5: the barrier returned with entries still queued", got)
+	}
+}
+
+// A barrier after shutdown says so instead of blocking for its whole budget or
+// sending on a closed channel.
+func TestDBLogWriter_FlushBarrierAfterStop(t *testing.T) {
+	w := newDBLogWriter(nil, time.Hour)
+	w.stop()
+	if err := w.flushBarrier(appLogFlushBarrierTimeout); !errors.Is(err, errLogWriterStopped) {
+		t.Fatalf("flushBarrier after stop = %v, want %v", err, errLogWriterStopped)
+	}
+	// stop is idempotent: shutdown paths may reach it twice.
+	w.stop()
+}
+
+// A barrier that gets into the queue but is never drained gives up on its own
+// budget rather than holding the operator's purge open indefinitely.
+func TestDBLogWriter_FlushBarrierGivesUp(t *testing.T) {
+	t.Parallel()
+	// No run goroutine: the barrier is enqueued and nothing ever answers it.
+	w := armed(&dbLogWriter{ch: make(chan logMsg, 1), sendTimeout: time.Second})
+	if err := w.flushBarrier(20 * time.Millisecond); !errors.Is(err, errLogWriterFlushSlow) {
+		t.Fatalf("flushBarrier with no writer running = %v, want %v", err, errLogWriterFlushSlow)
+	}
+}
+
+// With no writer configured there is nothing to drain, which is not an error:
+// ClearAppLogs runs this on every purge, DB or not.
+func TestFlushAppLogWriter_NoWriter(t *testing.T) {
+	saved := dbWriter.Load()
+	dbWriter.Store(nil)
+	defer func() { dbWriter.Store(saved) }()
+	if err := flushAppLogWriter(appLogFlushBarrierTimeout); err != nil {
+		t.Fatalf("flushAppLogWriter with no writer = %v, want nil", err)
 	}
 }

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -663,27 +663,64 @@ func (h *Handler) ClearAppLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var deleted int
-	if appLogBuffer != nil {
-		if all {
-			deleted = appLogBuffer.Clear()
-		} else {
-			deleted = appLogBuffer.ClearOlderThan(cutoff)
-		}
+	// Entries the writer has already queued would otherwise flush after the
+	// DELETE and reinstate rows the operator just purged, so drain the queue
+	// first. A barrier that does not complete, for any reason, says those
+	// entries may still be queued, which is worse than not deleting at all: it
+	// would answer 200 with a count the pending flush is about to undo. A deep
+	// queue and a fast DELETE are the normal combination under load, so the
+	// purge is refused and the operator is told to retry rather than served a
+	// number that is already wrong. That includes a writer that is stopping:
+	// its run goroutine is still draining thousands of queued entries into the
+	// pool, so "stopped" is not "stopped and drained". The only writer that
+	// skips the barrier is one that was never configured, which is a
+	// deployment with no database and so nothing queued anywhere.
+	if err := flushAppLogWriter(appLogFlushBarrierTimeout); err != nil {
+		respondError(w, "app log writer is still flushing its queue, retry the purge", err, http.StatusServiceUnavailable)
+		return
 	}
-	// Also delete from DB.
+
+	deleted := 0
 	if h.dbPool != nil {
 		query, args := `DELETE FROM app_logs`, []any(nil)
 		if !all {
 			query, args = `DELETE FROM app_logs WHERE created_at < $1`, []any{cutoff}
 		}
 		tag, err := h.dbPool.Pool().Exec(r.Context(), query, args...)
-		if err == nil {
-			deleted += int(tag.RowsAffected())
-			// The unfiltered total is derived from the cached level counts, so
-			// drop the cache now that the rows are gone; otherwise a poll within
-			// appLogCountCacheTTL would report a stale, non-zero total.
-			invalidateAppLogCountCache()
+		if err != nil {
+			// The ring buffer is left alone: it mirrors rows that are still
+			// there, and clearing it would report a purge that did not happen.
+			respondError(w, "failed to clear app logs", err, http.StatusInternalServerError)
+			return
+		}
+		deleted = int(tag.RowsAffected())
+		// The unfiltered total is derived from the cached level counts, so
+		// drop the cache now that the rows are gone; otherwise a poll within
+		// appLogCountCacheTTL would report a stale, non-zero total.
+		invalidateAppLogCountCache()
+	}
+
+	// The ring is cleared only once the rows behind it are gone. Its entries
+	// mirror those rows, so the deleted count stays the database's; the ring's
+	// own count is the answer only when there is no database holding them.
+	//
+	// For a ranged purge the mirror is approximate at the cutoff: the DELETE
+	// above filters on created_at, the row's insert time, while the ring holds
+	// the entry's own Timestamp, and the async writer puts a lag between the
+	// two. An entry logged just before the cutoff and inserted just after it
+	// can therefore survive one and not the other. Both clocks are honest
+	// about the same entry, the reported count is the database's, and the ring
+	// is a live view that ages out on its own, so the disagreement is left
+	// rather than papered over by re-reading one clock through the other.
+	if appLogBuffer != nil {
+		cleared := 0
+		if all {
+			cleared = appLogBuffer.Clear()
+		} else {
+			cleared = appLogBuffer.ClearOlderThan(cutoff)
+		}
+		if h.dbPool == nil {
+			deleted = cleared
 		}
 	}
 	writeJSON(w, map[string]int{"deleted": deleted})

--- a/internal/api/applogs_buffer.go
+++ b/internal/api/applogs_buffer.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -88,8 +90,14 @@ func invalidateAppLogCountCache() {
 // appLogBuffer is the global ring buffer that captures log output.
 var appLogBuffer *ringBuffer
 
-// dbWriter is the asynchronous database log writer (nil if no pool).
-var dbWriter *dbLogWriter
+// dbWriter is the asynchronous database log writer (nil if no pool). Atomic
+// because the producers read it from request and logging goroutines while
+// InitAppLogBuffer sets it, and every reader's decision (write the entry, hold
+// the purge behind a barrier) depends on which value it observes. It is set
+// once and never cleared: a stopped writer stays here so a producer arriving
+// after shutdown is refused and counted rather than seeing "no writer at all"
+// and dropping the entry silently.
+var dbWriter atomic.Pointer[dbLogWriter]
 
 // ringBuffer is a fixed-size circular buffer of AppLogEntry values.
 type ringBuffer struct {
@@ -110,11 +118,62 @@ const dbLogChannelSize = 5000
 // from stalling the hot path (log.Printf) indefinitely.
 const dbLogSendTimeout = 5 * time.Second
 
+// dbLogBatchSize is how many entries accumulate before the writer flushes them
+// as one INSERT.
+const dbLogBatchSize = 50
+
+// dbLogFlushTimeout bounds one batch INSERT.
+const dbLogFlushTimeout = 5 * time.Second
+
+// stopDrainTimeout bounds StopAppLogWriter end to end: the wait for the senders
+// already in flight, a flush already under way and the final drain of what is
+// still queued all share it. It has to be one deadline over all three, because
+// the queue holds up to dbLogChannelSize entries and draining them a batch at a
+// time with a deadline each would let a stalled database hold shutdown for a
+// hundred of those in a row, past any container grace period and with the
+// database pool never closed. What does not fit is counted as dropped instead.
+const stopDrainTimeout = 5 * time.Second
+
+// logMsg is what travels the writer's queue: an entry to persist, or a flush
+// barrier when flushed is non-nil. Barriers ride the same channel as entries so
+// everything queued ahead of one is written before it completes; on a channel
+// of their own they would be selected in arbitrary order and could complete
+// while entries were still in flight.
+type logMsg struct {
+	entry   AppLogEntry
+	flushed chan struct{}
+}
+
+// Why an entry never reached the database, as the reasons a caller has to tell
+// apart: a stopped writer is shutdown, a full queue is a database that has been
+// unreachable long enough to back the queue up, and a slow flush is a barrier
+// that ran out of budget waiting for the rows already queued.
+var (
+	errLogWriterStopped   = errors.New("writer stopped")
+	errLogWriterQueueFull = errors.New("writer queue full")
+	errLogWriterFlushSlow = errors.New("writer flush did not finish in time")
+)
+
 type dbLogWriter struct {
 	pool          *pgxpool.Pool
-	ch            chan AppLogEntry
+	ch            chan logMsg
 	done          chan struct{}
 	flushInterval time.Duration
+	// stopping closes when stop begins, which is what tells run to drain what
+	// is queued and return. The queue channel itself is never closed, so a send
+	// racing the stop cannot panic whatever else changes around it.
+	stopping chan struct{}
+	// life is the parent of every flush deadline, and a sender parked on a full
+	// queue watches it too. stop cancels it once stopDrainTimeout is up, so that
+	// single deadline ends all three at once instead of each carrying its own.
+	life    context.Context
+	endLife context.CancelFunc
+	// mu guards closed and, with it, every send on ch. A sender holds the read
+	// lock across its send and stop takes the write lock before retiring the
+	// queue, so an entry is either refused or queued for a run goroutine that is
+	// still there to drain it, and no recover stands in for the synchronisation.
+	mu     sync.RWMutex
+	closed bool
 	// sendTimeout is how long write blocks before discarding an entry, always
 	// dbLogSendTimeout in production. A field purely so the queue-full test can
 	// prove the drop in milliseconds instead of sitting out the real five
@@ -174,7 +233,10 @@ func (r *logDropReporter) drop(n int, reason string) {
 	r.pending += n
 	now := time.Now()
 	// No IsZero special case: the zero Time is far enough in the past that Sub
-	// saturates well past any interval, so the first drop always reports.
+	// saturates well past any interval, so the first drop always reports. That
+	// is also how the drops after reportPending are handled: it rearms the
+	// throttle to the zero Time rather than lifting it, so the first of them is
+	// said at once and the rest still aggregate on the interval.
 	if now.Sub(r.lastReport) < r.interval {
 		return
 	}
@@ -185,13 +247,19 @@ func (r *logDropReporter) drop(n int, reason string) {
 }
 
 // reportPending states whatever the throttle is still holding, so a shutdown
-// during an outage does not swallow the tail of it.
+// during an outage does not swallow the tail of it. It is the counter's last
+// scheduled reader, so it rearms the throttle on the way out: the next drop
+// reports itself immediately, having no later notice to be carried into, and
+// the ones behind it are throttled as usual. Lifting the throttle outright
+// instead would give a writer stopped while the log path is still busy one
+// stderr line per entry.
 func (r *logDropReporter) reportPending() {
 	if r == nil || r.dst == nil {
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.lastReport = time.Time{}
 	if r.pending == 0 {
 		return
 	}
@@ -206,11 +274,15 @@ func (r *logDropReporter) reportPending() {
 // it, which the race detector reports (and which is a real race, not a test
 // artifact, because the goroutine outlives the test that started it).
 func newDBLogWriter(pool *pgxpool.Pool, flushInterval time.Duration) *dbLogWriter {
+	life, endLife := context.WithCancel(context.Background())
 	w := &dbLogWriter{
 		pool:          pool,
-		ch:            make(chan AppLogEntry, dbLogChannelSize),
+		ch:            make(chan logMsg, dbLogChannelSize),
 		done:          make(chan struct{}),
 		flushInterval: flushInterval,
+		stopping:      make(chan struct{}),
+		life:          life,
+		endLife:       endLife,
 		sendTimeout:   dbLogSendTimeout,
 		drops:         &logDropReporter{dst: os.Stderr, interval: dbLogDropReportInterval},
 	}
@@ -222,23 +294,25 @@ func newDBLogWriter(pool *pgxpool.Pool, flushInterval time.Duration) *dbLogWrite
 const dbLogFlushInterval = 500 * time.Millisecond
 
 func (w *dbLogWriter) run() {
-	batch := make([]AppLogEntry, 0, 50)
+	batch := make([]AppLogEntry, 0, dbLogBatchSize)
 	ticker := time.NewTicker(w.flushInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case entry, ok := <-w.ch:
-			if !ok {
-				// Channel closed — flush remaining
+		case msg := <-w.ch:
+			if msg.flushed != nil {
+				// A barrier: everything queued before it is in batch, so
+				// writing it out now is what the waiter is waiting for.
 				if len(batch) > 0 {
 					w.flush(batch)
+					batch = batch[:0]
 				}
-				close(w.done)
-				return
+				close(msg.flushed)
+				continue
 			}
-			batch = append(batch, entry)
-			if len(batch) >= 50 {
+			batch = append(batch, msg.entry)
+			if len(batch) >= dbLogBatchSize {
 				w.flush(batch)
 				batch = batch[:0]
 			}
@@ -247,15 +321,88 @@ func (w *dbLogWriter) run() {
 				w.flush(batch)
 				batch = batch[:0]
 			}
+		case <-w.stopping:
+			w.drainTail(batch)
+			close(w.done)
+			return
 		}
 	}
 }
 
-func (w *dbLogWriter) flush(entries []AppLogEntry) {
-	if w.pool == nil || len(entries) == 0 {
-		return
+// drainTail writes out whatever is left when stop begins and accounts the rest
+// in one notice. Everything here runs under w.life, which stop cancels at
+// stopDrainTimeout, so a queue too deep or a database too slow to finish inside
+// that costs a single counted line rather than a shutdown that overruns its
+// grace period.
+//
+// A flush barrier still in the queue is passed over rather than closed: the
+// purge waiting on it must not be told the queue is drained by a writer that is
+// about to drop part of it. Its own timeout answers it instead.
+//
+// The whole drain accounts for itself in ONE notice. A batch the database
+// refused and a batch the deadline never let us hand over are the same hole in
+// the history from the reader's side, and reporting them separately turns one
+// cause into two lines that look like two incidents. So the batches written
+// here go through insert rather than flush (which reports on its own) and this
+// keeps the running total.
+func (w *dbLogWriter) drainTail(batch []AppLogEntry) {
+	refused := 0
+	reason := "shutdown drain exceeded " + stopDrainTimeout.String()
+	// Writes batch out unless the stop deadline has already expired. Once it
+	// has, batch is left alone so the count below covers it under the deadline
+	// that actually dropped it, instead of an INSERT on a cancelled context
+	// reporting it as a database failure first.
+	writeOut := func() {
+		if w.life.Err() != nil || len(batch) == 0 {
+			return
+		}
+		if err := w.insert(batch); err != nil {
+			refused += len(batch)
+			reason = "batch insert failed: " + err.Error()
+		}
+		batch = batch[:0]
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+drain:
+	for w.life.Err() == nil {
+		select {
+		case msg := <-w.ch:
+			if msg.flushed != nil {
+				continue
+			}
+			batch = append(batch, msg.entry)
+			if len(batch) >= dbLogBatchSize {
+				writeOut()
+			}
+		default:
+			break drain
+		}
+	}
+	writeOut()
+	if left := refused + len(batch) + len(w.ch); left > 0 {
+		w.drops.drop(left, reason)
+	}
+}
+
+// flush writes one batch and accounts for it if the database refused it. The
+// shutdown drain uses insert directly instead, so its whole tail is one notice.
+func (w *dbLogWriter) flush(entries []AppLogEntry) {
+	if err := w.insert(entries); err != nil {
+		w.drops.drop(len(entries), "batch insert failed: "+err.Error())
+	}
+}
+
+// insert writes one batch as a single INSERT and returns what the database
+// said. It never logs: a notice about the log writer routed through debuglog
+// would come straight back into this writer and recurse, which is why the
+// reporter writes to stderr directly.
+func (w *dbLogWriter) insert(entries []AppLogEntry) error {
+	if w.pool == nil || len(entries) == 0 {
+		return nil
+	}
+	// Derived from w.life rather than from Background, so the stop deadline ends
+	// a flush already in flight instead of adding its own five seconds on top.
+	ctx, cancel := context.WithTimeout(w.life, dbLogFlushTimeout)
 	defer cancel()
 
 	// Build batch INSERT
@@ -271,42 +418,113 @@ func (w *dbLogWriter) flush(entries []AppLogEntry) {
 		args = append(args, e.Timestamp, e.Level, e.Source, e.Message, e.Escaped, e.AttrsAt)
 	}
 	_, err := w.pool.Exec(ctx, builder.String(), args...)
-	if err != nil {
-		// Never debuglog here — it routes back into this writer and recurses.
-		// The reporter writes to stderr directly for that reason.
-		w.drops.drop(len(entries), "batch insert failed: "+err.Error())
+	return err
+}
+
+// send hands msg to the run goroutine, giving up when giveUp fires. The read
+// lock is what makes it safe: stop takes the write lock before it retires the
+// queue, so a sender that got past the closed check is one stop waits out.
+//
+// TryRLock rather than RLock, because RWMutex parks a new reader behind a
+// waiting writer: with a plain RLock, a caller arriving while stop is queued
+// behind another sender's send would wait out that whole send before its own
+// deadline was even in the select, and the hot log path would no longer be
+// bounded by its sendTimeout. TryRLock fails exactly when stop holds or is
+// waiting for the write lock, which is the answer this caller wants anyway.
+func (w *dbLogWriter) send(msg logMsg, giveUp <-chan time.Time) error {
+	if !w.mu.TryRLock() {
+		return errLogWriterStopped
+	}
+	defer w.mu.RUnlock()
+	if w.closed {
+		return errLogWriterStopped
+	}
+	select {
+	case w.ch <- msg:
+		return nil
+	case <-w.life.Done():
+		// The stop deadline expired while this sender was parked on a full
+		// queue. Refused here rather than left holding the read lock, so what
+		// bounds stop is that deadline and not this sender's own.
+		return errLogWriterStopped
+	case <-giveUp:
+		return errLogWriterQueueFull
 	}
 }
 
 func (w *dbLogWriter) write(entry AppLogEntry) {
-	defer func() {
-		if r := recover(); r != nil {
-			// The only expected panic is "send on closed channel" during
-			// shutdown (StopAppLogWriter closes w.ch). Surface anything else to
-			// stderr directly — never via debuglog, which routes back into this
-			// writer and would recurse.
-			fmt.Fprintf(os.Stderr, "applog: entry dropped, write panicked: %v\n", r)
-		}
-	}()
 	timer := time.NewTimer(w.sendTimeout)
 	defer timer.Stop()
-	select {
-	case w.ch <- entry:
+	err := w.send(logMsg{entry: entry}, timer.C)
+	if err == nil {
 		return
+	}
+	// DB writer is backed up, or already stopped — drop the entry rather than
+	// blocking the caller. The ring buffer still has it for live UI, and the
+	// full-queue case only happens once the DB has been unreachable long enough
+	// to fill the channel (~25s, see dbLogChannelSize) and then hold this caller
+	// for sendTimeout on top. Reported, because a history with holes in it and
+	// no notice is worse than a slow caller.
+	reason := err.Error()
+	if errors.Is(err, errLogWriterQueueFull) {
+		reason += " for " + w.sendTimeout.String()
+	}
+	w.drops.drop(1, reason)
+}
+
+// flushBarrier returns once everything queued before the call has been written
+// to the database. ClearAppLogs holds the purge behind it so entries still in
+// the queue cannot flush after the DELETE and reinstate rows that were just
+// removed. The whole wait, enqueue included, is bounded by timeout.
+func (w *dbLogWriter) flushBarrier(timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	done := make(chan struct{})
+	if err := w.send(logMsg{flushed: done}, timer.C); err != nil {
+		return err
+	}
+	select {
+	case <-done:
+		return nil
 	case <-timer.C:
-		// DB writer is backed up — drop the entry rather than blocking the
-		// caller. The ring buffer still has it for live UI, and this only
-		// happens once the DB has been unreachable long enough to fill the
-		// channel (~25s, see dbLogChannelSize) and then hold this caller for
-		// sendTimeout on top. Reported, because a history with holes in it and
-		// no notice is worse than a slow caller.
-		w.drops.drop(1, "writer queue full for "+w.sendTimeout.String())
+		return errLogWriterFlushSlow
 	}
 }
 
+// stop retires the queue and waits for the run goroutine to write out what is
+// left, bounded end to end by stopDrainTimeout.
+//
+// The deadline is armed before the lock, because the senders already in flight
+// hold the read lock for up to their own sendTimeout and a deadline armed after
+// acquiring it would not bound this stage at all. Cancelling w.life ends all
+// three things it has to cover at once: a sender parked on a full queue, a
+// flush already under way, and the tail drain.
+//
+// Marking closed under the write lock is what makes it safe against a
+// concurrent write: every sender holds the read lock across its send, so once
+// this returns from Lock no send is in flight and none can start. Waiting out
+// those senders is the price of the guarantee this exists for, that a send
+// which returned nil is a row in the database. Senders arriving from here on
+// are refused at once rather than queued behind this lock.
 func (w *dbLogWriter) stop() {
-	close(w.ch)
+	deadline := time.AfterFunc(stopDrainTimeout, w.endLife)
+	defer deadline.Stop()
+
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		// A second caller waits for the first caller's drain too. Returning on
+		// the flag alone would tell it the writer is stopped while batches are
+		// still going into a pool it is about to close, which is the same
+		// "stopped is not drained" reading the purge barrier refuses.
+		<-w.done
+		return
+	}
+	w.closed = true
+	close(w.stopping)
+	w.mu.Unlock()
 	<-w.done
+	w.endLife()
 	w.drops.reportPending()
 }
 
@@ -316,16 +534,38 @@ func InitAppLogBuffer(pool *pgxpool.Pool) {
 		entries: make([]AppLogEntry, appLogBufferSize),
 	}
 	if pool != nil {
-		dbWriter = newDBLogWriter(pool, dbLogFlushInterval)
+		dbWriter.Store(newDBLogWriter(pool, dbLogFlushInterval))
 	}
 	log.SetOutput(io.MultiWriter(&stderrLogFilter{dst: os.Stderr}, appLogBuffer))
 }
 
-// StopAppLogWriter stops the database log writer goroutine.
+// appLogFlushBarrierTimeout bounds the purge's wait for the async writer. Long
+// enough for a healthy writer to drain a full batch, short enough that a stalled
+// one does not hold the operator's request open.
+const appLogFlushBarrierTimeout = 5 * time.Second
+
+// flushAppLogWriter drains everything the async writer has queued so far, so a
+// purge cannot be followed by a flush that reinstates the rows it deleted. No
+// writer means nothing to drain.
+func flushAppLogWriter(timeout time.Duration) error {
+	if w := dbWriter.Load(); w != nil {
+		return w.flushBarrier(timeout)
+	}
+	return nil
+}
+
+// StopAppLogWriter stops the database log writer goroutine, bounded by
+// stopDrainTimeout: what the queue still holds is written out inside it and the
+// rest is counted as dropped on stderr.
+//
+// The global keeps pointing at the stopped writer. Clearing it would make every
+// producer skip the writer entirely, so the lines logged from here to process
+// exit would vanish with no notice at all; leaving it set means each one is
+// refused by the writer's own closed state and counted as a drop. It also keeps
+// a purge arriving afterwards behind the barrier, which answers 503, rather than
+// reading a nil as "no writer, nothing to flush" and deleting rows.
 func StopAppLogWriter() {
-	if dbWriter != nil {
-		w := dbWriter
-		dbWriter = nil
+	if w := dbWriter.Load(); w != nil {
 		w.stop()
 	}
 }
@@ -359,7 +599,7 @@ func (rb *ringBuffer) Write(p []byte) (n int, err error) {
 			Message:   msg,
 		}
 		rb.writeEntry(entry)
-		if w := dbWriter; w != nil {
+		if w := dbWriter.Load(); w != nil {
 			w.write(entry)
 		}
 	}

--- a/internal/api/applogs_handler_test.go
+++ b/internal/api/applogs_handler_test.go
@@ -23,7 +23,7 @@ func TestRingBufferWriteEntry(t *testing.T) {
 	InitAppLogBuffer(nil) // Initialize with nil pool for pure tests
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	entry := AppLogEntry{
@@ -47,7 +47,7 @@ func TestRingBufferWriteEntry_WrapAround(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	// Fill the buffer to capacity
@@ -90,7 +90,7 @@ func TestRingBufferGetEntries_Empty(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	entries := appLogBuffer.GetEntries()
@@ -103,7 +103,7 @@ func TestRingBufferGetEntries_Order(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	// Add entries in order
@@ -134,7 +134,7 @@ func TestRingBufferClear(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	// Add some entries
@@ -163,7 +163,7 @@ func TestRingBufferClearOlderThan(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	now := time.Now().UTC()
@@ -203,7 +203,7 @@ func TestRingBufferClearOlderThan_KeepsUnparseable(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	appLogBuffer.writeEntry(AppLogEntry{Timestamp: "not-a-timestamp", Message: "keep me"})
@@ -328,9 +328,13 @@ func splitFlatAttrs(line string) map[string]string {
 // these logs can be steered onto an attacker's chosen values. A CrowdSec or
 // fail2ban style reader taking remote_addr would ban a stranger.
 func TestAppSlogHandlerQuotesInjectedAttrValues(t *testing.T) {
-	savedBuf, savedWriter := appLogBuffer, dbWriter
-	appLogBuffer, dbWriter = nil, nil
-	defer func() { appLogBuffer, dbWriter = savedBuf, savedWriter }()
+	savedBuf, savedWriter := appLogBuffer, dbWriter.Load()
+	appLogBuffer = nil
+	dbWriter.Store(nil)
+	defer func() {
+		appLogBuffer = savedBuf
+		dbWriter.Store(savedWriter)
+	}()
 
 	var buf bytes.Buffer
 	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
@@ -368,9 +372,13 @@ func TestAppSlogHandlerQuotesInjectedAttrValues(t *testing.T) {
 // "auth: key owner disabled" it sits in front of remote_addr. Reading the
 // first key=<ip> token must still find the real client.
 func TestAppSlogHandlerQuotesValuePrecedingTheAddress(t *testing.T) {
-	savedBuf, savedWriter := appLogBuffer, dbWriter
-	appLogBuffer, dbWriter = nil, nil
-	defer func() { appLogBuffer, dbWriter = savedBuf, savedWriter }()
+	savedBuf, savedWriter := appLogBuffer, dbWriter.Load()
+	appLogBuffer = nil
+	dbWriter.Store(nil)
+	defer func() {
+		appLogBuffer = savedBuf
+		dbWriter.Store(savedWriter)
+	}()
 
 	var buf bytes.Buffer
 	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
@@ -396,9 +404,13 @@ func TestAppSlogHandlerQuotesValuePrecedingTheAddress(t *testing.T) {
 // An attribute value that contains a level or a scope marker must not be able
 // to restate either, and every value has to survive the round trip.
 func TestAppSlogHandlerQuotesValuesWithQuotesAndEquals(t *testing.T) {
-	savedBuf, savedWriter := appLogBuffer, dbWriter
-	appLogBuffer, dbWriter = nil, nil
-	defer func() { appLogBuffer, dbWriter = savedBuf, savedWriter }()
+	savedBuf, savedWriter := appLogBuffer, dbWriter.Load()
+	appLogBuffer = nil
+	dbWriter.Store(nil)
+	defer func() {
+		appLogBuffer = savedBuf
+		dbWriter.Store(savedWriter)
+	}()
 
 	var buf bytes.Buffer
 	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
@@ -659,11 +671,11 @@ func TestStderrLogFilterWrite_MultiLine(t *testing.T) {
 func TestInitAppLogBuffer(t *testing.T) {
 	// Save original values
 	origBuffer := appLogBuffer
-	origWriter := dbWriter
+	origWriter := dbWriter.Load()
 	origOutput := log.Writer()
 	defer func() {
 		appLogBuffer = origBuffer
-		dbWriter = origWriter
+		dbWriter.Store(origWriter)
 		log.SetOutput(origOutput)
 	}()
 
@@ -672,7 +684,7 @@ func TestInitAppLogBuffer(t *testing.T) {
 	if appLogBuffer == nil {
 		t.Error("InitAppLogBuffer should initialize appLogBuffer")
 	}
-	if dbWriter != nil {
+	if dbWriter.Load() != nil {
 		t.Error("InitAppLogBuffer with nil pool should not initialize dbWriter")
 	}
 
@@ -687,23 +699,31 @@ func TestInitAppLogBuffer(t *testing.T) {
 // StopAppLogWriter tests
 // ---------------------------------------------------------------------------
 
-func TestStopAppLogWriter(t *testing.T) {
-	// Save original values
-	origWriter := dbWriter
+// The stopped writer stays in the global. Clearing it would make every producer
+// skip the writer, so a line logged between here and process exit would be
+// dropped with nothing said about it anywhere; left in place, the writer's own
+// closed state refuses the entry and the drop is counted on stderr.
+func TestStopAppLogWriter_LeavesTheStoppedWriterInPlaceAndCountsWhatFollows(t *testing.T) {
+	origWriter := dbWriter.Load()
 	defer func() {
-		dbWriter = origWriter
+		dbWriter.Store(origWriter)
 	}()
 
-	// Create a writer
 	InitAppLogBuffer(nil)
+	var out syncBuffer
 	writer := newDBLogWriter(nil, dbLogFlushInterval)
-	dbWriter = writer
+	writer.drops = &logDropReporter{dst: &out, interval: time.Hour}
+	dbWriter.Store(writer)
 
-	// Stop it
 	StopAppLogWriter()
 
-	if dbWriter != nil {
-		t.Error("StopAppLogWriter should set dbWriter to nil")
+	w := dbWriter.Load()
+	if w != writer {
+		t.Fatalf("dbWriter = %p, want the stopped writer %p: producers after shutdown must still find it", w, writer)
+	}
+	w.write(AppLogEntry{Level: "info", Source: "test", Message: "logged after the writer stopped"})
+	if got := out.String(); !strings.Contains(got, "1 entries dropped") {
+		t.Errorf("notice = %q, want the post-shutdown entry counted as a drop", got)
 	}
 }
 
@@ -715,7 +735,7 @@ func TestRingBufferWrite_MultiLine(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	input := "2026/04/28 09:55:43 [proxy] INFO first\n2026/04/28 09:55:44 [auth] ERROR second\n"
@@ -737,7 +757,7 @@ func TestRingBufferWrite_EmptyLines(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	input := "\n\n2026/04/28 09:55:43 [proxy] INFO message\n\n"
@@ -798,13 +818,13 @@ func TestGetAppLogCounts_Cache(t *testing.T) {
 func TestGetAppLogs_NilBuffer(t *testing.T) {
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 	// Establish the nil-buffer precondition explicitly: appLogBuffer is a global
 	// that an earlier test may have initialized, so we cannot rely on it already
 	// being nil (the defer above only restores it afterwards).
 	appLogBuffer = nil
-	dbWriter = nil
+	dbWriter.Store(nil)
 	h := &Handler{dbPool: nil}
 	req := httptest.NewRequest(http.MethodGet, "/api/app-logs", http.NoBody)
 	rr := httptest.NewRecorder()
@@ -852,7 +872,7 @@ func TestGetAppLogs_WithLimitAndAfter(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	// Add 15 entries with different timestamps
@@ -915,7 +935,7 @@ func TestClearAppLogs_WithBuffer(t *testing.T) {
 	InitAppLogBuffer(nil)
 	defer func() {
 		appLogBuffer = nil
-		dbWriter = nil
+		dbWriter.Store(nil)
 	}()
 
 	// Add some entries

--- a/internal/api/applogs_slog.go
+++ b/internal/api/applogs_slog.go
@@ -131,7 +131,7 @@ func (h *appSlogHandler) Handle(_ context.Context, r slog.Record) error {
 	if appLogBuffer != nil {
 		appLogBuffer.writeEntry(entry)
 	}
-	if w := dbWriter; w != nil {
+	if w := dbWriter.Load(); w != nil {
 		w.write(entry)
 	}
 

--- a/internal/api/applogs_test.go
+++ b/internal/api/applogs_test.go
@@ -244,12 +244,12 @@ func TestDBLogWriter_BatchSizeFlush(t *testing.T) {
 
 	// Send 50 entries to trigger the batch-size flush path (lines 127-130)
 	for i := range 50 {
-		w.ch <- AppLogEntry{
+		w.ch <- logMsg{entry: AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
 			Source:    "test",
 			Message:   fmt.Sprintf("batch entry %d", i),
-		}
+		}}
 	}
 
 	// Poll until the batch-size flush lands in the DB or we time out. A fixed
@@ -292,12 +292,12 @@ func TestDBLogWriter_TickerFlush(t *testing.T) {
 
 	// Send a few entries (less than 50) and wait for the ticker to flush
 	for i := range 5 {
-		w.ch <- AppLogEntry{
+		w.ch <- logMsg{entry: AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
 			Source:    "ticker-test",
 			Message:   fmt.Sprintf("ticker entry %d", i),
-		}
+		}}
 	}
 
 	// Poll until the ticker flushes the entries or we time out.
@@ -336,12 +336,12 @@ func TestDBLogWriter_FlushDBError(t *testing.T) {
 
 	// Send entries — they'll be flushed but the DB write will fail silently
 	for i := range 5 {
-		w.ch <- AppLogEntry{
+		w.ch <- logMsg{entry: AppLogEntry{
 			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
 			Level:     "info",
 			Source:    "flush-error-test",
 			Message:   fmt.Sprintf("entry %d", i),
-		}
+		}}
 	}
 
 	// Wait for ticker flush (the batch is small, so ticker will flush it)
@@ -362,11 +362,11 @@ func TestRingBuffer_WriteWithDBWriter(t *testing.T) {
 	defer pool.Close()
 
 	// Save and restore global dbWriter
-	origDBWriter := dbWriter
-	dbWriter = newDBLogWriter(pool, 10*time.Millisecond)
+	origDBWriter := dbWriter.Load()
+	dbWriter.Store(newDBLogWriter(pool, 10*time.Millisecond))
 	defer func() {
-		dbWriter.stop()
-		dbWriter = origDBWriter
+		dbWriter.Load().stop()
+		dbWriter.Store(origDBWriter)
 	}()
 
 	rb := &ringBuffer{

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -33,6 +33,10 @@ type BackupHandler struct {
 	masterKey         string                 // set via SetSigningKey; empty disables backup signing and verification
 	schedulerCancelMu sync.Mutex
 	schedulerCancel   context.CancelFunc
+	// schedulerStopped is the running scheduler's join channel, so a second
+	// StartScheduler call is handed the goroutine that exists rather than a
+	// closed channel that would tell it there is nothing to wait for.
+	schedulerStopped chan struct{}
 }
 
 // NewBackupHandler creates a new BackupHandler.

--- a/internal/api/backup_scheduler.go
+++ b/internal/api/backup_scheduler.go
@@ -17,7 +17,13 @@ import (
 // runtime takes effect promptly instead of waiting a full backup_interval.
 const backupSchedulerIdlePoll = 1 * time.Minute
 
-// StartScheduler starts the periodic backup scheduler goroutine.
+// StartScheduler starts the periodic backup scheduler goroutine and returns a
+// channel closed once that goroutine has returned, so a caller that owns the
+// process lifetime can join it during shutdown instead of closing the pool
+// under a backup still running. A call that finds a scheduler already running
+// gets that scheduler's channel, so joining on it waits for the goroutine that
+// actually exists; only a call with no settings store, which starts nothing and
+// leaves nothing running, hands back an already-closed channel.
 //
 // The goroutine always runs (regardless of the current backup_enabled
 // value) and re-reads backup_enabled and backup_interval from the settings
@@ -25,23 +31,30 @@ const backupSchedulerIdlePoll = 1 * time.Minute
 // a server restart: when disabled it polls on a short idle interval; when
 // enabled it creates a backup and applies the rotation scheme, then sleeps
 // for backup_interval.
-func (h *BackupHandler) StartScheduler(ctx context.Context) {
+func (h *BackupHandler) StartScheduler(ctx context.Context) <-chan struct{} {
+	stopped := make(chan struct{})
 	if h.settingsRepo == nil {
-		return
+		close(stopped)
+		return stopped
 	}
 	// Guard against double-launch leaking the previous goroutine.
 	h.schedulerCancelMu.Lock()
 	if h.schedulerCancel != nil {
+		running := h.schedulerStopped
 		h.schedulerCancelMu.Unlock()
-		return
+		return running
 	}
 
 	schedCtx, cancel := context.WithCancel(ctx)
 	h.schedulerCancel = cancel
+	h.schedulerStopped = stopped
 	h.schedulerCancelMu.Unlock()
 	debuglog.Info("backup: scheduler started")
 
 	go func() {
+		// Registered first so it runs last: a joiner is released only once the
+		// panic handler below has had its say.
+		defer close(stopped)
 		defer func() {
 			if r := recover(); r != nil {
 				debuglog.Error("backup: scheduler panic recovered", "panic", r)
@@ -70,6 +83,7 @@ func (h *BackupHandler) StartScheduler(ctx context.Context) {
 			}
 		}
 	}()
+	return stopped
 }
 
 // StopScheduler stops the periodic backup scheduler.

--- a/internal/api/backup_scheduler_test.go
+++ b/internal/api/backup_scheduler_test.go
@@ -55,6 +55,79 @@ func TestStartScheduler_DoubleLaunch(t *testing.T) {
 	cancel()
 }
 
+// Shutdown joins the scheduler with the other background loops, which is only
+// possible if the caller is handed something to wait on that actually tracks
+// the goroutine. A cancelled context has to close it; a call that started
+// nothing has to hand back a channel that is already closed, or shutdown would
+// block on a scheduler that never existed.
+func TestStartScheduler_StoppedChannelJoinsTheGoroutine(t *testing.T) {
+	ss := &mockSettingsStore{
+		getWithDefaultFn: func(_ context.Context, _, defaultValue string) string { return defaultValue },
+		getBoolFn:        func(_ context.Context, _ string, _ bool) bool { return false },
+		getDurationFn: func(_ context.Context, _ string, defaultValue time.Duration) time.Duration {
+			return defaultValue
+		},
+	}
+	h := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, ss)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := h.StartScheduler(ctx)
+	select {
+	case <-stopped:
+		t.Fatal("the scheduler reported itself stopped before it was cancelled")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelling the context did not release the join; shutdown would close the pool under a running backup")
+	}
+
+	// Nothing started, nothing to wait for.
+	idle := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, nil)
+	select {
+	case <-idle.StartScheduler(context.Background()):
+	default:
+		t.Fatal("a scheduler that never started must hand back a closed channel")
+	}
+}
+
+// A second launch finds a scheduler already running and starts nothing, but a
+// caller holding its channel is joining on the goroutine that does exist. A
+// closed channel there would tell that caller the scheduler has stopped while
+// the first one's goroutine is still writing, and the pool would close under it.
+func TestStartScheduler_DoubleLaunchReturnsTheRunningScheduler(t *testing.T) {
+	ss := &mockSettingsStore{
+		getWithDefaultFn: func(_ context.Context, _, defaultValue string) string { return defaultValue },
+		getBoolFn:        func(_ context.Context, _ string, _ bool) bool { return false },
+		getDurationFn: func(_ context.Context, _ string, defaultValue time.Duration) time.Duration {
+			return defaultValue
+		},
+	}
+	h := NewBackupHandler("postgres://x", t.TempDir(), &mockAdminAuth{}, ss)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	first := h.StartScheduler(ctx)
+	second := h.StartScheduler(ctx)
+
+	select {
+	case <-second:
+		t.Fatal("the second launch reported the scheduler stopped while the first one is still running")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	cancel()
+	for name, ch := range map[string]<-chan struct{}{"first": first, "second": second} {
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("the %s caller's channel never closed: it is not joined to the running scheduler", name)
+		}
+	}
+}
+
 func TestStopScheduler(t *testing.T) {
 	ss := &mockSettingsStore{
 		getWithDefaultFn: func(_ context.Context, key, defaultValue string) string {

--- a/internal/api/handler_applogs_test.go
+++ b/internal/api/handler_applogs_test.go
@@ -1090,10 +1090,14 @@ func TestGetAppLogs_SearchMatchesEscapedSpaces(t *testing.T) {
 // never the raw message text. A raw line through the legacy io.Writer path
 // never went through the encoder and must not claim the flag.
 func TestAppSlogHandler_MarksEntriesEscaped(t *testing.T) {
-	savedBuf, savedWriter := appLogBuffer, dbWriter
+	savedBuf, savedWriter := appLogBuffer, dbWriter.Load()
 	rb := &ringBuffer{entries: make([]AppLogEntry, appLogBufferSize)}
-	appLogBuffer, dbWriter = rb, nil
-	defer func() { appLogBuffer, dbWriter = savedBuf, savedWriter }()
+	appLogBuffer = rb
+	dbWriter.Store(nil)
+	defer func() {
+		appLogBuffer = savedBuf
+		dbWriter.Store(savedWriter)
+	}()
 
 	var buf bytes.Buffer
 	h := &appSlogHandler{level: slog.LevelInfo, stderr: &stderrLogFilter{dst: &buf}}
@@ -1219,4 +1223,270 @@ func TestGetAppLogs_EscapedFlagProvenance(t *testing.T) {
 	}
 	assertFlags("/logs/app?history=true&source=provtest")
 	assertFlags("/logs/app/cursor?source=provtest")
+}
+
+// withTestRingBuffer installs a fresh ring buffer (and no async writer) for the
+// duration of a test, restoring the package globals afterwards.
+func withTestRingBuffer(t *testing.T) *ringBuffer {
+	t.Helper()
+	savedBuf, savedWriter := appLogBuffer, dbWriter.Load()
+	rb := &ringBuffer{entries: make([]AppLogEntry, appLogBufferSize)}
+	appLogBuffer = rb
+	dbWriter.Store(nil)
+	t.Cleanup(func() {
+		appLogBuffer = savedBuf
+		dbWriter.Store(savedWriter)
+	})
+	return rb
+}
+
+// ringHas reports whether the ring still holds an entry with this message. The
+// ring also collects whatever the server logs while a test runs, so assertions
+// are about the seeded entries, not about the buffer's exact length.
+func ringHas(rb *ringBuffer, message string) bool {
+	for _, e := range rb.GetEntries() {
+		if e.Message == message {
+			return true
+		}
+	}
+	return false
+}
+
+// fillRing writes n entries into the ring buffer.
+func fillRing(rb *ringBuffer, source string, n int) {
+	for i := range n {
+		rb.writeEntry(AppLogEntry{
+			Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+			Level:     "info",
+			Source:    source,
+			Message:   fmt.Sprintf("ring entry %d", i),
+		})
+	}
+}
+
+// A DELETE the database refused used to answer 200 with a count taken from the
+// ring buffer it had already emptied, so the operator saw a purge that never
+// happened and lost the live view on top of it. The failure is a 500 and the
+// ring is left holding what the rows still hold.
+func TestClearAppLogs_FailedDeleteAnswers500AndKeepsRing(t *testing.T) {
+	h := newTestHandler(t)
+	rb := withTestRingBuffer(t)
+	fillRing(rb, "failed-delete", 4)
+
+	// A cancelled request context is what the pool's Exec refuses on.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody).WithContext(ctx))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: a refused delete answered success", rec.Code)
+	}
+	for i := range 4 {
+		if !ringHas(rb, fmt.Sprintf("ring entry %d", i)) {
+			t.Fatalf("ring entry %d is gone: the buffer was cleared for a delete that failed", i)
+		}
+	}
+}
+
+// Entries the async writer had already queued used to flush after the DELETE,
+// putting rows back that the operator had just purged. The purge drains the
+// writer first, so nothing lands behind it.
+func TestClearAppLogs_QueuedEntriesDoNotResurface(t *testing.T) {
+	h := newTestHandler(t)
+	withTestRingBuffer(t)
+	pool := h.Pool().Pool()
+
+	// A flush interval that will not fire during the test: only the purge's own
+	// barrier, or the writer's shutdown, can move these entries.
+	w := newDBLogWriter(pool, time.Hour)
+	dbWriter.Store(w)
+	const source = "resurface-test"
+	for i := range 5 {
+		w.write(testEntry(source, fmt.Sprintf("queued %d", i)))
+	}
+
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Shutting the writer down flushes anything it is still holding. If the
+	// purge had not drained it first, these rows would reappear now.
+	w.stop()
+	if got := countAppLogs(t, pool, source); got != 0 {
+		t.Fatalf("%d purged rows came back from the writer queue", got)
+	}
+}
+
+// The ring mirrors rows the database already holds, so summing the two reported
+// a purge of twice what existed. With a database configured the count is the
+// rows it deleted.
+func TestClearAppLogs_CountIsNotDoubled(t *testing.T) {
+	h := newTestHandler(t)
+	rb := withTestRingBuffer(t)
+	fillRing(rb, "double-count", 5)
+
+	pool := h.Pool().Pool()
+	for i := range 3 {
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+			 VALUES (gen_random_uuid(), NOW(), 'info', 'double-count', 'msg', NOW())`); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]int
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["deleted"] != 3 {
+		t.Fatalf("deleted = %d, want 3 (the rows), not the ring added on top", resp["deleted"])
+	}
+	if ringHas(rb, "ring entry 0") {
+		t.Fatal("the ring was not cleared after a successful purge")
+	}
+}
+
+// Without a database the ring is all there is, so its own count is the answer.
+func TestClearAppLogs_RingCountWhenNoDB(t *testing.T) {
+	rb := withTestRingBuffer(t)
+	const seeded = 6
+	fillRing(rb, "ring-only", seeded)
+
+	rec := httptest.NewRecorder()
+	(&Handler{}).ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear: status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]int
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The server keeps logging into the swapped-in ring while this test runs, so
+	// the count is at least the six seeded entries, never an exact buffer
+	// length snapshotted before the call.
+	if resp["deleted"] < seeded {
+		t.Fatalf("deleted = %d, want at least the %d seeded: with no database the ring count is the only count", resp["deleted"], seeded)
+	}
+	for i := range seeded {
+		if ringHas(rb, fmt.Sprintf("ring entry %d", i)) {
+			t.Fatalf("seeded entry %d survived the purge", i)
+		}
+	}
+
+	// The ranged purge takes the same route: only the entries past the cutoff go,
+	// and the count is still the ring's own.
+	rb.writeEntry(AppLogEntry{Timestamp: time.Now().UTC().Add(-8 * 24 * time.Hour).Format(time.RFC3339Nano), Level: "info", Source: "ring-only", Message: "stale"})
+	rb.writeEntry(AppLogEntry{Timestamp: time.Now().UTC().Format(time.RFC3339Nano), Level: "info", Source: "ring-only", Message: "fresh"})
+
+	rec = httptest.NewRecorder()
+	(&Handler{}).ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", strings.NewReader(`{"older_than":"1w"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ranged clear: status %d: %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode ranged: %v", err)
+	}
+	if resp["deleted"] != 1 {
+		t.Fatalf("ranged deleted = %d, want 1 (the stale entry only)", resp["deleted"])
+	}
+	if ringHas(rb, "stale") {
+		t.Fatal("the stale entry survived the ranged purge")
+	}
+	if !ringHas(rb, "fresh") {
+		t.Fatal("the ranged purge took the fresh entry too")
+	}
+}
+
+// A barrier that does not complete means entries are still queued and will
+// flush after the DELETE, reinstating the rows the operator asked to be gone.
+// The purge refuses rather than answer 200 with a count the pending flush is
+// about to undo. The writer here has no run goroutine, so the barrier is
+// accepted and never answered: the deep-queue case, not a dead database.
+func TestClearAppLogs_StalledFlushBarrierRefusesThePurge(t *testing.T) {
+	h := newTestHandler(t)
+	rb := withTestRingBuffer(t)
+	fillRing(rb, "stalled-barrier", 3)
+
+	pool := h.Pool().Pool()
+	const source = "stalled-barrier-rows"
+	for i := range 3 {
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+			 VALUES (gen_random_uuid(), NOW(), 'info', $1, 'msg', NOW())`, source); err != nil {
+			t.Fatalf("insert row %d: %v", i, err)
+		}
+	}
+
+	saved := dbWriter.Load()
+	t.Cleanup(func() { dbWriter.Store(saved) })
+	dbWriter.Store(armed(&dbLogWriter{
+		ch:          make(chan logMsg, 1),
+		done:        make(chan struct{}),
+		sendTimeout: dbLogSendTimeout,
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: a purge ran under a queue that will reinstate the rows", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "retry") {
+		t.Errorf("body = %q, want a retry message the operator can act on", rec.Body.String())
+	}
+	if got := countAppLogs(t, pool, source); got != 3 {
+		t.Fatalf("%d rows left of 3: the refused purge deleted anyway", got)
+	}
+	for i := range 3 {
+		if !ringHas(rb, fmt.Sprintf("ring entry %d", i)) {
+			t.Fatalf("ring entry %d is gone: the buffer was cleared for a purge that did not happen", i)
+		}
+	}
+}
+
+// A writer that refuses the barrier because it is stopped is refused too. The
+// global still points at it for as long as the stop runs, and during that window
+// the run goroutine is draining what is queued into the pool, so "stopped" read
+// as "stopped and drained" is exactly the flush the barrier exists to prevent.
+// Only a writer that was never configured skips the barrier, and that is a
+// deployment with no database and nothing queued anywhere.
+func TestClearAppLogs_StoppedWriterRefusesThePurge(t *testing.T) {
+	h := newTestHandler(t)
+	rb := withTestRingBuffer(t)
+	fillRing(rb, "stopped-writer", 1)
+
+	pool := h.Pool().Pool()
+	const source = "stopped-writer-rows"
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+		 VALUES (gen_random_uuid(), NOW(), 'info', $1, 'msg', NOW())`, source); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	saved := dbWriter.Load()
+	t.Cleanup(func() { dbWriter.Store(saved) })
+	w := newDBLogWriter(pool, time.Hour)
+	w.stop()
+	dbWriter.Store(w)
+
+	rec := httptest.NewRecorder()
+	h.ClearAppLogs(rec, httptest.NewRequest(http.MethodDelete, "/logs/app", http.NoBody))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: a purge ran against a writer whose queue it could not confirm drained", rec.Code)
+	}
+	if got := countAppLogs(t, pool, source); got != 1 {
+		t.Fatalf("%d rows left of 1: the refused purge deleted anyway", got)
+	}
+	if !ringHas(rb, "ring entry 0") {
+		t.Fatal("ring entry is gone: the buffer was cleared for a purge that did not happen")
+	}
 }

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -513,6 +513,7 @@ The `docker-compose.yml` sets up the following services:
 | **Volumes** | `./.data:/data` | Persistent data storage (admin token, etc.) |
 | **Volumes** | `/var/run/docker.sock:/var/run/docker.sock:ro` *(commented out by default)* | Read-only Docker socket access for container stats in sidebar |
 | **Restart** | `unless-stopped` | Auto-restart on failure or daemon restart |
+| **Stop grace period** | `75s` | How long Docker waits after SIGTERM before SIGKILL. See "Graceful shutdown" below |
 | **Depends on** | `db` (healthy) | Waits for PostgreSQL to be ready |
 
 **Environment variables (docker-compose.yml):**
@@ -536,6 +537,27 @@ environment:
   - TRUSTED_PROXIES=
   - KNOWN_PROXIES=
 ```
+
+**Graceful shutdown.** On SIGTERM (`docker compose stop`, `docker compose down`, a container
+restart) the server winds down in stages rather than dropping what is in flight. It cancels the
+background maintenance loops, ends every open SSE stream and proxied stream so they finish with a
+proper terminal frame, then stops accepting and drains the HTTP requests still running, joins the
+background loops, flushes the pending audit rows, flushes the application log writer, flushes the
+OTLP log exporter if one is configured, and closes the database pool last.
+
+Each stage is budgeted. Worst case, in order: 10s HTTP drain + 35s background join + 10s audit
+drain (one record's 5s insert plus the 5s retention prune it piggybacks) + 5s app-log writer stop
++ 5s OTLP flush = 65s. The join budget is the 30s ceiling of the scheduled-disable sweep plus a 5s
+margin: that sweep deliberately finishes the statement it has already started, and the join waits
+it out rather than letting the database pool close underneath it. The retention and stale-log
+sweeps are the other way round. They carry no ceiling at all, so that a first sweep over a large
+backlog runs as long as the database needs, and when the join budget expires they are cancelled
+rather than awaited. The closes around all of this (the event bus, the proxy handler, discovery,
+the docker client, the rate limiters and the database pool) carry no budget of their own, so the
+`stop_grace_period: 75s` on the `app` service is a ceiling with headroom over the 65s, not the sum.
+Docker's default grace is 10s, which would SIGKILL the process partway through the drain and lose
+the audit rows and the last log lines, so the setting is not optional. If you run Model Hotel
+outside this compose file (Kubernetes, systemd, your own compose), give it the same 75s.
 
 #### `db` - PostgreSQL 16
 

--- a/wiki/Request-Logging.md
+++ b/wiki/Request-Logging.md
@@ -208,7 +208,11 @@ Request body:
 
 **Accepted values:** `1h`, `1d`, `1w`, `1m`, `all`. For `DELETE /api/logs/app` the body is optional; an empty body clears everything.
 
-Response: `204 No Content` on success.
+`DELETE /api/logs/app` purges in a fixed order: it first drains the asynchronous app-log writer, so entries already queued cannot flush back in behind the delete; then it deletes the rows; then it clears the in-memory ring buffer. A delete the database refuses answers `500` and leaves the ring buffer intact, so the live view still matches the rows that are still there. The reported `deleted` count is the number of database rows removed, or the number of ring entries cleared when no database is configured, never the two added together. A ranged purge matches rows on their insert time and ring entries on the entry's own timestamp, so at the cutoff itself the two can disagree by the writer's flush lag.
+
+If that first drain does not finish, `DELETE /api/logs/app` answers `503 Service Unavailable` and nothing is deleted: no rows, no ring entries, no count. A healthy writer clears its queue in milliseconds however busy the gateway is, so a 503 means the writer is stalled behind an unreachable database or the process is shutting down; retry once the log history is moving again. The same answer covers a writer that is shutting down, since its queue is still draining into the database, and one that has already stopped: the stopped writer stays in place for the rest of the process lifetime, so a purge arriving after shutdown is refused rather than run against a queue nothing can confirm was drained. Retry the purge; once the queue is written out it succeeds, and if it keeps answering `503` the database is not keeping up with the log write rate.
+
+Response for `DELETE /api/logs/purge`: `204 No Content` on success. `DELETE /api/logs/app` answers `200 OK` with `{"deleted": N}`.
 
 ## Viewing Logs
 


### PR DESCRIPTION
## What

Third and last follow-up from the simplification pass (#941), agreed after the Codex audit: the app-log purge and writer had no single owner, and `cmd/server` shut down in the wrong order (database closed before the background loops were cancelled, log writer stopped before the last producers).

## Changes

App logs:
- `DELETE /api/logs/app` asks the writer for a flush barrier first; if the queue cannot drain within 5 s (a stalled database or a shutdown in progress) it answers 503 and deletes nothing. Otherwise: DELETE, then clear the ring, one count (rows when a database is configured, ring entries otherwise). A failed DELETE answers 500 with the ring intact.
- The writer stops without a `recover()` on a closed channel: senders check the closed state under the lock the stop takes, and the final drain has one 5 s deadline with a reported drop count. The writer global is an atomic pointer.

Shutdown (`cmd/server`), in the order it now executes:
1. cancel the root context;
2. close the event bus (ends SSE streams) and raise the proxy shutdown signal (streams end inside their 8 s grace);
3. drain HTTP on a fresh 10 s context;
4. join every background loop (all ten registered, including the backup scheduler and startup discovery) within 35 s, which covers the scheduled-disable sweep's 30 s ceiling; no pass can start after the cancel, and a stuck maintenance pass is cut at expiry so the pool is never closed under it;
5. wait for audit inserts (10 s worst case);
6. stop the remaining producers, then the log writer (5 s), then the OTLP exporter (5 s);
7. close the database last.

Enforced budget 65 s; `stop_grace_period: 75s` on the app service (the HA compose's 30 s is Front Desk's own budget and unchanged). Wiki Configuration and Request-Logging updated.

## Verification

- Tests: purge barrier, failed-delete 500 with ring intact, queued entries do not resurface, single count, 503 on a stalled queue; concurrent write during stop never panics and never loses a write that returned; join budget covers the sweep ceiling; a loop that ignores ctx trips the bounded wait; startup discovery joined; scheduler stop channel semantics.
- `make lint` 0 issues, vet, gofmt, gci, size gate, compose config; suites of `internal/api`, `cmd/server`, `internal/proxy`, `cmd/frontdesk`.
- Five Opus review rounds (the budget was re-derived from the code independently in the last three until enforced and claimed agreed).
- Dev stack rebuilt from the branch and stopped gracefully with the sequence and timing checked in the container log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
