### PR TITLE
fix(auth): key-cache eviction joins the shutdown group; restore scan-error tests

### DIFF
--- a/cmd/frontdesk/main.go
+++ b/cmd/frontdesk/main.go
@@ -25,6 +25,7 @@ import (
 	gowa "github.com/go-webauthn/webauthn/webauthn"
 
 	"github.com/hugalafutro/model-hotel/internal/admin"
+	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/config"
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/events"
@@ -190,6 +191,10 @@ func main() {
 	srv.StartBackground(ctx, srv.RunFleetState)
 	srv.StartBackground(ctx, srv.RunBackupWatch)
 	srv.StartBackground(ctx, srv.RunAlerts)
+	// Member tokens are decrypted through the same key cache the gateway uses,
+	// so Front Desk runs the eviction sweep too; without it expired entries stay
+	// in the map for the life of the process.
+	srv.StartBackground(ctx, auth.KeyCacheEvictionLoop)
 
 	// Listener posture (header/idle timeouts, per-request body deadline) is
 	// decided once in httpx.NewServer, shared with the gateway. Front Desk

--- a/cmd/server/background.go
+++ b/cmd/server/background.go
@@ -2,8 +2,10 @@ package main
 
 // Background maintenance loops for the server binary: the periodic discovery
 // scheduler, quota polling, stale request-log cleanup, log retention, scheduled
-// provider disables, and WebAuthn session pruning. Each runs for the app
-// lifetime and exits on ctx cancellation.
+// provider disables, WebAuthn session pruning, phrase-staleness checks, the
+// alert dispatcher, the backup scheduler, and the key-cache eviction sweep
+// from internal/auth. Each runs for the app lifetime, exits on ctx
+// cancellation, and joins the shutdown budget through the background group.
 
 import (
 	"context"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/alert"
 	"github.com/hugalafutro/model-hotel/internal/api"
 	"github.com/hugalafutro/model-hotel/internal/audit"
+	"github.com/hugalafutro/model-hotel/internal/auth"
 	"github.com/hugalafutro/model-hotel/internal/authcookie"
 	"github.com/hugalafutro/model-hotel/internal/clientip"
 	"github.com/hugalafutro/model-hotel/internal/config"
@@ -460,6 +461,9 @@ func main() {
 	background.Go("scheduled-disable", func() {
 		scheduledDisableLoop(ctx, drainCtx, providerRepo, failoverRepo, time.Minute)
 	})
+	// Expired decrypted provider keys are swept on the key cache TTL, so a key
+	// removed from a provider stops sitting in memory once its entry lapses.
+	background.Go("key-cache-eviction", func() { auth.KeyCacheEvictionLoop(ctx) })
 
 	// Listener posture (header/idle timeouts, per-request body deadline) is
 	// decided once in httpx.NewServer, shared with Front Desk.

--- a/internal/auth/key_cache.go
+++ b/internal/auth/key_cache.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"sync"
@@ -29,7 +30,6 @@ const DefaultKeyCacheTTL = 10 * time.Minute
 
 func init() {
 	keyCacheTTLNanos.Store(int64(DefaultKeyCacheTTL))
-	startKeyCacheEviction()
 }
 
 // getKeyCacheTTL returns the current key cache TTL.
@@ -102,16 +102,28 @@ func WarmKeyCache(encryptedKey, keyNonce, keySalt []byte, masterKey string) {
 	}
 }
 
-func startKeyCacheEviction() {
-	go func() {
-		ticker := time.NewTicker(getKeyCacheTTL())
-		defer ticker.Stop()
-		for range ticker.C {
+// KeyCacheEvictionLoop sweeps expired entries on a ticker that adopts the
+// current TTL at each tick and returns when ctx is done. Each binary that decrypts keys starts it on
+// its own background group, so the sweep is joined at shutdown instead of
+// running unjoinably for the life of every process that links this package. A
+// tick that lands together with the cancellation starts no sweep, so the join
+// budget is never spent on work begun after the cancel.
+func KeyCacheEvictionLoop(ctx context.Context) {
+	ticker := time.NewTicker(getKeyCacheTTL())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return
+			}
 			evictExpiredKeyCacheEntries()
 			// Reset the ticker to pick up any TTL changes.
 			ticker.Reset(getKeyCacheTTL())
 		}
-	}()
+	}
 }
 
 func evictExpiredKeyCacheEntries() {

--- a/internal/auth/key_cache.go
+++ b/internal/auth/key_cache.go
@@ -111,17 +111,23 @@ func WarmKeyCache(encryptedKey, keyNonce, keySalt []byte, masterKey string) {
 func KeyCacheEvictionLoop(ctx context.Context) {
 	ticker := time.NewTicker(getKeyCacheTTL())
 	defer ticker.Stop()
+	runKeyCacheEviction(ctx, ticker.C, func() { ticker.Reset(getKeyCacheTTL()) })
+}
+
+// runKeyCacheEviction is the loop body behind KeyCacheEvictionLoop with the
+// tick source and the TTL re-arm injected, so a test can hand it a cancelled
+// context together with a pending tick and prove that no sweep starts.
+func runKeyCacheEviction(ctx context.Context, ticks <-chan time.Time, rearm func()) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticks:
 			if ctx.Err() != nil {
 				return
 			}
 			evictExpiredKeyCacheEntries()
-			// Reset the ticker to pick up any TTL changes.
-			ticker.Reset(getKeyCacheTTL())
+			rearm()
 		}
 	}
 }

--- a/internal/auth/key_cache_test.go
+++ b/internal/auth/key_cache_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -516,7 +517,25 @@ func TestDecryptCached_CacheExpiryEndToEnd(t *testing.T) {
 	}
 }
 
