### PR TITLE
Refuse rate-limited requests without charging the bucket that refused them

### DIFF
--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -132,6 +132,19 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 		ip := clientip.Resolve(r, l.trustedProxies)
 		entry := l.getLimiter(r.Context(), ip)
 
+		// Refuse before reserving when the bucket already says the wait is past
+		// the ceiling, so a refusal costs the IP nothing: see peekWait for what
+		// the reserve-then-cancel route costs instead. The reading can be stale
+		// by the time the reservation below is taken, which is the case the
+		// cancel on the over-max_wait path still covers. The zero test keeps the
+		// settings read off the path of a request the bucket can serve outright.
+		if wait := peekWait(entry.limiter, time.Now()); wait > 0 && wait > l.maxWait(r.Context()) {
+			entry.noteRejected(ip)
+			writeRateLimitHeaders(w, entry.limiter, wait, ipLogLabel)
+			util.WriteOpenAIError(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
 		reservation := entry.limiter.Reserve()
 		if !reservation.OK() {
 			entry.noteRejected(ip)
@@ -146,11 +159,7 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 			// sleep and proceed instead of rejecting immediately. The IP is still
 			// under pressure, so an open throttle episode stays open (only a
 			// no-delay serve below closes it).
-			maxWait := time.Duration(defaultMaxWaitMs) * time.Millisecond
-			if l.settings != nil {
-				maxWait = time.Duration(l.settings.GetInt(r.Context(), settingsKeyIPMaxWaitMs, defaultMaxWaitMs)) * time.Millisecond
-			}
-			if delay <= maxWait {
+			if delay <= l.maxWait(r.Context()) {
 				if !waitOrCancel(r.Context(), delay) {
 					// Client left during the wait: give the budget back.
 					reservation.Cancel()
@@ -174,6 +183,15 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 		writeRateLimitHeaders(w, entry.limiter, 0, ipLogLabel)
 		next.ServeHTTP(w, r)
 	})
+}
+
+// maxWait is how long a request may be held before the limiter gives up on it,
+// shared with the per-key limiter so one setting governs both.
+func (l *IPLimiter) maxWait(ctx context.Context) time.Duration {
+	if l.settings == nil {
+		return time.Duration(defaultMaxWaitMs) * time.Millisecond
+	}
+	return time.Duration(l.settings.GetInt(ctx, settingsKeyIPMaxWaitMs, defaultMaxWaitMs)) * time.Millisecond
 }
 
 func (l *IPLimiter) getLimiter(ctx context.Context, ip string) *bucketEntry {

--- a/internal/ratelimit/ip_limiter.go
+++ b/internal/ratelimit/ip_limiter.go
@@ -134,10 +134,10 @@ func (l *IPLimiter) Middleware(next http.Handler) http.Handler {
 
 		// Refuse before reserving when the bucket already says the wait is past
 		// the ceiling, so a refusal costs the IP nothing: see peekWait for what
-		// the reserve-then-cancel route costs instead. The reading can be stale
-		// by the time the reservation below is taken, which is the case the
-		// cancel on the over-max_wait path still covers. The zero test keeps the
-		// settings read off the path of a request the bucket can serve outright.
+		// the reserve-then-cancel route costs instead, and for what a reading
+		// that goes stale before the reservation below still leaves behind. The
+		// zero test keeps the settings read off the path of a request the
+		// bucket can serve outright.
 		if wait := peekWait(entry.limiter, time.Now()); wait > 0 && wait > l.maxWait(r.Context()) {
 			entry.noteRejected(ip)
 			writeRateLimitHeaders(w, entry.limiter, wait, ipLogLabel)

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -1097,3 +1097,45 @@ func TestIPLimiter_ClientLeftDuringWaitRefundsToken(t *testing.T) {
 		t.Errorf("IP bucket = %.2f tokens, want about 0: the abandoned request kept its token", got)
 	}
 }
+
+// The per-IP bucket owes the same debt-free refusal as the per-key one: an
+// unauthenticated flood is exactly what this limiter exists for, so its
+// refusals must not leave the address throttled past the flood.
+func TestIPLimiter_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
+	settings := &stubIPSettings{values: map[string]string{
+		"rate_limit_ip_enabled":  "true",
+		"rate_limit_ip_rps":      "1", // refill is negligible over the flood
+		"rate_limit_ip_burst":    "5",
+		"rate_limit_max_wait_ms": "0",
+	}}
+	lim := NewIPLimiter(1, 5, nil, settings)
+	defer lim.Stop()
+
+	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const flood = 200
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range flood {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			req := httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)
+			req.RemoteAddr = "203.0.113.7:1234"
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	entry, ok := lim.limiters["203.0.113.7"]
+	if !ok {
+		t.Fatal("IP bucket missing")
+	}
+	if got := entry.limiter.Tokens(); got < -1 {
+		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -1: a refusal must cost nothing", got, flood)
+	}
+}

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -1115,7 +1115,7 @@ func TestIPLimiter_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	const flood = 200
+	const flood = 2000
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for range flood {
@@ -1135,7 +1135,11 @@ func TestIPLimiter_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 	if !ok {
 		t.Fatal("IP bucket missing")
 	}
-	if got := entry.limiter.Tokens(); got < -1 {
-		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -1: a refusal must cost nothing", got, flood)
+	// The slack is for the requests that read the bucket in the same few
+	// instructions and still reserve and cancel each other's refunds; that
+	// window holds a handful, where refusing by reservation put the whole
+	// refused crowd in debt (measured between -15 and -282 on this flood).
+	if got := entry.limiter.Tokens(); got < -5 {
+		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -5: refusals must not scale into debt", got, flood)
 	}
 }

--- a/internal/ratelimit/ip_limiter_test.go
+++ b/internal/ratelimit/ip_limiter_test.go
@@ -1139,6 +1139,7 @@ func TestIPLimiter_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 	// instructions and still reserve and cancel each other's refunds; that
 	// window holds a handful, where refusing by reservation put the whole
 	// refused crowd in debt (measured between -15 and -282 on this flood).
+	// The slack held at every GOMAXPROCS from 1 to 64, worst case -1.
 	if got := entry.limiter.Tokens(); got < -5 {
 		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -5: refusals must not scale into debt", got, flood)
 	}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -191,9 +191,12 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			// Refuse before reserving when the buckets already say the wait is
 			// past the ceiling, so a refusal costs the identity nothing: see
 			// peekWait for what the reserve-then-cancel route costs instead.
-			// The reading can be stale by the time the reservations below are
-			// taken, which is the case the cancels on the over-max_wait path
-			// still cover.
+			// A reading can go stale before the reservations below are taken,
+			// and a request that slips through then cancels on the
+			// over-max_wait path, which hands its token back only if no other
+			// slipped-through request reserved in between. So this narrows the
+			// debt to what fits in a window a few instructions wide rather than
+			// abolishing it; what is left no longer grows with the flood.
 			if peeked, by, id := peekAdmission(entry, keyHash, userEntry, userKey, now); peeked > maxWait {
 				reject(by, id, peeked)
 				return

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -197,7 +197,9 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			// slipped-through request reserved in between. So this narrows the
 			// debt to what fits in a window a few instructions wide rather than
 			// abolishing it; what is left no longer grows with the flood.
-			if peeked, by, id := peekAdmission(entry, keyHash, userEntry, userKey, now); peeked > maxWait {
+			// The zero test is what keeps a max_wait that somehow arrived
+			// negative from refusing a request the bucket can serve outright.
+			if peeked, by, id := peekAdmission(entry, keyHash, userEntry, userKey, now); peeked > 0 && peeked > maxWait {
 				reject(by, id, peeked)
 				return
 			}
@@ -288,9 +290,21 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 // peekAdmission reports the longest wait either admission stage still needs
 // before it can hand this request a token, and which stage that is, without
 // taking anything from either bucket.
+//
+// A stage that can never serve, its burst below one, answers no wait at all, so
+// the reservation path refuses the request instead. That keeps the refusal in
+// the name of the stage that can never serve it, rather than handing it to a
+// co-stage that merely happens to be saturated and promising a retry time no
+// amount of waiting can honour.
 func peekAdmission(entry *bucketEntry, keyID string, userEntry *bucketEntry, userID string, now time.Time) (time.Duration, *bucketEntry, string) {
+	if entry.limiter.Burst() < 1 {
+		return 0, entry, keyID
+	}
 	wait := peekWait(entry.limiter, now)
 	if userEntry != nil {
+		if userEntry.limiter.Burst() < 1 {
+			return 0, userEntry, userID
+		}
 		if uw := peekWait(userEntry.limiter, now); uw > wait {
 			return uw, userEntry, userID
 		}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -180,13 +180,30 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			// admitUserTPM pins for the same reason.
 			now := time.Now()
 
+			// reject answers one 429, naming the stage that refused so an
+			// owner-wide refusal reads differently from a per-key one.
+			reject := func(by *bucketEntry, id string, retryAfter time.Duration) {
+				by.noteRejected(id)
+				writeRateLimitHeaders(w, by.limiter, retryAfter, "")
+				util.WriteOpenAIError(w, rejectedBy(by, userEntry), http.StatusTooManyRequests)
+			}
+
+			// Refuse before reserving when the buckets already say the wait is
+			// past the ceiling, so a refusal costs the identity nothing: see
+			// peekWait for what the reserve-then-cancel route costs instead.
+			// The reading can be stale by the time the reservations below are
+			// taken, which is the case the cancels on the over-max_wait path
+			// still cover.
+			if peeked, by, id := peekAdmission(entry, keyHash, userEntry, userKey, now); peeked > maxWait {
+				reject(by, id, peeked)
+				return
+			}
+
 			var userRes *rate.Reservation
 			if userEntry != nil {
 				userRes = userEntry.limiter.ReserveN(now, 1)
 				if !userRes.OK() {
-					userEntry.noteRejected(userKey)
-					writeRateLimitHeaders(w, userEntry.limiter, 0, "")
-					util.WriteOpenAIError(w, "user rate limit exceeded", http.StatusTooManyRequests)
+					reject(userEntry, userKey, 0)
 					return
 				}
 			}
@@ -196,9 +213,7 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 				if userRes != nil {
 					userRes.CancelAt(now)
 				}
-				entry.noteRejected(keyHash)
-				writeRateLimitHeaders(w, entry.limiter, 0, "")
-				util.WriteOpenAIError(w, "rate limit exceeded", http.StatusTooManyRequests)
+				reject(entry, keyHash, 0)
 				return
 			}
 
@@ -251,13 +266,7 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 				if userRes != nil {
 					userRes.CancelAt(now)
 				}
-				limitedBy.noteRejected(limitedKey)
-				writeRateLimitHeaders(w, limitedBy.limiter, delay, "")
-				msg := "rate limit exceeded"
-				if limitedBy == userEntry {
-					msg = "user rate limit exceeded"
-				}
-				util.WriteOpenAIError(w, msg, http.StatusTooManyRequests)
+				reject(limitedBy, limitedKey, delay)
 				return
 			}
 
@@ -271,6 +280,28 @@ func (l *Limiter) Middleware(enabled bool) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// peekAdmission reports the longest wait either admission stage still needs
+// before it can hand this request a token, and which stage that is, without
+// taking anything from either bucket.
+func peekAdmission(entry *bucketEntry, keyID string, userEntry *bucketEntry, userID string, now time.Time) (time.Duration, *bucketEntry, string) {
+	wait := peekWait(entry.limiter, now)
+	if userEntry != nil {
+		if uw := peekWait(userEntry.limiter, now); uw > wait {
+			return uw, userEntry, userID
+		}
+	}
+	return wait, entry, keyID
+}
+
+// rejectedBy names the stage a 429 came from, so an owner whose whole account
+// is saturated is not told one of their keys is.
+func rejectedBy(by, userEntry *bucketEntry) string {
+	if by == userEntry {
+		return "user rate limit exceeded"
+	}
+	return "rate limit exceeded"
 }
 
 // getLimiter returns (or creates) the rate.Limiter for the given key.

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1771,7 +1771,7 @@ func TestMiddleware_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	const flood = 200
+	const flood = 2000
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for range flood {
@@ -1789,7 +1789,11 @@ func TestMiddleware_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 	if !ok {
 		t.Fatal("key bucket missing")
 	}
-	if got := entry.limiter.Tokens(); got < -1 {
-		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -1: a refusal must cost nothing", got, flood)
+	// The slack is for the requests that read the bucket in the same few
+	// instructions and still reserve and cancel each other's refunds; that
+	// window holds a handful, where refusing by reservation put the whole
+	// refused crowd in debt (measured between -15 and -282 on this flood).
+	if got := entry.limiter.Tokens(); got < -5 {
+		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -5: refusals must not scale into debt", got, flood)
 	}
 }

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1723,3 +1723,73 @@ func TestMiddleware_ZeroBurstRejectRefundsOwnerToken(t *testing.T) {
 		t.Errorf("owner bucket = %.2f tokens, want ~50: the rejected request kept its owner token", got)
 	}
 }
+
+func TestPeekWait(t *testing.T) {
+	now := time.Now()
+
+	full := rate.NewLimiter(10, 2)
+	if got := peekWait(full, now); got != 0 {
+		t.Errorf("full bucket: peekWait = %v, want 0", got)
+	}
+
+	full.AllowN(now, 2)
+	got := peekWait(full, now)
+	if got < 95*time.Millisecond || got > 105*time.Millisecond {
+		t.Errorf("empty bucket at 10 rps: peekWait = %v, want ~100ms", got)
+	}
+	if left := full.TokensAt(now); left < -0.001 || left > 0.001 {
+		t.Errorf("bucket = %.4f tokens after the read, want 0: reading must not charge", left)
+	}
+
+	if got := peekWait(rate.NewLimiter(10, 0), now); got != 0 {
+		t.Errorf("zero-burst bucket: peekWait = %v, want 0 so the reservation refuses it", got)
+	}
+
+	// A rate slow enough that the wait overflows a duration reports the
+	// unreachable wait rather than a wrapped negative one.
+	crawling := rate.NewLimiter(1e-300, 1)
+	crawling.AllowN(now, 1)
+	if got := peekWait(crawling, now); got != rate.InfDuration {
+		t.Errorf("unreachable bucket: peekWait = %v, want InfDuration", got)
+	}
+}
+
+// A flood of refused requests must leave the bucket at empty rather than deep in
+// debt. Refusing by reserving and cancelling only looks free: a cancel restores
+// nothing once a later reservation has moved the bucket's last event past it, so
+// every concurrent refusal used to take a token it never gave back and the key
+// stayed throttled long after the flood.
+func TestMiddleware_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
+	lim, repo := newTestLimiter()
+	defer lim.Stop()
+	repo.set("rate_limit_enabled", "true")
+	repo.set(settingsKeyRPS, "1") // refill is negligible over the flood
+	repo.set(settingsKeyBurst, "5")
+	repo.set(settingsKeyMaxWaitMs, "0")
+
+	handler := lim.Middleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const flood = 200
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range flood {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			handler.ServeHTTP(httptest.NewRecorder(), requestWithKey("flooded-key"))
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	entry, ok := lim.limiters["flooded-key"]
+	if !ok {
+		t.Fatal("key bucket missing")
+	}
+	if got := entry.limiter.Tokens(); got < -1 {
+		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -1: a refusal must cost nothing", got, flood)
+	}
+}

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -1752,6 +1753,15 @@ func TestPeekWait(t *testing.T) {
 	if got := peekWait(crawling, now); got != rate.InfDuration {
 		t.Errorf("unreachable bucket: peekWait = %v, want InfDuration", got)
 	}
+
+	// The rate whose wait lands exactly on 2^63, one nanosecond past the
+	// largest duration: converting it back wraps to a large negative wait,
+	// which would read as a bucket ready to serve.
+	boundary := rate.NewLimiter(rate.Limit(1e9/math.Pow(2, 63)), 1)
+	boundary.AllowN(now, 1)
+	if got := peekWait(boundary, now); got != rate.InfDuration {
+		t.Errorf("bucket one tick past the longest duration: peekWait = %v, want InfDuration", got)
+	}
 }
 
 // A flood of refused requests must leave the bucket at empty rather than deep in
@@ -1793,7 +1803,41 @@ func TestMiddleware_RefusedFloodLeavesTheBucketAtEmpty(t *testing.T) {
 	// instructions and still reserve and cancel each other's refunds; that
 	// window holds a handful, where refusing by reservation put the whole
 	// refused crowd in debt (measured between -15 and -282 on this flood).
+	// The slack held at every GOMAXPROCS from 1 to 64, worst case -1.
 	if got := entry.limiter.Tokens(); got < -5 {
 		t.Errorf("bucket = %.2f tokens after %d requests on a burst of 5, want no worse than -5: refusals must not scale into debt", got, flood)
+	}
+}
+
+// An owner bucket that can never serve refuses in its own name, with no retry
+// time, even while the key beside it is saturated and would otherwise win the
+// comparison and answer for it.
+func TestMiddleware_ZeroBurstOwnerRefusesInItsOwnName(t *testing.T) {
+	lim, repo := newTestLimiter()
+	defer lim.Stop()
+	repo.set("rate_limit_enabled", "true")
+	repo.set(settingsKeyRPS, "0.001")
+	repo.set(settingsKeyBurst, "1")
+	repo.set(settingsKeyMaxWaitMs, "0")
+
+	handler := lim.Middleware(true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, ownedRPSReq("key-owner-zero", "uid-owner-zero", 0.001, 0))
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rr.Code)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "user rate limit") {
+		t.Errorf("expected the owner stage to answer, got %q", body)
+	}
+	if h := rr.Header().Get("Retry-After"); h != "" {
+		t.Errorf("Retry-After = %q, want none: no wait makes a zero-burst owner serve", h)
+	}
+	if entry, ok := lim.limiters["key-owner-zero"]; ok {
+		if got := entry.limiter.Tokens(); got < 0.9 {
+			t.Errorf("key bucket = %.2f tokens, want ~1: the owner refused before the key was charged", got)
+		}
 	}
 }

--- a/internal/ratelimit/throttle.go
+++ b/internal/ratelimit/throttle.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"math"
 	"net/http"
 	"strconv"
 	"sync"
@@ -145,6 +146,33 @@ func bucketRate(rps float64, burst int) (float64, int) {
 		return 1e6, 1e6
 	}
 	return rps, burst
+}
+
+// peekWait reports how long a bucket needs before it can hand out one token,
+// without taking anything. A reservation answers the same question, but it
+// charges for the answer and gives the charge back only while no later
+// reservation has moved the bucket's last event past it: under a flood every
+// refusal reserves and cancels, almost none of the cancels refund, and the
+// bucket sinks far below empty, throttling the identity long after the flood
+// has stopped. A read leaves the bucket where it was.
+//
+// A bucket that can never hand out a token (burst below one) reports no wait,
+// because no amount of waiting would help and the reservation path already
+// refuses it, free of charge and without promising a retry time.
+func peekWait(lim *rate.Limiter, now time.Time) time.Duration {
+	limit := float64(lim.Limit())
+	if lim.Burst() < 1 || limit <= 0 {
+		return 0
+	}
+	deficit := 1 - lim.TokensAt(now)
+	if deficit <= 0 {
+		return 0
+	}
+	wait := deficit / limit * float64(time.Second)
+	if wait > math.MaxInt64 {
+		return rate.InfDuration
+	}
+	return time.Duration(wait)
 }
 
 // runCleanup drives a limiter's idle-entry sweep until its stop channel closes.

--- a/internal/ratelimit/throttle.go
+++ b/internal/ratelimit/throttle.go
@@ -161,13 +161,18 @@ func bucketRate(rps float64, burst int) (float64, int) {
 // each other's refunds as before, so what survives is bounded by that window
 // instead of by the size of the flood.
 //
-// A read can only be more pessimistic than the reservation it stands in for,
-// and only by a token another request handed back in between, so a refusal it
-// decides is one the bucket could not have served an instant earlier.
+// A read can differ from the reservation it stands in for in either direction,
+// by whatever another request took or handed back in between: too optimistic is
+// the window above, too pessimistic refuses a request that a refund had just
+// made servable, which is a refusal the bucket would have given an instant
+// earlier anyway.
 //
 // A bucket that can never hand out a token (burst below one) reports no wait,
 // because no amount of waiting would help and the reservation path already
-// refuses it, free of charge and without promising a retry time.
+// refuses it, free of charge and without promising a retry time. A rate of zero
+// or less cannot reach here, since bucketRate turns "no cap" into a very large
+// rate, but it is guarded anyway: the division would otherwise answer with the
+// sign of the rate rather than with a wait.
 func peekWait(lim *rate.Limiter, now time.Time) time.Duration {
 	limit := float64(lim.Limit())
 	if lim.Burst() < 1 || limit <= 0 {
@@ -178,7 +183,10 @@ func peekWait(lim *rate.Limiter, now time.Time) time.Duration {
 		return 0
 	}
 	wait := deficit / limit * float64(time.Second)
-	if wait > math.MaxInt64 {
+	// Not a strict compare: float64(math.MaxInt64) is 2^63, one past the
+	// largest duration, and converting it back would wrap to a large negative
+	// one that reads as no wait at all.
+	if wait >= math.MaxInt64 {
 		return rate.InfDuration
 	}
 	return time.Duration(wait)

--- a/internal/ratelimit/throttle.go
+++ b/internal/ratelimit/throttle.go
@@ -156,6 +156,15 @@ func bucketRate(rps float64, burst int) (float64, int) {
 // bucket sinks far below empty, throttling the identity long after the flood
 // has stopped. A read leaves the bucket where it was.
 //
+// It narrows the debt rather than abolishing it. Requests that read the bucket
+// in the same few instructions all see the same free token, reserve, and cancel
+// each other's refunds as before, so what survives is bounded by that window
+// instead of by the size of the flood.
+//
+// A read can only be more pessimistic than the reservation it stands in for,
+// and only by a token another request handed back in between, so a refusal it
+// decides is one the bucket could not have served an instant earlier.
+//
 // A bucket that can never hand out a token (burst below one) reports no wait,
 // because no amount of waiting would help and the reservation path already
 // refuses it, free of charge and without promising a retry time.


### PR DESCRIPTION
## What this fixes

A request whose wait exceeded `max_wait` used to reserve a token, read the delay, then cancel. A cancel restores the token only while no later reservation has moved the bucket's last event past it, so under concurrency almost none of them restore anything: every refusal took a token it never gave back, and the bucket sank far below empty and held the identity throttled long after the flood had passed.

Both limiters now read the bucket before reserving and refuse outright when the wait is already past the ceiling. Reading answers the same question, costs nothing, and leaves the bucket where it was, so refusals no longer scale into debt.

Measured on a burst of 5 with 2000 concurrent requests:

| | bucket after the flood |
|---|---|
| before | -15 to -282 tokens |
| after | 0 |

This is the residual left over from #976, which fixed the refund that never happened on the zero-delay paths. That one made the cancels correct where they could work; this one stops relying on cancels where they cannot.

## What it does not fix

Requests that read the bucket within the same few instructions still reserve and cancel each other's refunds, so a handful of tokens can go missing. The tests carry that slack explicitly. What the change removes is the debt that grew with the size of the flood.

## Scope

The per-key stage pair (key plus owner aggregate) and the per-IP net in front of them, where an unauthenticated flood is the whole point of the limiter. The admission set is unchanged: tokens can only move against a peek between the read and the reservation, and any slip is re-checked against the ceiling after reserving.

## Review

Two rounds on GLM-5.3 and DeepSeek V4.1 Flash, since Codex is out of allowance. Round one caught a comment claiming the cancels covered the whole race, and a 200-request flood small enough that the old code sometimes finished level and passed. Round two caught three corners, all now fixed with tests that fail without them:

- A stage whose burst is below one reports no wait, which let a saturated co-stage answer the 429 in its own name and advertise a retry time the refusing stage could never honour.
- A wait landing exactly one nanosecond past the longest duration passed a strict compare and converted back to a large negative wait, reading as a bucket ready to serve.
- A negative `max_wait`, unreachable through validation today, would have refused requests the bucket could serve outright.

Nothing above low in the second round. Both reviewers stress-ran the flood tests across GOMAXPROCS 1 to 64 without a failure.

## Checks

`go test ./internal/ratelimit/ ./internal/proxy/`, `-race`, `golangci-lint`, and `scripts/ci/size-gate.sh` all pass. Package coverage 97.1 percent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
