### PR TITLE
Refuse key-wiping imports, bound the sync fence, keep the TPM debit, and rename the redaction marker

### DIFF
--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -95,6 +95,12 @@ var errStaleSourceGen = errors.New("configsync: import source generation is olde
 // would delete every provider. Import maps it to a 400 refusal.
 var errWouldWipeProviders = errors.New("configsync: refusing to wipe every provider off a populated member")
 
+// errWouldWipeVirtualKeys is the same rail for virtual keys. The structural
+// guard in import only refuses an envelope that is empty in providers, keys AND
+// settings at once, so an envelope carrying providers but omitting the keys
+// reaches the declarative delete and takes every credential off the member.
+var errWouldWipeVirtualKeys = errors.New("configsync: refusing to wipe every virtual key off a populated member")
+
 // errInvalidSyncedURL is returned by apply when a syncable url-typed setting in
 // the envelope fails the same netguard validation the interactive PUT
 // /api/settings handler enforces. Import maps it to a 400 refusal. A standing

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -234,6 +234,14 @@ func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) err
 // also has no providers is a harmless no-op and is allowed (fleet bootstrap or
 // keys-only sync onto an empty member).
 func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
+	// Locked before the count and held to commit, for the same reason the key
+	// rail locks: a provider created between this count and the reconcile would
+	// be deleted for being absent from an envelope written before it existed.
+	// Providers are locked before virtual_keys here and nowhere in the other
+	// order, so two imports cannot deadlock against each other.
+	if _, err := tx.Exec(ctx, `LOCK TABLE providers IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+		return err
+	}
 	if len(providers) == 0 {
 		var existing int
 		if err := tx.QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&existing); err != nil {
@@ -261,7 +269,8 @@ func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK)
 	// reconcile that follows: a key created in that window would be deleted for
 	// being absent from the envelope, and the survivor check would read a member
 	// that started empty. SHARE ROW EXCLUSIVE blocks writers and other imports
-	// while still allowing plain reads.
+	// while still allowing plain reads. Always taken after the providers lock,
+	// so the two rails cannot deadlock.
 	if _, err := tx.Exec(ctx, `LOCK TABLE virtual_keys IN SHARE ROW EXCLUSIVE MODE`); err != nil {
 		return false, err
 	}

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -102,6 +102,9 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := validateSyncedProviderNames(env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}
+	if err := lockReconciledTables(ctx, tx); err != nil {
+		return applyOutcome{}, err
+	}
 	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}
@@ -224,6 +227,33 @@ func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) err
 	return nil
 }
 
+// reconcileLockTimeout bounds how long an import waits for the tables it is
+// about to reconcile. Without it a slow import holds dashboard CRUD off those
+// tables for as long as it runs, and a wedged one holds it off forever; with it
+// the import fails and Front Desk retries, which is the recoverable direction.
+const reconcileLockTimeout = "5s"
+
+// lockReconciledTables takes a write lock on every table the import replaces
+// declaratively, before the first count any rail reads. Each of those deletes
+// removes rows absent from the envelope, so a row created between a rail's count
+// and its delete would be destroyed for being missing from an envelope written
+// before it existed.
+//
+// SHARE ROW EXCLUSIVE blocks writers and other imports while still allowing
+// plain reads. The order is fixed here and these are the only LOCK TABLE
+// statements in the codebase, so two imports cannot deadlock against each other.
+func lockReconciledTables(ctx context.Context, tx pgx.Tx) error {
+	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '`+reconcileLockTimeout+`'`); err != nil {
+		return err
+	}
+	for _, table := range []string{"providers", "virtual_keys", "users", "model_failover_groups"} {
+		if _, err := tx.Exec(ctx, `LOCK TABLE `+table+` IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // guardAgainstProviderWipe is the destructive-wipe rail. The declarative delete
 // in apply removes every provider absent from the envelope, so an envelope with
 // zero providers would delete the member's entire provider set, cascading to
@@ -234,14 +264,6 @@ func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) err
 // also has no providers is a harmless no-op and is allowed (fleet bootstrap or
 // keys-only sync onto an empty member).
 func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []ExportProvider) error {
-	// Locked before the count and held to commit, for the same reason the key
-	// rail locks: a provider created between this count and the reconcile would
-	// be deleted for being absent from an envelope written before it existed.
-	// Providers are locked before virtual_keys here and nowhere in the other
-	// order, so two imports cannot deadlock against each other.
-	if _, err := tx.Exec(ctx, `LOCK TABLE providers IN SHARE ROW EXCLUSIVE MODE`); err != nil {
-		return err
-	}
 	if len(providers) == 0 {
 		var existing int
 		if err := tx.QueryRow(ctx, `SELECT count(*) FROM providers`).Scan(&existing); err != nil {
@@ -265,15 +287,6 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 // guardKeysSurvived needs to tell a wipe apart from a member that never had
 // keys.
 func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) (hadKeys bool, err error) {
-	// Held to commit, so no interactive create lands between this count and the
-	// reconcile that follows: a key created in that window would be deleted for
-	// being absent from the envelope, and the survivor check would read a member
-	// that started empty. SHARE ROW EXCLUSIVE blocks writers and other imports
-	// while still allowing plain reads. Always taken after the providers lock,
-	// so the two rails cannot deadlock.
-	if _, err := tx.Exec(ctx, `LOCK TABLE virtual_keys IN SHARE ROW EXCLUSIVE MODE`); err != nil {
-		return false, err
-	}
 	var existing int
 	if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
 		return false, err

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -105,7 +105,8 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}
-	if err := guardAgainstVirtualKeyWipe(ctx, tx, env.Config.VirtualKeys); err != nil {
+	hadKeys, err := guardAgainstVirtualKeyWipe(ctx, tx, env.Config.VirtualKeys)
+	if err != nil {
 		return applyOutcome{}, err
 	}
 
@@ -155,6 +156,15 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	}
 	vkHashes := names(env.Config.VirtualKeys, func(v ExportVK) string { return v.KeyHash })
 	if _, err := tx.Exec(ctx, `DELETE FROM virtual_keys WHERE key_hash <> ALL($1)`, vkHashes); err != nil {
+		return applyOutcome{}, err
+	}
+	// The rail above reads the count before the reconcile, so it only catches an
+	// envelope that carries no keys at all. An envelope whose keys every one fail
+	// to upsert (an unresolvable provider name on each) reaches here having
+	// deleted the member's own keys and inserted nothing, which is the same
+	// outcome by a longer road. Checking after the delete, inside the same
+	// transaction, catches both and rolls the whole import back.
+	if err := guardKeysSurvived(ctx, tx, hadKeys); err != nil {
 		return applyOutcome{}, err
 	}
 
@@ -243,15 +253,34 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 // it: that one only refuses an envelope empty in providers, keys and settings
 // together. An empty key list onto a member that has none is a bootstrap and is
 // allowed, matching the provider rail.
-func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) error {
-	if len(keys) == 0 {
-		var existing int
-		if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
-			return err
-		}
-		if existing > 0 {
-			return errWouldWipeVirtualKeys
-		}
+// It reports whether the member held any keys before the reconcile, which
+// guardKeysSurvived needs to tell a wipe apart from a member that never had
+// keys.
+func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) (hadKeys bool, err error) {
+	var existing int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
+		return false, err
+	}
+	if len(keys) == 0 && existing > 0 {
+		return true, errWouldWipeVirtualKeys
+	}
+	return existing > 0, nil
+}
+
+// guardKeysSurvived is the second half of the credential rail, run after the
+// upsert and the declarative delete. A populated member that comes out of the
+// reconcile with no keys has been wiped whatever route it took there, so the
+// import is refused and the transaction rolls back.
+func guardKeysSurvived(ctx context.Context, tx pgx.Tx, hadKeys bool) error {
+	if !hadKeys {
+		return nil
+	}
+	var remaining int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&remaining); err != nil {
+		return err
+	}
+	if remaining == 0 {
+		return errWouldWipeVirtualKeys
 	}
 	return nil
 }
@@ -572,6 +601,14 @@ func readAppliedSourceGen(ctx context.Context, tx pgx.Tx) (gen int64, present bo
 		// wedging the fence on a 500.
 		debuglog.Warn("configsync: unparseable stored source generation, flooring to 0", "value", raw)
 		return 0, true, nil //nolint:nilerr // intentional: corrupt marker floors but stays present
+	}
+	if n < 0 || n > maxSourceGen {
+		// Outside the range a primary can produce, so it was written by a forged
+		// header before the parse bound existed. Flooring it the same way a corrupt
+		// marker floors is what unpins the member: the next genuine push is no
+		// longer stale against it and rewrites a clean value.
+		debuglog.Warn("configsync: out-of-range stored source generation, flooring to 0", "value", raw)
+		return 0, true, nil
 	}
 	return n, true, nil
 }

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -257,6 +257,14 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 // guardKeysSurvived needs to tell a wipe apart from a member that never had
 // keys.
 func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) (hadKeys bool, err error) {
+	// Held to commit, so no interactive create lands between this count and the
+	// reconcile that follows: a key created in that window would be deleted for
+	// being absent from the envelope, and the survivor check would read a member
+	// that started empty. SHARE ROW EXCLUSIVE blocks writers and other imports
+	// while still allowing plain reads.
+	if _, err := tx.Exec(ctx, `LOCK TABLE virtual_keys IN SHARE ROW EXCLUSIVE MODE`); err != nil {
+		return false, err
+	}
 	var existing int
 	if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
 		return false, err

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -105,6 +105,9 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}
+	if err := guardAgainstVirtualKeyWipe(ctx, tx, env.Config.VirtualKeys); err != nil {
+		return applyOutcome{}, err
+	}
 
 	if err := upsertProviders(ctx, tx, env.Config.Providers, h.validateProviderURL); err != nil {
 		return applyOutcome{}, err
@@ -228,6 +231,26 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 		}
 		if existing > 0 {
 			return errWouldWipeProviders
+		}
+	}
+	return nil
+}
+
+// guardAgainstVirtualKeyWipe is the same rail for credentials. The delete below
+// removes every key absent from the envelope, so an envelope that carries
+// providers but omits virtual_keys takes every credential off the member and
+// every client loses access at once. Import's structural guard does not catch
+// it: that one only refuses an envelope empty in providers, keys and settings
+// together. An empty key list onto a member that has none is a bootstrap and is
+// allowed, matching the provider rail.
+func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) error {
+	if len(keys) == 0 {
+		var existing int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
+			return err
+		}
+		if existing > 0 {
+			return errWouldWipeVirtualKeys
 		}
 	}
 	return nil

--- a/internal/api/configsync_apply_errors_test.go
+++ b/internal/api/configsync_apply_errors_test.go
@@ -100,6 +100,16 @@ func TestConfigSyncApply_FailedStatementAbortsTheApply(t *testing.T) {
 			t.Fatal("expected an error from the cancelled context")
 		}
 	})
+	t.Run("guardAgainstVirtualKeyWipe", func(t *testing.T) {
+		if _, err := guardAgainstVirtualKeyWipe(cctx, beginApplyTx(t), nil); err == nil {
+			t.Fatal("expected an error from the cancelled context")
+		}
+	})
+	t.Run("guardKeysSurvived", func(t *testing.T) {
+		if err := guardKeysSurvived(cctx, beginApplyTx(t), true); err == nil {
+			t.Fatal("expected an error from the cancelled context")
+		}
+	})
 }
 
 // users.grants is TEXT[] NOT NULL, so a synced user whose envelope carried no

--- a/internal/api/configsync_fence_test.go
+++ b/internal/api/configsync_fence_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -236,6 +237,28 @@ func TestConfigSync_CommitFenceUnparseableHeaderIsUnfenced(t *testing.T) {
 	}
 	if got := storedSourceGen(t); got != "" {
 		t.Errorf("marker after unparseable-header import = %q, want still unset", got)
+	}
+}
+
+// TestConfigSync_CommitFenceOutOfRangeGenIsUnfenced pins the bound on the
+// header. Front Desk counts the generation up from zero in a 32-bit column, so
+// a value past that cannot come from a real primary. Storing one would pin the
+// marker where every genuine push afterwards reads as stale, with no API call
+// that lowers it again, so the import applies unfenced and leaves no marker.
+func TestConfigSync_CommitFenceOutOfRangeGenIsUnfenced(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	base := doExport(t, r)
+
+	for _, gen := range []int64{math.MaxInt64, math.MaxInt32 + 1, -1} {
+		resp, rec := doImportGen(t, r, withExtraProvider(base, "extra"), &gen)
+		if rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+			t.Fatalf("gen %d: code=%d applied=%v stale=%v, want 200 applied not-stale", gen, rec.Code, resp.Applied, resp.Stale)
+		}
+		if got := storedSourceGen(t); got != "" {
+			t.Fatalf("gen %d: marker = %q, want still unset", gen, got)
+		}
 	}
 }
 

--- a/internal/api/configsync_fence_test.go
+++ b/internal/api/configsync_fence_test.go
@@ -260,6 +260,40 @@ func TestConfigSync_CommitFenceOutOfRangeGenIsUnfenced(t *testing.T) {
 			t.Fatalf("gen %d: marker = %q, want still unset", gen, got)
 		}
 	}
+
+	// The top of the range is inclusive and still fences, so an off-by-one in the
+	// bound cannot pass unnoticed.
+	edge := int64(math.MaxInt32)
+	if resp, rec := doImportGen(t, r, base, &edge); rec.Code != http.StatusOK || !resp.Applied {
+		t.Fatalf("gen MaxInt32: code=%d applied=%v, want 200 applied", rec.Code, resp.Applied)
+	}
+	if got := storedSourceGen(t); got != strconv.FormatInt(edge, 10) {
+		t.Errorf("marker after gen MaxInt32 = %q, want %d", got, edge)
+	}
+}
+
+// TestConfigSync_CommitFenceOutOfRangeStoredMarkerUnpins covers a member forged
+// into a corner before the bound existed: its marker holds a value no primary
+// can reach, so every genuine push reads as stale. Flooring an out-of-range
+// stored marker is what lets the next valid push through and rewrites it.
+func TestConfigSync_CommitFenceOutOfRangeStoredMarkerUnpins(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	base := doExport(t, r)
+	setStoredSourceGen(t, strconv.FormatInt(math.MaxInt64, 10))
+
+	gen := int64(7)
+	resp, rec := doImportGen(t, r, withExtraProvider(base, "extra"), &gen)
+	if rec.Code != http.StatusOK || !resp.Applied || resp.Stale {
+		t.Fatalf("import onto a pinned member: code=%d applied=%v stale=%v, want 200 applied not-stale", rec.Code, resp.Applied, resp.Stale)
+	}
+	if !providerNames(t)["extra"] {
+		t.Error("the unpinning import should have applied its config")
+	}
+	if got := storedSourceGen(t); got != "7" {
+		t.Errorf("marker after unpinning import = %q, want 7", got)
+	}
 }
 
 // TestConfigSync_CommitFenceCorruptMarkerStillFences: a corrupt (non-numeric)

--- a/internal/api/configsync_import.go
+++ b/internal/api/configsync_import.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"math"
 	"net/http"
 	"slices"
 	"strconv"
@@ -78,6 +79,13 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 		debuglog.Debug("configsync: refused stale import", "source_gen", sourceGenLabel(sourceGen))
 		writeJSON(w, importResponse{SchemaVersionOK: true, MasterKeyOK: true, Applied: false, Stale: true, Diff: diff})
 		return
+	case errors.Is(err, errWouldWipeVirtualKeys):
+		// The envelope carries no virtual keys but this member has some: applying
+		// it would delete every credential the member serves. Same 400 as the
+		// provider rail, for the same reason.
+		debuglog.Warn("configsync: refused key-wiping import")
+		http.Error(w, "refusing to import a config that would delete every virtual key on this member", http.StatusBadRequest)
+		return
 	case errors.Is(err, errWouldWipeProviders):
 		// The envelope carries no providers but this member has some: applying it
 		// would delete every provider. A 400 so the caller sees a deliberate
@@ -107,9 +115,17 @@ func (h *ConfigSyncHandler) Import(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// maxSourceGen bounds the generation a member will fence itself on. Front Desk
+// counts auto_sync_gen up from zero in a 32-bit column, so anything past that
+// range cannot have come from a real primary, and storing it would pin the
+// marker where no genuine push can ever reach it again: every later generation
+// reads as stale and no API call lowers the marker back.
+const maxSourceGen = math.MaxInt32
+
 // parseSourceGen reads the optional fleet source-generation header. It returns
-// nil when the header is absent or unparseable, so a malformed or missing value
-// degrades to an unfenced import rather than rejecting a legitimate push.
+// nil when the header is absent, unparseable, or outside the range a primary
+// can produce, so a malformed value degrades to an unfenced import rather than
+// rejecting a legitimate push.
 func parseSourceGen(raw string) *int64 {
 	if raw == "" {
 		return nil
@@ -117,6 +133,10 @@ func parseSourceGen(raw string) *int64 {
 	n, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		debuglog.Warn("configsync: ignoring unparseable source-generation header", "value", raw)
+		return nil
+	}
+	if n < 0 || n > maxSourceGen {
+		debuglog.Warn("configsync: ignoring out-of-range source-generation header", "value", raw)
 		return nil
 	}
 	return &n

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -64,9 +64,10 @@ func TestConfigSync_EmptyKeyListOntoEmptyMemberApplies(t *testing.T) {
 }
 
 // TestConfigSync_RefusesImportThatLeavesNoKeys covers the longer road to the
-// same wipe: the envelope carries keys, so the pre-reconcile rail passes, but
-// every one of them fails to upsert. The delete still removes the member's own
-// keys, and the member ends the transaction with no credentials.
+// same wipe: the envelope carries a key, so the pre-reconcile rail passes, but
+// the key names a provider restriction that does not resolve on this member, so
+// the upsert skips it. The declarative delete still clears the member's own key
+// and the member ends the transaction with no credentials at all.
 func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 	cleanConfigTables(t)
 	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
@@ -78,22 +79,34 @@ func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 	r := newConfigSyncRouter(t, configSyncMasterKey)
 
 	env := doExport(t, r)
-	// One key, carrying an owner the envelope's roster cannot resolve, so the
-	// upsert skips it while the delete still clears the member's own key.
-	unresolvable := "nobody"
+	unknownProvider := []string{"a-provider-this-member-does-not-have"}
 	env.Config.VirtualKeys = []ExportVK{{
-		Name: "incoming", KeyHash: "hash-incoming", KeyPreview: "mh-***", OwnerUsername: &unresolvable,
+		Name: "incoming", KeyHash: "hash-incoming", KeyPreview: "mh-***",
+		AllowedProviderNames: &unknownProvider,
 	}}
-	env.Config.Users = nil
 
 	_, rec := doImportGen(t, r, env, nil)
-
-	var keys int
-	if err := apiTestDB.Pool().QueryRow(context.Background(),
-		`SELECT count(*) FROM virtual_keys`).Scan(&keys); err != nil {
-		t.Fatalf("count keys: %v", err)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("import that leaves no keys: code=%d, want 400", rec.Code)
 	}
-	if keys == 0 {
-		t.Fatalf("import left the member with no keys (code=%d body=%q)", rec.Code, rec.Body.String())
+
+	names := map[string]bool{}
+	rows, err := apiTestDB.Pool().Query(context.Background(), `SELECT name FROM virtual_keys`)
+	if err != nil {
+		t.Fatalf("query keys: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan key: %v", err)
+		}
+		names[n] = true
+	}
+	if !names["live-key"] {
+		t.Error("the refused import must roll back, leaving the member's own key")
+	}
+	if names["incoming"] {
+		t.Error("the skipped key must not have landed")
 	}
 }

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -89,6 +89,12 @@ func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("import that leaves no keys: code=%d, want 400", rec.Code)
 	}
+	// Named, not just counted: an ingest-side rejection of the unknown provider
+	// restriction would also be a rolled-back 400, and would never reach the
+	// delete this rail exists to catch.
+	if !strings.Contains(rec.Body.String(), "virtual key") {
+		t.Fatalf("refusal body = %q, want the key rail's own message", rec.Body.String())
+	}
 
 	names := map[string]bool{}
 	rows, err := apiTestDB.Pool().Query(context.Background(), `SELECT name FROM virtual_keys`)
@@ -102,6 +108,9 @@ func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 			t.Fatalf("scan key: %v", err)
 		}
 		names[n] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate keys: %v", err)
 	}
 	if !names["live-key"] {
 		t.Error("the refused import must roll back, leaving the member's own key")

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -62,3 +62,38 @@ func TestConfigSync_EmptyKeyListOntoEmptyMemberApplies(t *testing.T) {
 		t.Error("a keyless envelope onto a keyless member should apply")
 	}
 }
+
+// TestConfigSync_RefusesImportThatLeavesNoKeys covers the longer road to the
+// same wipe: the envelope carries keys, so the pre-reconcile rail passes, but
+// every one of them fails to upsert. The delete still removes the member's own
+// keys, and the member ends the transaction with no credentials.
+func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	if _, err := apiTestDB.Pool().Exec(context.Background(), `
+		INSERT INTO virtual_keys (name, key_hash, key_preview)
+		VALUES ('live-key', 'hash-live-key', 'mh-***')`); err != nil {
+		t.Fatalf("seed virtual key: %v", err)
+	}
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	env := doExport(t, r)
+	// One key, carrying an owner the envelope's roster cannot resolve, so the
+	// upsert skips it while the delete still clears the member's own key.
+	unresolvable := "nobody"
+	env.Config.VirtualKeys = []ExportVK{{
+		Name: "incoming", KeyHash: "hash-incoming", KeyPreview: "mh-***", OwnerUsername: &unresolvable,
+	}}
+	env.Config.Users = nil
+
+	_, rec := doImportGen(t, r, env, nil)
+
+	var keys int
+	if err := apiTestDB.Pool().QueryRow(context.Background(),
+		`SELECT count(*) FROM virtual_keys`).Scan(&keys); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if keys == 0 {
+		t.Fatalf("import left the member with no keys (code=%d body=%q)", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestConfigSync_RefusesKeyWipingImport covers the credential half of the
+// destructive-wipe rail. The declarative delete removes every key absent from
+// the envelope, and import's structural guard only refuses an envelope that is
+// empty in providers, keys and settings at once, so an envelope carrying
+// providers but omitting virtual_keys used to reach the delete and take every
+// credential off the member in one push.
+func TestConfigSync_RefusesKeyWipingImport(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	if _, err := apiTestDB.Pool().Exec(context.Background(), `
+		INSERT INTO virtual_keys (name, key_hash, key_preview)
+		VALUES ('live-key', 'hash-live-key', 'mh-***')`); err != nil {
+		t.Fatalf("seed virtual key: %v", err)
+	}
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	env := doExport(t, r)
+	env.Config.VirtualKeys = nil
+
+	_, rec := doImportGen(t, r, env, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("key-wiping import: code=%d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "virtual key") {
+		t.Errorf("refusal body = %q, want it to name the virtual keys", rec.Body.String())
+	}
+
+	var keys int
+	if err := apiTestDB.Pool().QueryRow(context.Background(),
+		`SELECT count(*) FROM virtual_keys`).Scan(&keys); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if keys != 1 {
+		t.Errorf("virtual keys after refused import = %d, want the seeded key to survive", keys)
+	}
+}
+
+// TestConfigSync_EmptyKeyListOntoEmptyMemberApplies is the other side: a member
+// with no keys yet is a bootstrap, not a wipe, so the same envelope applies.
+func TestConfigSync_EmptyKeyListOntoEmptyMemberApplies(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	env := doExport(t, r)
+	env.Config.VirtualKeys = nil
+
+	resp, rec := doImportGen(t, r, withExtraProvider(env, "extra"), nil)
+	if rec.Code != http.StatusOK || !resp.Applied {
+		t.Fatalf("bootstrap import: code=%d applied=%v, want 200 applied", rec.Code, resp.Applied)
+	}
+	if !providerNames(t)["extra"] {
+		t.Error("a keyless envelope onto a keyless member should apply")
+	}
+}

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -30,8 +30,8 @@ func TestConfigSync_RefusesKeyWipingImport(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("key-wiping import: code=%d, want 400", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "virtual key") {
-		t.Errorf("refusal body = %q, want it to name the virtual keys", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "delete every virtual key") {
+		t.Errorf("refusal body = %q, want the key rail's own message", rec.Body.String())
 	}
 
 	var keys int
@@ -92,7 +92,7 @@ func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 	// Named, not just counted: an ingest-side rejection of the unknown provider
 	// restriction would also be a rolled-back 400, and would never reach the
 	// delete this rail exists to catch.
-	if !strings.Contains(rec.Body.String(), "virtual key") {
+	if !strings.Contains(rec.Body.String(), "delete every virtual key") {
 		t.Fatalf("refusal body = %q, want the key rail's own message", rec.Body.String())
 	}
 
@@ -117,5 +117,31 @@ func TestConfigSync_RefusesImportThatLeavesNoKeys(t *testing.T) {
 	}
 	if names["incoming"] {
 		t.Error("the skipped key must not have landed")
+	}
+}
+
+// TestConfigSync_RefusesProviderWipingImport is the provider half of the same
+// rail, held to the same standard: the refusal has to be the rail's own, and the
+// member's provider has to survive the rollback.
+func TestConfigSync_RefusesProviderWipingImport(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	env := doExport(t, r)
+	env.Config.Providers = nil
+	// Settings keep the envelope past import's structural guard, which refuses
+	// one that is empty in providers, keys and settings together.
+	env.Config.Settings = map[string]string{"request_timeout": "1m0s"}
+
+	_, rec := doImportGen(t, r, env, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("provider-wiping import: code=%d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "delete every provider") {
+		t.Errorf("refusal body = %q, want the provider rail's own message", rec.Body.String())
+	}
+	if !providerNames(t)["openai"] {
+		t.Error("the refused import must roll back, leaving the member's provider")
 	}
 }

--- a/internal/db/migration_redacted_marker_test.go
+++ b/internal/db/migration_redacted_marker_test.go
@@ -22,13 +22,14 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
-			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'clean-row')`)
+			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'name-row', 'clean-row')`)
 	})
 
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO request_logs (model_id, status_code, attempts) VALUES
 		('marker-row', 200, '[{"provider": "Neuralwatt", "detail": "[content]open"},
 		                     {"provider": "Z.ai", "detail": "plain [content] run"}]'::jsonb),
+		('name-row',   200, '[{"provider": "[content] Inc", "model": "m", "detail": "HTTP 503"}]'::jsonb),
 		('clean-row',  200, '[{"provider": "Ollama", "detail": "circuit breaker open"}]'::jsonb)`); err != nil {
 		t.Fatalf("seed request logs: %v", err)
 	}
