### PR TITLE
test(netguard): clear proxy env before the metadata-block tests

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -64,9 +64,9 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	return httpx.DecodeJSON(w, r, logComponent, httpx.MaxJSONBody, v)
 }
 
-// decodeJSONLimit is decodeJSON with an endpoint-specific ceiling, for the two
+// decodeJSONLimit is decodeJSON with an endpoint-specific ceiling, for the
 // routes whose payload is legitimately larger or smaller than the default: a
-// config-sync import and the fleet announce heartbeat.
+// config-sync import, the fleet announce heartbeat and a quota-snapshot push.
 func decodeJSONLimit(w http.ResponseWriter, r *http.Request, limit int64, v any) bool {
 	return httpx.DecodeJSON(w, r, logComponent, limit, v)
 }

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -5,10 +5,24 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 )
+
+// TestMain strips the proxy variables before any test runs. NewClient honours
+// HTTP(S)_PROXY on purpose, and behind a proxy the metadata literal is dialled
+// by the proxy, not by the guarded dialer, so every "blocked address" assertion
+// in this package would fail under a sandbox or CI job that exports one.
+// net/http reads these variables once per process, so t.Setenv inside a test
+// would be too late once any earlier test has issued a request.
+func TestMain(m *testing.M) {
+	for _, k := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		os.Unsetenv(k)
+	}
+	os.Exit(m.Run())
+}
 
 func TestBlockedIP(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
`NewClient` honours `HTTP(S)_PROXY` on purpose, so whenever a proxy is exported the metadata literal is dialled by the proxy instead of the guarded dialer and three `internal/netguard` tests fail (`TestNewClient_RejectsMetadataLiteral`, `TestDialControlErrorIsSentinel`, `TestNewClientWithRetry_StillBlocksMetadata`). Reproduced with `HTTP_PROXY=http://127.0.0.1:9 go test ./internal/netguard/`.

`net/http` memoises the proxy configuration on the first request (`envProxyOnce`), so a per-test `t.Setenv` is too late; a `TestMain` now unsets `HTTP_PROXY`, `HTTPS_PROXY` and their lower-case twins before any test runs. `NO_PROXY` is left alone: it can only narrow proxying, never cause it. Proxy behaviour itself stays covered by the stubbed `proxyconnect` cases in `retry_test.go`.

Also updates the `decodeJSONLimit` comment, which named two callers while three routes use it (config import, fleet announce, quota-snapshot push).

Origin: informational notes from today's Strix diff scan of #940 through #950 (0 vulnerabilities). Two Opus review rounds; both nits applied.