-func TestStartKeyCacheEviction_FiresPeriodically(t *testing.T) {
+// startEvictionLoop runs KeyCacheEvictionLoop on its own context and returns a
+// stop function that cancels it and waits for the goroutine to return, so a
+// sweep cannot still be in flight once the caller moves on. Both halves are
+// safe to repeat: cancelling twice is a no-op and a receive on a closed channel
+// returns immediately.
+func startEvictionLoop() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		KeyCacheEvictionLoop(ctx)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+func TestKeyCacheEvictionLoop_FiresPeriodically(t *testing.T) {
 	// Set very short TTL
 	orig := getKeyCacheTTL()
 	defer SetKeyCacheTTL(orig)
@@ -527,9 +546,11 @@ func TestStartKeyCacheEviction_FiresPeriodically(t *testing.T) {
 	keyCache = make(map[string]cacheEntry)
 	keyCacheMu.Unlock()
 
-	// Start a second eviction loop with the short TTL; the one from init ticks
-	// at the default TTL and would not fire inside this test.
-	startKeyCacheEviction()
+	// An eviction loop with the short TTL, stopped before the deferred TTL
+	// restore above so no tick can observe the restored value. Deferred rather
+	// than registered on t.Cleanup for that ordering: LIFO runs this stop first.
+	stop := startEvictionLoop()
+	defer stop()
 
 	// Add an expired entry directly
 	keyCacheMu.Lock()

--- a/internal/auth/key_cache_test.go
+++ b/internal/auth/key_cache_test.go
@@ -572,6 +572,46 @@ func TestKeyCacheEvictionLoop_FiresPeriodically(t *testing.T) {
 	}
 }
 
+// A tick that is already pending when the context is cancelled must not start
+// a sweep: whichever select arm wins, the loop returns without touching the
+// cache. Both arms are ready, so the choice is random per run; the repetition
+// makes each arm near certain to be exercised while the assertion holds for
+// either.
+func TestRunKeyCacheEviction_PendingTickAfterCancelSweepsNothing(t *testing.T) {
+	keyCacheMu.Lock()
+	keyCache = map[string]cacheEntry{"expired": {plaintext: "x", expiresAt: time.Now().Add(-time.Hour)}}
+	keyCacheMu.Unlock()
+	t.Cleanup(func() {
+		keyCacheMu.Lock()
+		keyCache = make(map[string]cacheEntry)
+		keyCacheMu.Unlock()
+	})
+
+	for range 32 {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		ticks := make(chan time.Time, 1)
+		ticks <- time.Now()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			runKeyCacheEviction(ctx, ticks, func() { t.Error("rearm called after cancel") })
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("loop did not return after cancel")
+		}
+	}
+
+	keyCacheMu.RLock()
+	_, exists := keyCache["expired"]
+	keyCacheMu.RUnlock()
+	if !exists {
+		t.Error("a sweep ran after the context was cancelled")
+	}
+}
+
 func TestSetKeyCacheTTL_AffectsNewEntryExpiry(t *testing.T) {
 	// Save original TTL, defer restore
 	orig := getKeyCacheTTL()

--- a/internal/clientip/clientip.go
+++ b/internal/clientip/clientip.go
@@ -113,9 +113,10 @@ func rightmostUntrustedIP(xff string, trustedProxies []*net.IPNet) string {
 }
 
 // isIPInTrustedNets checks whether a bare IP address string belongs to any
-// trusted proxy CIDR. It takes a bare IP rather than a "host:port" pair
-// because SplitHostPort would break an IPv6 address written with ::
-// zero-compression (e.g. "2001:db8::1" reads as host "2001:db8::1" port "0").
+// trusted proxy CIDR. It takes a bare IP rather than a "host:port" pair because
+// SplitHostPort rejects an unbracketed IPv6 literal outright ("2001:db8::1"
+// fails with "too many colons in address"), so every caller parses the address
+// itself and hands the result straight to net.ParseIP.
 func isIPInTrustedNets(ipStr string, trustedNets []*net.IPNet) bool {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {

--- a/internal/clientip/clientip_test.go
+++ b/internal/clientip/clientip_test.go
@@ -440,8 +440,9 @@ func TestIsIPInTrustedNets_IPv6ZeroCompression(t *testing.T) {
 	_, cidr, _ := net.ParseCIDR("2001:db8::/32")
 	nets := []*net.IPNet{cidr}
 
-	// :: zero-compression should work correctly (the reason isIPInTrustedNets exists
-	// instead of relying on IsTrustedProxy which requires host:port format)
+	// isIPInTrustedNets takes an address that has already been extracted from any
+	// host:port form, so net.ParseIP sees the whole IPv6 literal and its ::
+	// zero-compression expands before net.IPNet.Contains compares it.
 	if !isIPInTrustedNets("2001:db8::1", nets) {
 		t.Error("2001:db8::1 with zero-compression should be in 2001:db8::/32")
 	}

--- a/internal/provider/discovery_xai_http_test.go
+++ b/internal/provider/discovery_xai_http_test.go
@@ -439,32 +439,6 @@ func TestDiscoverXAI_FallbackToMinimalModels(t *testing.T) {
 	}
 }
 
-// Test discoverXAI with 429 rate limit - should fallback to catalog
-func TestDiscoverXAI_RateLimitFallback(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/language-models" || r.URL.Path == "/models" {
-			http.Error(w, "Rate Limited", http.StatusTooManyRequests)
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
-
-	svc := &DiscoveryService{httpClient: server.Client()}
-	provider := &Provider{
-		ID:      uuid.New(),
-		BaseURL: server.URL,
-	}
-
-	ctx := context.Background()
-	_, err := svc.discoverXAI(ctx, provider, "test-api-key")
-	// 429 is not treated as a no-access error (only 403 is), so it returns an error
-	if err == nil {
-		t.Fatal("expected error for 429 status, got nil")
-		return
-	}
-}
-
 // Test discoverXAI with HTTP error (not 403) - should return error
 func TestDiscoverXAI_HttpError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -732,9 +706,11 @@ func TestDiscoverXAIMinimalModels_429ReturnsError(t *testing.T) {
 	}
 }
 
+// TestDiscoverXAI_429DoesNotFallbackToCatalog pins retry-then-error: a 429 is a
+// retryable status, so both endpoints exhaust their retries and discovery
+// returns an error. Only a 403 marks an account as having no access and falls
+// back to the catalog.
 func TestDiscoverXAI_429DoesNotFallbackToCatalog(t *testing.T) {
-	// Both endpoints return 429 (rate limit) which is NOT treated as httpError
-	// Only 403 triggers httpError catalog fallback, so 429 returns an error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/language-models" || r.URL.Path == "/models" {
 			w.WriteHeader(http.StatusTooManyRequests)
@@ -1036,8 +1012,9 @@ func TestDiscoverXAI_LanguageModelsEmpty_MinimalModelsEmpty(t *testing.T) {
 		t.Fatalf("expected no error with empty live, got: %v", err)
 	}
 	// Empty-but-successful endpoints return empty (not the catalog) so
-	// RecordMissingModels stays a no-op; the no-access 403/429 path still
-	// returns the catalog (covered by TestDiscoverXAI_RateLimitFallback).
+	// RecordMissingModels stays a no-op. A 403 is the only status that falls
+	// back to the catalog; a 429 retries and then errors (covered by
+	// TestDiscoverXAI_429DoesNotFallbackToCatalog).
 	if len(models) != 0 {
 		t.Errorf("expected 0 models when live is empty, got %d", len(models))
 	}

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -537,9 +537,9 @@ func TestIPLimiter_ConcurrentAccess(t *testing.T) {
 // Tests moved from ip_limiter_coverage_test.go
 // ---------------------------------------------------------------------------
 
-// TestIPLimiter_CleanupLoopStop verifies that Stop() closes the channel
+// TestIPLimiter_CleanupGoroutineStop verifies that Stop() closes the channel
 // properly so the cleanup goroutine exits.
-func TestIPLimiter_CleanupLoopStop(t *testing.T) {
+func TestIPLimiter_CleanupGoroutineStop(t *testing.T) {
 	lim := NewIPLimiter(10, 20, nil, ipSettingsNoBackpressure())
 
 	// Stop() should close the channel without panicking
@@ -789,11 +789,11 @@ func TestIPLimiter_MiddlewareReservationNotOK(t *testing.T) {
 	}
 }
 
-// TestIPLimiter_CleanupLoop_Integration verifies that the cleanup goroutine
+// TestIPLimiter_CleanupGoroutine_Integration verifies that the cleanup goroutine
 // started by NewIPLimiter actually removes stale IP entries when triggered.
 // It inserts entries with expired lastUsed timestamps, calls cleanup() directly
 // (same function the ticker calls), and verifies removal.
-func TestIPLimiter_CleanupLoop_Integration(t *testing.T) {
+func TestIPLimiter_CleanupGoroutine_Integration(t *testing.T) {
 	lim := NewIPLimiter(10, 20, nil, ipSettingsNoBackpressure())
 	defer lim.Stop()
 
@@ -818,7 +818,7 @@ func TestIPLimiter_CleanupLoop_Integration(t *testing.T) {
 	}
 	lim.mu.Unlock()
 
-	// Call cleanup directly (same code the cleanupLoop ticker invokes)
+	// Call cleanup directly (the same sweep runCleanup invokes on its ticker)
 	lim.cleanup()
 
 	lim.mu.Lock()
@@ -831,25 +831,24 @@ func TestIPLimiter_CleanupLoop_Integration(t *testing.T) {
 	}
 }
 
-// TestIPLimiter_CleanupLoopTickerStartStop verifies that the IPLimiter's
-// cleanupLoop goroutine can be started and stopped without panic.
-// The ticker fires every 5 minutes in production; we just test start/stop.
-func TestIPLimiter_CleanupLoopTickerStartStop(t *testing.T) {
+// TestIPLimiter_CleanupGoroutineStartStop verifies that the IPLimiter's cleanup
+// goroutine can be started and stopped without panic. The ticker fires every 5
+// minutes in production, so only start and stop are exercised here.
+func TestIPLimiter_CleanupGoroutineStartStop(t *testing.T) {
 	lim := NewIPLimiter(10, 20, nil, ipSettingsNoBackpressure())
 
 	// Give the goroutine a moment to start
 	time.Sleep(20 * time.Millisecond)
 
-	// Stop should close stopCh, causing cleanupLoop to exit
+	// Stop should close stopCh, causing the cleanup goroutine to exit
 	lim.Stop()
 	// No panic = success
 }
 
-// TestIPLimiter_CleanupLoop_TickerPathRemovesStaleEntries verifies that the
-// cleanup function (called by cleanupLoop on ticker.C) actually removes
-// stale IP entries. Since the production ticker is 5 minutes, we simulate
-// the ticker.C path by calling cleanup() directly.
-func TestIPLimiter_CleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
+// TestIPLimiter_CleanupGoroutine_TickerPathRemovesStaleEntries verifies that the
+// sweep runCleanup invokes on ticker.C removes stale IP entries. Since the
+// production ticker is 5 minutes, cleanup() is called directly.
+func TestIPLimiter_CleanupGoroutine_TickerPathRemovesStaleEntries(t *testing.T) {
 	lim := NewIPLimiter(10, 20, nil, ipSettingsNoBackpressure())
 	defer lim.Stop()
 
@@ -890,13 +889,11 @@ func TestIPLimiter_CleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
 	}
 }
 
-// TestIPLimiter_CleanupLoop_TickerBranch_Unreachable documents that the
-// ticker.C select branch in IPLimiter.cleanupLoop (line 188) cannot be
-// directly tested because the production ticker is 5 minutes. The cleanup()
-// function called on ticker.C IS tested directly via
-// TestIPLimiter_CleanupRemovesStale and TestIPLimiter_CleanupLoop_TickerPathRemovesStaleEntries.
-// Only the select routing (ticker.C path) is untested; the actual cleanup
-// logic is fully covered. This is a structural limitation.
+// The ticker.C select branch in runCleanup cannot be exercised directly for the
+// IP limiter either: the production ticker is 5 minutes. The cleanup() function
+// that branch calls is covered by TestIPLimiter_CleanupRemovesStale and
+// TestIPLimiter_CleanupGoroutine_TickerPathRemovesStaleEntries, so only the
+// select routing is untested. A structural limitation.
 
 // TestIPEntry_ThrottleEdgeLogging mirrors TestKeyEntry_ThrottleEdgeLogging for
 // the per-IP limiter: one "started" per episode (not per rejection), one

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -591,9 +591,9 @@ func TestMiddleware_PerKeyOverrides(t *testing.T) {
 // Tests moved from limiter_coverage_test.go
 // ---------------------------------------------------------------------------
 
-// TestCleanupLoop_StopsOnChannelClose verifies that Stop() properly closes
+// TestCleanupGoroutine_StopsOnChannelClose verifies that Stop() properly closes
 // the stop channel so the cleanup goroutine exits.
-func TestCleanupLoop_StopsOnChannelClose(t *testing.T) {
+func TestCleanupGoroutine_StopsOnChannelClose(t *testing.T) {
 	lim, _ := newTestLimiter()
 
 	// Stop() should close the channel without panicking
@@ -978,11 +978,11 @@ func TestMiddleware_NonBackpressurePassesContextValues(t *testing.T) {
 	}
 }
 
-// TestCleanupLoop_Integration verifies that the cleanup goroutine started by
+// TestCleanupGoroutine_Integration verifies that the cleanup goroutine started by
 // NewLimiter actually removes stale entries when triggered. It inserts entries
 // with expired lastUsed timestamps, calls cleanup() directly (same function
 // the ticker calls), and verifies removal.
-func TestCleanupLoop_Integration(t *testing.T) {
+func TestCleanupGoroutine_Integration(t *testing.T) {
 	lim, _ := newTestLimiter()
 	defer lim.Stop()
 
@@ -1007,7 +1007,7 @@ func TestCleanupLoop_Integration(t *testing.T) {
 	}
 	lim.mu.Unlock()
 
-	// Call cleanup directly (same code the cleanupLoop ticker invokes)
+	// Call cleanup directly (the same sweep runCleanup invokes on its ticker)
 	lim.cleanup()
 
 	lim.mu.Lock()
@@ -1020,55 +1020,20 @@ func TestCleanupLoop_Integration(t *testing.T) {
 	}
 }
 
-// TestCleanupLoop_TickerFiresCleanup verifies that the cleanupLoop's
-// ticker.C branch calls cleanup(). We insert a stale entry, wait for
-// the ticker to fire, and verify the entry is removed.
-func TestCleanupLoop_TickerFiresCleanup(t *testing.T) {
-	lim := &Limiter{
-		limiters: make(map[string]*bucketEntry),
-		settings: newStubSettings(),
-		stopCh:   make(chan struct{}),
-	}
-
-	// Insert a stale entry (lastUsed well in the past)
-	lim.mu.Lock()
-	lim.limiters["ticker-stale"] = &bucketEntry{
-		prefix:   keyLogPrefix,
-		label:    keyLogLabel,
-		limiter:  rate.NewLimiter(1, 1),
-		lastUsed: time.Now().Add(-2 * time.Hour),
-	}
-	lim.mu.Unlock()
-
-	// Start cleanupLoop in a goroutine; it ticks every 5 minutes in prod.
-	// We can't wait 5 minutes, so we test the cleanup() method directly
-	// (which is what cleanupLoop calls on ticker.C).
-	go runCleanup(lim.stopCh, lim.cleanup)
-
-	// Give the goroutine a moment to start, then stop it.
-	time.Sleep(50 * time.Millisecond)
-	lim.Stop()
-
-	// Verify the stale entry was NOT cleaned up yet (5-min ticker hasn't fired).
-	// The cleanup() method itself is tested in TestCleanup_StaleEntries.
-	// This test confirms cleanupLoop can be started and stopped without panic.
-}
-
-// TestNewLimiter_StartsCleanupLoop verifies that NewLimiter starts the
-// cleanupLoop goroutine (which can be stopped via Stop()).
-func TestNewLimiter_StartsCleanupLoop(t *testing.T) {
+// TestNewLimiter_StartsCleanupGoroutine verifies that NewLimiter starts the
+// cleanup goroutine (which can be stopped via Stop()).
+func TestNewLimiter_StartsCleanupGoroutine(t *testing.T) {
 	lim := NewLimiter(newStubSettings())
-	// Should have a running cleanupLoop goroutine
+	// Should have a running cleanup goroutine
 	time.Sleep(20 * time.Millisecond)
 	lim.Stop()
 	// No panic = success
 }
 
-// TestCleanupLoop_TickerPathRemovesStaleEntries verifies that when the
-// cleanupLoop's ticker fires, it actually removes stale entries from
-// the limiters map. Since the production ticker is 5 minutes, we test
-// by calling cleanup() directly (same function called on ticker.C).
-func TestCleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
+// TestCleanupGoroutine_TickerPathRemovesStaleEntries verifies that the sweep
+// runCleanup invokes on ticker.C removes stale entries from the limiters map.
+// Since the production ticker is 5 minutes, cleanup() is called directly.
+func TestCleanupGoroutine_TickerPathRemovesStaleEntries(t *testing.T) {
 	lim := &Limiter{
 		limiters: make(map[string]*bucketEntry),
 		settings: newStubSettings(),
@@ -1096,8 +1061,8 @@ func TestCleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
 	}
 	lim.mu.Unlock()
 
-	// Start the cleanupLoop goroutine to verify it can start/stop,
-	// then directly call cleanup() to simulate the ticker.C path.
+	// Start the cleanup goroutine to verify it can start and stop, then call
+	// cleanup() directly to stand in for the ticker.C path.
 	go runCleanup(lim.stopCh, lim.cleanup)
 	time.Sleep(20 * time.Millisecond)
 
@@ -1119,9 +1084,9 @@ func TestCleanupLoop_TickerPathRemovesStaleEntries(t *testing.T) {
 	lim.Stop()
 }
 
-// TestCleanupLoop_ConcurrentStopAndTick verifies that cleanupLoop handles
+// TestCleanupGoroutine_ConcurrentStopAndTick verifies that runCleanup handles
 // the race between the stop channel and the ticker gracefully.
-func TestCleanupLoop_ConcurrentStopAndTick(t *testing.T) {
+func TestCleanupGoroutine_ConcurrentStopAndTick(t *testing.T) {
 	for range 10 {
 		lim := &Limiter{
 			limiters: make(map[string]*bucketEntry),
@@ -1135,15 +1100,13 @@ func TestCleanupLoop_ConcurrentStopAndTick(t *testing.T) {
 	}
 }
 
-// TestCleanupLoop_TickerBranch_Unreachable documents that the ticker.C
-// select branch in cleanupLoop (line 258) cannot be directly tested
-// because the production ticker is 5 minutes, and there's no way to
-// inject a shorter ticker without modifying the function signature.
-// The cleanup() function called by the ticker branch IS tested directly
-// via TestCleanup_RemovesStaleEntries, TestCleanupLoop_TickerPathRemovesStaleEntries,
-// and TestCleanupLoop_Integration. Only the select case routing itself
-// (ticker.C vs stopCh) is untested; the actual cleanup logic is fully covered.
-// This is a structural limitation, not a gap in test intent.
+// The ticker.C select branch in runCleanup cannot be exercised directly: the
+// production ticker is 5 minutes and the interval is not injectable. The
+// cleanup() function that branch calls is covered by
+// TestCleanup_RemovesStaleEntries, TestCleanupGoroutine_TickerPathRemovesStaleEntries
+// and TestCleanupGoroutine_Integration, so only the select routing itself
+// (ticker.C vs stopCh) is untested. A structural limitation, not a gap in
+// test intent.
 
 // ---------------------------------------------------------------------------
 // Edge-triggered throttle logging

--- a/internal/webauthn/scan_test.go
+++ b/internal/webauthn/scan_test.go
@@ -1,0 +1,52 @@
+package webauthn
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// errScanner stands in for a corrupt or schema-mismatched row: every Scan fails
+// with the configured error.
+type errScanner struct{ err error }
+
+func (s errScanner) Scan(...any) error { return s.err }
+
+// scanHelpers pairs each row-scanning helper with a name so both are held to
+// the same error contract.
+var scanHelpers = []struct {
+	name string
+	scan func(scanner) error
+}{
+	{"credential", func(r scanner) error { _, err := scanCredential(r); return err }},
+	{"session", func(r scanner) error { _, err := scanSession(r); return err }},
+}
+
+// TestScanHelpers_PropagateScanError pins that only pgx.ErrNoRows becomes
+// ErrNotFound: any other scan failure reaches the caller unchanged, so a
+// corrupt row is never mistaken for a missing one. A helper that translated
+// this error would fail the check, since the sentinel it would return does not
+// wrap want.
+func TestScanHelpers_PropagateScanError(t *testing.T) {
+	want := errors.New("column type mismatch")
+	for _, h := range scanHelpers {
+		t.Run(h.name, func(t *testing.T) {
+			if err := h.scan(errScanner{err: want}); !errors.Is(err, want) {
+				t.Fatalf("scan error = %v, want %v", err, want)
+			}
+		})
+	}
+}
+
+// TestScanHelpers_NoRowsBecomesNotFound pins the one scan error the helpers do
+// translate, so callers can branch on ErrNotFound.
+func TestScanHelpers_NoRowsBecomesNotFound(t *testing.T) {
+	for _, h := range scanHelpers {
+		t.Run(h.name, func(t *testing.T) {
+			if err := h.scan(errScanner{err: pgx.ErrNoRows}); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("scan error = %v, want ErrNotFound", err)
+			}
+		})
+	}
+}

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -35,7 +35,7 @@ Decrypted provider keys are held in an in-memory cache to avoid re-deriving the 
 - **TTL**: 10 minutes (configurable via `key_cache_ttl` setting) - cached entries expire and must be re-decrypted
 - **Thread safety**: Protected by `sync.RWMutex` - multiple goroutines can read concurrently; writes are exclusive
 - **Cache key**: Derived from the hex-encoded ciphertext + nonce + salt, so changing a provider's key invalidates the cache entry naturally
-- **Eviction**: A background goroutine runs periodically, purging expired entries
+- **Eviction**: Each server binary runs a sweep on its background group, ticking on the current TTL and purging expired entries; it is joined at shutdown
 - **Warm-up**: On startup, all enabled providers' keys are pre-loaded into the cache (`WarmKeyCache`)
 
 This is a security trade-off: caching reduces Argon2id computation overhead on hot paths, but means decrypted keys exist in memory for up to 10 minutes. In practice, this is acceptable because:


### PR DESCRIPTION
Follow-up to the whole-repo simplification pass, from the Codex audit of the remaining Go packages (six LOW items) plus what two Opus review rounds found on the way.

**Key-cache eviction lifecycle.** The sweep that drops expired decrypted keys ran from a package `init()` goroutine that nothing could stop: it leaked into every test binary importing `internal/auth` and sat outside the server's shutdown budget. `KeyCacheEvictionLoop(ctx)` is a context-driven loop in the same shape as the other maintenance loops (ctx checked before each sweep, exits on cancel); `cmd/server` runs it in the background group so it joins `background.Wait`, and Front Desk runs it through `StartBackground` since it decrypts member tokens through the same cache. The periodic test now owns its loop's lifetime and stops it before restoring the TTL. Wiki Security page updated.

**Restored and corrected tests.** Fake-scanner tests for `scanCredential` and `scanSession` in `internal/webauthn` (a non-ErrNoRows scan error propagates and is not `ErrNotFound`), which the pass had dropped. The xAI 429 test that claimed a catalog fallback duplicated the retry-then-error test 300 lines below; the survivor keeps an accurate comment. In `internal/ratelimit`, 34 mentions of the deleted `cleanupLoop` across test names and comments now name the cleanup goroutine and `runCleanup`, a test that asserted nothing was removed, and the clientip trusted-net doc no longer claims `net.SplitHostPort` accepts a bare IPv6 literal.

Gates: gofmt, golangci-lint, go vet, race tests for auth, webauthn, clientip, ratelimit, cmd/server tests, size gate. Deployed on dev, healthy. Codex reviews the merged diff once its window rolls over.
