### PR TITLE
fix(bellhop): render day-granular quota dates in the device zone

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaBadges.kt
@@ -42,6 +42,7 @@ import com.hugalafutro.bellhop.data.quotaBadgeLabel
 import com.hugalafutro.bellhop.data.quotaMeters
 import com.hugalafutro.bellhop.ui.common.LocalTimePattern
 import com.hugalafutro.bellhop.ui.common.TightTouchTarget
+import com.hugalafutro.bellhop.ui.events.formatEventDate
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import com.hugalafutro.bellhop.ui.theme.SeverityErrorBg
 import com.hugalafutro.bellhop.ui.theme.SeverityWarnBg
@@ -279,7 +280,7 @@ private fun QuotaDetailRows(data: QuotaData) {
             if (data.period.currentPeriodEnd.isNotBlank()) {
                 QuotaDetailRow(
                     stringResource(R.string.quota_field_period_end),
-                    isoDatePart(data.period.currentPeriodEnd),
+                    formatEventDate(data.period.currentPeriodEnd),
                 )
             }
             QuotaDetailRow(stringResource(R.string.quota_field_allow_overage), if (data.allowOverage) yes else no)
@@ -361,11 +362,11 @@ private fun QuotaDetailRows(data: QuotaData) {
             if (data.subscriptionPeriodEnd.valid) {
                 QuotaDetailRow(
                     stringResource(R.string.quota_field_subscription_end),
-                    isoDatePart(data.subscriptionPeriodEnd.time),
+                    formatEventDate(data.subscriptionPeriodEnd.time),
                 )
             }
             if (data.suspendedAt.valid) {
-                QuotaDetailRow(stringResource(R.string.quota_field_suspended), isoDatePart(data.suspendedAt.time))
+                QuotaDetailRow(stringResource(R.string.quota_field_suspended), formatEventDate(data.suspendedAt.time))
             }
         }
         is QuotaData.NeuralWatt -> {
@@ -520,14 +521,6 @@ private fun meterLabel(kind: QuotaMeterKind): Int =
  * ceiling worth drawing a bar against, so a row and a bar never both claim the
  * same reading. */
 private fun isCapped(limit: Long?): Boolean = limit != null && limit > 0L
-
-/** isoDatePart trims an RFC3339 timestamp to its date portion; a value that
- * isn't RFC3339-shaped (no "T") is returned as-is rather than dropped, so a
- * foreign format still shows something instead of going blank. */
-private fun isoDatePart(iso: String): String {
-    val t = iso.indexOf('T')
-    return if (t > 0) iso.substring(0, t) else iso
-}
 
 /** usd formats a dollar amount with a fixed Locale, mirroring
  * [com.hugalafutro.bellhop.data]'s widget-facing formatters, so the sheet

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/ui/events/EventsScreen.kt
@@ -49,6 +49,7 @@ import com.hugalafutro.bellhop.ui.theme.MonoFamily
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Locale
 
 /**
@@ -317,6 +318,18 @@ internal fun formatEventTime(
         Instant.parse(createdAt).atZone(ZoneId.systemDefault()).format(format)
     } catch (e: Exception) {
         createdAt
+    }
+
+// formatEventDate renders a day-granular RFC3339 timestamp as a date in the
+// device's zone, so an end-of-period stamp near midnight reads as the local day
+// rather than the UTC one. Same fallback as [formatEventTime]: anything
+// unparseable comes back verbatim instead of blanking the row.
+internal fun formatEventDate(iso: String): String =
+    try {
+        val format = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())
+        Instant.parse(iso).atZone(ZoneId.systemDefault()).format(format)
+    } catch (e: DateTimeParseException) {
+        iso
     }
 
 // eventClipboardText renders one event as a plain-text block for the clipboard:

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaResetFormatTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/ui/dashboard/QuotaResetFormatTest.kt
@@ -1,5 +1,6 @@
 package com.hugalafutro.bellhop.ui.dashboard
 
+import com.hugalafutro.bellhop.ui.events.formatEventDate
 import com.hugalafutro.bellhop.ui.events.formatEventTime
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -8,10 +9,11 @@ import java.util.Locale
 import java.util.TimeZone
 
 /**
- * Pins the reset-time rendering the OpenCode Go detail rows use. The gateway
- * sends UTC, so the row has to read at the device's zone and on the clock face
- * Settings chose, and a value that isn't RFC3339-shaped has to survive rather
- * than blank the sheet.
+ * Pins the timestamp rendering the quota detail rows use: the reset time on the
+ * OpenCode Go rows, and the day-granular period ends on the NanoGPT and Ollama
+ * Cloud rows. The gateway sends UTC, so both have to read at the device's zone
+ * (and the time on the clock face Settings chose), and a value that isn't
+ * RFC3339-shaped has to survive rather than blank the sheet.
  */
 class QuotaResetFormatTest {
     // A fixed moment in a fixed zone and locale so the expected reading is not
@@ -42,6 +44,22 @@ class QuotaResetFormatTest {
     fun honoursThe12HourSetting() =
         inPragueEnUs {
             assertEquals("Sep 8, 2026 · 8:25 PM", formatEventTime(resetsAt, "h:mm a"))
+        }
+
+    // 22:30 UTC is already the next day in Prague, the case a UTC-only reading
+    // gets wrong.
+    private val periodEnd = "2026-09-08T22:30:00Z"
+
+    @Test
+    fun readsADayGranularEndAtTheDeviceZone() =
+        inPragueEnUs {
+            assertEquals("Sep 9, 2026", formatEventDate(periodEnd))
+        }
+
+    @Test
+    fun leavesAForeignDateAlone() =
+        inPragueEnUs {
+            assertEquals("soon", formatEventDate("soon"))
         }
 
     @Test


### PR DESCRIPTION
The NanoGPT period-end row and the subscription-end and suspended-at rows on the quota sheet trimmed the RFC3339 timestamp to its UTC date, so a user near midnight local time read the wrong day. The same flaw was fixed for the OpenCode Go reset rows in #953; this applies it to the three older day-granular rows.

`formatEventDate` sits beside `formatEventTime` (same shape: `Instant.parse` at the device zone, the raw string back when the value is not RFC3339, so a provider that sends a bare date still shows it). `isoDatePart` had no other user and is gone. Unit tests: an instant at 22:30 UTC renders as the next day in Europe/Prague; a non-timestamp string comes back verbatim. Gates: compileDebugKotlin, the touched unit test class, ktlint. One Opus review round, no findings beyond placement, which follows the existing precedent. No version bump.
