### PR TITLE
fix(web): asError keeps nullish rejections readable; finish the shared settings query and type adoptions

### DIFF
--- a/frontdesk/web/src/api/types.ts
+++ b/frontdesk/web/src/api/types.ts
@@ -427,13 +427,6 @@ export interface NanoGPTUsageTokenInfo {
 	resetAt: number;
 }
 
-export interface NanoGPTUsageDailyImages {
-	used: number;
-	remaining: number;
-	percentUsed: number;
-	resetAt: number;
-}
-
 export interface NanoGPTUsage {
 	active: boolean;
 	provider: string;
@@ -442,7 +435,7 @@ export interface NanoGPTUsage {
 	limits: NanoGPTUsageLimits;
 	allowOverage: boolean;
 	period: { currentPeriodEnd: string };
-	dailyImages: NanoGPTUsageDailyImages | null;
+	dailyImages: NanoGPTUsageTokenInfo | null;
 	dailyInputTokens: NanoGPTUsageTokenInfo | null;
 	weeklyInputTokens: NanoGPTUsageTokenInfo | null;
 }

--- a/web/src/components/ProviderQuotaPanel.tsx
+++ b/web/src/components/ProviderQuotaPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "../hooks/useLocalStorage";
 import { useQuotaData } from "../hooks/useQuotaData";
 import { quotaRefreshCooldownMs } from "../hooks/useQuotaRefresh";
+import { useSettingsQuery } from "../hooks/useSettingsQuery";
 import { CollapseBody, CollapsibleToggle } from "./CollapsibleToggle";
 import { QuotaBadges } from "./QuotaBadge";
 
@@ -52,10 +53,7 @@ export function ProviderQuotaPanel() {
 		staleTime: 60_000,
 	});
 
-	const { data: settings } = useQuery({
-		queryKey: ["settings"],
-		queryFn: () => api.settings.get(),
-	});
+	const { data: settings } = useSettingsQuery();
 
 	// Derive the refresh interval from the server setting. Query invalidation
 	// (triggered when the Settings page saves the value) re-runs this without a

--- a/web/src/hooks/__tests__/usePersistedJSON.test.tsx
+++ b/web/src/hooks/__tests__/usePersistedJSON.test.tsx
@@ -1,32 +1,31 @@
 import { renderHook } from "@testing-library/react";
-import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ToastProvider } from "../../context/ToastContext";
 import { usePersistedJSON } from "../usePersistedJSON";
 
