### PR TITLE
Keep crafted request bodies out of the debug log and bound the login throttle key

### DIFF
--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -103,10 +103,6 @@ var dummyHash = sync.OnceValue(func() string {
 	return hash
 })
 
-// maxLoginUsername is the longest username a login will consider, matching the
-// 1-64 character bound the user create and update handlers enforce.
-const maxLoginUsername = 64
-
 // Login exchanges username+password for a session token. Uniform 401 for
 // unknown user, wrong password, and disabled account; per-IP and per-username
 // backoff on failures.
@@ -132,11 +128,14 @@ func (h *UserLoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 		respondBadRequest(w, "username and password are required", nil)
 		return
 	}
-	// No account can carry a username this long: the create path caps it at the
-	// same length. Refusing here keeps a body-sized string out of the per-account
-	// throttle and off the database, and answers with the same 401 an unknown
-	// user gets, so it tells an attacker nothing new.
-	if len(req.Username) > maxLoginUsername {
+	// No account can carry a username this long: create and update cap it at the
+	// same number of bytes. Refusing here keeps a body-sized string from ever
+	// becoming a per-account throttle key or a database query, and answers with
+	// the same 401 an unknown user gets, so it tells an attacker nothing new.
+	// The failure is recorded against the per-IP throttle, which is what
+	// throttleKey holds; the per-account one is never touched, which is the
+	// point.
+	if len(req.Username) > user.MaxUsernameBytes {
 		h.throttle.RecordFailure(throttleKey)
 		debuglog.Warn("userlogin: login failed", "remote_addr", clientip.From(r), "reason", "username too long")
 		http.Error(w, "invalid username or password", http.StatusUnauthorized)

--- a/internal/adminauth/userlogin.go
+++ b/internal/adminauth/userlogin.go
@@ -103,6 +103,10 @@ var dummyHash = sync.OnceValue(func() string {
 	return hash
 })
 
+// maxLoginUsername is the longest username a login will consider, matching the
+// 1-64 character bound the user create and update handlers enforce.
+const maxLoginUsername = 64
+
 // Login exchanges username+password for a session token. Uniform 401 for
 // unknown user, wrong password, and disabled account; per-IP and per-username
 // backoff on failures.
@@ -126,6 +130,16 @@ func (h *UserLoginHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Username == "" || req.Password == "" {
 		respondBadRequest(w, "username and password are required", nil)
+		return
+	}
+	// No account can carry a username this long: the create path caps it at the
+	// same length. Refusing here keeps a body-sized string out of the per-account
+	// throttle and off the database, and answers with the same 401 an unknown
+	// user gets, so it tells an attacker nothing new.
+	if len(req.Username) > maxLoginUsername {
+		h.throttle.RecordFailure(throttleKey)
+		debuglog.Warn("userlogin: login failed", "remote_addr", clientip.From(r), "reason", "username too long")
+		http.Error(w, "invalid username or password", http.StatusUnauthorized)
 		return
 	}
 

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -191,6 +191,13 @@ func TestUserLogin_Failures(t *testing.T) {
 		// with the same 401 an unknown user gets keeps the body-sized string out
 		// of the per-account throttle without telling an attacker anything.
 		{"over-long username", `{"username":"` + strings.Repeat("a", 65) + `","password":"whatever1"}`, http.StatusUnauthorized},
+		// The bound is bytes, the same measure create and update use, so a name
+		// of 64 multibyte characters is over it on both paths and consistently
+		// refused rather than creatable-but-unable-to-log-in.
+		{"64 multibyte characters", `{"username":"` + strings.Repeat("é", 64) + `","password":"whatever1"}`, http.StatusUnauthorized},
+		// The last byte length that can name an account still reaches the normal
+		// unknown-user path rather than the new refusal.
+		{"exactly at the bound", `{"username":"` + strings.Repeat("a", 64) + `","password":"whatever1"}`, http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -195,9 +195,6 @@ func TestUserLogin_Failures(t *testing.T) {
 		// of 64 multibyte characters is over it on both paths and consistently
 		// refused rather than creatable-but-unable-to-log-in.
 		{"64 multibyte characters", `{"username":"` + strings.Repeat("é", 64) + `","password":"whatever1"}`, http.StatusUnauthorized},
-		// The last byte length that can name an account still reaches the normal
-		// unknown-user path rather than the new refusal.
-		{"exactly at the bound", `{"username":"` + strings.Repeat("a", 64) + `","password":"whatever1"}`, http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -756,5 +753,20 @@ func TestUserLogin_TotpPostgresStoreRoundTrip(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("user_totp rows survived user deletion: %d", n)
+	}
+}
+
+// TestUserLogin_MaxLengthUsernameCanLogIn pins the bound as inclusive, end to
+// end. Asserting a 401 on the over-long case cannot do that: an off-by-one
+// would refuse the longest legal account and still answer 401, which is what
+// an unknown user gets anyway.
+func TestUserLogin_MaxLengthUsernameCanLogIn(t *testing.T) {
+	name := strings.Repeat("a", user.MaxUsernameBytes)
+	u := testUser(t, name, "correct-horse", true)
+	_, _, _, r := newLoginFixture(t, u)
+
+	w := doLogin(t, r, `{"username":"`+name+`","password":"correct-horse"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login with a %d byte username = %d, want 200 (body %s)", len(name), w.Code, w.Body.String())
 	}
 }

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,6 +187,10 @@ func TestUserLogin_Failures(t *testing.T) {
 		{"empty password", `{"username":"alice","password":""}`, http.StatusBadRequest},
 		{"empty username", `{"username":"","password":"x"}`, http.StatusBadRequest},
 		{"malformed body", `{"username":`, http.StatusBadRequest},
+		// No account can be this long: create caps a username at 64. Answering
+		// with the same 401 an unknown user gets keeps the body-sized string out
+		// of the per-account throttle without telling an attacker anything.
+		{"over-long username", `{"username":"` + strings.Repeat("a", 65) + `","password":"whatever1"}`, http.StatusUnauthorized},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -155,7 +155,7 @@ func (req *userRequest) limits() user.Limits {
 func (req *userRequest) validate() (user.Role, error) {
 	req.Username = strings.TrimSpace(req.Username)
 	if req.Username == "" || len(req.Username) > user.MaxUsernameBytes {
-		return "", errors.New("username must be 1-64 bytes")
+		return "", errors.New("username must be 1-64 characters")
 	}
 	if strings.ContainsAny(req.Username, " \t\n") {
 		return "", errors.New("username must not contain whitespace")

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -154,8 +154,8 @@ func (req *userRequest) limits() user.Limits {
 // validate normalizes and checks the shared create/update fields.
 func (req *userRequest) validate() (user.Role, error) {
 	req.Username = strings.TrimSpace(req.Username)
-	if req.Username == "" || len(req.Username) > 64 {
-		return "", errors.New("username must be 1-64 characters")
+	if req.Username == "" || len(req.Username) > user.MaxUsernameBytes {
+		return "", errors.New("username must be 1-64 bytes")
 	}
 	if strings.ContainsAny(req.Username, " \t\n") {
 		return "", errors.New("username must not contain whitespace")

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -410,30 +411,50 @@ func metricModelLabel(modelID string, kind ErrorKind) string {
 // field from writing a megabyte to the log.
 const upstreamModelLogCap = 120
 
-// logUpstreamModel logs the model name the upstream body actually carries, for
-// debugging rewrite issues. It decodes that one field rather than slicing the
-// front of the body: a caller controls their own field names, so a nested model
-// key used to put the caller's own text in the log, which is request content
-// this gateway promises never to store. A body that does not decode names no
-// model and logs nothing, which is also what keeps a multipart body out of the
-// debug log.
+// debugEnabled reports whether a Debug record can reach the output at all.
+// debuglog.Init and debuglog.SetHandler both install their handler as the slog
+// default and set its level from DEBUG_LOG and DEBUG_LOG_SCOPES together, so
+// the default logger's own answer is the gate, not a second opinion on it.
+// A var so a test can drive both sides of the branch without touching the
+// process-wide logger that parallel tests in this package share.
+var debugEnabled = func() bool {
+	return slog.Default().Enabled(context.Background(), slog.LevelDebug)
+}
+
+// upstreamModelDecodes counts bodies actually decoded, so a test can prove the
+// gate skipped the expensive half rather than merely that nothing was logged.
+var upstreamModelDecodes atomic.Uint64
+
+// upstreamModelAttr returns the model name the upstream body carries, sanitized
+// and bounded, and whether there is one to log.
 //
-// The decode runs only when a debug record would actually be emitted. Bodies
-// reach tens of megabytes on the image endpoints, and this sits on the hot path
-// once per candidate and again per retry, so parsing one to discard the result
-// would cost every request what only a debugging session wants.
-//
-// The value is caller-controlled, so it is sanitized and bounded like any other
-// upstream text: nothing says a model field holds a short identifier.
-func logUpstreamModel(upstreamBody []byte) {
-	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
-		return
-	}
+// It decodes the one field it wants rather than slicing the front of the body:
+// a caller controls their own field names, so a nested model key used to put the
+// caller's own text in the log, which is request content this gateway promises
+// never to store. A body that does not decode names no model, which is also
+// what keeps a multipart body out of the debug log. The value is caller text
+// like any other, so nothing says it is a short identifier.
+func upstreamModelAttr(upstreamBody []byte) (string, bool) {
+	upstreamModelDecodes.Add(1)
 	var decoded struct {
 		Model string `json:"model"`
 	}
 	if err := json.Unmarshal(upstreamBody, &decoded); err != nil || decoded.Model == "" {
+		return "", false
+	}
+	return util.SanitizeLogBody(decoded.Model, upstreamModelLogCap), true
+}
+
+// logUpstreamModel logs the model name the upstream body carries, for debugging
+// rewrite issues, and only when a debug record would be written. Bodies reach
+// tens of megabytes on the image endpoints and this sits on the hot path once
+// per candidate and again per retry, so parsing one to discard the result would
+// cost every request what only a debugging session wants.
+func logUpstreamModel(upstreamBody []byte) {
+	if !debugEnabled() {
 		return
 	}
-	debuglog.Debug("proxy: upstream body model", "upstream_model", util.SanitizeLogBody(decoded.Model, upstreamModelLogCap))
+	if model, ok := upstreamModelAttr(upstreamBody); ok {
+		debuglog.Debug("proxy: upstream body model", "upstream_model", model)
+	}
 }

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -403,3 +403,19 @@ func metricModelLabel(modelID string, kind ErrorKind) string {
 	}
 	return modelID
 }
+
+// logUpstreamModel logs the model name the upstream body actually carries, for
+// debugging rewrite issues. It decodes that one field rather than slicing the
+// front of the body: a caller controls their own field names, so a nested model
+// key used to put the caller's own text in the log, which is request content
+// this gateway promises never to store. A body that does not decode, or names
+// no model, logs nothing.
+func logUpstreamModel(upstreamBody []byte) {
+	var decoded struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(upstreamBody, &decoded); err != nil || decoded.Model == "" {
+		return
+	}
+	debuglog.Debug("proxy: upstream body model", "upstream_model", decoded.Model)
+}

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -404,18 +405,35 @@ func metricModelLabel(modelID string, kind ErrorKind) string {
 	return modelID
 }
 
+// upstreamModelLogCap bounds the model name in the debug line. A real model id
+// is a short token; the cap is what stops a caller who sends a megabyte in that
+// field from writing a megabyte to the log.
+const upstreamModelLogCap = 120
+
 // logUpstreamModel logs the model name the upstream body actually carries, for
 // debugging rewrite issues. It decodes that one field rather than slicing the
 // front of the body: a caller controls their own field names, so a nested model
 // key used to put the caller's own text in the log, which is request content
-// this gateway promises never to store. A body that does not decode, or names
-// no model, logs nothing.
+// this gateway promises never to store. A body that does not decode names no
+// model and logs nothing, which is also what keeps a multipart body out of the
+// debug log.
+//
+// The decode runs only when a debug record would actually be emitted. Bodies
+// reach tens of megabytes on the image endpoints, and this sits on the hot path
+// once per candidate and again per retry, so parsing one to discard the result
+// would cost every request what only a debugging session wants.
+//
+// The value is caller-controlled, so it is sanitized and bounded like any other
+// upstream text: nothing says a model field holds a short identifier.
 func logUpstreamModel(upstreamBody []byte) {
+	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
 	var decoded struct {
 		Model string `json:"model"`
 	}
 	if err := json.Unmarshal(upstreamBody, &decoded); err != nil || decoded.Model == "" {
 		return
 	}
-	debuglog.Debug("proxy: upstream body model", "upstream_model", decoded.Model)
+	debuglog.Debug("proxy: upstream body model", "upstream_model", util.SanitizeLogBody(decoded.Model, upstreamModelLogCap))
 }

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -620,11 +619,7 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 		if needsRewrite {
 			upstreamBody = paramrewrite.BuildUpstreamBody(st.bodyBytes, providerType, candidate.model.ModelID, st.reqModel, st.isStreaming, &h.deprecationCache, &h.paramRenameCache, nil, learnedScopeFor(candidate))
 		}
-		// Log the actual model name in the upstream body for debugging rewrite
-		// issues. Chat-only: multipart bodies must never reach debug logs.
-		if upstreamModel, _, _ := strings.Cut(string(upstreamBody), ","); strings.Contains(upstreamModel, `"model"`) {
-			debuglog.Debug("proxy: upstream body model", "upstream_model_snippet", upstreamModel)
-		}
+		logUpstreamModel(upstreamBody)
 	}
 
 	proxyReq, err := newRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(upstreamBody))

--- a/internal/proxy/proxy_failover_model_log_test.go
+++ b/internal/proxy/proxy_failover_model_log_test.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// attrCaptureHandler records the message AND its attributes, which is the whole
+// point here: the leak this guards against travels in an attribute value, so a
+// handler that keeps only the message would assert nothing.
+type attrCaptureHandler struct {
+	mu    *sync.Mutex
+	lines *[]string
+	attrs []slog.Attr
+}
+
+func (h *attrCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *attrCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+		return true
+	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.lines = append(*h.lines, b.String())
+	return nil
+}
+
+func (h *attrCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &attrCaptureHandler{mu: h.mu, lines: h.lines, attrs: append(append([]slog.Attr{}, h.attrs...), attrs...)}
+}
+
+func (h *attrCaptureHandler) WithGroup(string) slog.Handler { return h }
+
+// TestLogUpstreamModel_LogsTheModelNotTheBody pins the no-content-logging
+// invariant on the one debug line that reads the upstream body. The value used
+// to be the body sliced up to its first comma, logged whenever that slice held
+// the token "model", and a caller controls their own field names: a nested
+// object with a model key put the caller's text in the log verbatim, and a
+// comma-free model value was logged whole.
+func TestLogUpstreamModel_LogsTheModelNotTheBody(t *testing.T) {
+	var logged []string
+	var mu sync.Mutex
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
+
+	// A nested model key before the first comma: this is the shape the old slice
+	// logged, caller text and all. Marshal sorts the keys, so metadata leads.
+	const secret = "caller text with no comma at all"
+	body, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"model": secret},
+		"model":    "gpt-5",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	logUpstreamModel(body)
+
+	mu.Lock()
+	got := strings.Join(logged, "\n")
+	mu.Unlock()
+	if !strings.Contains(got, "upstream body model") {
+		t.Fatalf("expected the model line to be logged, got %q", got)
+	}
+	if !strings.Contains(got, "gpt-5") {
+		t.Errorf("the line should name the model, got %q", got)
+	}
+	if strings.Contains(got, secret) {
+		t.Errorf("request content reached the log: %q", got)
+	}
+}
+
+// A body carrying no model, or one that does not decode at all, logs nothing
+// rather than falling back to raw bytes.
+func TestLogUpstreamModel_SilentWithoutAModel(t *testing.T) {
+	var logged []string
+	var mu sync.Mutex
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
+
+	logUpstreamModel([]byte(`{"messages":[{"role":"user","content":"secret"}]}`))
+	logUpstreamModel([]byte(`not json at all, secret`))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logged) != 0 {
+		t.Errorf("expected no log lines, got %v", logged)
+	}
+}

--- a/internal/proxy/proxy_failover_model_log_test.go
+++ b/internal/proxy/proxy_failover_model_log_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 )
 
+// These tests replace the process-wide slog default, so they must not run in
+// parallel with anything else in this package that logs.
+//
 // attrCaptureHandler records the message AND its attributes, which is the whole
 // point here: the leak this guards against travels in an attribute value, so a
 // handler that keeps only the message would assert nothing.
@@ -74,8 +77,8 @@ func TestLogUpstreamModel_LogsTheModelNotTheBody(t *testing.T) {
 	if !strings.Contains(got, "upstream body model") {
 		t.Fatalf("expected the model line to be logged, got %q", got)
 	}
-	if !strings.Contains(got, "gpt-5") {
-		t.Errorf("the line should name the model, got %q", got)
+	if !strings.Contains(got, "upstream_model=gpt-5") {
+		t.Errorf("the line should carry the model under upstream_model, got %q", got)
 	}
 	if strings.Contains(got, secret) {
 		t.Errorf("request content reached the log: %q", got)
@@ -99,4 +102,71 @@ func TestLogUpstreamModel_SilentWithoutAModel(t *testing.T) {
 	if len(logged) != 0 {
 		t.Errorf("expected no log lines, got %v", logged)
 	}
+}
+
+// The decode is the expensive half, and bodies reach tens of megabytes, so it
+// must not run at all when no debug record would be emitted.
+func TestLogUpstreamModel_SilentWhenDebugIsOff(t *testing.T) {
+	var logged []string
+	var mu sync.Mutex
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(&levelGate{
+		inner: &attrCaptureHandler{mu: &mu, lines: &logged},
+		level: slog.LevelInfo,
+	}))
+
+	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logged) != 0 {
+		t.Errorf("expected nothing logged with debug off, got %v", logged)
+	}
+}
+
+// A model value is caller text, so it is bounded like any other upstream string
+// rather than logged at whatever length the caller chose.
+func TestLogUpstreamModel_BoundsTheValue(t *testing.T) {
+	var logged []string
+	var mu sync.Mutex
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
+
+	body, err := json.Marshal(map[string]any{"model": strings.Repeat("m", 4096)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	logUpstreamModel(body)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logged) != 1 {
+		t.Fatalf("expected one line, got %v", len(logged))
+	}
+	if len(logged[0]) > 512 {
+		t.Errorf("logged line is %d bytes, want the model bounded", len(logged[0]))
+	}
+}
+
+// levelGate refuses records below its level, the way a production handler
+// configured at Info does.
+type levelGate struct {
+	inner slog.Handler
+	level slog.Level
+}
+
+func (h *levelGate) Enabled(_ context.Context, l slog.Level) bool { return l >= h.level }
+
+func (h *levelGate) Handle(ctx context.Context, r slog.Record) error {
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *levelGate) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &levelGate{inner: h.inner.WithAttrs(attrs), level: h.level}
+}
+
+func (h *levelGate) WithGroup(name string) slog.Handler {
+	return &levelGate{inner: h.inner.WithGroup(name), level: h.level}
 }

--- a/internal/proxy/proxy_failover_model_log_test.go
+++ b/internal/proxy/proxy_failover_model_log_test.go
@@ -1,65 +1,19 @@
 package proxy
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"log/slog"
 	"strings"
-	"sync"
 	"testing"
 )
 
-// These tests replace the process-wide slog default, so they must not run in
-// parallel with anything else in this package that logs.
-//
-// attrCaptureHandler records the message AND its attributes, which is the whole
-// point here: the leak this guards against travels in an attribute value, so a
-// handler that keeps only the message would assert nothing.
-type attrCaptureHandler struct {
-	mu    *sync.Mutex
-	lines *[]string
-	attrs []slog.Attr
-}
-
-func (h *attrCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
-
-func (h *attrCaptureHandler) Handle(_ context.Context, r slog.Record) error {
-	var b strings.Builder
-	b.WriteString(r.Message)
-	for _, a := range h.attrs {
-		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
-	}
-	r.Attrs(func(a slog.Attr) bool {
-		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
-		return true
-	})
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	*h.lines = append(*h.lines, b.String())
-	return nil
-}
-
-func (h *attrCaptureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &attrCaptureHandler{mu: h.mu, lines: h.lines, attrs: append(append([]slog.Attr{}, h.attrs...), attrs...)}
-}
-
-func (h *attrCaptureHandler) WithGroup(string) slog.Handler { return h }
-
-// TestLogUpstreamModel_LogsTheModelNotTheBody pins the no-content-logging
+// TestUpstreamModelAttr_CarriesTheModelNotTheBody pins the no-content-logging
 // invariant on the one debug line that reads the upstream body. The value used
 // to be the body sliced up to its first comma, logged whenever that slice held
 // the token "model", and a caller controls their own field names: a nested
-// object with a model key put the caller's text in the log verbatim, and a
-// comma-free model value was logged whole.
-func TestLogUpstreamModel_LogsTheModelNotTheBody(t *testing.T) {
-	var logged []string
-	var mu sync.Mutex
-	original := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(original) })
-	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
-
-	// A nested model key before the first comma: this is the shape the old slice
+// object with a model key put the caller's text in the log verbatim.
+func TestUpstreamModelAttr_CarriesTheModelNotTheBody(t *testing.T) {
+	t.Parallel()
+	// A nested model key before the first comma is the shape the old slice
 	// logged, caller text and all. Marshal sorts the keys, so metadata leads.
 	const secret = "caller text with no comma at all"
 	body, err := json.Marshal(map[string]any{
@@ -69,16 +23,13 @@ func TestLogUpstreamModel_LogsTheModelNotTheBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal body: %v", err)
 	}
-	logUpstreamModel(body)
 
-	mu.Lock()
-	got := strings.Join(logged, "\n")
-	mu.Unlock()
-	if !strings.Contains(got, "upstream body model") {
-		t.Fatalf("expected the model line to be logged, got %q", got)
+	got, ok := upstreamModelAttr(body)
+	if !ok {
+		t.Fatal("a body naming a model should log one")
 	}
-	if !strings.Contains(got, "upstream_model=gpt-5") {
-		t.Errorf("the line should carry the model under upstream_model, got %q", got)
+	if got != "gpt-5" {
+		t.Errorf("logged value = %q, want the model alone", got)
 	}
 	if strings.Contains(got, secret) {
 		t.Errorf("request content reached the log: %q", got)
@@ -86,87 +37,61 @@ func TestLogUpstreamModel_LogsTheModelNotTheBody(t *testing.T) {
 }
 
 // A body carrying no model, or one that does not decode at all, logs nothing
-// rather than falling back to raw bytes.
-func TestLogUpstreamModel_SilentWithoutAModel(t *testing.T) {
-	var logged []string
-	var mu sync.Mutex
-	original := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(original) })
-	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
-
-	logUpstreamModel([]byte(`{"messages":[{"role":"user","content":"secret"}]}`))
-	logUpstreamModel([]byte(`not json at all, secret`))
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(logged) != 0 {
-		t.Errorf("expected no log lines, got %v", logged)
+// rather than falling back to raw bytes. The second case is what keeps a
+// multipart body out of the debug log.
+func TestUpstreamModelAttr_SilentWithoutAModel(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{
+		`{"messages":[{"role":"user","content":"secret"}]}`,
+		`not json at all, secret`,
+		"--boundary\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nsecret\r\n",
+	} {
+		if got, ok := upstreamModelAttr([]byte(body)); ok {
+			t.Errorf("body %q logged %q, want nothing", body, got)
+		}
 	}
 }
 
-// The decode is the expensive half, and bodies reach tens of megabytes, so it
-// must not run at all when no debug record would be emitted.
-func TestLogUpstreamModel_SilentWhenDebugIsOff(t *testing.T) {
-	var logged []string
-	var mu sync.Mutex
-	original := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(original) })
-	slog.SetDefault(slog.New(&levelGate{
-		inner: &attrCaptureHandler{mu: &mu, lines: &logged},
-		level: slog.LevelInfo,
-	}))
-
-	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(logged) != 0 {
-		t.Errorf("expected nothing logged with debug off, got %v", logged)
-	}
-}
-
-// A model value is caller text, so it is bounded like any other upstream string
-// rather than logged at whatever length the caller chose.
-func TestLogUpstreamModel_BoundsTheValue(t *testing.T) {
-	var logged []string
-	var mu sync.Mutex
-	original := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(original) })
-	slog.SetDefault(slog.New(&attrCaptureHandler{mu: &mu, lines: &logged}))
-
+// A model value is caller text, so it is bounded rather than logged at whatever
+// length the caller chose.
+func TestUpstreamModelAttr_BoundsTheValue(t *testing.T) {
+	t.Parallel()
 	body, err := json.Marshal(map[string]any{"model": strings.Repeat("m", 4096)})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	logUpstreamModel(body)
-
-	mu.Lock()
-	defer mu.Unlock()
-	if len(logged) != 1 {
-		t.Fatalf("expected one line, got %v", len(logged))
+	got, ok := upstreamModelAttr(body)
+	if !ok {
+		t.Fatal("a body naming a model should log one")
 	}
-	if len(logged[0]) > 512 {
-		t.Errorf("logged line is %d bytes, want the model bounded", len(logged[0]))
+	// The sanitizer marks a value it truncated, so the result is the cap plus
+	// that marker rather than exactly the cap.
+	if len(got) > upstreamModelLogCap+16 {
+		t.Errorf("logged value is %d bytes, want the cap plus a truncation marker", len(got))
+	}
+	if !strings.HasPrefix(got, strings.Repeat("m", 64)) {
+		t.Errorf("logged value = %q, want the head of the model kept", got)
 	}
 }
 
-// levelGate refuses records below its level, the way a production handler
-// configured at Info does.
-type levelGate struct {
-	inner slog.Handler
-	level slog.Level
-}
+// TestLogUpstreamModel_SkipsTheDecodeWhenDebugIsOff proves the gate does the
+// thing it exists for. Asserting that nothing was logged would pass either way,
+// since the handler drops the record anyway; the decode counter is what
+// distinguishes a skipped parse from a parsed-then-dropped one.
+func TestLogUpstreamModel_SkipsTheDecodeWhenDebugIsOff(t *testing.T) {
+	original := debugEnabled
+	t.Cleanup(func() { debugEnabled = original })
 
-func (h *levelGate) Enabled(_ context.Context, l slog.Level) bool { return l >= h.level }
+	debugEnabled = func() bool { return false }
+	before := upstreamModelDecodes.Load()
+	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
+	if after := upstreamModelDecodes.Load(); after != before {
+		t.Errorf("decode ran with debug off: %d -> %d", before, after)
+	}
 
-func (h *levelGate) Handle(ctx context.Context, r slog.Record) error {
-	return h.inner.Handle(ctx, r)
-}
-
-func (h *levelGate) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &levelGate{inner: h.inner.WithAttrs(attrs), level: h.level}
-}
-
-func (h *levelGate) WithGroup(name string) slog.Handler {
-	return &levelGate{inner: h.inner.WithGroup(name), level: h.level}
+	debugEnabled = func() bool { return true }
+	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
+	if after := upstreamModelDecodes.Load(); after == before {
+		t.Error("decode should run when debug is on")
+	}
 }

--- a/internal/totp/throttle.go
+++ b/internal/totp/throttle.go
@@ -1,6 +1,7 @@
 package totp
 
 import (
+	"crypto/sha256"
 	"sync"
 	"time"
 )
@@ -8,6 +9,17 @@ import (
 // maxThrottleEntries bounds the in-memory key map so a key-rotating attacker
 // cannot grow it without limit; once exceeded, expired entries are swept.
 const maxThrottleEntries = 4096
+
+// digest reduces a caller's key to a fixed 32 bytes. Callers key on values that
+// arrive from the network (a client address, or the username field of an
+// unauthenticated login body, which is only bounded by the JSON body limit), and
+// the map holds an entry until a later failure sweeps it. Hashing means an
+// entry costs the same whatever the caller passed, and keys stay opaque: the map
+// only ever compares them.
+func digest(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return string(sum[:])
+}
 
 // Throttle applies per-key exponential backoff to repeated failures, layered on
 // top of the per-IP request-rate limiter. It is in-memory and single-instance
@@ -52,7 +64,7 @@ func NewThrottle(maxFailures int, baseDelay, maxDelay time.Duration) *Throttle {
 func (t *Throttle) Allowed(key string) (bool, time.Duration) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	e := t.entries[key]
+	e := t.entries[digest(key)]
 	if e == nil {
 		return true, 0
 	}
@@ -71,10 +83,11 @@ func (t *Throttle) RecordFailure(key string) {
 	if len(t.entries) > maxThrottleEntries {
 		t.sweepLocked(now)
 	}
-	e := t.entries[key]
+	k := digest(key)
+	e := t.entries[k]
 	if e == nil {
 		e = &throttleEntry{}
-		t.entries[key] = e
+		t.entries[k] = e
 	}
 	e.failures++
 	e.lastSeen = now
@@ -87,7 +100,7 @@ func (t *Throttle) RecordFailure(key string) {
 func (t *Throttle) RecordSuccess(key string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	delete(t.entries, key)
+	delete(t.entries, digest(key))
 }
 
 // backoffFor returns the lock duration for a given failure count: 0 until

--- a/internal/totp/throttle_key_test.go
+++ b/internal/totp/throttle_key_test.go
@@ -1,0 +1,49 @@
+package totp
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestThrottle_KeysAreBounded pins what keeps an unauthenticated flood from
+// holding the heap: callers key on values that arrive from the network, and the
+// map holds an entry until a later failure sweeps it, so the stored key has to
+// cost the same whatever was passed.
+func TestThrottle_KeysAreBounded(t *testing.T) {
+	th := NewThrottle(1, time.Second, time.Minute)
+	huge := "user:" + strings.Repeat("a", 1<<20)
+
+	th.RecordFailure(huge)
+	th.RecordFailure(huge)
+
+	th.mu.Lock()
+	defer th.mu.Unlock()
+	if len(th.entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(th.entries))
+	}
+	for k := range th.entries {
+		if len(k) != 32 {
+			t.Errorf("stored key is %d bytes, want the 32 byte digest", len(k))
+		}
+	}
+}
+
+// The digest must not cost accuracy: a key still throttles itself and leaves
+// every other key alone.
+func TestThrottle_HashedKeysStayDistinct(t *testing.T) {
+	th := NewThrottle(1, time.Minute, time.Minute)
+	th.RecordFailure("a")
+	th.RecordFailure("a")
+
+	if ok, _ := th.Allowed("a"); ok {
+		t.Error("the failing key should be locked out")
+	}
+	if ok, _ := th.Allowed("b"); !ok {
+		t.Error("a different key must be unaffected")
+	}
+	th.RecordSuccess("a")
+	if ok, _ := th.Allowed("a"); !ok {
+		t.Error("success should clear the key's backoff")
+	}
+}

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -16,6 +16,12 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/db"
 )
 
+// MaxUsernameBytes is the longest username an account can carry, measured in
+// bytes because that is what the create and update handlers check. Login reads
+// it too: a longer string cannot name an account, so it is refused before it
+// becomes a throttle key or a query.
+const MaxUsernameBytes = 64
+
 // Role separates full operators from grant-limited users.
 type Role string
 


### PR DESCRIPTION
## What

A Strix full scan through `hotel/glm53` returned two findings. Both verified in the code, both fixed here, each with a test that fails against the old behaviour.

## The debug line that read the request body

The upstream-request builder logged the body sliced up to its first comma, whenever that slice contained the token `"model"`. A caller controls their own field names, so this leaks:

```
{"metadata":{"model":"caller text with no comma"},"model":"m"}
  -> logged: {"metadata":{"model":"caller text with no comma"}
```

A comma-free model value is also logged whole. It needs debug logging enabled, and the exposure is narrower than "any prompt": the token has to appear before the first comma, which in practice means a nested `model` key rather than ordinary chat content. It is still caller-controlled text in a log this gateway promises holds none, so it decodes the one field it wants instead.

The helper moved to `logging.go` because `proxy_failover.go` was one line under the size ceiling.

## The login throttle key

`POST /api/auth/login` used the raw username as the per-account backoff key. That string arrives unauthenticated and is bounded only by the 1 MiB JSON body ceiling, and an entry survives until a later failure sweeps it, so a flood of distinct megabyte usernames sits on the heap. The scan measured 150 MiB retained.

Two changes, the second being the root-cause one:

- Login refuses a username longer than 64 characters, which is what the create and update handlers already enforce, so no such account can exist. It answers with the same 401 an unknown user gets, and the string never becomes a key or a database query. This adds no charset restriction: usernames stay permissive.
- The throttle hashes every key to a fixed 32 bytes internally. That covers the per-IP and TOTP callers too, and any future one, rather than patching the single path the scan happened to walk.

## Verification

Full backend suite, lint and size gate all pass. The log test was checked in both directions: it fails against the old slicing code with "request content reached the log" and passes against the fix. The throttle tests pin that a 1 MiB key is stored as 32 bytes and that hashing did not cost lockout accuracy.

## Scan context

Full scan, completed, 533 requests, 59.1M input tokens, 166k output, two tool failures. Baseline recorded at `8ee44674`. Z.ai never drained its window, so the quota failover path was not exercised this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
