### PR TITLE
test(auth): record the post-cancel rearm instead of failing from the loop goroutine

### DIFF
--- a/internal/auth/key_cache.go
+++ b/internal/auth/key_cache.go
@@ -103,11 +103,14 @@ func WarmKeyCache(encryptedKey, keyNonce, keySalt []byte, masterKey string) {
 }
 
 // KeyCacheEvictionLoop sweeps expired entries on a ticker that adopts the
-// current TTL at each tick and returns when ctx is done. Each binary that decrypts keys starts it on
-// its own background group, so the sweep is joined at shutdown instead of
-// running unjoinably for the life of every process that links this package. A
-// tick that lands together with the cancellation starts no sweep, so the join
-// budget is never spent on work begun after the cancel.
+// current TTL at each tick and returns when ctx is done. Each binary that
+// decrypts keys starts it on its own background group, so the sweep is joined
+// at shutdown instead of running unjoinably for the life of every process
+// that links this package. Nothing starts it implicitly: a binary that links
+// this package, decrypts keys and never runs the loop keeps expired plaintext
+// entries in memory for its whole life. A tick that lands together with the
+// cancellation starts no sweep, so the join budget is never spent on work
+// begun after the cancel.
 func KeyCacheEvictionLoop(ctx context.Context) {
 	ticker := time.NewTicker(getKeyCacheTTL())
 	defer ticker.Stop()

--- a/internal/auth/key_cache_test.go
+++ b/internal/auth/key_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -587,6 +588,10 @@ func TestRunKeyCacheEviction_PendingTickAfterCancelSweepsNothing(t *testing.T) {
 		keyCacheMu.Unlock()
 	})
 
+	// The stub records instead of failing directly: a t.Error from the loop
+	// goroutine after the timeout below has ended the test would panic and
+	// mask the real failure.
+	var rearmed atomic.Bool
 	for range 32 {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -595,12 +600,15 @@ func TestRunKeyCacheEviction_PendingTickAfterCancelSweepsNothing(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			runKeyCacheEviction(ctx, ticks, func() { t.Error("rearm called after cancel") })
+			runKeyCacheEviction(ctx, ticks, func() { rearmed.Store(true) })
 		}()
 		select {
 		case <-done:
 		case <-time.After(time.Second):
 			t.Fatal("loop did not return after cancel")
+		}
+		if rearmed.Load() {
+			t.Fatal("rearm called after cancel")
 		}
 	}
 

--- a/internal/webauthn/scan_test.go
+++ b/internal/webauthn/scan_test.go
@@ -24,8 +24,8 @@ var scanHelpers = []struct {
 }
 
 // TestScanHelpers_PropagateScanError pins that only pgx.ErrNoRows becomes
-// ErrNotFound: any other scan failure reaches the caller unchanged, so a
-// corrupt row is never mistaken for a missing one. A helper that translated
+// ErrNotFound: any other scan failure is not translated, so a corrupt row is
+// never mistaken for a missing one. A helper that translated
 // this error would fail the check, since the sentinel it would return does not
 // wrap want.
 func TestScanHelpers_PropagateScanError(t *testing.T) {


### PR DESCRIPTION
Three small follow-ups on the key-cache eviction lifecycle change, from a GLM-5.3 second-opinion review run through the gateway (`opencode run` with the merged diff inline), confirmed by an Opus round:

- The post-cancel test stub called `t.Error` from the loop goroutine. On the timeout path that call would land after `t.Fatal` had ended the test and panic with "Log after test completed", masking the real failure. The stub records into an `atomic.Bool` that the test asserts after the loop has exited, so the test still fails if the `ctx.Err()` guard is removed and stays quiet otherwise.
- The `KeyCacheEvictionLoop` doc states that nothing starts the loop implicitly: a binary that links `internal/auth`, decrypts keys and never runs the loop keeps expired plaintext entries in memory. Only `cmd/server` and `cmd/frontdesk` link the package and both run it.
- The webauthn scan-error test comment now says what `errors.Is` proves (the error is not translated to `ErrNotFound`) rather than "unchanged".

The review's three other items (Front Desk decrypt path, `SetKeyCacheTTL` bounds, clientip callers) were checked against the code and need no change.
