### PR TITLE
Price DeepSeek's Flash family at V4.1 Flash rates

### DIFF
--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -68,14 +68,16 @@ func InjectProviderParams(raw map[string]any, providerType, modelID string) {
 		// on the strength of one afternoon's probing, since re-adding it after a
 		// silent upstream change would mean debugging it from a 400 first.
 		//
-		// deepseek-reasoner is matched by name because it names no version: it
-		// is a permanent alias onto deepseek-v4-flash with thinking on, so it
-		// reaches the same backend as an id the substring test already covers.
+		// deepseek-flash (V4.1 Flash) and deepseek-reasoner are matched by name
+		// because neither names a version. Both think, and both reach the same
+		// backend as the v4 ids the substring test already covers: deepseek-flash
+		// is what every legacy Flash-family name now resolves to.
 		// deepseek-chat stays out on purpose — it is the same model with
 		// thinking off, and returns no reasoning_content to echo back.
 		modelLower := strings.ToLower(modelID)
 		isReasoningModel := strings.Contains(modelLower, "v4") ||
 			strings.Contains(modelLower, "r1") ||
+			modelLower == "deepseek-flash" ||
 			modelLower == "deepseek-reasoner"
 		if isReasoningModel && backfillDeepSeekReasoning(raw) {
 			debuglog.Debug("proxy: backfilled reasoning_content on assistant messages for deepseek", "model", modelID)

--- a/internal/paramrewrite/inject.go
+++ b/internal/paramrewrite/inject.go
@@ -68,16 +68,16 @@ func InjectProviderParams(raw map[string]any, providerType, modelID string) {
 		// on the strength of one afternoon's probing, since re-adding it after a
 		// silent upstream change would mean debugging it from a 400 first.
 		//
-		// deepseek-flash (V4.1 Flash) and deepseek-reasoner are matched by name
-		// because neither names a version. Both think, and both reach the same
-		// backend as the v4 ids the substring test already covers: deepseek-flash
-		// is what every legacy Flash-family name now resolves to.
-		// deepseek-chat stays out on purpose — it is the same model with
-		// thinking off, and returns no reasoning_content to echo back.
+		// The flash substring covers deepseek-flash (V4.1 Flash), which names no
+		// version and is what every legacy Flash-family name now resolves to, and
+		// keeps covering whatever DeepSeek calls the next one. deepseek-reasoner
+		// is matched by name because it names neither a version nor a family.
+		// deepseek-chat stays out on purpose: it is the same model with thinking
+		// off, and returns no reasoning_content to echo back.
 		modelLower := strings.ToLower(modelID)
 		isReasoningModel := strings.Contains(modelLower, "v4") ||
 			strings.Contains(modelLower, "r1") ||
-			modelLower == "deepseek-flash" ||
+			strings.Contains(modelLower, "flash") ||
 			modelLower == "deepseek-reasoner"
 		if isReasoningModel && backfillDeepSeekReasoning(raw) {
 			debuglog.Debug("proxy: backfilled reasoning_content on assistant messages for deepseek", "model", modelID)

--- a/internal/paramrewrite/inject_test.go
+++ b/internal/paramrewrite/inject_test.go
@@ -167,9 +167,28 @@ func TestInjectProviderParams_DeepSeekNonReasoning(t *testing.T) {
 	}
 }
 
+// TestInjectProviderParams_DeepSeekFlash covers V4.1 Flash, whose id carries no
+// version either. Every legacy Flash-family name resolves to it, it thinks by
+// default, and the v4/r1 substring test does not match it.
+func TestInjectProviderParams_DeepSeekFlash(t *testing.T) {
+	raw := map[string]any{
+		"model": "deepseek-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Q1"},
+			map[string]any{"role": "assistant", "content": "A1"},
+			map[string]any{"role": "user", "content": "Q2"},
+		},
+	}
+	InjectProviderParams(raw, "deepseek", "deepseek-flash")
+	assistant := raw["messages"].([]any)[1].(map[string]any)
+	if _, exists := assistant["reasoning_content"]; !exists {
+		t.Error("assistant message missing reasoning_content")
+	}
+}
+
 // TestInjectProviderParams_DeepSeekReasonerAlias covers the alias whose name
 // carries no version. deepseek-reasoner is absent from DeepSeek's /models
-// listing and resolves to deepseek-v4-flash with thinking on, so it needs the
+// listing and resolves to deepseek-flash with thinking on, so it needs the
 // same backfill as the versioned id, which the v4/r1 substring test misses.
 func TestInjectProviderParams_DeepSeekReasonerAlias(t *testing.T) {
 	raw := map[string]any{

--- a/internal/provider/catalogs/deepseek.json
+++ b/internal/provider/catalogs/deepseek.json
@@ -1,33 +1,43 @@
 [
   {
+    "model_id": "deepseek-flash",
+    "description": "DeepSeek V4.1 Flash, the current Flash model and the target every legacy Flash-family name resolves to. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "context_length": 1000000,
+    "max_output_tokens": 384000,
+    "reasoning": true,
+    "input_price_per_million_cache_hit": 0.003,
+    "input_price_per_million_cache_miss": 0.15,
+    "output_price_per_million": 0.6
+  },
+  {
     "model_id": "deepseek-chat",
-    "description": "Alias for deepseek-v4-flash with thinking off. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Alias onto deepseek-flash with thinking off. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": false,
-    "input_price_per_million_cache_hit": 0.007,
-    "input_price_per_million_cache_miss": 0.22,
-    "output_price_per_million": 0.66
+    "input_price_per_million_cache_hit": 0.003,
+    "input_price_per_million_cache_miss": 0.15,
+    "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-reasoner",
-    "description": "Alias for deepseek-v4-flash with thinking on. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Alias onto deepseek-flash with thinking on. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
-    "input_price_per_million_cache_hit": 0.007,
-    "input_price_per_million_cache_miss": 0.22,
-    "output_price_per_million": 0.66
+    "input_price_per_million_cache_hit": 0.003,
+    "input_price_per_million_cache_miss": 0.15,
+    "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-v4-flash",
-    "description": "DeepSeek V4 Flash. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Legacy name for DeepSeek V4 Flash; the API now serves deepseek-flash under it and bills at that rate. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
-    "input_price_per_million_cache_hit": 0.007,
-    "input_price_per_million_cache_miss": 0.22,
-    "output_price_per_million": 0.66
+    "input_price_per_million_cache_hit": 0.003,
+    "input_price_per_million_cache_miss": 0.15,
+    "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-v4-pro",
@@ -41,14 +51,14 @@
   },
   {
     "model_id": "deepseek-v4-flash-vision-exp",
-    "description": "DeepSeek V4 Flash Vision (experimental); accepts image input. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Legacy name for DeepSeek V4 Flash Vision (experimental); accepts image input and the API now serves deepseek-flash under it. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
     "vision": true,
     "input_modalities": "[\"text\",\"image\"]",
-    "input_price_per_million_cache_hit": 0.007,
-    "input_price_per_million_cache_miss": 0.22,
-    "output_price_per_million": 0.66
+    "input_price_per_million_cache_hit": 0.003,
+    "input_price_per_million_cache_miss": 0.15,
+    "output_price_per_million": 0.6
   }
 ]

--- a/internal/provider/catalogs_embed_test.go
+++ b/internal/provider/catalogs_embed_test.go
@@ -164,12 +164,16 @@ func TestDeepSeekCatalog_VisionModel(t *testing.T) {
 // else can catch a typo here: models.dev still carries the pre-V4 figures, so a
 // diff against it reports every one of these rows as diverging by design.
 func TestDeepSeekCatalog_Prices(t *testing.T) {
-	// cache-hit / cache-miss / output, dollars per million tokens.
+	// cache-hit / cache-miss / output, dollars per million tokens. Every
+	// Flash-family id resolves to deepseek-flash upstream, so they share its
+	// price; deepseek-v4-pro is the only row still on its own rate, until
+	// DeepSeek reroutes that id to Flash too.
 	want := map[string][3]float64{
-		"deepseek-chat":                {0.007, 0.22, 0.66},
-		"deepseek-reasoner":            {0.007, 0.22, 0.66},
-		"deepseek-v4-flash":            {0.007, 0.22, 0.66},
-		"deepseek-v4-flash-vision-exp": {0.007, 0.22, 0.66},
+		"deepseek-flash":               {0.003, 0.15, 0.6},
+		"deepseek-chat":                {0.003, 0.15, 0.6},
+		"deepseek-reasoner":            {0.003, 0.15, 0.6},
+		"deepseek-v4-flash":            {0.003, 0.15, 0.6},
+		"deepseek-v4-flash-vision-exp": {0.003, 0.15, 0.6},
 		"deepseek-v4-pro":              {0.022, 0.66, 1.98},
 	}
 	catalog := GetDeepSeekModels()
@@ -194,13 +198,13 @@ func TestDeepSeekCatalog_Prices(t *testing.T) {
 }
 
 // TestDeepSeekCatalog_ThinkingModes pins which rows report reasoning. DeepSeek
-// V4 models default to thinking mode, and deepseek-chat is the one alias that
-// selects the non-thinking preset on the same underlying deepseek-v4-flash.
-// Verified against the live API: a bare "say hi" to deepseek-v4-flash returns
-// reasoning_content with 16 reasoning tokens, the same call to deepseek-chat
-// returns none.
+// models default to thinking mode, and deepseek-chat is the one alias that
+// selects the non-thinking preset on the same underlying deepseek-flash.
+// Verified against the live API: a bare "hi" to deepseek-flash bills reasoning
+// tokens, the same call to deepseek-chat bills none.
 func TestDeepSeekCatalog_ThinkingModes(t *testing.T) {
 	want := map[string]bool{
+		"deepseek-flash":               true,
 		"deepseek-chat":                false,
 		"deepseek-reasoner":            true,
 		"deepseek-v4-flash":            true,

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -52,10 +52,10 @@ type DeepSeekModelSpec struct {
 // Flash's price. deepseek-chat still selects the non-thinking preset.
 //
 // deepseek-v4-pro is the last row still on its own price, and the only one that
-// answers as itself rather than as deepseek-flash. DeepSeek has announced that
-// it will serve deepseek-flash under the id at Flash's rate; once the id stops
-// echoing itself back, this row over-meters by more than 4x and has to be
-// repriced or dropped. Dropping it does not retire the model on its own:
+// answers as itself rather than as deepseek-flash. Once that id stops echoing
+// itself back, DeepSeek is serving Flash under it at Flash's rate and this row
+// meters every request several times over, so it has to be repriced or dropped
+// then. Dropping it does not retire the model on its own:
 // DiscoverDeepSeek unions the catalog into the live listing, so a catalog row
 // can never be recorded as missing.
 var deepseekCatalog = loadCatalog[[]DeepSeekModelSpec]("deepseek.json")

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -40,11 +40,24 @@ type DeepSeekModelSpec struct {
 
 // deepseekCatalog is not an ordinary price-override channel. models.dev still
 // carries DeepSeek's pre-V4 rates (0.14/0.28) under the V4 model IDs, and knows
-// nothing at all about deepseek-v4-flash-vision-exp, so these rows are the only
-// correct pricing MH has. deepseek-chat and deepseek-reasoner are absent from
-// the live /models listing entirely — they are permanent aliases onto
-// deepseek-v4-flash, non-thinking and thinking respectively — so the catalog is
-// also the only thing surfacing them.
+// nothing about deepseek-flash or deepseek-v4-flash-vision-exp, so these rows
+// are the only correct pricing MH has. deepseek-chat and deepseek-reasoner are
+// absent from the live /models listing entirely, so the catalog is also the only
+// thing surfacing them.
+//
+// deepseek-flash is DeepSeek V4.1 Flash and the only Flash id DeepSeek still
+// documents. deepseek-chat, deepseek-reasoner, deepseek-v4-flash and
+// deepseek-v4-flash-vision-exp all resolve to it upstream (verified by the id
+// each one echoes back in its response), so every Flash-family row carries V4.1
+// Flash's price. deepseek-chat still selects the non-thinking preset.
+//
+// deepseek-v4-pro is the last row still on its own price, and the only one that
+// answers as itself rather than as deepseek-flash. DeepSeek has announced that
+// it will serve deepseek-flash under the id at Flash's rate; once the id stops
+// echoing itself back, this row over-meters by more than 4x and has to be
+// repriced or dropped. Dropping it does not retire the model on its own:
+// DiscoverDeepSeek unions the catalog into the live listing, so a catalog row
+// can never be recorded as missing.
 var deepseekCatalog = loadCatalog[[]DeepSeekModelSpec]("deepseek.json")
 
 // GetDeepSeekModels returns the full DeepSeek model catalog.

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -479,9 +479,9 @@ Its quota endpoint is the part that needed code: see [Additional Provider APIs](
 
 **Source files:** `discovery_deepseek.go`, `deepseek_catalog.go`, `catalog_merge.go`
 
-**Method:** Calls `GET /models` (OpenAI-compatible list endpoint), converts the listing to clean stubs, and merges them with the built-in `deepseekCatalog` (5 rows) via [`mergeLiveAndCatalog`](#live--catalog-merge). The catalog backfills context length, max output, reasoning flag, input modalities, and pricing (cache-miss maps to the standard input price; cache-hit is carried separately). Uncatalogued models are clean stubs filled by models.dev; there is no hardcoded context default.
+**Method:** Calls `GET /models` (OpenAI-compatible list endpoint), converts the listing to clean stubs, and merges them with the built-in `deepseekCatalog` (6 rows) via [`mergeLiveAndCatalog`](#live--catalog-merge). The catalog backfills context length, max output, reasoning flag, input modalities, and pricing (cache-miss maps to the standard input price; cache-hit is carried separately). Uncatalogued models are clean stubs filled by models.dev; there is no hardcoded context default.
 
-Two of the five rows are not price overrides but the only source of the model at all: `deepseek-chat` and `deepseek-reasoner` are permanent aliases onto `deepseek-v4-flash` (thinking off and on) and are absent from the live listing entirely. The other three exist because models.dev still carries DeepSeek's pre-V4 rates under the V4 IDs. Catalog prices are DeepSeek's **off-peak** rates, which apply for 17 of every 24 hours; peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at exactly double, and a model row holds one figure, so metering under-reports during that window.
+Two of the six rows are not price overrides but the only source of the model at all: `deepseek-chat` and `deepseek-reasoner` are permanent aliases (thinking off and on) and are absent from the live listing entirely. The rest exist because models.dev carries no entry for `deepseek-flash` and still lists DeepSeek's pre-V4 rates under the V4 IDs. `deepseek-flash` is V4.1 Flash and the only Flash id DeepSeek documents; `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` all resolve to it upstream, so every Flash-family row carries its price. `deepseek-v4-pro` is the one row still on its own rate. Catalog prices are DeepSeek's **off-peak** rates, which apply for 17 of every 24 hours; peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at exactly double, and a model row holds one figure, so metering under-reports during that window.
 
 **Catalog provides:**
 
@@ -899,7 +899,7 @@ The `lookupFuzzyIn` helper implements this logic (the canonical-provider and cro
 | Reasoning capability | Only if false |
 | Tool calling capability | Only if false |
 | Structured output capability | Only if false, and never for an image-output model on a provider that reaches Google's own route (Google AI Studio, Vertex AI express, and OpenCode Zen for its `gemini-*` ids), whose JSON mode the API refuses (google-gemini/cookbook#1028) |
-| Vision capability | Only if false, and only when the `attachment` flag is corroborated by an `image` input modality (or by no input list at all). models.dev sets `attachment` on models whose only input is text, `deepseek-chat` among them, which answer an image with a 400. |
+| Vision capability | Only if false, and only when the `attachment` flag is corroborated by an `image` input modality (or by no input list at all). models.dev sets `attachment` on models whose only input is text, `deepseek-chat` among them. |
 | Input modalities | Only if empty or `"[]"` |
 | Output modalities | Only if empty or `"[]"` |
 | Owned by / family | Only if empty |
@@ -1077,7 +1077,7 @@ Model IDs follow the format provided by each provider:
 |----------|-------------------|
 | OpenAI | `gpt-4o`, `gpt-4o-2024-08-06`, `o1-preview` |
 | Anthropic | `claude-sonnet-4-5-20250514`, `claude-3-5-haiku-20241022` |
-| DeepSeek | `deepseek-chat`, `deepseek-reasoner` |
+| DeepSeek | `deepseek-flash`, `deepseek-chat`, `deepseek-reasoner` |
 | xAI | `grok-4.3`, `grok-4.5` |
 | Google | `gemini-2.5-flash`, `gemini-3.6-flash` (stripped from `models/gemini-3.6-flash`) |
 | Ollama | `llama3.2:3b`, `gemma3:4b` |


### PR DESCRIPTION
## What

DeepSeek released V4.1 Flash on 2026-09-10 under a new id, `deepseek-flash`, and repointed every legacy Flash-family name at it. This repriced the whole family and added the missing row.

Verified against the live API through the dev gateway, one request per id, reading back the model each one reports:

| requested | answered as |
|---|---|
| `deepseek-v4-flash` | `deepseek-flash` |
| `deepseek-chat` | `deepseek-flash` (no reasoning tokens) |
| `deepseek-reasoner` | `deepseek-flash` |
| `deepseek-v4-flash-vision-exp` | `deepseek-flash` |
| `deepseek-v4-pro` | `deepseek-v4-pro` |

## Why it matters

`deepseek-flash` was discovering as a bare stub: no price, so it metered at zero; no context length; and capabilities all false despite the model doing both tool calls and thinking, which a probe confirmed.

The four legacy rows still carried the pre-V4.1 rates, over-metering every DeepSeek-direct request by 47% on input, 10% on output and 133% on cache hits.

## Changes

- New `deepseek-flash` catalog row: 1M context, 384K max output, reasoning, at DeepSeek's off-peak rates 0.003 / 0.15 / 0.60.
- The four legacy Flash rows moved onto the same rates. `deepseek-v4-pro` keeps Pro's price, since it still answers as itself.
- `deepseek-flash` now matches the `reasoning_content` backfill in the parameter rewriter. It thinks by default and its name carries no version, so the v4/r1 substring test missed it.
- Pinned figures and stale alias references updated in the catalog tests.

Vision is deliberately left off the new row. The old evidence for that flag was DeepSeek returning HTTP 400 on non-vision ids, and that discriminator is gone: `deepseek-v4-pro` now accepts an image without complaint too, so acceptance proves nothing. The row follows what DeepSeek documents.

## Verification

Full backend suite 6209 passed, lint clean, size gate exit 0, diff coverage 100%. Dev container rebuilt and DeepSeek rediscovered: all six rows carry the right prices, context and capabilities, and a live call to `deepseek-flash` metered against a priced row instead of a null one.

## Follow-up

`deepseek-v4-pro` is served by `deepseek-flash` at Flash's rate from 2026-09-14 04:00 UTC. A scheduled routine opens the repricing PR then. The DeepSeek-direct member of the `ds4pro` failover group also needs removing at that point, or the group quietly serves a Flash where a Pro is expected.

Worth knowing: `DiscoverDeepSeek` unions the catalog into the live listing, so a catalog row can never be recorded as missing. Retiring a DeepSeek model always means deleting its row by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