-const wrapper = ({ children }: { children: ReactNode }) => (
-	<ToastProvider>{children}</ToastProvider>
-);
+const mockToast = vi.fn();
+
+vi.mock("../../context/ToastContext", () => ({
+	useToast: () => ({ toast: mockToast }),
+}));
 
 describe("usePersistedJSON", () => {
 	afterEach(() => {
 		localStorage.clear();
+		mockToast.mockClear();
 		vi.restoreAllMocks();
 	});
 
 	it("mirrors the value into localStorage", () => {
-		renderHook(
-			() => usePersistedJSON("thing", { a: 1 }, true, "warn.storageFull"),
-			{ wrapper },
+		renderHook(() =>
+			usePersistedJSON("thing", { a: 1 }, true, "warn.storageFull"),
 		);
 
 		expect(localStorage.getItem("thing")).toBe('{"a":1}');
 	});
 
 	it("writes nothing while disabled", () => {
-		renderHook(
-			() => usePersistedJSON("thing", { a: 1 }, false, "warn.storageFull"),
-			{ wrapper },
+		renderHook(() =>
+			usePersistedJSON("thing", { a: 1 }, false, "warn.storageFull"),
 		);
 
 		expect(localStorage.getItem("thing")).toBeNull();
@@ -41,11 +40,13 @@ describe("usePersistedJSON", () => {
 
 		const { rerender } = renderHook(
 			({ value }) => usePersistedJSON("thing", value, true, "warn.storageFull"),
-			{ wrapper, initialProps: { value: { a: 1 } } },
+			{ initialProps: { value: { a: 1 } } },
 		);
 		rerender({ value: { a: 2 } });
 		rerender({ value: { a: 3 } });
 
 		expect(spy).toHaveBeenCalledTimes(3);
+		expect(mockToast).toHaveBeenCalledTimes(1);
+		expect(mockToast).toHaveBeenCalledWith("warn.storageFull", "warning");
 	});
 });

--- a/web/src/hooks/__tests__/useProviderGroups.test.tsx
+++ b/web/src/hooks/__tests__/useProviderGroups.test.tsx
@@ -32,15 +32,21 @@ describe("useProviderGroups", () => {
 		expect(result.current.collapsed.size).toBe(0);
 	});
 
-	it("forgets a collapse for a provider no longer in view", () => {
+	it("hides a provider no longer in view and restores its collapse on return", () => {
+		const openAIOnly = models.filter((m) => m.provider_name === "OpenAI");
 		const { result, rerender } = renderHook(
 			({ list }) => useProviderGroups(list),
 			{ initialProps: { list: models } },
 		);
 
 		act(() => result.current.collapseAll());
-		rerender({ list: models.filter((m) => m.provider_name === "OpenAI") });
-
+		rerender({ list: openAIOnly });
 		expect([...result.current.collapsed]).toEqual(["OpenAI"]);
+
+		rerender({ list: models });
+		expect([...result.current.collapsed].sort()).toEqual([
+			"Anthropic",
+			"OpenAI",
+		]);
 	});
 });

--- a/web/src/hooks/useProviderGroups.ts
+++ b/web/src/hooks/useProviderGroups.ts
@@ -4,8 +4,11 @@ import { toggleInSet } from "../utils/collections";
 /**
  * Groups models by provider for the pickers, with the per-provider collapse
  * state beside them. `collapsed` only ever names providers currently in view,
- * so a provider that leaves the list (filtered out) and comes back is expanded
- * rather than remembering a collapse the operator can no longer see.
+ * so a caller never renders a chevron for a provider that is not on screen.
+ * toggleCollapse leaves the absent keys in the underlying state, which costs
+ * a few strings and hands a provider that leaves the list and comes back the
+ * collapse the operator last chose for it; collapseAll and expandAll rewrite
+ * the set from the providers on screen, so they drop that memory.
  */
 export function useProviderGroups<T extends { provider_name: string }>(
 	models: readonly T[],

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -22,6 +22,7 @@ import { useQuotaData } from "../hooks/useQuotaData";
 import { useQuotaRefresh } from "../hooks/useQuotaRefresh";
 import { useReadOnly } from "../hooks/useReadOnly";
 import { useRefreshDiscoveryBadge } from "../hooks/useRefreshDiscoveryBadge";
+import { useSettingsQuery } from "../hooks/useSettingsQuery";
 import { countLabel } from "../utils/format";
 import { ModelDetailModal } from "./Models/ModelDetailModal";
 import { AddProviderModal } from "./Providers/AddProviderModal";
@@ -71,10 +72,7 @@ export function Providers() {
 		staleTime: 60_000,
 	});
 
-	const { data: settings } = useQuery({
-		queryKey: ["settings"],
-		queryFn: () => api.settings.get(),
-	});
+	const { data: settings } = useSettingsQuery();
 
 	const modelCounts = useMemo(() => {
 		const map = new Map<string, number>();

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Settings as SettingsIcon } from "@/lib/icons";
@@ -12,6 +12,7 @@ import { PageHeader } from "../components/PageHeader";
 import { ResetButton } from "../components/ResetButton";
 import { useToast } from "../context/ToastContext";
 import { useManaged } from "../hooks/useManaged";
+import { useSettingsQuery } from "../hooks/useSettingsQuery";
 import { AlertsSettings } from "./Settings/AlertsSettings";
 import { AppearanceSettings } from "./Settings/AppearanceSettings";
 import { AuthenticationSettings } from "./Settings/AuthenticationSettings";
@@ -118,10 +119,7 @@ export function Settings() {
 		"settings_alertsCollapsed",
 	);
 
-	const { isLoading } = useQuery({
-		queryKey: ["settings"],
-		queryFn: () => api.settings.get(),
-	});
+	const { isLoading } = useSettingsQuery();
 
 	// --- Reset all settings (double-confirm: type RESET) ---
 	const [resetAllOpen, setResetAllOpen] = useState(false);

--- a/web/src/pages/Settings/useBackupActions.ts
+++ b/web/src/pages/Settings/useBackupActions.ts
@@ -5,6 +5,7 @@ import { api, getAuthHeaders } from "../../api/client";
 import type { BackupClassification } from "../../api/types";
 import { useToast } from "../../context/ToastContext";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
+import { useSettingsQuery } from "../../hooks/useSettingsQuery";
 import { downloadBlob } from "../../utils/download";
 import { SETTING_DEFAULTS, settingOr } from "./defaults";
 
@@ -39,10 +40,7 @@ export function useBackupActions() {
 		queryFn: () => api.backups.list(),
 	});
 
-	const { data: settings, isPending: settingsPending } = useQuery({
-		queryKey: ["settings"],
-		queryFn: () => api.settings.get(),
-	});
+	const { data: settings, isPending: settingsPending } = useSettingsQuery();
 
 	// GFS bucket per backup, so each row can carry a Grandfather/Father/Son tag.
 	// Sourced from the prune-preview classifier, which groups every backup by age

--- a/web/src/pages/Settings/useSettingsMutations.ts
+++ b/web/src/pages/Settings/useSettingsMutations.ts
@@ -1,12 +1,12 @@
 import {
 	type QueryClient,
 	useMutation,
-	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { api } from "../../api/client";
 import { useToast } from "../../context/ToastContext";
+import { useSettingsQuery } from "../../hooks/useSettingsQuery";
 
 // The alert card's two reads describe stored settings from the server's side:
 // the decrypted destination list and the apprise-api reachability probe. Any
@@ -19,9 +19,9 @@ export function invalidateAlertReads(queryClient: QueryClient) {
 }
 
 /**
- * useSettingsMutations provides the shared query + mutation + toast pattern
- * used by all Settings pages. Each page was previously duplicating the same
- * ~40-line block (useQuery, updateMutation, resetSettingMutation, toast calls).
+ * useSettingsMutations is the shared settings read, mutation and toast bundle
+ * every Settings page builds on: the settings query through useSettingsQuery,
+ * the update and reset mutations, and the success and error toasts.
  *
  * Returns:
  * - settings: the current settings object (or undefined while loading)
@@ -34,10 +34,7 @@ export function useSettingsMutations() {
 	const { toast } = useToast();
 	const queryClient = useQueryClient();
 
-	const { data: settings } = useQuery({
-		queryKey: ["settings"],
-		queryFn: () => api.settings.get(),
-	});
+	const { data: settings } = useSettingsQuery();
 
 	const updateMutation = useMutation({
 		mutationFn: (updates: Record<string, string>) =>

--- a/web/src/pages/Users/UserModal.tsx
+++ b/web/src/pages/Users/UserModal.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import type { DashboardUser } from "../../api/types";
+import type { DashboardUser, UserRole } from "../../api/types";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { ErrorCallout } from "../../components/ErrorCallout";
 import { Modal } from "../../components/Modal";
@@ -164,7 +164,7 @@ export function UserModal({
 					<select
 						id="user-role"
 						value={role}
-						onChange={(e) => setRole(e.target.value as "admin" | "user")}
+						onChange={(e) => setRole(e.target.value as UserRole)}
 						className="ui-input"
 						disabled={isSelf || managed}
 					>

--- a/web/src/pages/Users/useUserForm.ts
+++ b/web/src/pages/Users/useUserForm.ts
@@ -2,7 +2,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../../api/client";
-import type { DashboardUser, UserUpsertRequest } from "../../api/types";
+import type {
+	DashboardUser,
+	UserRole,
+	UserUpsertRequest,
+} from "../../api/types";
 import { useIdentity } from "../../context/IdentityContext";
 import { errorMessage } from "../../utils/errors";
 import { isBreachedPasswordError } from "../../utils/passwordPolicy";
@@ -32,7 +36,7 @@ export function useUserForm({
 	const [displayName, setDisplayName] = useState(user?.display_name ?? "");
 	const [email, setEmail] = useState(user?.email ?? "");
 	const [password, setPassword] = useState("");
-	const [role, setRole] = useState<"admin" | "user">(user?.role ?? "user");
+	const [role, setRole] = useState<UserRole>(user?.role ?? "user");
 	const [grants, setGrants] = useState<string[]>(user?.grants ?? []);
 	const [enabled, setEnabled] = useState(user?.enabled ?? true);
 	const [limitRps, setLimitRps] = useState(

--- a/web/src/utils/__tests__/errors.test.ts
+++ b/web/src/utils/__tests__/errors.test.ts
@@ -49,6 +49,10 @@ describe("asError", () => {
 
 	it("wraps anything else", () => {
 		expect(asError("boom").message).toBe("boom");
-		expect(asError(undefined).message).toBe("");
+	});
+
+	it("spells a nullish rejection out instead of leaving it blank", () => {
+		expect(asError(undefined).message).toBe("undefined");
+		expect(asError(null).message).toBe("null");
 	});
 });

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -23,7 +23,11 @@ export function errorStatus(err: unknown): number | undefined {
 	return typeof status === "number" ? status : undefined;
 }
 
-/** The value as an Error, wrapping anything that is not already one. */
+/**
+ * The value as an Error, wrapping anything that is not already one. A nullish
+ * rejection keeps its "null"/"undefined" spelling rather than collapsing to an
+ * empty message, so a callout rendering `error.message` is never blank.
+ */
 export function asError(err: unknown): Error {
-	return err instanceof Error ? err : new Error(String(err ?? ""));
+	return err instanceof Error ? err : new Error(String(err));
 }


### PR DESCRIPTION
Six findings from the Codex audit of the simplify pass over the dashboard's utils, hooks, api, context and shared web code (one MEDIUM, five LOW), each verified against the code and applied, then checked by an Opus round.

**asError (MEDIUM).** The shared helper turned a `null` or `undefined` rejection into an Error with an empty message. Its two consumers render the message directly, so a discrepancy refresh or a stagger retry that failed that way showed no banner and fell into the "nothing is wrong" empty state. The fallback is `String(err)` again, as the replaced call sites had, with the nullish case pinned by its own test.

**The rest (LOW).** Providers, Settings, ProviderQuotaPanel, useBackupActions and useSettingsMutations still duplicated the settings `useQuery` block byte for byte; all five read through `useSettingsQuery`. `useProviderGroups` keeps a filtered-out provider's collapse state (a provider that leaves the list and comes back keeps the operator's choice); the comment and test say so, including the remove-then-readd case and the fact that collapse-all and expand-all rewrite the set from what is on screen. The persisted-JSON quota test asserts exactly one warning toast instead of only counting failed writes. The user form and modal use the `UserRole` API type. Front Desk drops `NanoGPTUsageDailyImages`, a field-for-field duplicate of `NanoGPTUsageTokenInfo` with no other importer.

Gates: Biome, ESLint, `tsc -b` and the touched vitest files in both frontends, i18n and size gates. No locale changes.
