### PR TITLE
fix(quota): refused OpenCode Go windows read as spent everywhere; MiniMax business errors are unknown

### DIFF
--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaModels.kt
@@ -390,6 +390,25 @@ data class OpenCodeGoWindow(
     val resetsAt: String = "",
 )
 
+/**
+ * Whether OpenCode Go is refusing this window. Any non-empty status other than
+ * the documented "ok" counts, so an undocumented value fails closed rather than
+ * reading as healthy; the compare is trimmed and case-insensitive so a casing
+ * drift upstream changes nothing. An absent status decides nothing.
+ */
+fun OpenCodeGoWindow.isRefused(): Boolean {
+    val s = status.trim()
+    return s.isNotEmpty() && !s.equals("ok", ignoreCase = true)
+}
+
+/**
+ * The share of the window to render, clamped to 0-100. A refused window reads
+ * as fully used whatever percent it carries: it serves nothing and counts as
+ * spent, so a bar or a badge showing its raw 0 would contradict the spent
+ * styling.
+ */
+fun OpenCodeGoWindow.usedPercent(): Double = if (isRefused()) 100.0 else percent.coerceIn(0.0, 100.0)
+
 // ── Parsing ──────────────────────────────────────────────────────────────
 
 /**
@@ -537,8 +556,8 @@ fun quotaBadgeLabel(
         // Rolling (5h) over weekly, the two windows a session actually runs
         // into; monthly is a bar and a row in the detail sheet.
         is QuotaData.OpenCodeGo -> {
-            val rolling = applyBarMode(data.usage.rolling.percent, mode)
-            val weekly = applyBarMode(data.usage.weekly.percent, mode)
+            val rolling = applyBarMode(data.usage.rolling.usedPercent(), mode)
+            val weekly = applyBarMode(data.usage.weekly.usedPercent(), mode)
             "${formatPercent(rolling)}/${formatPercent(weekly)}"
         }
     }
@@ -719,9 +738,9 @@ fun quotaMeters(pq: ProviderQuota): List<QuotaMeter> {
         // the reset times ride alongside as detail rows.
         is QuotaData.OpenCodeGo ->
             listOf(
-                QuotaMeter(QuotaMeterKind.FIVE_HOUR, data.usage.rolling.percent),
-                QuotaMeter(QuotaMeterKind.WEEKLY, data.usage.weekly.percent),
-                QuotaMeter(QuotaMeterKind.MONTHLY, data.usage.monthly.percent),
+                QuotaMeter(QuotaMeterKind.FIVE_HOUR, data.usage.rolling.usedPercent()),
+                QuotaMeter(QuotaMeterKind.WEEKLY, data.usage.weekly.usedPercent()),
+                QuotaMeter(QuotaMeterKind.MONTHLY, data.usage.monthly.usedPercent()),
             )
         // Balance-only and plan-only: no ceiling exists to meter against.
         is QuotaData.DeepSeek, is QuotaData.OllamaCloud -> emptyList()

--- a/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaSpent.kt
+++ b/android/app/src/main/kotlin/com/hugalafutro/bellhop/data/QuotaSpent.kt
@@ -132,11 +132,11 @@ private fun isNeuralWattSpent(q: QuotaData.NeuralWatt): Boolean {
     return energySpent && credits < NEURALWATT_CREDITS_SPENT_FLOOR_USD
 }
 
-// percent is the consumed share, so 100 is a full window. Only "ok" is a
-// documented status, so any other non-empty value is OpenCode Go refusing the
-// window; an absent status decodes to "" and decides nothing.
-private fun isOpenCodeGoWindowSpent(w: OpenCodeGoWindow): Boolean =
-    w.percent >= 100.0 || (w.status.isNotEmpty() && w.status != "ok")
+// percent is the consumed share, so 100 is a full window, and a refused window
+// already reads as 100 through usedPercent, which is what the badge and the
+// meters render; one comparison covers both so a provider cannot read as spent
+// while its bars show room left.
+private fun isOpenCodeGoWindowSpent(w: OpenCodeGoWindow): Boolean = w.usedPercent() >= 100.0
 
 // Rolling, weekly and monthly, the same three windows the gateway walks.
 private fun isOpenCodeGoSpent(u: QuotaData.OpenCodeGo): Boolean =

--- a/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
+++ b/android/app/src/test/kotlin/com/hugalafutro/bellhop/data/QuotaModelsTest.kt
@@ -518,6 +518,33 @@ class QuotaModelsTest {
     }
 
     @Test
+    fun openCodeGoRefusedWindowReadsAsFullyUsed() {
+        // A refused window serves nothing and marks the provider spent, so the
+        // badge must not print the percentage such a payload carries. Only "ok"
+        // is documented, in any casing.
+        val data =
+            QuotaData.OpenCodeGo(
+                usage =
+                    OpenCodeGoWindows(
+                        rolling = OpenCodeGoWindow(status = "exceeded", percent = 10.0),
+                        weekly = OpenCodeGoWindow(status = " Ok ", percent = 15.0),
+                    ),
+            )
+        val wrapped = pq(data, QuotaType.OPENCODE_GO)
+
+        assertEquals("100%/15%", quotaBadgeLabel(wrapped, QuotaBarMode.USED))
+        assertEquals("0%/85%", quotaBadgeLabel(wrapped, QuotaBarMode.REMAINING))
+    }
+
+    @Test
+    fun openCodeGoPercentIsClampedToTheBarRange() {
+        // An out-of-range percent would render as "120%" and a negative
+        // remainder, so usedPercent clamps the way the web selector does.
+        assertEquals(100.0, OpenCodeGoWindow(status = "ok", percent = 120.0).usedPercent(), 0.001)
+        assertEquals(0.0, OpenCodeGoWindow(status = "ok", percent = -20.0).usedPercent(), 0.001)
+    }
+
+    @Test
     fun detailBearingTypesMatchTheWebDashboardsModals() {
         // Model Hotel's web dashboard opens a quota modal for seven of the nine
         // types; DeepSeek and Ollama Cloud get a badge that only refreshes,

--- a/frontdesk/web/src/components/__tests__/QuotaBadge.test.tsx
+++ b/frontdesk/web/src/components/__tests__/QuotaBadge.test.tsx
@@ -397,6 +397,11 @@ describe("QuotaBadge", () => {
 		expect(screen.getByTestId("quota-badge-opencode-go:flagged")).toHaveClass(
 			"fd-quota-pill-spent",
 		);
+		// The refused window reads as fully used, so the pill cannot show the
+		// 10% it carries next to the spent styling.
+		expect(
+			screen.getByTestId("quota-badge-opencode-go:flagged"),
+		).toHaveTextContent("100%/-");
 		expect(
 			screen.getByTestId("quota-badge-opencode-go:healthy"),
 		).not.toHaveClass("fd-quota-pill-spent");

--- a/frontdesk/web/src/components/quota/OpenCodeGoQuotaModal.tsx
+++ b/frontdesk/web/src/components/quota/OpenCodeGoQuotaModal.tsx
@@ -12,7 +12,10 @@ import {
 	resetSublabel,
 } from "./shared";
 
-/** The label each window is shown under, in the order OpenCode Go reports. */
+/**
+ * The label each window is shown under, keyed by window. The order the bars
+ * render in comes from getOpenCodeGoWindows, not from this record.
+ */
 const WINDOW_LABEL_KEYS = {
 	rolling: "quota.modal.openCodeGoRolling",
 	weekly: "quota.modal.openCodeGoWeekly",

--- a/internal/provider/discovery_opencode_go.go
+++ b/internal/provider/discovery_opencode_go.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/model"
@@ -96,7 +97,9 @@ func (d *DiscoveryService) GetOpenCodeGoUsage(ctx context.Context, provider *Pro
 // openCodeGoNoSubscription reports whether a 403 body is OpenCode Go saying the
 // key carries no active Go subscription, rather than rejecting the key itself.
 // The shape is {"type":"error","error":{"type":"EntitlementError"}}; anything
-// else, an unparseable body included, is not that claim.
+// else, an unparseable body included, is not that claim. The type name is
+// matched case-insensitively: a casing drift upstream would otherwise turn
+// every key without a subscription into an invalid-key badge.
 func openCodeGoNoSubscription(err error) bool {
 	httpErr := &httpError{}
 	if !errors.As(err, &httpErr) {
@@ -110,5 +113,5 @@ func openCodeGoNoSubscription(err error) bool {
 	if json.Unmarshal(httpErr.Body, &body) != nil {
 		return false
 	}
-	return body.Error.Type == "EntitlementError"
+	return strings.EqualFold(strings.TrimSpace(body.Error.Type), "EntitlementError")
 }

--- a/internal/provider/discovery_opencode_go_test.go
+++ b/internal/provider/discovery_opencode_go_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -249,36 +250,45 @@ func TestGetOpenCodeGoUsage_KeyInvalid401(t *testing.T) {
 // TestGetOpenCodeGoUsage_NoSubscription403 covers a healthy key without an
 // active Go subscription: 403 EntitlementError is the expected answer for that
 // plan, so it reports no data and no error (204 + null payload upstream) and
-// must not reach either the ERROR log or the dead-key path.
+// must not reach either the ERROR log or the dead-key path. The casing of the
+// type name is upstream's to change, and a drift there must not demote every
+// key without a subscription to a dead key.
 func TestGetOpenCodeGoUsage_NoSubscription403(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}`))
-	}))
-	defer server.Close()
+	for _, tc := range []struct{ name, errType string }{
+		{"as observed live", "EntitlementError"},
+		{"cased differently upstream", "entitlementerror"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = fmt.Fprintf(w, `{"type":"error","error":{"type":%q,"message":"OpenCode Go subscription required."}}`, tc.errType)
+			}))
+			defer server.Close()
 
-	var logged strings.Builder
-	debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	t.Cleanup(func() { debuglog.SetHandler(debuglog.StdoutHandler()) })
+			var logged strings.Builder
+			debuglog.SetHandler(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			t.Cleanup(func() { debuglog.SetHandler(debuglog.StdoutHandler()) })
 
-	masterKey := "test-master-key-for-testing-only-32bytes!"
-	prov, err := newQuotaTestProvider(server.URL, "zen-key-without-go", masterKey)
-	if err != nil {
-		t.Fatalf("encrypt: %v", err)
-	}
-	service := &DiscoveryService{httpClient: server.Client()}
+			masterKey := "test-master-key-for-testing-only-32bytes!"
+			prov, err := newQuotaTestProvider(server.URL, "zen-key-without-go", masterKey)
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			service := &DiscoveryService{httpClient: server.Client()}
 
-	// The nil error is what proves the 403 EntitlementError was not classified
-	// as a dead key: ErrProviderKeyInvalid would surface here.
-	usage, err := service.GetOpenCodeGoUsage(context.Background(), prov, masterKey)
-	if err != nil || usage != nil {
-		t.Fatalf("GetOpenCodeGoUsage = (%v, %v), want (nil, nil)", usage, err)
-	}
-	if strings.Contains(logged.String(), "level=ERROR") || strings.Contains(logged.String(), "level=WARN") {
-		t.Errorf("no-subscription 403 logged above INFO: %s", logged.String())
-	}
-	if !strings.Contains(logged.String(), "no active Go subscription") {
-		t.Errorf("expected the no-subscription INFO line, got: %s", logged.String())
+			// The nil error is what proves the 403 EntitlementError was not
+			// classified as a dead key: ErrProviderKeyInvalid would surface here.
+			usage, err := service.GetOpenCodeGoUsage(context.Background(), prov, masterKey)
+			if err != nil || usage != nil {
+				t.Fatalf("GetOpenCodeGoUsage = (%v, %v), want (nil, nil)", usage, err)
+			}
+			if strings.Contains(logged.String(), "level=ERROR") || strings.Contains(logged.String(), "level=WARN") {
+				t.Errorf("no-subscription 403 logged above INFO: %s", logged.String())
+			}
+			if !strings.Contains(logged.String(), "no active Go subscription") {
+				t.Errorf("expected the no-subscription INFO line, got: %s", logged.String())
+			}
+		})
 	}
 }
 

--- a/internal/quota/normalize.go
+++ b/internal/quota/normalize.go
@@ -331,10 +331,14 @@ func assessOpenCodeGo(payload json.RawMessage) Assessment {
 
 // openCodeGoWindowSpent reports whether one OpenCode Go window is spent. The
 // percent is the consumed share, so 100 is a full window. Only "ok" is a
-// documented status, so any other non-empty value is OpenCode Go refusing the
-// window; an absent status decodes to "" and decides nothing.
+// documented status, so any other non-empty value counts as OpenCode Go
+// refusing the window: an undocumented status fails closed rather than reading
+// as healthy, since a refused window serves nothing whatever its percent says.
+// The status compare is trimmed and case-insensitive so a casing drift upstream
+// changes nothing. An absent status decodes to "" and decides nothing.
 func openCodeGoWindowSpent(w provider.OpenCodeGoUsageWindow) bool {
-	return w.Percent >= 100 || (w.Status != "" && w.Status != "ok")
+	status := strings.TrimSpace(w.Status)
+	return w.Percent >= 100 || (status != "" && !strings.EqualFold(status, "ok"))
 }
 
 // minimaxModelRemain is the subset of a MiniMax model_remains entry the quota
@@ -358,11 +362,23 @@ type minimaxModelRemain struct {
 
 type minimaxQuotaPayload struct {
 	ModelRemains []minimaxModelRemain `json:"model_remains"`
+	BaseResp     struct {
+		StatusCode int `json:"status_code"`
+	} `json:"base_resp"`
 }
 
 func assessMiniMax(payload json.RawMessage) Assessment {
 	var res minimaxQuotaPayload
 	if err := json.Unmarshal(payload, &res); err != nil {
+		return Assessment{}
+	}
+	// MiniMax answers business errors ("no active token plan subscription" and
+	// the rest) inside an HTTP 200 that the poller stores like any other
+	// snapshot. Such a body carries no windows, so reading it as understood
+	// would report health and put the provider in buildQuotaAdvice's recovered
+	// set, dropping the pin of a provider whose own answer says nothing about
+	// its windows. Only status_code 0 is a payload that was answered.
+	if res.BaseResp.StatusCode != 0 {
 		return Assessment{}
 	}
 	var e earliestReset

--- a/internal/quota/normalize_test.go
+++ b/internal/quota/normalize_test.go
@@ -839,6 +839,25 @@ func TestAssess_MiniMax_HealthyModelNotExhausted(t *testing.T) {
 	}
 }
 
+// TestAssess_MiniMax_BusinessErrorEnvelopeIsNoOpinion covers the HTTP 200
+// MiniMax answers business errors with. It carries no windows, so reading it
+// as understood would report health and release the pin of a provider whose
+// payload says nothing about its quota.
+func TestAssess_MiniMax_BusinessErrorEnvelopeIsNoOpinion(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"base_resp": map[string]any{"status_code": 2062, "status_msg": "no active token plan"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := Assess("minimax", Snapshot{Kind: "usage", Payload: payload})
+
+	if got.OK {
+		t.Error("a base_resp error envelope is not an understood payload")
+	}
+}
+
 func TestAssess_MiniMax_ZeroTotalIsNotExhausted(t *testing.T) {
 	// A zero total means "no limit reported", not "limit fully consumed" —
 	// and on this plan tier the percent fallback is absent from the payload
@@ -1045,6 +1064,23 @@ func TestAssess_OpenCodeGo_NonOKStatusIsExhausted(t *testing.T) {
 	}
 	if got.ResetsAt.Format(time.RFC3339Nano) != weekly {
 		t.Errorf("got ResetsAt=%s, want the refused window's reset %s", got.ResetsAt.Format(time.RFC3339Nano), weekly)
+	}
+}
+
+// TestAssess_OpenCodeGo_PaddedMixedCaseOKIsHealthy holds the status compare
+// insensitive to casing and surrounding space: a drift to "Ok" upstream must
+// not read as OpenCode Go refusing every window.
+func TestAssess_OpenCodeGo_PaddedMixedCaseOKIsHealthy(t *testing.T) {
+	payload := openCodeGoPayload(t,
+		map[string]any{"status": "Ok ", "percent": 5, "resetsAt": time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano)},
+		map[string]any{"status": " OK", "percent": 40, "resetsAt": time.Now().Add(50 * time.Hour).UTC().Format(time.RFC3339Nano)},
+		map[string]any{"status": "ok", "percent": 9, "resetsAt": time.Now().Add(600 * time.Hour).UTC().Format(time.RFC3339Nano)},
+	)
+
+	got := Assess("opencode-go", Snapshot{Kind: "usage", Payload: payload})
+
+	if !got.OK || got.Exhausted {
+		t.Fatalf("got OK=%v Exhausted=%v, want OK with nothing exhausted", got.OK, got.Exhausted)
 	}
 }
 

--- a/web-shared/quota/opencodeGo.ts
+++ b/web-shared/quota/opencodeGo.ts
@@ -6,6 +6,11 @@ import type { OpenCodeGoUsageResponse } from "./types";
 // it directly; the spent rule reads the same clamped value, and a window at or
 // past 100 is spent either way. A percent that is absent or not a finite number
 // reads as 0 rather than rendering NaN.
+//
+// A refused window reports 100 regardless of the percent it carries: OpenCode
+// Go serves nothing from it, and it counts as spent, so a label or a bar
+// showing the 0 such a payload arrives with would contradict the spent styling
+// around it.
 
 export type OpenCodeGoWindowKey = "rolling" | "weekly" | "monthly";
 
@@ -19,6 +24,18 @@ export interface OpenCodeGoWindow {
 	status?: string;
 }
 
+/**
+ * Whether OpenCode Go is refusing this window. Only "ok" is a documented
+ * status, so any other non-empty value counts as a refusal: an undocumented
+ * value fails closed rather than reading as healthy. The comparison is trimmed
+ * and case-insensitive so a casing drift upstream changes nothing. An absent
+ * status decides nothing.
+ */
+export function isOpenCodeGoWindowRefused(status?: string): boolean {
+	const s = status?.trim().toLowerCase();
+	return !!s && s !== "ok";
+}
+
 export function getOpenCodeGoWindows(
 	u: OpenCodeGoUsageResponse | undefined | null,
 ): OpenCodeGoWindow[] {
@@ -29,9 +46,10 @@ export function getOpenCodeGoWindows(
 		const w = usage[key];
 		if (!w) continue;
 		const n = Number(w.percent);
+		const clamped = Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 0;
 		windows.push({
 			key,
-			percent: Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 0,
+			percent: isOpenCodeGoWindowRefused(w.status) ? 100 : clamped,
 			resetsAt: w.resetsAt,
 			status: w.status,
 		});

--- a/web-shared/quota/spent.ts
+++ b/web-shared/quota/spent.ts
@@ -151,14 +151,12 @@ export function isNeuralWattQuotaSpent(q: NeuralWattQuotaLike): boolean {
 
 // Any of the three windows blocks the whole subscription, as assessOpenCodeGo
 // walks them: a window at its ceiling, or one whose status OpenCode Go reports
-// as something other than "ok". An absent status is unknown, never spent.
+// as something other than "ok". The selector already reports a refused window
+// as 100, so one comparison covers both and the badge cannot read as spent
+// while showing a percentage below its ceiling. An absent status is unknown,
+// never spent.
 export function isOpenCodeGoQuotaSpent(u: OpenCodeGoUsageResponse): boolean {
-	return getOpenCodeGoWindows(u).some((w) => {
-		const status = w.status?.trim();
-		return (
-			w.percent >= 100 || (status != null && status !== "" && status !== "ok")
-		);
-	});
+	return getOpenCodeGoWindows(u).some((w) => w.percent >= 100);
 }
 
 /**

--- a/web/src/components/__tests__/OpenCodeGoQuotaModal.test.tsx
+++ b/web/src/components/__tests__/OpenCodeGoQuotaModal.test.tsx
@@ -27,14 +27,22 @@ describe("OpenCodeGoQuotaModal", () => {
 		localStorage.clear();
 	});
 
-	it("renders one bar per window, in report order", () => {
+	it("renders one bar per window, rolling then weekly then monthly", () => {
 		renderWithProviders(<OpenCodeGoQuotaModal {...defaultProps} />);
 		expect(
 			screen.getByRole("heading", { name: "OpenCode Go Plan Quota" }),
 		).toBeInTheDocument();
-		for (const key of ["rolling", "weekly", "monthly"]) {
-			expect(screen.getByTestId(`opencode-go-${key}-bar`)).toBeInTheDocument();
-		}
+		// The modal renders into a portal, so the bars are read from the
+		// document rather than from the render container.
+		expect(
+			[...document.querySelectorAll("[data-testid$='-bar']")].map((el) =>
+				el.getAttribute("data-testid"),
+			),
+		).toEqual([
+			"opencode-go-rolling-bar",
+			"opencode-go-weekly-bar",
+			"opencode-go-monthly-bar",
+		]);
 		expect(screen.getByText("Rolling Quota (5h)")).toBeInTheDocument();
 		expect(screen.getByText("Weekly Quota")).toBeInTheDocument();
 		expect(screen.getByText("Monthly Quota")).toBeInTheDocument();

--- a/web/src/components/__tests__/QuotaBadge.test.tsx
+++ b/web/src/components/__tests__/QuotaBadge.test.tsx
@@ -932,6 +932,25 @@ describe("QuotaBadge", () => {
 			);
 			expect(screen.getByRole("button")).toHaveTextContent("OCG-/-");
 		});
+
+		// A refused window reads as spent, so the pill must not show the 0
+		// percent such a payload carries beside the spent styling.
+		it("reads a refused window as fully used", () => {
+			render(
+				<QuotaBadge
+					type="opencode-go"
+					variant="card"
+					barMode="used"
+					opencodeGoUsage={{
+						usage: {
+							rolling: { status: "exceeded", percent: 0 },
+							weekly: { status: "ok", percent: 34 },
+						},
+					}}
+				/>,
+			);
+			expect(screen.getByRole("button")).toHaveTextContent("100%/34%");
+		});
 	});
 });
 

--- a/web/src/hooks/__tests__/quotaSpent.test.ts
+++ b/web/src/hooks/__tests__/quotaSpent.test.ts
@@ -307,6 +307,12 @@ describe("isQuotaPayloadSpent", () => {
 			spent: { usage: { monthly: { status: "exceeded", percent: 0 } } },
 			healthy: { usage: { monthly: { status: "ok", percent: 0 } } },
 		},
+		{
+			type: "opencode-go",
+			why: "the ok status is read past its casing and padding",
+			spent: { usage: { monthly: { status: "Refused", percent: 0 } } },
+			healthy: { usage: { monthly: { status: " Ok ", percent: 0 } } },
+		},
 	];
 
 	for (const c of cases) {

--- a/web/src/pages/Providers/AddProviderModal.tsx
+++ b/web/src/pages/Providers/AddProviderModal.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isOpenCodeGoQuotaVisible } from "@web-shared/quota";
 import { type SubmitEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../../api/client";
@@ -145,14 +146,16 @@ export function AddProviderModal({
 				switch (providerType) {
 					// OpenCode Go answers 204 with no body when the key carries no
 					// active Go subscription, so an empty result is a "no plan"
-					// notice rather than a detected quota.
+					// notice rather than a detected quota. The toast asks the badge's
+					// own visibility rule, so a payload carrying a usage object with
+					// no window in it reads the same way in both places.
 					case "opencode-go": {
 						const goUsage = await api.providers.getOpenCodeGoUsage(
 							newProvider.id,
 						);
 						onToast(
 							t(
-								goUsage?.usage
+								goUsage && isOpenCodeGoQuotaVisible(goUsage)
 									? "providers.toast_quota_detected_opencode_go"
 									: "providers.toast_no_plan_opencode_go",
 							),

--- a/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
+++ b/web/src/pages/Providers/__tests__/AddProviderModal.test.tsx
@@ -1701,6 +1701,32 @@ describe("AddProviderModal", () => {
 			);
 		});
 
+		// The toast asks the badge's visibility rule, so a usage object with no
+		// window in it is a "no plan" notice rather than a detected quota: a
+		// badge would have nothing to show for it either.
+		it("shows the OpenCode Go no-plan toast for a payload with no window", async () => {
+			server.use(
+				http.post("/api/providers", async ({ request }) => {
+					const body = await request.json();
+					return HttpResponse.json(openCodeGoProvider(body), { status: 201 });
+				}),
+				http.get("/api/providers/:id/usage", () =>
+					HttpResponse.json({ usage: {} }),
+				),
+			);
+			await submitOpenCodeGo();
+			await waitFor(() => {
+				expect(onToast).toHaveBeenCalledWith(
+					"No active OpenCode Go plan",
+					"info",
+				);
+			});
+			expect(onToast).not.toHaveBeenCalledWith(
+				"OpenCode Go quota detected",
+				"info",
+			);
+		});
+
 		it("shows DeepSeek balance with USD currency", async () => {
 			server.use(
 				http.post("/api/providers", async ({ request }) => {

--- a/web/src/utils/__tests__/webShared.test.ts
+++ b/web/src/utils/__tests__/webShared.test.ts
@@ -229,4 +229,17 @@ describe("getOpenCodeGoWindows", () => {
 		});
 		expect(windows.map((w) => w.percent)).toEqual([0, 0, 42]);
 	});
+
+	// A refused window serves nothing and reads as spent, so it must not render
+	// as room left; only "ok" is documented, in any casing.
+	it("reports a refused window as fully used and an ok one as reported", () => {
+		const windows = getOpenCodeGoWindows({
+			usage: {
+				rolling: { status: "exceeded", percent: 0 },
+				weekly: { status: " Ok ", percent: 12 },
+				monthly: { status: "", percent: 3 },
+			},
+		});
+		expect(windows.map((w) => w.percent)).toEqual([100, 12, 3]);
+	});
 });


### PR DESCRIPTION
Follow-up to #953 from a GLM-5.3 second-opinion review of its merged diff (run through the gateway with the diff inline), each item verified against the code by two Opus rounds.

**Refused windows.** A window whose status is anything but `ok` counts as spent, but its figures still read 0 percent used next to spent styling in the dashboard pill, the Front Desk pill and the Bellhop badge and bars. The shared selector, Bellhop's meters and the pill now report such a window as fully used, so label, bars and styling agree; the spent rule collapses to "any window at 100 percent". Status comparison is trimmed and case-insensitive in Go, TypeScript and Kotlin, and the `EntitlementError` match that separates "no subscription" from "dead key" is case-insensitive too, so a casing drift upstream cannot demote every Go key to a 424 badge.

**MiniMax business errors.** A MiniMax quota body with a non-zero `base_resp.status_code` (for example 2062, no active token plan) decoded to zero windows and assessed as healthy, which put the provider in the recovered set and released its pin on every poll. It now assesses as unknown, the same verdict the null and undatable cases got in #953. The add-provider probe's "quota detected" toast follows the badge visibility rule instead of the truthiness of an empty usage object, and the OpenCode Go modal test asserts window order rather than presence.

Gates: gofmt, golangci-lint, Go tests for quota and provider, both frontends' lint, typecheck and full vitest suites, i18n and size gates, Bellhop unit tests and ktlint. Deployed on dev; the usage endpoint still answers with the live payload.
