### PR TITLE
fix(proxy): recognise the Z.ai 5-hour usage limit 429 as exhaustion

### DIFF
--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -121,7 +121,8 @@ const (
 	// no Retry-After. Two seconds is the typical slot-freeing gap.
 	defaultSaturatedRetryAfter = 2 * time.Second
 	// pinHintWindow is the pin for a usage window whose reset the body names
-	// but does not date (Ollama's session cap, generic quota phrases).
+	// but does not date, or dates in a form nothing here parses (Ollama's
+	// session cap, Z.ai's 5-hour window, generic quota phrases).
 	pinHintWindow = 30 * time.Minute
 	// pinHintWeekly is the pin for an explicitly weekly cap. Two hours, not a
 	// week: the pin ceiling (circuit_breaker_quota_pin_max) and the probe on
@@ -181,6 +182,13 @@ var rateLimitPhrases = []rateLimitPhrase{
 	// below. The Z.ai entry pins pinHintWeekly rather than the named reset
 	// instant: nothing here parses that date format.
 	{phrase: "limit exhausted", also: "reset", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
+	// The 5-hour window uses different words from the weekly one (code 1308).
+	// The generic window pin is enough: the quota advisor retargets it to the
+	// exact reset from the next usage snapshot, and the dated reset in the body
+	// is Beijing time, which nothing here parses. No second substring: the
+	// phrase is not saturation vocabulary, so a reworded or reset-less body
+	// must still land here rather than fall back to unknown.
+	{phrase: "usage limit reached", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Z.ai Coding Plan (code 1308, \"Usage limit reached for 5 hour. Your limit will reset at ...\")", observed: "2026-09-08"},
 	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "session usage limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "usage limit", also: "upgrade", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud (\"you have reached your session usage limit, upgrade for higher limits\")", observed: "2026-08-31"},

--- a/internal/proxy/rate_limit_classify_test.go
+++ b/internal/proxy/rate_limit_classify_test.go
@@ -77,6 +77,17 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantPin:   pinHintWeekly,
 		},
 		{
+			// Verbatim from prod, 2026-09-08 19:11 UTC, glm-5.3 on the Coding Plan
+			// under a Strix run: the 5-hour window spent, worded unlike the
+			// weekly cap. Time fixes it, the generic window pin applies and the
+			// quota advisor retargets it to the snapshot's exact reset.
+			name:      "Z.ai coding plan code 1308 5-hour usage limit reached",
+			status:    429,
+			body:      `{"error":{"code":"1308","message":"Usage limit reached for 5 hour. Your limit will reset at 2026-09-09 05:38:28"}}`,
+			wantClass: rateLimitExhausted,
+			wantPin:   pinHintWindow,
+		},
+		{
 			// Holds the line the entry above could have crossed: "exhausted"
 			// beside a concurrency limit is a busy provider, and it must reach
 			// the saturated entries rather than open a circuit with a 2h pin.


### PR DESCRIPTION
Tonight's Strix run drained the Z.ai Coding Plan 5-hour window. The live 429 body was

```
{"error":{"code":"1308","message":"Usage limit reached for 5 hour. Your limit will reset at 2026-09-09 05:38:28"}}
```

The phrase table knew only the weekly code 1310 wording ("Weekly/Monthly Limit Exhausted"), so this body classified as unrecognised: the breaker took a plain failure charge and the model was pinned only because the quota poller happened to have a fresh exhaustion reading the same second. Without that snapshot the circuit would have re-probed every few minutes until the next poll.

`usage limit reached` is now an exhausted phrase with the generic window pin (30 min). The advisor retargets that pin to the snapshot's exact reset, and the dated reset in the body is Beijing time, which the classifier does not parse. No second substring: the phrase is not saturation vocabulary and shadows nothing (every existing test body re-checked, Ollama's say "reached your session usage limit", OpenAI's "Rate limit reached"). Verbatim test case added; `pinHintWindow` doc widened to cover a dated-but-unparsed reset.

One Opus review round, both nits applied.
