### PR TITLE
fix(web): derive arena history ids from Web Crypto bytes

### DIFF
--- a/web/src/utils/arenaHistory.ts
+++ b/web/src/utils/arenaHistory.ts
@@ -273,8 +273,17 @@ export function getArenaHistoryCount(): number {
 	return getArenaHistory().length;
 }
 
+// The suffix comes from the Web Crypto generator rather than Math.random: the
+// id is persisted to localStorage, and a Math.random value stored there makes
+// CodeQL flag every localStorage read in the app as insecure randomness.
+// getRandomValues works in plain-http LAN contexts too, unlike randomUUID.
 export function generateHistoryId(): string {
-	return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+	const bytes = new Uint8Array(4);
+	crypto.getRandomValues(bytes);
+	const suffix = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+		"",
+	);
+	return `${Date.now()}-${suffix}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the twelve open CodeQL `js/insecure-randomness` alerts (#94 to #105) filed on the simplify-pass merge.

The sink they name is every range and metric value the dashboard reads through `useLocalStorage`. The source is `generateHistoryId` in the arena history, which built its suffix from `Math.random` and persisted the id to localStorage; CodeQL treats localStorage as one tainted store, so every read in the app inherited the flag. Nothing there is security-relevant, but the honest fix is to remove the source rather than dismiss twelve alerts: the suffix is now four `crypto.getRandomValues` bytes as hex. `getRandomValues` works in plain-http LAN contexts, which `crypto.randomUUID` does not. Format, callers and tests are unchanged.

The two remaining `Math.random` uses (the chat dice pick and the request-stagger jitter) never reach storage or a request, so they carry no alert.
