### PR TITLE
fix(proxy): keep the Z.ai 5-hour phrase below the weekly entries

### DIFF
--- a/internal/proxy/rate_limit_classify.go
+++ b/internal/proxy/rate_limit_classify.go
@@ -182,14 +182,16 @@ var rateLimitPhrases = []rateLimitPhrase{
 	// below. The Z.ai entry pins pinHintWeekly rather than the named reset
 	// instant: nothing here parses that date format.
 	{phrase: "limit exhausted", also: "reset", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Z.ai Coding Plan (code 1310, \"Weekly/Monthly Limit Exhausted. Your limit will reset at ...\")", observed: "2026-09-01"},
+	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	// The 5-hour window uses different words from the weekly one (code 1308).
+	// It sits below every weekly entry: a body naming a weekly usage limit
+	// as reached must keep the weekly pin, not this shorter one.
 	// The generic window pin is enough: the quota advisor retargets it to the
 	// exact reset from the next usage snapshot, and the dated reset in the body
 	// is Beijing time, which nothing here parses. No second substring: the
 	// phrase is not saturation vocabulary, so a reworded or reset-less body
 	// must still land here rather than fall back to unknown.
 	{phrase: "usage limit reached", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Z.ai Coding Plan (code 1308, \"Usage limit reached for 5 hour. Your limit will reset at ...\")", observed: "2026-09-08"},
-	{phrase: "weekly usage limit", class: rateLimitExhausted, pinHint: pinHintWeekly, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "session usage limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud", observed: "2026-08-31"},
 	{phrase: "usage limit", also: "upgrade", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Ollama Cloud (\"you have reached your session usage limit, upgrade for higher limits\")", observed: "2026-08-31"},
 	{phrase: "overage_limit", class: rateLimitExhausted, pinHint: pinHintWindow, provider: "Neuralwatt (docs; not yet observed live)", observed: "2026-08-31"},

--- a/internal/proxy/rate_limit_classify_test.go
+++ b/internal/proxy/rate_limit_classify_test.go
@@ -88,6 +88,15 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantPin:   pinHintWindow,
 		},
 		{
+			// A weekly body worded with "reached" must keep the weekly pin: the
+			// 1308 entry sits below the weekly ones so the longer window wins.
+			name:      "weekly usage limit reached keeps the weekly pin over the 1308 entry",
+			status:    429,
+			body:      `{"error":"you have reached your weekly usage limit. Weekly usage limit reached, upgrade for higher limits"}`,
+			wantClass: rateLimitExhausted,
+			wantPin:   pinHintWeekly,
+		},
+		{
 			// Holds the line the entry above could have crossed: "exhausted"
 			// beside a concurrency limit is a busy provider, and it must reach
 			// the saturated entries rather than open a circuit with a 2h pin.


### PR DESCRIPTION
From the Codex retro review of #955: the new generic `usage limit reached` entry sat above Ollama's `weekly usage limit` entry, so a body such as "weekly usage limit reached" would take the 30-minute window pin before the weekly entry could assign its 2-hour pin, against the table's longest-window-first rule. The entry now sits below every weekly phrase, with an overlap test asserting the weekly pin wins. No other verdict changes; the verbatim 1308 case still classifies as exhausted with the window pin.

Gates: gofmt, golangci-lint, the classifier test group, size gate.
