### PR TITLE
Line the attempt trail breaker verdict up under the provider name

### DIFF
--- a/web/src/components/AttemptTrail.tsx
+++ b/web/src/components/AttemptTrail.tsx
@@ -96,8 +96,9 @@ export function AttemptTrail({
 		if (detail === HEDGE_SUPERSEDED_DETAIL) return false;
 		return a.status ? detail !== statusBadgeLabel(a.status, t) : true;
 	};
-	// A skipped attempt never reached the breaker, so it carries no verdict to
-	// show; the SKIPPED badge on the first line is the whole story.
+	// A skip IS the breaker's verdict: it refused the candidate before the
+	// request left. The SKIPPED badge on the first line says that already, so
+	// the row does not repeat it as a second-line verdict.
 	const showsVerdict = (
 		a: AttemptRecord,
 	): a is AttemptRecord & { breaker: string } =>
@@ -175,7 +176,10 @@ export function AttemptTrail({
 							// lives here rather than beside the timing because a row that
 							// runs long wraps it to its own line anyway, and a wrapped
 							// flex child starts at the left edge, under the number.
-							<span className="basis-full flex items-baseline gap-x-2 pl-8">
+							<span
+								className="basis-full flex items-baseline gap-x-2 pl-8"
+								data-testid="attempt-trail-meta"
+							>
 								{showsVerdict(a) && (
 									// The shield marks the verdict as the breaker's, not
 									// another word of the timing above it.

--- a/web/src/components/AttemptTrail.tsx
+++ b/web/src/components/AttemptTrail.tsx
@@ -96,6 +96,12 @@ export function AttemptTrail({
 		if (detail === HEDGE_SUPERSEDED_DETAIL) return false;
 		return a.status ? detail !== statusBadgeLabel(a.status, t) : true;
 	};
+	// A skipped attempt never reached the breaker, so it carries no verdict to
+	// show; the SKIPPED badge on the first line is the whole story.
+	const showsVerdict = (
+		a: AttemptRecord,
+	): a is AttemptRecord & { breaker: string } =>
+		Boolean(a.breaker) && a.breaker !== "skipped";
 	return (
 		<div className="mb-6" data-testid="attempt-trail">
 			<DetailSectionHeader icon={Layers}>
@@ -162,31 +168,34 @@ export function AttemptTrail({
 								{formatMs(a.duration_ms, 1)}
 							</span>
 						)}
-						{a.breaker && a.breaker !== "skipped" && (
-							// The shield marks the verdict as the breaker's, not another
-							// word of the timing beside it.
-							<span
-								className="inline-flex items-center gap-1 text-xs text-(--text-tertiary)"
-								title={t("components.requestLogDetail.attemptBreaker", {
-									verdict: a.breaker,
-								})}
-							>
-								{(() => {
-									const Icon = BREAKER_VERDICT_ICONS[a.breaker] ?? Shield;
-									return <Icon size={11} aria-hidden="true" />;
-								})()}
-								{t(
-									BREAKER_VERDICT_KEYS[a.breaker] ??
-										"components.requestLogDetail.attemptBreaker",
-									{ verdict: a.breaker },
-								)}
-							</span>
-						)}
-						{(kindSaysMore(a) || detailSaysMore(a)) && (
-							// A second line only for what the first one does not already
-							// say; indented past the number column so it lines up with the
-							// provider name.
+						{(showsVerdict(a) || kindSaysMore(a) || detailSaysMore(a)) && (
+							// A second line carrying the breaker verdict and whatever the
+							// first line does not already say, indented past the number
+							// column so it lines up with the provider name. The verdict
+							// lives here rather than beside the timing because a row that
+							// runs long wraps it to its own line anyway, and a wrapped
+							// flex child starts at the left edge, under the number.
 							<span className="basis-full flex items-baseline gap-x-2 pl-8">
+								{showsVerdict(a) && (
+									// The shield marks the verdict as the breaker's, not
+									// another word of the timing above it.
+									<span
+										className="inline-flex items-center gap-1 text-xs text-(--text-tertiary)"
+										title={t("components.requestLogDetail.attemptBreaker", {
+											verdict: a.breaker,
+										})}
+									>
+										{(() => {
+											const Icon = BREAKER_VERDICT_ICONS[a.breaker] ?? Shield;
+											return <Icon size={11} aria-hidden="true" />;
+										})()}
+										{t(
+											BREAKER_VERDICT_KEYS[a.breaker] ??
+												"components.requestLogDetail.attemptBreaker",
+											{ verdict: a.breaker },
+										)}
+									</span>
+								)}
 								{kindSaysMore(a) && (
 									<span className="font-mono text-xs text-(--text-secondary)">
 										{a.error_kind}

--- a/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
+++ b/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
@@ -200,9 +200,10 @@ describe("RequestLogDetail attempt trail", () => {
 	});
 
 	it("puts the breaker verdict on the indented line, under the provider", () => {
-		// The verdict used to sit beside the timing, where a long row wrapped it
-		// onto its own line at the left edge, under the attempt number instead of
-		// the provider name.
+		// The verdict belongs on the row's own indented line, which carries the
+		// left padding that lines it up with the provider column. Beside the
+		// timing it would wrap to the container's left edge on a long row, under
+		// the attempt number.
 		renderWithProviders(
 			<RequestLogDetail
 				requestLog={{
@@ -223,10 +224,31 @@ describe("RequestLogDetail attempt trail", () => {
 				onClose={onClose}
 			/>,
 		);
-		const verdict = screen.getByTitle(/breaker/i);
-		const line = verdict.parentElement;
-		expect(line?.className).toContain("pl-8");
-		expect(line?.className).toContain("basis-full");
+		const line = screen.getByTestId("attempt-trail-meta");
+		expect(line).toHaveClass("basis-full", "pl-8");
+		expect(line.firstElementChild).toHaveAttribute("title");
+	});
+
+	it("gives a skipped attempt no verdict line: the badge already says it", () => {
+		renderWithProviders(
+			<RequestLogDetail
+				requestLog={{
+					...baseLog,
+					attempts: [
+						{
+							attempt: -1,
+							provider_id: "prov-1",
+							provider: "Neuralwatt",
+							model: "glm-5.3",
+							duration_ms: 0,
+							breaker: "skipped",
+						},
+					],
+				}}
+				onClose={onClose}
+			/>,
+		);
+		expect(screen.queryByTestId("attempt-trail-meta")).toBeNull();
 	});
 
 	it("leaves out a last detail the terminal message quotes mid-sentence", () => {

--- a/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
+++ b/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
@@ -199,6 +199,36 @@ describe("RequestLogDetail attempt trail", () => {
 		expect(row).not.toHaveTextContent("refused connection");
 	});
 
+	it("puts the breaker verdict on the indented line, under the provider", () => {
+		// The verdict used to sit beside the timing, where a long row wrapped it
+		// onto its own line at the left edge, under the attempt number instead of
+		// the provider name.
+		renderWithProviders(
+			<RequestLogDetail
+				requestLog={{
+					...baseLog,
+					attempts: [
+						{
+							attempt: 0,
+							provider_id: "prov-1",
+							provider: "Z.ai Coding Plan",
+							model: "glm-5.3",
+							status: 200,
+							duration_ms: 79837,
+							hedged: true,
+							breaker: "success",
+						},
+					],
+				}}
+				onClose={onClose}
+			/>,
+		);
+		const verdict = screen.getByTitle(/breaker/i);
+		const line = verdict.parentElement;
+		expect(line?.className).toContain("pl-8");
+		expect(line?.className).toContain("basis-full");
+	});
+
 	it("leaves out a last detail the terminal message quotes mid-sentence", () => {
 		// A hedged loser with no provider sentence carries the bare status,
 		// which the terminal message embeds rather than ends with.


### PR DESCRIPTION
## What

The circuit breaker verdict on an attempt trail row now sits on the indented second line, under the provider name, instead of beside the timing on the first line.

## Why

The row is a wrapping flex container. The verdict sat after the duration, so any row long enough to wrap pushed it onto a line of its own, and a wrapped flex child starts at the container's left edge: under the attempt number, not under the provider. A hedged 200 with a long duration reproduces it every time.

The second line already existed for the error kind and detail, already carried the `pl-8` indent that lines up with the provider column, and is skipped entirely when there is nothing to say. Moving the verdict into it makes the position deterministic rather than dependent on how wide the row happened to be.

## Test

`RequestLogDetail.attempts.test.tsx` gains a case asserting the verdict's line carries both `basis-full` and `pl-8`, so a future move back onto the first line fails rather than silently regressing the alignment. Ten tests pass in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