@@ -42,14 +43,19 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 		want  string
 	}{
 		{"marker-row", `[{"detail": "[redacted]open", "provider": "Neuralwatt"}, {"detail": "plain [redacted] run", "provider": "Z.ai"}]`},
+		// The marker is rewritten in details only: a provider name is data this
+		// migration has no business editing.
+		{"name-row", `[{"model": "m", "detail": "HTTP 503", "provider": "[content] Inc"}]`},
 		{"clean-row", `[{"detail": "circuit breaker open", "provider": "Ollama"}]`},
 	} {
-		var got string
+		var same bool
 		if err := testPool.QueryRow(ctx,
-			`SELECT attempts::text FROM request_logs WHERE model_id = $1`, tc.model).Scan(&got); err != nil {
+			`SELECT attempts = $2::jsonb FROM request_logs WHERE model_id = $1`, tc.model, tc.want).Scan(&same); err != nil {
 			t.Fatalf("read %s: %v", tc.model, err)
 		}
-		if got != tc.want {
+		if !same {
+			var got string
+			_ = testPool.QueryRow(ctx, `SELECT attempts::text FROM request_logs WHERE model_id = $1`, tc.model).Scan(&got)
 			t.Errorf("%s attempts = %s, want %s", tc.model, got, tc.want)
 		}
 	}

--- a/internal/db/migration_redacted_marker_test.go
+++ b/internal/db/migration_redacted_marker_test.go
@@ -22,7 +22,7 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
-			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'name-row', 'clean-row')`)
+			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'name-row', 'clean-row', 'empty-row', 'object-row', 'null-row')`)
 	})
 
 	if _, err := testPool.Exec(ctx, `
@@ -30,7 +30,10 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 		('marker-row', 200, '[{"provider": "Neuralwatt", "detail": "[content]open"},
 		                     {"provider": "Z.ai", "detail": "plain [content] run"}]'::jsonb),
 		('name-row',   200, '[{"provider": "[content] Inc", "model": "m", "detail": "HTTP 503"}]'::jsonb),
-		('clean-row',  200, '[{"provider": "Ollama", "detail": "circuit breaker open"}]'::jsonb)`); err != nil {
+		('clean-row',  200, '[{"provider": "Ollama", "detail": "circuit breaker open"}]'::jsonb),
+		('empty-row',  200, '[]'::jsonb),
+		('object-row', 200, '{"detail": "[content]open"}'::jsonb),
+		('null-row',   200, NULL)`); err != nil {
 		t.Fatalf("seed request logs: %v", err)
 	}
 
@@ -47,6 +50,10 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 		// migration has no business editing.
 		{"name-row", `[{"model": "m", "detail": "HTTP 503", "provider": "[content] Inc"}]`},
 		{"clean-row", `[{"detail": "circuit breaker open", "provider": "Ollama"}]`},
+		// A row the column's missing array constraint allows: left alone rather
+		// than aborting the migration, and with it the startup that runs it.
+		{"empty-row", `[]`},
+		{"object-row", `{"detail": "[content]open"}`},
 	} {
 		var same bool
 		if err := testPool.QueryRow(ctx,
@@ -58,5 +65,17 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 			_ = testPool.QueryRow(ctx, `SELECT attempts::text FROM request_logs WHERE model_id = $1`, tc.model).Scan(&got)
 			t.Errorf("%s attempts = %s, want %s", tc.model, got, tc.want)
 		}
+	}
+
+	// A NULL attempts column is the shape every row carried before the trail
+	// existed. It must survive as NULL rather than becoming an empty array,
+	// which would read as "this request tried nothing".
+	var isNull bool
+	if err := testPool.QueryRow(ctx,
+		`SELECT attempts IS NULL FROM request_logs WHERE model_id = 'null-row'`).Scan(&isNull); err != nil {
+		t.Fatalf("read null-row: %v", err)
+	}
+	if !isNull {
+		t.Error("a NULL attempts column should stay NULL")
 	}
 }

--- a/internal/db/migration_redacted_marker_test.go
+++ b/internal/db/migration_redacted_marker_test.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+)
+
+// TestRedactedMarkerMigrationRewritesStoredAttempts covers migration 083. The
+// old content fence left "[content]" in an attempt detail where it dropped a
+// run of text, which reads as though the log holds request content. The
+// migration rewrites the marker to "[redacted]" and leaves every other detail
+// alone. It runs directly rather than through runMigrations, which has already
+// applied it to the shared database.
+func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
+	ctx := context.Background()
+	b, err := fs.ReadFile(embeddedMigrations, "migrations/083_redacted_marker_in_attempt_details.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	sql := string(b)
+
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(),
+			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'clean-row')`)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO request_logs (model_id, status_code, attempts) VALUES
+		('marker-row', 200, '[{"provider": "Neuralwatt", "detail": "[content]open"},
+		                     {"provider": "Z.ai", "detail": "plain [content] run"}]'::jsonb),
+		('clean-row',  200, '[{"provider": "Ollama", "detail": "circuit breaker open"}]'::jsonb)`); err != nil {
+		t.Fatalf("seed request logs: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration: %v", err)
+	}
+
+	for _, tc := range []struct {
+		model string
+		want  string
+	}{
+		{"marker-row", `[{"detail": "[redacted]open", "provider": "Neuralwatt"}, {"detail": "plain [redacted] run", "provider": "Z.ai"}]`},
+		{"clean-row", `[{"detail": "circuit breaker open", "provider": "Ollama"}]`},
+	} {
+		var got string
+		if err := testPool.QueryRow(ctx,
+			`SELECT attempts::text FROM request_logs WHERE model_id = $1`, tc.model).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", tc.model, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s attempts = %s, want %s", tc.model, got, tc.want)
+		}
+	}
+}

--- a/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
+++ b/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
@@ -10,8 +10,27 @@
 -- happened to contain a matching run. Nothing of the prompt is in there.
 --
 -- Rewrite the marker to "[redacted]", which says what actually happened. Only
--- the attempts column is touched: no error_message row carries the marker,
--- because the fence never ran over the terminal message.
-UPDATE request_logs
-SET attempts = REPLACE(attempts::text, '[content]', '[redacted]')::jsonb
-WHERE attempts::text LIKE '%[content]%';
+-- the detail field of each attempt is rewritten, not the whole JSON text: a
+-- provider or model name is data this migration has no business editing, however
+-- unlikely such a name is. Only the attempts column is touched, because no
+-- error_message row carries the marker: the fence never ran over the terminal
+-- message.
+UPDATE request_logs AS l
+SET attempts = (
+    SELECT jsonb_agg(
+        CASE
+            WHEN jsonb_typeof(a -> 'detail') = 'string' AND a ->> 'detail' LIKE '%[content]%'
+                THEN jsonb_set(a, '{detail}', to_jsonb(REPLACE(a ->> 'detail', '[content]', '[redacted]')))
+            ELSE a
+        END
+        ORDER BY ord
+    )
+    FROM jsonb_array_elements(l.attempts) WITH ORDINALITY AS t(a, ord)
+)
+WHERE jsonb_typeof(l.attempts) = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(l.attempts) AS e
+    WHERE jsonb_typeof(e -> 'detail') = 'string'
+      AND e ->> 'detail' LIKE '%[content]%'
+  );

--- a/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
+++ b/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
@@ -1,0 +1,17 @@
+-- Attempt trail details written before the content fence moved to the capture
+-- points carry the marker "[content]" where the fence replaced a run of text an
+-- upstream message shared with the request. The marker means the run was thrown
+-- away, but it reads like the opposite: a log claiming to hold request content,
+-- in a gateway whose headline promise is that it never stores any.
+--
+-- The rows are worse than merely ambiguous. What the old fence matched was
+-- usually the gateway's OWN sentence, so a skipped candidate reads
+-- "[content]open", the remains of "circuit breaker open" after the request
+-- happened to contain a matching run. Nothing of the prompt is in there.
+--
+-- Rewrite the marker to "[redacted]", which says what actually happened. Only
+-- the attempts column is touched: no error_message row carries the marker,
+-- because the fence never ran over the terminal message.
+UPDATE request_logs
+SET attempts = REPLACE(attempts::text, '[content]', '[redacted]')::jsonb
+WHERE attempts::text LIKE '%[content]%';

--- a/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
+++ b/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
@@ -15,6 +15,11 @@
 -- unlikely such a name is. Only the attempts column is touched, because no
 -- error_message row carries the marker: the fence never ran over the terminal
 -- message.
+--
+-- The column carries no array constraint, and a WHERE clause is not evaluation
+-- order, so every jsonb_array_elements call is fed a value normalized to an
+-- array first. One row holding an object or a scalar would otherwise abort the
+-- migration and with it the startup that runs it.
 UPDATE request_logs AS l
 SET attempts = (
     SELECT jsonb_agg(
@@ -25,12 +30,15 @@ SET attempts = (
         END
         ORDER BY ord
     )
-    FROM jsonb_array_elements(l.attempts) WITH ORDINALITY AS t(a, ord)
+    FROM jsonb_array_elements(
+        CASE WHEN jsonb_typeof(l.attempts) = 'array' THEN l.attempts ELSE '[]'::jsonb END
+    ) WITH ORDINALITY AS t(a, ord)
 )
-WHERE jsonb_typeof(l.attempts) = 'array'
-  AND EXISTS (
+WHERE EXISTS (
     SELECT 1
-    FROM jsonb_array_elements(l.attempts) AS e
+    FROM jsonb_array_elements(
+        CASE WHEN jsonb_typeof(l.attempts) = 'array' THEN l.attempts ELSE '[]'::jsonb END
+    ) AS e
     WHERE jsonb_typeof(e -> 'detail') = 'string'
       AND e ->> 'detail' LIKE '%[content]%'
-  );
+);

--- a/internal/proxy/helpers.go
+++ b/internal/proxy/helpers.go
@@ -272,7 +272,7 @@ func (h *Handler) recordTokenUsage(vkHash string, logData *requestLogData, promp
 	if h.tpmLimiter != nil {
 		switch {
 		case vkHash != "":
-			h.tpmLimiter.Debit(vkHash, totalTokens)
+			h.tpmLimiter.Debit(vkHash, logData.ownerUserID, totalTokens)
 		default:
 			h.tpmLimiter.DebitUser(logData.ownerUserID, totalTokens)
 		}

--- a/internal/proxy/token_usage_test.go
+++ b/internal/proxy/token_usage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/virtualkey"
 )
 
@@ -205,3 +206,48 @@ func (w *notifyOnMatchWriter) Write(p []byte) (int, error) {
 func (w *notifyOnMatchWriter) WriteHeader(statusCode int) { w.inner.WriteHeader(statusCode) }
 
 func (w *notifyOnMatchWriter) Flush() {}
+
+// TestTokenUsage_KeyedCompletionChargesTheOwner pins the wiring the TPM
+// limiter now depends on: it takes the owner from the completing request rather
+// than from a lookup, so the owner recorded on the request's log data has to be
+// the one admission reserved against. If a keyed path ever builds that data
+// without the owner, the aggregate charge is silently dropped and only the key
+// is limited.
+func TestTokenUsage_KeyedCompletionChargesTheOwner(t *testing.T) {
+	h := newIntegrationHandler()
+	defer stopUnitHandlerIntegration(h)
+	pool := testDB.Pool()
+	vkRepo := virtualkey.NewRepository(pool)
+	ctx := context.Background()
+	keyHash := fmt.Sprintf("%x", sha256.Sum256([]byte("owner-charge-key")))
+	vk, err := vkRepo.Create(ctx, "owner-charge-key", keyHash, "owner...key", nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create virtual key: %v", err)
+	}
+	defer func() { _ = vkRepo.Delete(ctx, vk.ID) }()
+
+	const ownerID = "11111111-2222-3333-4444-555555555555"
+	userTPM := 600
+	ownedReq := func() *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/api/chat/completions", http.NoBody)
+		c := context.WithValue(r.Context(), ctxkeys.VirtualKeyOwnerIDKey, ownerID)
+		c = context.WithValue(c, ctxkeys.UserRateLimitTPMKey, &userTPM)
+		return r.WithContext(c)
+	}
+	admit := func() int {
+		rec := httptest.NewRecorder()
+		h.tpmLimiter.UserMiddleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, ownedReq())
+		return rec.Code
+	}
+
+	if code := admit(); code != http.StatusOK {
+		t.Fatalf("first admission = %d, want 200", code)
+	}
+	h.recordTokenUsage(keyHash, &requestLogData{virtualKeyName: "owner-charge-key", ownerUserID: ownerID}, userTPM*2, 0, 0)
+
+	if code := admit(); code != http.StatusTooManyRequests {
+		t.Errorf("admission after the owner was charged = %d, want 429", code)
+	}
+}

--- a/internal/proxy/token_usage_test.go
+++ b/internal/proxy/token_usage_test.go
@@ -228,6 +228,7 @@ func TestTokenUsage_KeyedCompletionChargesTheOwner(t *testing.T) {
 
 	const ownerID = "11111111-2222-3333-4444-555555555555"
 	userTPM := 600
+	keyTPM := 600
 	ownedReq := func() *http.Request {
 		r := httptest.NewRequest(http.MethodPost, "/api/chat/completions", http.NoBody)
 		c := context.WithValue(r.Context(), ctxkeys.VirtualKeyOwnerIDKey, ownerID)
@@ -242,12 +243,32 @@ func TestTokenUsage_KeyedCompletionChargesTheOwner(t *testing.T) {
 		return rec.Code
 	}
 
+	keyAdmit := func() int {
+		rec := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", http.NoBody)
+		c := context.WithValue(r.Context(), ctxkeys.VirtualKeyHashKey, keyHash)
+		c = context.WithValue(c, ctxkeys.VirtualKeyRateLimitTPMKey, &keyTPM)
+		h.tpmLimiter.Middleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rec, r.WithContext(c))
+		return rec.Code
+	}
+
 	if code := admit(); code != http.StatusOK {
-		t.Fatalf("first admission = %d, want 200", code)
+		t.Fatalf("first owner admission = %d, want 200", code)
+	}
+	if code := keyAdmit(); code != http.StatusOK {
+		t.Fatalf("first key admission = %d, want 200", code)
 	}
 	h.recordTokenUsage(keyHash, &requestLogData{virtualKeyName: "owner-charge-key", ownerUserID: ownerID}, userTPM*2, 0, 0)
 
 	if code := admit(); code != http.StatusTooManyRequests {
 		t.Errorf("admission after the owner was charged = %d, want 429", code)
+	}
+
+	// The same call charges the key's own bucket, so the other half of the
+	// failure mode (owner limited, key not) cannot pass either.
+	if code := keyAdmit(); code != http.StatusTooManyRequests {
+		t.Errorf("key admission after the key was charged = %d, want 429", code)
 	}
 }

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -51,13 +51,30 @@ type TPMLimiter struct {
 	// caps remembers the budget each bucket was last sized to, so a debit that
 	// arrives after the idle sweep evicted the bucket can rebuild it and land
 	// the charge instead of dropping it. A request streaming for longer than
-	// the idle cutoff, on a key with no other traffic, is exactly that case.
-	// It outlives the buckets on purpose and holds one int per key the process
-	// has admitted, which is bounded by the number of real keys and users.
-	caps     map[string]int
+	// the idle cutoff, on a key with no other traffic, is exactly that case,
+	// and it takes the key's assoc entry with it, so the owner's aggregate
+	// needs the same memory or the owner still gets its minute free.
+	//
+	// Entries outlive the buckets and are swept on their own, much longer,
+	// horizon: past capMemoTTL no request can still be in flight, so keeping
+	// them would only grow the map for every key the process ever admitted.
+	caps     map[string]*capMemo
 	settings SettingsReader
 	stopCh   chan struct{}
 }
+
+// capMemo is the budget (and owner bucket, for a key) a bucket was last built
+// with, kept so an evicted bucket can be rebuilt to take a late debit.
+type capMemo struct {
+	tpm      int
+	userKey  string
+	lastUsed time.Time
+}
+
+// capMemoTTL bounds how long a cap memo outlives its bucket. It has to exceed
+// the longest request the gateway will hold open, which the stall watchdog and
+// the upstream timeouts keep far below an hour.
+const capMemoTTL = time.Hour
 
 type assocEntry struct {
 	userKey  string
@@ -79,7 +96,7 @@ func NewTPMLimiter(settings SettingsReader) *TPMLimiter {
 	l := &TPMLimiter{
 		buckets:  make(map[string]*tpmEntry),
 		assoc:    make(map[string]*assocEntry),
-		caps:     make(map[string]int),
+		caps:     make(map[string]*capMemo),
 		settings: settings,
 		stopCh:   make(chan struct{}),
 	}
@@ -264,15 +281,22 @@ func (l *TPMLimiter) Debit(keyHash string, tokens int) {
 	}
 	l.debitBucket(keyHash, tokens)
 	// Also debit the owner's aggregate bucket when the key is associated with
-	// one (recorded at admission).
+	// one (recorded at admission). The idle sweep takes the assoc entry at the
+	// same cutoff as the bucket, so a request that outlives it falls back to the
+	// cap memo: without that the key's own budget is charged and the owner's
+	// aggregate is not, which is the same free minute one layer up.
 	l.mu.Lock()
-	a, ok := l.assoc[keyHash]
-	if ok {
+	userKey := ""
+	if a, ok := l.assoc[keyHash]; ok {
 		a.lastUsed = time.Now()
+		userKey = a.userKey
+	} else if memo, ok := l.caps[keyHash]; ok {
+		memo.lastUsed = time.Now()
+		userKey = memo.userKey
 	}
 	l.mu.Unlock()
-	if ok && a.userKey != "" {
-		l.debitBucket(a.userKey, tokens)
+	if userKey != "" {
+		l.debitBucket(userKey, tokens)
 	}
 }
 
@@ -304,10 +328,11 @@ func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 	case ok:
 		entry.lastUsed = time.Now()
 	default:
-		if tpm, known := l.caps[bucketKey]; known && tpm > 0 {
+		if memo, known := l.caps[bucketKey]; known && memo.tpm > 0 {
+			memo.lastUsed = time.Now()
 			entry = &tpmEntry{
-				limiter:  rate.NewLimiter(rate.Limit(float64(tpm)/60.0), tpm),
-				tpm:      tpm,
+				limiter:  rate.NewLimiter(rate.Limit(float64(memo.tpm)/60.0), memo.tpm),
+				tpm:      memo.tpm,
 				lastUsed: time.Now(),
 			}
 			l.buckets[bucketKey] = entry
@@ -338,10 +363,19 @@ func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 }
 
 // setAssoc records (or clears, when userKey is empty) the key-to-owner bucket
-// association consulted by Debit.
+// association consulted by Debit. The owner is mirrored into the key's cap memo,
+// which outlives the assoc entry, so a debit arriving after the sweep still
+// finds the owner bucket to charge.
 func (l *TPMLimiter) setAssoc(keyHash, userKey string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	memo, ok := l.caps[keyHash]
+	if !ok {
+		memo = &capMemo{}
+		l.caps[keyHash] = memo
+	}
+	memo.userKey = userKey
+	memo.lastUsed = time.Now()
 	if userKey == "" {
 		delete(l.assoc, keyHash)
 		return
@@ -411,7 +445,13 @@ func (l *TPMLimiter) getEntry(keyHash string, tpm int) *tpmEntry {
 	} else {
 		entry.lastUsed = time.Now()
 	}
-	l.caps[keyHash] = tpm
+	memo, ok := l.caps[keyHash]
+	if !ok {
+		memo = &capMemo{}
+		l.caps[keyHash] = memo
+	}
+	memo.tpm = tpm
+	memo.lastUsed = time.Now()
 	return entry
 }
 
@@ -434,7 +474,8 @@ func (l *TPMLimiter) cleanup() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	cutoff := time.Now().Add(-10 * time.Minute)
+	now := time.Now()
+	cutoff := now.Add(-10 * time.Minute)
 	for key, entry := range l.buckets {
 		if entry.lastUsed.Before(cutoff) {
 			delete(l.buckets, key)
@@ -443,6 +484,16 @@ func (l *TPMLimiter) cleanup() {
 	for key, a := range l.assoc {
 		if a.lastUsed.Before(cutoff) {
 			delete(l.assoc, key)
+		}
+	}
+	// Cap memos are what let a debit rebuild an evicted bucket, so they are held
+	// far longer than the bucket itself. Past this horizon no request that was
+	// admitted against the memo can still be running, and keeping it would grow
+	// the map by one entry for every key the process ever saw.
+	memoCutoff := now.Add(-capMemoTTL)
+	for key, memo := range l.caps {
+		if memo.lastUsed.Before(memoCutoff) {
+			delete(l.caps, key)
 		}
 	}
 }

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -44,42 +44,30 @@ const defaultTPM = 0
 type TPMLimiter struct {
 	mu      sync.Mutex
 	buckets map[string]*tpmEntry
-	// assoc maps a key hash to its owner's "user:<uuid>" bucket key so Debit
-	// (which only knows the key hash) can also debit the owner's aggregate
-	// bucket. Refreshed on every admission, evicted alongside idle buckets.
-	assoc map[string]*assocEntry
 	// caps remembers the budget each bucket was last sized to, so a debit that
 	// arrives after the idle sweep evicted the bucket can rebuild it and land
 	// the charge instead of dropping it. A request streaming for longer than
-	// the idle cutoff, on a key with no other traffic, is exactly that case,
-	// and it takes the key's assoc entry with it, so the owner's aggregate
-	// needs the same memory or the owner still gets its minute free.
+	// the idle cutoff, on a key with no other traffic, is exactly that case.
 	//
 	// Entries outlive the buckets and are swept on their own, much longer,
-	// horizon: past capMemoTTL no request can still be in flight, so keeping
-	// them would only grow the map for every key the process ever admitted.
+	// horizon, so the map does not grow by one entry for every key the process
+	// ever admitted.
 	caps     map[string]*capMemo
 	settings SettingsReader
 	stopCh   chan struct{}
 }
 
-// capMemo is the budget (and owner bucket, for a key) a bucket was last built
-// with, kept so an evicted bucket can be rebuilt to take a late debit.
+// capMemo is the budget a bucket was last built with, kept so an evicted bucket
+// can be rebuilt to take a late debit.
 type capMemo struct {
 	tpm      int
-	userKey  string
 	lastUsed time.Time
 }
 
 // capMemoTTL bounds how long a cap memo outlives its bucket. It has to exceed
-// the longest request the gateway will hold open, which the stall watchdog and
-// the upstream timeouts keep far below an hour.
-const capMemoTTL = time.Hour
-
-type assocEntry struct {
-	userKey  string
-	lastUsed time.Time
-}
+// the longest request the gateway can hold open, which is request_timeout times
+// ten for a stream, so this covers every request_timeout up to two hours.
+const capMemoTTL = 24 * time.Hour
 
 // tpmEntry is a per-key token-budget bucket. The rate.Limiter is configured as
 // limit = tpm/60 tokens refilled per second, burst = tpm (a full minute's
@@ -95,7 +83,6 @@ type tpmEntry struct {
 func NewTPMLimiter(settings SettingsReader) *TPMLimiter {
 	l := &TPMLimiter{
 		buckets:  make(map[string]*tpmEntry),
-		assoc:    make(map[string]*assocEntry),
 		caps:     make(map[string]*capMemo),
 		settings: settings,
 		stopCh:   make(chan struct{}),
@@ -137,11 +124,9 @@ func (l *TPMLimiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			}
 
 			// User-level aggregate stage: all keys owned by one user share a
-			// "user:<uuid>" budget. The key-to-owner association is recorded
-			// (or cleared) on every admission so Debit, which only sees the
-			// key hash, can debit the owner's bucket too.
-			userKey, _ := userTPMFromCtx(r.Context())
-			l.setAssoc(keyHash, userKey)
+			// "user:<uuid>" budget. Completion passes the same owner back to
+			// Debit, so the charge cannot land on a different owner than the
+			// admission did, however the key is reassigned meanwhile.
 			// The owner token is reserved (not committed) here and only kept
 			// once every later gate passes. A request that clears this stage
 			// but is then rejected by the per-key gate cancels the reservation,
@@ -272,39 +257,29 @@ func (l *TPMLimiter) admitUserTPM(ctx context.Context, w http.ResponseWriter, no
 
 // Debit removes the actual token total from a key's budget after a request
 // completes, driving the budget toward (and past) zero so subsequent requests
-// are throttled. It is a no-op when no bucket exists for the key (no cap in
-// effect, or the bucket was evicted) — admission creates the bucket, so a
-// capped request always has one by completion. Safe for concurrent use.
-func (l *TPMLimiter) Debit(keyHash string, tokens int) {
+// are throttled, and charges the same total to the owner's aggregate bucket
+// when the request carried an owner.
+//
+// The owner comes from the request that is completing, not from a lookup: a key
+// reassigned to another user mid-request would otherwise charge whoever owns it
+// at completion rather than whoever was admitted. It is a no-op for a bucket
+// that neither exists nor has a live cap memo to rebuild from, which is what no
+// cap in effect looks like. Safe for concurrent use.
+func (l *TPMLimiter) Debit(keyHash, ownerUserID string, tokens int) {
 	if tokens <= 0 {
 		return
 	}
 	l.debitBucket(keyHash, tokens)
-	// Also debit the owner's aggregate bucket when the key is associated with
-	// one (recorded at admission). The idle sweep takes the assoc entry at the
-	// same cutoff as the bucket, so a request that outlives it falls back to the
-	// cap memo: without that the key's own budget is charged and the owner's
-	// aggregate is not, which is the same free minute one layer up.
-	l.mu.Lock()
-	userKey := ""
-	if a, ok := l.assoc[keyHash]; ok {
-		a.lastUsed = time.Now()
-		userKey = a.userKey
-	} else if memo, ok := l.caps[keyHash]; ok {
-		memo.lastUsed = time.Now()
-		userKey = memo.userKey
-	}
-	l.mu.Unlock()
-	if userKey != "" {
-		l.debitBucket(userKey, tokens)
+	if ownerUserID != "" {
+		l.debitBucket(userBucketKey(ownerUserID), tokens)
 	}
 }
 
 // DebitUser removes the actual token total from an owner's aggregate bucket
 // directly, for requests that never had a virtual key to debit through (the
 // admin chat surface). Debit already reaches the owner bucket for keyed
-// requests via the association recorded at admission, so the two are mutually
-// exclusive: calling both for one request would charge the owner twice.
+// requests, so the two are mutually exclusive: calling both for one request
+// would charge the owner twice.
 //
 // No-op when the owner has no bucket, which is what "no owner-level TPM cap"
 // looks like — admission creates the bucket, so a capped request always has one
@@ -319,8 +294,9 @@ func (l *TPMLimiter) DebitUser(userID string, tokens int) {
 // debitBucket removes tokens from one bucket. A bucket the idle sweep evicted
 // while the request was still in flight is rebuilt at its remembered budget so
 // the charge still lands: dropping it would let a request that outlives the
-// idle cutoff spend a key's whole minute for free. A key with no remembered
-// budget has no cap in effect, and is a no-op. Safe for concurrent use.
+// idle cutoff spend a key's whole minute for free. A bucket with neither an
+// entry nor a live cap memo has no cap in effect, and is a no-op. Safe for
+// concurrent use.
 func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 	l.mu.Lock()
 	entry, ok := l.buckets[bucketKey]
@@ -360,27 +336,6 @@ func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 		entry.limiter.ReserveN(now, n)
 		remaining -= n
 	}
-}
-
-// setAssoc records (or clears, when userKey is empty) the key-to-owner bucket
-// association consulted by Debit. The owner is mirrored into the key's cap memo,
-// which outlives the assoc entry, so a debit arriving after the sweep still
-// finds the owner bucket to charge.
-func (l *TPMLimiter) setAssoc(keyHash, userKey string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	memo, ok := l.caps[keyHash]
-	if !ok {
-		memo = &capMemo{}
-		l.caps[keyHash] = memo
-	}
-	memo.userKey = userKey
-	memo.lastUsed = time.Now()
-	if userKey == "" {
-		delete(l.assoc, keyHash)
-		return
-	}
-	l.assoc[keyHash] = &assocEntry{userKey: userKey, lastUsed: time.Now()}
 }
 
 // userBucketKey namespaces an owner's aggregate bucket away from the key-hash
@@ -445,13 +400,12 @@ func (l *TPMLimiter) getEntry(keyHash string, tpm int) *tpmEntry {
 	} else {
 		entry.lastUsed = time.Now()
 	}
-	memo, ok := l.caps[keyHash]
-	if !ok {
-		memo = &capMemo{}
-		l.caps[keyHash] = memo
+	if memo, known := l.caps[keyHash]; known {
+		memo.tpm = tpm
+		memo.lastUsed = time.Now()
+	} else {
+		l.caps[keyHash] = &capMemo{tpm: tpm, lastUsed: time.Now()}
 	}
-	memo.tpm = tpm
-	memo.lastUsed = time.Now()
 	return entry
 }
 
@@ -479,11 +433,6 @@ func (l *TPMLimiter) cleanup() {
 	for key, entry := range l.buckets {
 		if entry.lastUsed.Before(cutoff) {
 			delete(l.buckets, key)
-		}
-	}
-	for key, a := range l.assoc {
-		if a.lastUsed.Before(cutoff) {
-			delete(l.assoc, key)
 		}
 	}
 	// Cap memos are what let a debit rebuild an evicted bucket, so they are held

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -47,7 +47,14 @@ type TPMLimiter struct {
 	// assoc maps a key hash to its owner's "user:<uuid>" bucket key so Debit
 	// (which only knows the key hash) can also debit the owner's aggregate
 	// bucket. Refreshed on every admission, evicted alongside idle buckets.
-	assoc    map[string]*assocEntry
+	assoc map[string]*assocEntry
+	// caps remembers the budget each bucket was last sized to, so a debit that
+	// arrives after the idle sweep evicted the bucket can rebuild it and land
+	// the charge instead of dropping it. A request streaming for longer than
+	// the idle cutoff, on a key with no other traffic, is exactly that case.
+	// It outlives the buckets on purpose and holds one int per key the process
+	// has admitted, which is bounded by the number of real keys and users.
+	caps     map[string]int
 	settings SettingsReader
 	stopCh   chan struct{}
 }
@@ -72,6 +79,7 @@ func NewTPMLimiter(settings SettingsReader) *TPMLimiter {
 	l := &TPMLimiter{
 		buckets:  make(map[string]*tpmEntry),
 		assoc:    make(map[string]*assocEntry),
+		caps:     make(map[string]int),
 		settings: settings,
 		stopCh:   make(chan struct{}),
 	}
@@ -284,14 +292,27 @@ func (l *TPMLimiter) DebitUser(userID string, tokens int) {
 	l.debitBucket(userBucketKey(userID), tokens)
 }
 
-// debitBucket removes tokens from one bucket. No-op when the bucket does not
-// exist (no cap in effect, or evicted) — admission creates the bucket, so a
-// capped request always has one by completion. Safe for concurrent use.
+// debitBucket removes tokens from one bucket. A bucket the idle sweep evicted
+// while the request was still in flight is rebuilt at its remembered budget so
+// the charge still lands: dropping it would let a request that outlives the
+// idle cutoff spend a key's whole minute for free. A key with no remembered
+// budget has no cap in effect, and is a no-op. Safe for concurrent use.
 func (l *TPMLimiter) debitBucket(bucketKey string, tokens int) {
 	l.mu.Lock()
 	entry, ok := l.buckets[bucketKey]
-	if ok {
+	switch {
+	case ok:
 		entry.lastUsed = time.Now()
+	default:
+		if tpm, known := l.caps[bucketKey]; known && tpm > 0 {
+			entry = &tpmEntry{
+				limiter:  rate.NewLimiter(rate.Limit(float64(tpm)/60.0), tpm),
+				tpm:      tpm,
+				lastUsed: time.Now(),
+			}
+			l.buckets[bucketKey] = entry
+			ok = true
+		}
 	}
 	l.mu.Unlock()
 	if !ok {
@@ -390,6 +411,7 @@ func (l *TPMLimiter) getEntry(keyHash string, tpm int) *tpmEntry {
 	} else {
 		entry.lastUsed = time.Now()
 	}
+	l.caps[keyHash] = tpm
 	return entry
 }
 

--- a/internal/ratelimit/tpm_limiter.go
+++ b/internal/ratelimit/tpm_limiter.go
@@ -65,8 +65,12 @@ type capMemo struct {
 }
 
 // capMemoTTL bounds how long a cap memo outlives its bucket. It has to exceed
-// the longest request the gateway can hold open, which is request_timeout times
-// ten for a stream, so this covers every request_timeout up to two hours.
+// the longest request the gateway can hold open, and that is not a constant:
+// the ceiling is request_timeout (default one minute) times ten for a stream,
+// and request_timeout is an operator-set duration with no upper bound. A day
+// covers every request_timeout up to two hours and twenty-four minutes. Past
+// that a debit can still be dropped, which is the same failure this memo exists
+// to fix, one order of magnitude further out.
 const capMemoTTL = 24 * time.Hour
 
 // tpmEntry is a per-key token-budget bucket. The rate.Limiter is configured as

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -201,6 +201,36 @@ func TestTPMLimiter_DebitNoBucketIsNoop(t *testing.T) {
 	}
 }
 
+// TestTPMLimiter_DebitAfterEvictionStillCharges covers a request that outlives
+// the idle sweep: a stream longer than the cutoff, on a key with no other
+// traffic, has its bucket evicted between admission and completion. Dropping
+// that debit would hand the key a whole minute's budget for free.
+func TestTPMLimiter_DebitAfterEvictionStillCharges(t *testing.T) {
+	l, _ := newTestTPMLimiter(t)
+	const tpm = 500
+
+	if !tpmAdmit(t, l, "k", tpm) {
+		t.Fatal("fresh budget should admit")
+	}
+	// Age the bucket past the cutoff and sweep it, as the background cleanup
+	// would while the request is still streaming.
+	l.mu.Lock()
+	l.buckets["k"].lastUsed = time.Now().Add(-11 * time.Minute)
+	l.mu.Unlock()
+	l.cleanup()
+	l.mu.Lock()
+	evicted := len(l.buckets)
+	l.mu.Unlock()
+	if evicted != 0 {
+		t.Fatalf("sweep should have evicted the idle bucket, %d left", evicted)
+	}
+
+	l.Debit("k", 2*tpm)
+	if tpmAdmit(t, l, "k", tpm) {
+		t.Fatal("the debit must land on a rebuilt bucket and exhaust the budget")
+	}
+}
+
 func TestTPMLimiter_TPMChangeReplacesBucket(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -59,8 +59,8 @@ func TestTPMLimiter_DebitNonPositiveIsNoop(t *testing.T) {
 	}
 	before := tokensOf()
 
-	l.Debit("k", 0)
-	l.Debit("k", -100)
+	l.Debit("k", "", 0)
+	l.Debit("k", "", -100)
 
 	// A real debit reserves tokens, reducing the count; a non-positive debit must
 	// reserve nothing. The token count only ever rises (refill), so it must not
@@ -136,7 +136,7 @@ func TestTPMLimiter_DrainAndReject(t *testing.T) {
 	}
 	// Debit more than a full minute's budget to drive the budget clearly
 	// negative, then admission must reject.
-	l.Debit("k", 2*tpm)
+	l.Debit("k", "", 2*tpm)
 	if tpmAdmit(t, l, "k", tpm) {
 		t.Fatal("exhausted budget should reject")
 	}
@@ -151,7 +151,7 @@ func TestTPMLimiter_OverCapSingleDebit(t *testing.T) {
 	if !tpmAdmit(t, l, "k", tpm) {
 		t.Fatal("fresh budget should admit")
 	}
-	l.Debit("k", tpm*5)
+	l.Debit("k", "", tpm*5)
 	if tpmAdmit(t, l, "k", tpm) {
 		t.Fatal("over-cap debit should leave the budget exhausted")
 	}
@@ -162,7 +162,7 @@ func TestTPMLimiter_PerKeyIsolation(t *testing.T) {
 	const tpm = 500
 
 	tpmAdmit(t, l, "a", tpm)
-	l.Debit("a", 2*tpm)
+	l.Debit("a", "", 2*tpm)
 	if tpmAdmit(t, l, "a", tpm) {
 		t.Fatal("key a should be exhausted")
 	}
@@ -178,7 +178,7 @@ func TestTPMLimiter_Refill(t *testing.T) {
 	const tpm = 600
 
 	tpmAdmit(t, l, "k", tpm)
-	l.Debit("k", tpm) // drains a full minute's budget to ~0
+	l.Debit("k", "", tpm) // drains a full minute's budget to ~0
 	if tpmAdmit(t, l, "k", tpm) {
 		t.Fatal("budget should be exhausted right after draining")
 	}
@@ -192,7 +192,7 @@ func TestTPMLimiter_DebitNoBucketIsNoop(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 	// Debiting a key with no active bucket (no cap in effect) must not panic
 	// or create a bucket.
-	l.Debit("ghost", 1000)
+	l.Debit("ghost", "", 1000)
 	l.mu.Lock()
 	n := len(l.buckets)
 	l.mu.Unlock()
@@ -225,7 +225,7 @@ func TestTPMLimiter_DebitAfterEvictionStillCharges(t *testing.T) {
 		t.Fatalf("sweep should have evicted the idle bucket, %d left", evicted)
 	}
 
-	l.Debit("k", 2*tpm)
+	l.Debit("k", "", 2*tpm)
 	if tpmAdmit(t, l, "k", tpm) {
 		t.Fatal("the debit must land on a rebuilt bucket and exhaust the budget")
 	}
@@ -240,18 +240,16 @@ func TestTPMLimiter_OwnerDebitSurvivesEviction(t *testing.T) {
 	const tpm = 500
 	owner := userBucketKey("owner-1")
 
-	l.setAssoc("k", owner)
 	l.getEntry("k", tpm)
 	l.getEntry(owner, tpm)
 
 	l.mu.Lock()
 	l.buckets["k"].lastUsed = time.Now().Add(-11 * time.Minute)
 	l.buckets[owner].lastUsed = time.Now().Add(-11 * time.Minute)
-	l.assoc["k"].lastUsed = time.Now().Add(-11 * time.Minute)
 	l.mu.Unlock()
 	l.cleanup()
 
-	l.Debit("k", 2*tpm)
+	l.Debit("k", "owner-1", 2*tpm)
 
 	l.mu.Lock()
 	ownerEntry, ok := l.buckets[owner]
@@ -283,7 +281,7 @@ func TestTPMLimiter_CapMemoIsSwept(t *testing.T) {
 	if memoLeft {
 		t.Error("a memo older than the TTL should be swept")
 	}
-	l.Debit("k", 10_000)
+	l.Debit("k", "", 10_000)
 	l.mu.Lock()
 	n := len(l.buckets)
 	l.mu.Unlock()
@@ -296,7 +294,7 @@ func TestTPMLimiter_TPMChangeReplacesBucket(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 
 	tpmAdmit(t, l, "k", 100)
-	l.Debit("k", 500) // exhaust the 100-TPM bucket
+	l.Debit("k", "", 500) // exhaust the 100-TPM bucket
 	if tpmAdmit(t, l, "k", 100) {
 		t.Fatal("100-TPM bucket should be exhausted")
 	}
@@ -346,7 +344,7 @@ func TestTPMMiddleware_EnvDisabledIsNoop(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 	tpm := 1
 	tpmAdmit(t, l, "k", tpm)
-	l.Debit("k", 100) // exhaust
+	l.Debit("k", "", 100) // exhaust
 	// enabled=false (env kill-switch) → middleware must pass through regardless.
 	h := l.Middleware(false)(okHandler())
 	rec := httptest.NewRecorder()
@@ -361,7 +359,7 @@ func TestTPMMiddleware_DBDisabledIsNoop(t *testing.T) {
 	s.set(settingsKeyEnabled, "false")
 	tpm := 1
 	tpmAdmit(t, l, "k", tpm)
-	l.Debit("k", 100)
+	l.Debit("k", "", 100)
 	h := l.Middleware(true)(okHandler())
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, tpmReq("k", &tpm))
@@ -385,7 +383,7 @@ func TestTPMMiddleware_RejectsWhenExhausted(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 	tpm := 600
 	tpmAdmit(t, l, "k", tpm)
-	l.Debit("k", 2*tpm) // drive negative
+	l.Debit("k", "", 2*tpm) // drive negative
 
 	h := l.Middleware(true)(okHandler())
 	rec := httptest.NewRecorder()
@@ -412,7 +410,7 @@ func TestTPMMiddleware_GlobalDefaultApplies(t *testing.T) {
 	}
 
 	// Exhaust the global-default budget, then the next request is rejected.
-	l.Debit("k", 2*600)
+	l.Debit("k", "", 2*600)
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, tpmReq("k", nil))
 	if rec.Code != http.StatusTooManyRequests {
@@ -426,7 +424,7 @@ func TestTPMMiddleware_PerKeyOverridesGlobal(t *testing.T) {
 
 	tpm := 600 // restrictive per-key override
 	tpmAdmit(t, l, "k", tpm)
-	l.Debit("k", 2*tpm)
+	l.Debit("k", "", 2*tpm)
 
 	h := l.Middleware(true)(okHandler())
 	rec := httptest.NewRecorder()
@@ -462,7 +460,7 @@ func TestTPMMiddleware_UserAggregateBudget(t *testing.T) {
 	}
 
 	// Debit through key A far past the aggregate budget.
-	l.Debit("key-a", userTPM*2)
+	l.Debit("key-a", "uid-1", userTPM*2)
 
 	// Key B, same owner, must now be rejected by the user stage.
 	rec = httptest.NewRecorder()
@@ -558,7 +556,7 @@ func TestTPMLimiter_DebitDebitsOwnerBucket(t *testing.T) {
 	keyBefore := tokensOf("key-a")
 	userBefore := tokensOf("user:uid-1")
 
-	l.Debit("key-a", 300)
+	l.Debit("key-a", "uid-1", 300)
 
 	if after := tokensOf("key-a"); after >= keyBefore {
 		t.Errorf("key bucket not debited: before=%v after=%v", keyBefore, after)
@@ -568,12 +566,13 @@ func TestTPMLimiter_DebitDebitsOwnerBucket(t *testing.T) {
 	}
 }
 
-// TestTPMLimiter_AssocClearedWhenOwnerRemoved verifies that once a key stops
-// carrying owner context (ownership cleared at runtime), its next admission
-// clears the stale association so Debit no longer charges the old owner.
-func TestTPMLimiter_AssocClearedWhenOwnerRemoved(t *testing.T) {
+// TestTPMLimiter_UnownedCompletionLeavesTheOwnerAlone verifies the other half
+// of taking the owner from the completing request: a debit that carries no
+// owner charges the key alone, so a request made while the key was unowned
+// cannot land on whoever owned it before or after.
+func TestTPMLimiter_UnownedCompletionLeavesTheOwnerAlone(t *testing.T) {
 	l, s := newTestTPMLimiter(t)
-	s.set(settingsKeyTPM, "1200")
+	s.set(settingsKeyTPM, "600")
 	h := l.Middleware(true)(okHandler())
 
 	rec := httptest.NewRecorder()
@@ -582,24 +581,15 @@ func TestTPMLimiter_AssocClearedWhenOwnerRemoved(t *testing.T) {
 		t.Fatalf("admission failed: %d", rec.Code)
 	}
 
-	// Re-admit without owner context: association must be cleared.
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", http.NoBody)
-	req = req.WithContext(context.WithValue(req.Context(), ctxkeys.VirtualKeyHashKey, "key-a"))
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("re-admission failed: %d", rec.Code)
-	}
-
 	userTokens := func() float64 {
 		l.mu.Lock()
 		defer l.mu.Unlock()
 		return l.buckets["user:uid-1"].limiter.Tokens()
 	}
 	before := userTokens()
-	l.Debit("key-a", 300)
+	l.Debit("key-a", "", 300)
 	if after := userTokens(); after < before {
-		t.Errorf("stale association still debited the old owner: before=%v after=%v", before, after)
+		t.Errorf("an unowned completion debited an owner: before=%v after=%v", before, after)
 	}
 }
 
@@ -729,13 +719,13 @@ func TestTPMUserMiddleware_SharesTheBucketWithKeyedTraffic(t *testing.T) {
 	userTPM := 600
 
 	// Admit an owned key on the /v1 middleware: creates the owner bucket and
-	// the key->owner association Debit follows.
+	// the owner the completion hands back to Debit.
 	rec := httptest.NewRecorder()
 	l.Middleware(true)(okHandler()).ServeHTTP(rec, ownedTPMReq("key-a", "uid-9", userTPM))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("keyed request should pass, got %d", rec.Code)
 	}
-	l.Debit("key-a", userTPM*2)
+	l.Debit("key-a", "uid-9", userTPM*2)
 
 	rec = httptest.NewRecorder()
 	l.UserMiddleware(true)(okHandler()).ServeHTTP(rec, sessionTPMReq("uid-9", &userTPM))

--- a/internal/ratelimit/tpm_limiter_test.go
+++ b/internal/ratelimit/tpm_limiter_test.go
@@ -231,6 +231,67 @@ func TestTPMLimiter_DebitAfterEvictionStillCharges(t *testing.T) {
 	}
 }
 
+// TestTPMLimiter_OwnerDebitSurvivesEviction is the aggregate half of the same
+// case. The sweep takes the key's assoc entry at the same cutoff as its bucket,
+// so a debit landing after it has to find the owner through the cap memo, or
+// the key is charged and the owner it belongs to is not.
+func TestTPMLimiter_OwnerDebitSurvivesEviction(t *testing.T) {
+	l, _ := newTestTPMLimiter(t)
+	const tpm = 500
+	owner := userBucketKey("owner-1")
+
+	l.setAssoc("k", owner)
+	l.getEntry("k", tpm)
+	l.getEntry(owner, tpm)
+
+	l.mu.Lock()
+	l.buckets["k"].lastUsed = time.Now().Add(-11 * time.Minute)
+	l.buckets[owner].lastUsed = time.Now().Add(-11 * time.Minute)
+	l.assoc["k"].lastUsed = time.Now().Add(-11 * time.Minute)
+	l.mu.Unlock()
+	l.cleanup()
+
+	l.Debit("k", 2*tpm)
+
+	l.mu.Lock()
+	ownerEntry, ok := l.buckets[owner]
+	l.mu.Unlock()
+	if !ok {
+		t.Fatal("the owner bucket should have been rebuilt to take the debit")
+	}
+	if ownerEntry.limiter.Tokens() > 0 {
+		t.Errorf("owner budget = %v tokens, want it exhausted by the debit", ownerEntry.limiter.Tokens())
+	}
+}
+
+// TestTPMLimiter_CapMemoIsSwept pins the bound on that memory: the memo outlives
+// the bucket so a late debit can rebuild it, but not forever, or the map grows
+// by one entry for every key the process ever admits.
+func TestTPMLimiter_CapMemoIsSwept(t *testing.T) {
+	l, _ := newTestTPMLimiter(t)
+	l.getEntry("k", 500)
+
+	l.mu.Lock()
+	l.buckets["k"].lastUsed = time.Now().Add(-11 * time.Minute)
+	l.caps["k"].lastUsed = time.Now().Add(-capMemoTTL - time.Minute)
+	l.mu.Unlock()
+	l.cleanup()
+
+	l.mu.Lock()
+	_, memoLeft := l.caps["k"]
+	l.mu.Unlock()
+	if memoLeft {
+		t.Error("a memo older than the TTL should be swept")
+	}
+	l.Debit("k", 10_000)
+	l.mu.Lock()
+	n := len(l.buckets)
+	l.mu.Unlock()
+	if n != 0 {
+		t.Errorf("with no memo the debit must not rebuild a bucket, got %d", n)
+	}
+}
+
 func TestTPMLimiter_TPMChangeReplacesBucket(t *testing.T) {
 	l, _ := newTestTPMLimiter(t)
 


### PR DESCRIPTION
## What

A Strix full scan ran against master through the new `hotel/ds41flash` group and returned three findings. All three verified as real, all three fixed here, each with a test that fails without the fix. The scan also prompted the fourth change, which cleans up the redaction marker in stored logs.

## The findings

**Config-sync import could wipe every virtual key.** The apply step deletes every key absent from the envelope. Import's structural guard only refuses an envelope empty in providers, keys *and* settings together, and the destructive-wipe rail only covered providers. So an envelope carrying providers but omitting `virtual_keys` passed both and took every credential off the member in one push, cutting off every client at once. There is now a matching rail for keys, refusing with a 400 the same way. An empty key list onto a member with no keys stays allowed, since that is a bootstrap.

**The commit fence accepted an unbounded source generation.** Front Desk counts `auto_sync_gen` up from zero in a 32-bit column, but the member stored whatever 64-bit value `X-Fleet-Source-Gen` carried. An import carrying `MaxInt64` pinned the marker permanently: every genuine push afterwards reads as stale, and no API call lowers the marker again. The header is now ignored outside the range a primary can produce, which degrades to an unfenced import exactly as an unparseable value already did.

**A TPM debit was dropped when the idle sweep evicted the bucket mid-request.** The limiter charges tokens on completion and no-oped when the bucket was gone, on the assumption that admission always leaves one. A stream outliving the ten minute idle cutoff, on a key with no other traffic, breaks that assumption: the key spent a whole minute's budget for free while `virtual_keys.tokens_used` and the request log stayed accurate. The limiter now remembers each bucket's budget and rebuilds an evicted one so the charge lands.

## The marker rename

Attempt details written before the content fence moved to the capture points carry a `[content]` marker where the fence dropped a run of text an upstream message shared with the request. It means the run was thrown away, but it reads like the opposite in a gateway whose promise is that it stores no request content. What it usually redacted was the gateway's own sentence, which is why a skipped candidate reads `[content]open`, the remains of "circuit breaker open". Migration 083 rewrites the marker to `[redacted]` in the `attempts` column. No `error_message` row carries it.

## Verification

Full backend suite passes, lint clean on all three changed packages, size gate exit 0. New tests: an evicted-then-debited bucket still exhausts the budget, a key-wiping import is refused while a bootstrap one applies, an out-of-range generation leaves the marker unset, and the migration rewrites the marker while leaving an untouched detail byte-identical.

## Scan context

Full scan, completed, 698 requests, 107.4M input tokens with 98% served from cache, 552k output. One malformed `apply_patch` tool call, which Strix returned to the agent as a result. No gateway errors: every request came back 200. The baseline is recorded at `70cc436f`, so the next run on this model is a diff scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
