### PR TITLE
Fail over to the next candidate when a 2xx carries no answer

### DIFF
--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -77,7 +77,7 @@ func TestHandleNonStreamingResponse_EmptyAnswerChargesTheBreaker(t *testing.T) {
 			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(tc.body)), Header: make(http.Header)}
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
-			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 			h.recordAnswerOutcome(st, candidate, logData, 200)
 
 			charged := h.circuitBreaker.GetState(providerID, "") == failover.StateOpen
@@ -336,7 +336,7 @@ func TestHandleNonStreamingResponse_AnInterruptedReadIsNotCharged(t *testing.T) 
 			}
 			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)).WithContext(ctx)
 
-			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+			h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 			h.recordAnswerOutcome(st, candidate, logData, 200)
 
 			if logData.errorKind != tc.wantKind {
@@ -503,7 +503,7 @@ func TestHandleNonStreamingResponse_AnOversizedBodyIsNotTheProvidersFault(t *tes
 		strings.Repeat("x", nonStreamingBodyCap) + `"}}]}`
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(huge)), Header: make(http.Header)}
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 	h.recordAnswerOutcome(st, candidate, logData, 200)
 
 	if logData.errorKind != KindProviderBadRequest {
@@ -553,7 +553,7 @@ func TestServeBufferedJSONPassthrough_EmptyEmbeddingsChargesTheBreaker(t *testin
 			}
 			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(tc.body)), Header: make(http.Header)}
 
-			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5)
+			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5, false)
 
 			charged := h.circuitBreaker.GetState(providerID, candidate.model.ModelID) == failover.StateOpen
 			if charged != tc.wantCharge {
@@ -591,7 +591,7 @@ func TestServeBufferedJSONPassthrough_AClientHangingUpIsNotCharged(t *testing.T)
 	cancel()
 	req := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody).WithContext(ctx)
 
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5)
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5, false)
 
 	if h.circuitBreaker.GetState(providerID, "") == failover.StateOpen {
 		t.Error("an abandoned pass-through read was charged to the provider")
@@ -754,7 +754,7 @@ func TestHandleNonStreamingResponse_ABodyThatDiedOnTheWireIsCharged(t *testing.T
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body), Header: make(http.Header)}
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 	h.recordAnswerOutcome(st, candidate, logData, 200)
 
 	if logData.errorKind != KindProviderError {
@@ -795,7 +795,7 @@ func TestServeBufferedJSONPassthrough_AnEmptyBodilessSuccessIsANoOp(t *testing.T
 	}
 	resp := &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(bytes.NewBufferString("")), Header: make(http.Header)}
 
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5)
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5, false)
 
 	// The earlier failure must still be on the clock: at threshold 2 a second
 	// one opens the circuit, which it cannot do if the 204 credited a success.
@@ -825,7 +825,7 @@ func TestServeBufferedJSONPassthrough_AnAbandonedRequestIsNotCharged(t *testing.
 	cancel()
 	req := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody).WithContext(ctx)
 
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5)
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), req, st, candidate, resp, "application/json", 1, 5, false)
 
 	if h.circuitBreaker.GetState(providerID, "") == failover.StateOpen {
 		t.Error("an abandoned pass-through request was charged to the provider")
@@ -948,7 +948,7 @@ func TestHandleNonStreamingResponse_ACompleteBodyBehindAnUncleanCloseIsServed(t 
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body), Header: make(http.Header)}
 	w := httptest.NewRecorder()
 
-	h.handleNonStreamingResponse(w, withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(w, withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody)), logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 	h.recordAnswerOutcome(st, candidate, logData, 200)
 
 	if !strings.Contains(w.Body.String(), "hello") {
@@ -992,7 +992,7 @@ func TestHandleNativeNonStreaming_AnInterruptedReadIsClassified(t *testing.T) {
 			}
 			req := httptest.NewRequest("POST", "/v1/messages", http.NoBody).WithContext(ctx)
 
-			h.handleNativeNonStreaming(httptest.NewRecorder(), req, st, resp, 1, 5)
+			h.handleNativeNonStreaming(httptest.NewRecorder(), req, st, modelCandidate{}, resp, 1, 5, false)
 
 			if logData.errorKind != tc.wantKind {
 				t.Errorf("errorKind = %q, want %q", logData.errorKind, tc.wantKind)
@@ -1055,7 +1055,7 @@ func TestPassthrough_TheCreditLandsOnTheModelItServed(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(embeddingsAnswer)), Header: make(http.Header)}
 			},
 			serve: func(h *Handler, st *requestState, cand modelCandidate, resp *http.Response) {
-				h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, resp, "application/json", 1, 5)
+				h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, resp, "application/json", 1, 5, false)
 			},
 		},
 		{
@@ -1068,7 +1068,7 @@ func TestPassthrough_TheCreditLandsOnTheModelItServed(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusBadRequest, Body: io.NopCloser(bytes.NewBufferString(`{"error":{"message":"bad input"}}`)), Header: make(http.Header)}
 			},
 			serve: func(h *Handler, st *requestState, cand modelCandidate, resp *http.Response) {
-				h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, resp, "application/json", 1, 5)
+				h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, cand, resp, "application/json", 1, 5, false)
 			},
 		},
 		{
@@ -1077,7 +1077,7 @@ func TestPassthrough_TheCreditLandsOnTheModelItServed(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: {\"type\":\"x\"}\n\n")), Header: make(http.Header)}
 			},
 			serve: func(h *Handler, st *requestState, cand modelCandidate, resp *http.Response) {
-				h.serveStreamedPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody), st, cand, resp, "text/event-stream", true, 1, 5)
+				h.serveStreamedPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody), st, cand, resp, "text/event-stream", true, 1, 5, false)
 			},
 		},
 	} {
@@ -1127,7 +1127,7 @@ func TestServeStreamedPassthrough_ADeadBodyChargesTheModelItAskedFor(t *testing.
 	}
 
 	h.serveStreamedPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody),
-		passthroughState(providerID), cand, resp, "audio/mpeg", false, 1, 5)
+		passthroughState(providerID), cand, resp, "audio/mpeg", false, 1, 5, false)
 
 	if got := h.circuitBreaker.GetState(providerID, cand.model.ModelID); got != failover.StateOpen {
 		t.Errorf("the model's circuit is %v, want open: a dead 200 was charged somewhere else", got)

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -34,7 +34,13 @@ func (h *Handler) buildNativeAnthropicRequest(ctx context.Context, st *requestSt
 // response (any 2xx). The upstream body is already an Anthropic message, so it
 // is forwarded verbatim. Token usage is read from the Anthropic usage block for
 // metering and quota, mirroring handleNonStreamingResponse.
-func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Request, st *requestState, resp *http.Response, attempt int, responseHeaderMs float64) candidateOutcome {
+//
+// canFailOver says whether the group still has a candidate behind this one. A
+// success whose body never arrives is a request this provider did not serve,
+// so while a sibling can still be asked it is failed over to rather than
+// answered with this gateway's 502, the same rule the translated path applies
+// to a 2xx that is not a completion.
+func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, canFailOver bool) candidateOutcome {
 	logData := st.logData
 	defer func() {
 		if r.Context().Err() == nil {
@@ -46,6 +52,13 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body, err := httpx.ReadCappedBody(resp.Body, nonStreamingBodyCap)
 	if err != nil {
 		debuglog.Warn("proxy: native anthropic read failed", "error", err, "provider", logData.providerName)
+		// An interrupted read is excluded the same way the translated path
+		// excludes it: nobody is waiting for the answer a second provider would
+		// produce. Everything else goes to the sibling, charged or not by
+		// rejectUntranslatableBody's own rule.
+		if _, aborted := cancelKind(r.Context(), err); canFailOver && !aborted {
+			return h.rejectUntranslatableBody(st, candidate, logData, "native anthropic", resp.StatusCode, err, attempt, r)
+		}
 		// Finalize the log row so it does not orphan in the in-flight state. A
 		// read failure on a success body is a provider or transport fault,
 		// unless it was interrupted rather than broken, which cancelKind
@@ -84,6 +97,22 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	inputTokens, outputTokens, _ := h.clampReportedUsage(usage.PromptTokens, usage.CompletionTokens, 0, logData)
 	totalDuration := util.MillisSince(st.startTime)
 
+	// What clears the model's gone-strike streak (see dispatchNonStreaming), so the
+	// bar is content and not bytes: `200 {"content":[]}` is what an aggregator in
+	// front of a retired model returns between its refusals, and crediting it
+	// would stop the streak ever reaching three consecutive strikes. Tokens
+	// corroborate, for a provider that answers without reporting usage. Same
+	// judgement chatAnswerCarriesContent makes on the OpenAI-shaped path.
+	carriesContent := outputTokens > 0 || anthropic.ResponseCarriesContent(body)
+	// An answer carrying nothing goes to the sibling while there is one, the
+	// same rule and the same bar the translated path applies (completionFault).
+	// Above every stamp below, because a candidate the loop is about to leave
+	// must write neither a completed row nor a token charge for an answer the
+	// client will never see.
+	if canFailOver && !carriesContent {
+		return h.rejectUntranslatableBody(st, candidate, logData, "native anthropic", resp.StatusCode, errEmptyCompletion, attempt, r)
+	}
+
 	// The status the provider actually sent, not a flattened 200: a relay may
 	// answer a native message 201, and recording 200 would put a number in the
 	// request log that no upstream ever returned.
@@ -102,13 +131,6 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.tokensPromptCacheMiss = clampTokenCount(usage.CacheMissTokens)
 	logData.failoverAttempt = attempt
 	logData.state = "completed"
-	// What clears the model's gone-strike streak (see attemptCandidate), so the
-	// bar is content and not bytes: `200 {"content":[]}` is what an aggregator in
-	// front of a retired model returns between its refusals, and crediting it
-	// would stop the streak ever reaching three consecutive strikes. Tokens
-	// corroborate, for a provider that answers without reporting usage. Same
-	// judgement chatAnswerCarriesContent makes on the OpenAI-shaped path.
-	carriesContent := outputTokens > 0 || anthropic.ResponseCarriesContent(body)
 	logData.deliveredContent = carriesContent
 	// The question the breaker asks of the same body: did anything come back.
 	// ResponseCarriesContent reads block PRESENCE, which is the native analogue

--- a/internal/proxy/anthropic_native_test.go
+++ b/internal/proxy/anthropic_native_test.go
@@ -74,7 +74,7 @@ func TestHandleNativeNonStreaming(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0)
+	outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false)
 	aw.Finalize()
 
 	if outcome != outcomeServed {
@@ -131,7 +131,7 @@ func TestHandleNativeNonStreaming_JudgesContentNotBytes(t *testing.T) {
 			}
 			st := &requestState{startTime: time.Now(), logData: logData}
 
-			if got := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); got != outcomeServed {
+			if got := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false); got != outcomeServed {
 				t.Fatalf("outcome = %v, want outcomeServed", got)
 			}
 			aw.Finalize()
@@ -179,7 +179,7 @@ func TestHandleNativeNonStreaming_ReadErrorFinalizesLog(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0)
+	outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false)
 	aw.Finalize()
 
 	if outcome != outcomeFatal {
@@ -445,7 +445,7 @@ func runNativeNonStreamingWith(t *testing.T, anthropicBody string, masker creden
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+	if outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false); outcome != outcomeServed {
 		t.Fatalf("outcome = %v, want outcomeServed", outcome)
 	}
 	aw.Finalize()
@@ -612,7 +612,7 @@ func TestHandleNativeNonStreaming_AnOversizedBodyIsNotTheProvidersFault(t *testi
 	time.Sleep(100 * time.Millisecond)
 
 	h.deferAnswerJudgement(st, candidate, logData, http.StatusOK)
-	outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0)
+	outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false)
 	judgeAnswerNow(logData)
 	aw.Finalize()
 

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
 	"github.com/hugalafutro/model-hotel/internal/failover"
 	"github.com/hugalafutro/model-hotel/internal/gemini"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -282,12 +283,21 @@ func (h *Handler) creditBreaker(st *requestState, candidate modelCandidate) {
 	h.circuitBreaker.RecordSuccess(candidate.provider.ID, candidate.provider.Name, candidateModelID(candidate))
 }
 
-// rejectUntranslatableBody is the single outcome all three egress adapters have
-// for a success whose body they cannot turn into a completion.
+// rejectUntranslatableBody is the single outcome every path has for a success
+// whose body it cannot turn into an answer: the three egress adapters and the
+// two Gemini audio ones, the plain chat path whose body would not decode or
+// decoded empty, the native Anthropic path, and the two pass-through halves
+// whose body never arrived.
 //
 // One place because the outcome has four parts (the log, the breaker charge,
-// the request error and the failover), and three copies of it is how the charge
-// comes to be missing from one.
+// the request error and the failover), and a copy of it per call site is how
+// the charge comes to be missing from one.
+//
+// The callers differ in one thing only: whether they ask first. The chat,
+// native and pass-through paths reach here only while a sibling remains, since
+// on the last candidate the client is owed the specific error their handler
+// renders. The egress and audio adapters fail over unconditionally, so on a
+// last candidate their refusal is rendered by failAllExhausted instead.
 //
 // status is the 2xx the upstream answered before its body failed translation;
 // logData has not been stamped with it at this point.
@@ -303,6 +313,12 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt
 	logData.closeAttemptRecord(status, KindProviderError, errString(err), "", 0)
+	// This attempt's breaker verdict is the one just recorded, so a judgement
+	// armed for the handler that never got to write is disarmed here rather than
+	// left to fire on a candidate the loop has already moved past. Only the
+	// native Anthropic path can reach this with one armed, and it is disarmed in
+	// the shared place so a later caller cannot inherit the bug.
+	logData.judgeAnswer = nil
 	return outcomeFailover
 }
 
@@ -318,16 +334,23 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 // The speech and transcription adapters' refusals are the same two shapes:
 // an answer without an audio part or without text (a blocked prompt, a reply
 // of the other kind) is the model answering, and a body past the adapter's
-// cap is this gateway's own limit.
+// cap is this gateway's own limit. httpx.ErrBodyTooLarge is that same limit
+// under the sentinel the capped reads on the chat and native paths refuse
+// with, so an oversized answer fails over without its provider being charged
+// for sending too much.
 func translationIsProviderFault(err error) bool {
 	return !errors.Is(err, gemini.ErrPromptBlocked) && !errors.Is(err, errEgressBodyOversized) &&
+		!errors.Is(err, httpx.ErrBodyTooLarge) &&
 		!errors.Is(err, gemini.ErrSpeechNoAudio) && !errors.Is(err, errSpeechBodyOversized) &&
 		!errors.Is(err, gemini.ErrTranscriptionNoText) && !errors.Is(err, errTranscriptionBodyOversized)
 }
 
 // answerCarriesSomething reports whether a completion carries anything at all
 // from the provider. Its negation is requestLogData.emptyCompletion, the one
-// shape a 200 is charged for.
+// shape a 200 is charged for, and the bar completionFault fails a candidate on
+// while a sibling remains: the same question asked a moment earlier, so an
+// answer that would be charged is offered to the next provider instead of
+// being served.
 //
 // Deliberately NOT chatAnswerCarriesContent, which backs the retirement verdict
 // and stays narrow: `refusal` is the likeliest field for an aggregator to write

--- a/internal/proxy/gemini_speech.go
+++ b/internal/proxy/gemini_speech.go
@@ -144,7 +144,9 @@ func (h *Handler) serveGeminiReshaped(w http.ResponseWriter, r *http.Request, st
 		Header:     http.Header{"Content-Type": {contentType}, "Content-Length": {strconv.Itoa(len(out))}},
 		Body:       io.NopCloser(bytes.NewReader(out)),
 	}
-	h.servePassthroughResponse(w, r, st, candidate, delivered, attempt, responseHeaderMs)
+	// false: delivered carries this process's own buffer, so its read cannot
+	// fail and there is nothing here to fail over from.
+	h.servePassthroughResponse(w, r, st, candidate, delivered, attempt, responseHeaderMs, false)
 	return outcomeServed
 }
 

--- a/internal/proxy/gemini_speech_test.go
+++ b/internal/proxy/gemini_speech_test.go
@@ -185,7 +185,7 @@ func TestServeStreamedPassthrough_AdapterUsageWins(t *testing.T) {
 	h.serveStreamedPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "gemini-2.5-flash-preview-tts"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "audio/wav", false, 1, 10.0)
+	}, resp, "audio/wav", false, 1, 10.0, false)
 	if got := singleAddTokens(t, vkRepo); got != 261 {
 		t.Errorf("charged %d tokens, want the answer's 11 + 250 rather than the 100-token estimate", got)
 	}

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -190,7 +190,12 @@ const passthroughSSETailCap = 64 << 10 // 64KB
 // buffered JSON (headers received, body about to be read), and at the first
 // body byte for streamed responses, so a provider that returns 200 and then
 // produces nothing records a breaker failure instead of a success.
-func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64) {
+//
+// That commit point is also the last moment another candidate can be asked, so
+// a 2xx whose body never arrives returns outcomeFailover while hasMoreCandidates
+// holds, exactly as the chat path's does, instead of ending the loop with this
+// gateway's 502 and a healthy sibling never contacted.
+func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
 	defer func() {
 		// Drain remaining bytes so the Transport reuses the connection,
 		// unless the client already disconnected.
@@ -216,10 +221,9 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
 
 	if isJSON {
-		h.serveBufferedJSONPassthrough(w, r, st, candidate, resp, contentType, attempt, responseHeaderMs)
-		return
+		return h.serveBufferedJSONPassthrough(w, r, st, candidate, resp, contentType, attempt, responseHeaderMs, hasMoreCandidates)
 	}
-	h.serveStreamedPassthrough(w, r, st, candidate, resp, contentType, isSSE, attempt, responseHeaderMs)
+	return h.serveStreamedPassthrough(w, r, st, candidate, resp, contentType, isSSE, attempt, responseHeaderMs, hasMoreCandidates)
 }
 
 // serveBufferedJSONPassthrough handles the application/json shape: bounded
@@ -227,8 +231,9 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 // circuit breaker commits only once the buffered read succeeds, so a 200 whose
 // body dies mid-read records a failure rather than a success, and response
 // headers are written only after that point, leaving the read-error path free to
-// emit a clean OpenAI error response.
-func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64) {
+// fail over to a sibling, or on the last candidate to emit a clean OpenAI error
+// response.
+func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
 	logData := st.logData
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
@@ -237,13 +242,21 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		// under the attempt's context, so a caller hanging up and this gateway's
 		// own request_timeout both surface here as a failed read, and neither is
 		// the provider's doing. cancelKind is the package's classifier for that.
-		if _, aborted := cancelKind(r.Context(), err); !aborted {
+		_, aborted := cancelKind(r.Context(), err)
+		// Nothing has been written to the client yet, so while a sibling remains
+		// this is failed over rather than answered. An interrupted read is
+		// excluded there too: nobody is waiting for the answer a second provider
+		// would produce. Same rule, same shared outcome, as the chat path.
+		if hasMoreCandidates && !aborted {
+			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, err, attempt, r)
+		}
+		if !aborted {
 			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough body read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", err)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", err))
 		writeOpenAIError(w, "failed to read upstream response", http.StatusBadGateway)
-		return
+		return outcomeFatal
 	}
 	// The commit point is where the model has proved it is alive, so it is where
 	// its gone-strike streak stops being current. Without it "three CONSECUTIVE
@@ -297,6 +310,15 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		// chat completion that answers 204 has by definition produced no
 		// completion.
 	default:
+		// An answer carrying nothing goes to the sibling while there is one, the
+		// rule the chat path applies through completionFault, reached here on the
+		// only pass-through family whose body can be judged (an embeddings `200
+		// {"data":[]}`; passthroughAnswered says why the others cannot be). The
+		// reject path carries the same charge, so this is that verdict reached one
+		// candidate earlier, and nothing has been written to the client yet.
+		if hasMoreCandidates {
+			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, errEmptyCompletion, attempt, r)
+		}
 		h.chargeBreaker(st, candidate, resp.StatusCode, "response completed without delivering content")
 	}
 	// Oversized is judged on the bytes read, before masking can shrink a
@@ -349,7 +371,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "completed", "")
 		estimated, _ := h.chargePassthroughUsage(st, 0, 0, answered)
 		debuglog.Info("proxy: passthrough completed (oversized json)", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "estimated_prompt_tokens", estimated)
-		return
+		return outcomeServed
 	}
 
 	promptTokens, completionTokens := extractPassthroughUsage(body)
@@ -376,6 +398,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	// oversized branch does not size a response of vectors or base64 as text.
 	charged, estimatedPrompt := h.chargePassthroughUsage(st, promptTokens, completionTokens, answered)
 	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", len(body), "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_tokens", charged, "prompt_estimated", estimatedPrompt)
+	return outcomeServed
 }
 
 // chargePassthroughUsage debits a completed pass-through request, estimating
@@ -427,10 +450,11 @@ func (h *Handler) chargePassthroughUsage(st *requestState, promptTokens, complet
 }
 
 // serveStreamedPassthrough handles SSE and binary shapes: probe the first body
-// byte before committing (a breaker failure on a dead 200, and a clean 502 since
-// no headers have been written), then stream through, flushing per write for SSE
-// only, while retaining an SSE tail for usage metering.
-func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, isSSE bool, attempt int, responseHeaderMs float64) {
+// byte before committing (a breaker failure on a dead 200, and a sibling or, on
+// the last candidate, a clean 502, since no headers have been written), then
+// stream through, flushing per write for SSE only, while retaining an SSE tail
+// for usage metering.
+func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, isSSE bool, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
 	logData := st.logData
 
 	// Commit-point probe: a success whose body errors or ends before the first
@@ -442,13 +466,19 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	n, readErr := resp.Body.Read(firstByte)
 	emptyBodyIsFailure := !bodilessSuccessStatus(resp.StatusCode) || !errors.Is(readErr, io.EOF)
 	if n == 0 && readErr != nil && emptyBodyIsFailure {
+		// No headers have been written, so a sibling can still be asked, unless
+		// the attempt was interrupted rather than broken. Same rule and same
+		// shared outcome as the buffered twin above.
+		if hasMoreCandidates && r.Context().Err() == nil {
+			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, readErr, attempt, r)
+		}
 		if r.Context().Err() == nil {
 			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough first-byte read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", readErr)
 		h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, 0, 0, "failed", fmt.Sprintf("upstream body read error: %v", readErr))
 		writeOpenAIError(w, "upstream produced no response data", http.StatusBadGateway)
-		return
+		return outcomeFatal
 	}
 	// Not for a bodiless success: see the buffered twin above for why crediting
 	// an empty 204 erases the chat path's charges on the same model.
@@ -534,11 +564,12 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 		// audio/mpeg takes, where the SSE tail that would carry usage is never
 		// allocated, so the report is structurally always absent.
 		h.chargePassthroughUsage(st, promptTokens, completionTokens, written > 0)
-		return
+		return outcomeServed
 	}
 	h.finalizePassthroughLog(st, resp.StatusCode, attempt, responseHeaderMs, promptTokens, completionTokens, "completed", "")
 	charged, estimatedPrompt := h.chargePassthroughUsage(st, promptTokens, completionTokens, written > 0)
 	debuglog.Info("proxy: passthrough completed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "attempt", attempt, "status", resp.StatusCode, "bytes", written, "sse", isSSE, "prompt_tokens", promptTokens, "completion_tokens", completionTokens, "charged_tokens", charged, "prompt_estimated", estimatedPrompt)
+	return outcomeServed
 }
 
 // copyPassthroughHeaders sets the upstream Content-Type and (when present)

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -94,8 +94,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	if st.transcriptionFormat != "" {
 		return h.serveGeminiTranscriptionResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
 	}
-	h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
-	return outcomeServed
+	return h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs, hasMoreCandidates)
 }
 
 // passthroughAnswered reports whether a buffered pass-through response is the

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -1,0 +1,507 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
+	"github.com/hugalafutro/model-hotel/internal/model"
+)
+
+// A 2xx that carries no completion must not end the candidate loop. The client
+// is not committed to a provider until the answer is in hand, so an upstream
+// that answers 200 with something this gateway cannot decode is failed over to
+// the sibling instead of being turned into the gateway's own 502.
+
+const siblingCompletion = `{"id":"chatcmpl-sibling","object":"chat.completion","created":1,"model":"shared-model",` +
+	`"choices":[{"index":0,"message":{"role":"assistant","content":"the sibling answered"},"finish_reason":"stop"}],` +
+	`"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`
+
+// replayUpstream answers the first provider in the group with firstBody under
+// firstStatus and every later one with a valid completion. The two providers
+// are told apart by Host: buildReplayEnv gives them different base URLs and
+// dials both to this one server.
+func replayUpstream(t *testing.T, firstStatus int, firstBody string) *replayEnv {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.Host, "one-slot") {
+			w.WriteHeader(firstStatus)
+			_, _ = io.WriteString(w, firstBody)
+			return
+		}
+		_, _ = io.WriteString(w, siblingCompletion)
+	}))
+	t.Cleanup(upstream.Close)
+	return buildReplayEnv(t, upstream)
+}
+
+// The motivating bug: a relay answering 200 with an HTML error page used to be
+// rendered as a 502 by the first candidate, with the healthy sibling behind it
+// never asked.
+func TestNonCompletion2xx_FailsOverToTheSibling(t *testing.T) {
+	env := replayUpstream(t, http.StatusOK, "<html><body>502 Bad Gateway (from the relay)</body></html>")
+
+	w := replayRequest(t, env)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the sibling can serve this); body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "the sibling answered") {
+		t.Fatalf("the client did not get the sibling's completion: %s", w.Body.String())
+	}
+
+	trail := waitForTrail(t, "hotel/"+env.group, 2)
+	if len(trail) != 2 {
+		t.Fatalf("trail has %d attempts, want 2 (the garbled 200 and the sibling): %+v", len(trail), trail)
+	}
+	if trail[0].Status != http.StatusOK {
+		t.Errorf("attempt 0 status = %d, want the 200 the relay actually sent", trail[0].Status)
+	}
+	// The amplification brake: a relay that does this on every request is
+	// charged every time, so its circuit opens and it stops being a candidate.
+	if trail[0].Breaker != breakerCharge {
+		t.Errorf("attempt 0 breaker = %q, want %q; an uncharged failover would burn the candidate list on every request", trail[0].Breaker, breakerCharge)
+	}
+	if trail[0].ErrorKind != string(KindProviderError) {
+		t.Errorf("attempt 0 error_kind = %q, want %q", trail[0].ErrorKind, KindProviderError)
+	}
+	if trail[1].Breaker != breakerSuccess {
+		t.Errorf("attempt 1 breaker = %q, want %q", trail[1].Breaker, breakerSuccess)
+	}
+}
+
+// The asymmetry with the streaming path, closed: a stream that ends without a
+// single chunk has always gone to the sibling, so a completion object carrying
+// nothing does too. The last candidate still forwards it, since by then there is
+// nowhere else to ask.
+func TestEmptyCompletion_FailsOverToTheSibling(t *testing.T) {
+	env := replayUpstream(t, http.StatusOK, `{"id":"chatcmpl-empty","object":"chat.completion","created":1,"model":"shared-model","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":0,"total_tokens":1}}`)
+
+	w := replayRequest(t, env)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "the sibling answered") {
+		t.Fatalf("the empty answer was served instead of the sibling's: %s", w.Body.String())
+	}
+	trail := waitForTrail(t, "hotel/"+env.group, 2)
+	if len(trail) != 2 {
+		t.Fatalf("trail has %d attempts, want 2: %+v", len(trail), trail)
+	}
+	if trail[0].Breaker != breakerCharge {
+		t.Errorf("attempt 0 breaker = %q, want %q: an empty answer is charged whether it is served or failed over", trail[0].Breaker, breakerCharge)
+	}
+}
+
+// 204 promises no body, so the empty one it carries is the whole answer and the
+// decode failure behind it is expected. Failing over there would re-send the
+// prompt to a second provider for a request the first one completed.
+func TestNoContent2xx_IsServedRatherThanFailedOver(t *testing.T) {
+	env := replayUpstream(t, http.StatusNoContent, "")
+
+	w := replayRequest(t, env)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (the first provider's own answer); body: %s", w.Code, w.Body.String())
+	}
+	trail := waitForTrail(t, "hotel/"+env.group, 1)
+	if len(trail) != 1 {
+		t.Fatalf("trail has %d attempts, want 1: a 204 is an answer, not a failover: %+v", len(trail), trail)
+	}
+}
+
+// The last candidate has nobody behind it, so the same garbled 200 is still
+// rendered as the gateway's 502 rather than being lost.
+func TestNonCompletion2xx_LastCandidateStillAnswersTheClient(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("<html>not a completion</html>")),
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+	}
+	logData := &requestLogData{
+		id:             uuid.New().String(),
+		modelID:        "shared-model",
+		providerName:   "relay",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "pending",
+	}
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+	w := httptest.NewRecorder()
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("client status = %d, want 502", w.Code)
+	}
+	if logData.state != "failed" {
+		t.Errorf("state = %q, want failed", logData.state)
+	}
+}
+
+// completionFault is the verdict the whole change turns on, so each way out of
+// it is pinned here rather than only through the paths above.
+func TestCompletionFault(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	answered := nonStreamingAnswer{chat: ChatCompletionResponse{
+		Choices: []Choice{{Message: Message{Role: "assistant", Content: "hello"}}},
+	}}
+	refused := nonStreamingAnswer{chat: ChatCompletionResponse{
+		Choices: []Choice{{Message: Message{Role: "assistant", Extra: jsonExtras{"refusal": json.RawMessage(`"I cannot help with that"`)}}}},
+	}}
+
+	for _, tc := range []struct {
+		name    string
+		ctx     context.Context
+		status  int
+		ans     nonStreamingAnswer
+		wantErr bool
+	}{
+		{"a completion is served", context.Background(), http.StatusOK, answered, false},
+		{"a 201 completion is served", context.Background(), http.StatusCreated, answered, false},
+		// The asymmetry with the streaming probe, closed: a stream that ends
+		// without a chunk fails over, so an answer object carrying nothing does
+		// too.
+		{"a completion carrying nothing is a fault", context.Background(), http.StatusOK, nonStreamingAnswer{}, true},
+		// The bar is answerCarriesSomething, not len(choices): a refusal, a
+		// filtered answer and a reported token count are all the model answering.
+		{"a refusal is an answer", context.Background(), http.StatusOK, refused, false},
+		{"reported completion tokens are an answer", context.Background(), http.StatusOK, nonStreamingAnswer{chat: ChatCompletionResponse{Usage: Usage{CompletionTokens: 7}}}, false},
+		{"an undecodable 200 is a fault", context.Background(), http.StatusOK, nonStreamingAnswer{decodeErr: errors.New("invalid character '<'")}, true},
+		{"a body that died on the wire is a fault", context.Background(), http.StatusOK, nonStreamingAnswer{readErr: io.ErrUnexpectedEOF, decodeErr: io.ErrUnexpectedEOF}, true},
+		// The whole document arrived and parsed, and only then did the
+		// connection drop. That answer is complete: failing over on it would
+		// discard it and re-bill the prompt on a sibling.
+		{"a completion that parsed despite a broken read is served", context.Background(), http.StatusOK, nonStreamingAnswer{chat: answered.chat, readErr: io.ErrUnexpectedEOF}, false},
+		{"a non-2xx belongs to forwardUpstreamError", context.Background(), http.StatusInternalServerError, nonStreamingAnswer{decodeErr: errors.New("invalid character '<'")}, false},
+		{"204 carries no body by contract", context.Background(), http.StatusNoContent, nonStreamingAnswer{decodeErr: io.EOF}, false},
+		{"205 carries no body by contract", context.Background(), http.StatusResetContent, nonStreamingAnswer{decodeErr: io.EOF}, false},
+		{"an interrupted read is nobody's answer to serve", cancelled, http.StatusOK, nonStreamingAnswer{readErr: context.Canceled, decodeErr: context.Canceled}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.ans.completionFault(tc.ctx, tc.status); (err != nil) != tc.wantErr {
+				t.Errorf("completionFault = %v, want fault: %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A body past the gateway's own cap fails over like any other 2xx that is not a
+// completion, but the provider is not charged for it: the limit is this
+// gateway's, not the provider's failure.
+func TestOversizedBodyIsNotChargedToTheProvider(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", nonStreamingBodyCap+1))),
+		Header:     make(http.Header),
+	}
+	ans := readNonStreamingBody(resp, credentialMasker{})
+
+	err := ans.completionFault(context.Background(), http.StatusOK)
+	if err == nil {
+		t.Fatal("an oversized body is not a completion and must fail over")
+	}
+	if !errors.Is(err, httpx.ErrBodyTooLarge) {
+		t.Fatalf("err = %v, want it to wrap httpx.ErrBodyTooLarge", err)
+	}
+	if translationIsProviderFault(err) {
+		t.Error("the gateway's own body cap must not charge the provider's circuit")
+	}
+}
+
+// nonCompletionState is the minimum a dispatch needs: a log row to stamp and a
+// breaker to charge.
+func nonCompletionState(t *testing.T) (*requestState, modelCandidate) {
+	t.Helper()
+	logData := &requestLogData{
+		id:             uuid.New().String(),
+		modelID:        "shared-model",
+		providerName:   "relay",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "pending",
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, circuitBreakerEnabled: true}
+	return st, goneCandidateAt(&model.Model{ID: uuid.New(), ModelID: "shared-model"}, "relay", "http://relay.test")
+}
+
+// A body past the gateway's own cap goes to the sibling like any other answer
+// that is not a completion, and the provider is not charged on the way: the two
+// halves of the oversized rule, proven on the path rather than on the helper.
+func TestOversizedBody_FailsOverUncharged(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	oversized := strings.Repeat("x", nonStreamingBodyCap+1)
+
+	t.Run("chat", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(oversized)), Header: make(http.Header)}
+		w := httptest.NewRecorder()
+		req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+
+		if outcome := h.dispatchNonStreaming(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
+			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+		}
+		if st.logData.attemptBreaker == breakerCharge {
+			t.Error("the gateway's own body cap charged the provider's circuit")
+		}
+	})
+
+	t.Run("native anthropic", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.anthropicNativeAttempt = true
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(oversized)), Header: make(http.Header)}
+		rec := httptest.NewRecorder()
+		native := true
+		aw := newAnthropicResponseWriter(rec, "msg_o", "m")
+		aw.bindNativeFlag(&native)
+		req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+
+		if outcome := h.dispatchNonStreaming(aw, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
+			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		}
+		aw.Finalize()
+		if rec.Body.Len() != 0 {
+			t.Errorf("the client was written to before the sibling was tried: %s", rec.Body.String())
+		}
+		if st.logData.attemptBreaker == breakerCharge {
+			t.Error("the gateway's own body cap charged the provider's circuit")
+		}
+	})
+}
+
+// The pass-through families (embeddings, images, audio) had the same hole: a 2xx
+// whose body never arrives used to end the loop with this gateway's 502.
+func TestPassthrough2xxWithoutABody_FailsOverToTheSibling(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	t.Run("buffered json", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeEmbeddings
+		resp := &http.Response{StatusCode: http.StatusOK, Body: errorReadCloser{}, Header: make(http.Header)}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/embeddings", http.NoBody)
+
+		if outcome := h.serveBufferedJSONPassthrough(w, req, st, candidate, resp, "application/json", 0, 1.0, true); outcome != outcomeFailover {
+			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+		}
+		if st.logData.state == "failed" {
+			t.Error("the row was finalized on a candidate the loop has not finished with")
+		}
+		if st.logData.attemptBreaker != breakerCharge {
+			t.Errorf("breaker note = %q, want %q", st.logData.attemptBreaker, breakerCharge)
+		}
+	})
+
+	t.Run("streamed", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeTTS
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/audio/speech", http.NoBody)
+
+		if outcome := h.serveStreamedPassthrough(w, req, st, candidate, resp, "audio/mpeg", false, 0, 1.0, true); outcome != outcomeFailover {
+			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+		}
+		if st.logData.attemptBreaker != breakerCharge {
+			t.Errorf("breaker note = %q, want %q", st.logData.attemptBreaker, breakerCharge)
+		}
+	})
+}
+
+// The pass-through loop's own proof, through the real handler rather than its
+// sub-handlers: the first provider answers 200 with nothing at all, which is
+// what an embeddings answer carrying no vectors is, and the client gets the
+// sibling's list. Without the hasMoreCandidates argument reaching the two serve
+// halves correctly, this is the gateway's 502 with the second provider never
+// contacted.
+func TestEmbeddings_EmptyBodyFailsOverToTheSibling(t *testing.T) {
+	var emptyCalls, goodCalls atomic.Int32
+	envEmpty := newMultimodalEnv(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		emptyCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	}))
+	goodUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		goodCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"object":"list","data":[{"index":0,"embedding":[0.1,0.2]}],"usage":{"prompt_tokens":2,"total_tokens":2}}`)
+	}))
+	t.Cleanup(goodUpstream.Close)
+	_, _, goodModelUUID, _ := createMultimodalProvider(t, goodUpstream.URL)
+
+	groupName := envEmpty.modelName
+	failoverRepo := failover.NewRepository(testDB.Pool())
+	if _, err := failoverRepo.UpsertWithConfig(context.Background(), groupName,
+		[]uuid.UUID{envEmpty.modelUUID, goodModelUUID},
+		map[string]bool{envEmpty.modelUUID.String(): true, goodModelUUID.String(): true},
+		nil, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create failover group: %v", err)
+	}
+
+	req := envEmpty.request("/v1/embeddings", "application/json", strings.NewReader(fmt.Sprintf(`{"model":"hotel/%s","input":"hi"}`, groupName)))
+	w := httptest.NewRecorder()
+	envEmpty.handler.Embeddings(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failover; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"embedding"`) {
+		t.Errorf("body = %q, want the sibling's vectors", w.Body.String())
+	}
+	if emptyCalls.Load() != 1 || goodCalls.Load() != 1 {
+		t.Errorf("upstream calls: empty = %d, good = %d, want 1 each", emptyCalls.Load(), goodCalls.Load())
+	}
+}
+
+// A request the caller or this gateway's own timeout ended is never failed over:
+// the second provider would be answering nobody, and the prompt would be billed
+// twice for it. Each path that can now fail over is asked separately, since each
+// classifies the interruption itself.
+func TestInterruptedAttempt_IsNotFailedOver(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	gone := func(method, path string) *http.Request {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return httptest.NewRequest(method, path, http.NoBody).WithContext(ctx)
+	}
+
+	t.Run("chat, a body that decoded into nothing", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"choices":[]}`)), Header: make(http.Header)}
+		if outcome := h.dispatchNonStreaming(httptest.NewRecorder(), gone("POST", "/v1/chat/completions"), st, candidate, resp, 0, 1.0, true); outcome == outcomeFailover {
+			t.Error("an interrupted attempt was sent to a second provider")
+		}
+	})
+
+	t.Run("passthrough, buffered", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeEmbeddings
+		resp := &http.Response{StatusCode: http.StatusOK, Body: errorReadCloser{}, Header: make(http.Header)}
+		if outcome := h.serveBufferedJSONPassthrough(httptest.NewRecorder(), gone("POST", "/v1/embeddings"), st, candidate, resp, "application/json", 0, 1.0, true); outcome == outcomeFailover {
+			t.Error("an interrupted attempt was sent to a second provider")
+		}
+		if st.logData.attemptBreaker == breakerCharge {
+			t.Error("an interrupted read charged the provider's circuit")
+		}
+	})
+
+	t.Run("passthrough, streamed", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeTTS
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}
+		if outcome := h.serveStreamedPassthrough(httptest.NewRecorder(), gone("POST", "/v1/audio/speech"), st, candidate, resp, "audio/mpeg", false, 0, 1.0, true); outcome == outcomeFailover {
+			t.Error("an interrupted attempt was sent to a second provider")
+		}
+		if st.logData.attemptBreaker == breakerCharge {
+			t.Error("an interrupted read charged the provider's circuit")
+		}
+	})
+}
+
+// The native twin of the empty-completion rule: a message with no content blocks
+// and no output tokens goes to the sibling.
+func TestNativeEmptyMessage_FailsOverToTheSibling(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	st, candidate := nonCompletionState(t)
+	st.anthropicNativeAttempt = true
+	body := `{"id":"msg_empty","type":"message","role":"assistant","content":[],"usage":{"input_tokens":3,"output_tokens":0}}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	native := true
+	aw := newAnthropicResponseWriter(rec, "msg_empty", "m")
+	aw.bindNativeFlag(&native)
+
+	outcome := h.dispatchNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, candidate, resp, 0, 1.0, true)
+	aw.Finalize()
+
+	if outcome != outcomeFailover {
+		t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("the empty message was written to the client: %s", rec.Body.String())
+	}
+	if st.logData.state == "completed" {
+		t.Error("the row was finalized as completed on a candidate that answered nothing")
+	}
+	if st.logData.attemptBreaker != breakerCharge {
+		t.Errorf("breaker note = %q, want %q", st.logData.attemptBreaker, breakerCharge)
+	}
+}
+
+// The native Anthropic twin: its body is forwarded verbatim rather than decoded,
+// so the only way it can answer 2xx without an answer is a read that died. That
+// is failed over to the sibling too, and nothing is written to the client.
+func TestNativeNonStreaming_ReadFailureFailsOverWhenASiblingRemains(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	resp := &http.Response{StatusCode: http.StatusOK, Body: errorReadCloser{}, Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	native := true
+	aw := newAnthropicResponseWriter(rec, "msg_e", "m")
+	aw.bindNativeFlag(&native)
+	req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
+	logData := &requestLogData{
+		id:             uuid.New().String(),
+		modelID:        "claude-x",
+		virtualKeyName: "test-key",
+		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
+		state:          "streaming",
+	}
+	st := &requestState{startTime: time.Now(), logData: logData, circuitBreakerEnabled: true}
+	candidate := goneCandidateAt(&model.Model{ID: uuid.New(), ModelID: "claude-x"}, "Anthropic", "http://api.anthropic.test")
+	h.deferAnswerJudgement(st, candidate, logData, http.StatusOK)
+
+	outcome := h.handleNativeNonStreaming(aw, req, st, candidate, resp, 1, 10.0, true)
+
+	if outcome != outcomeFailover {
+		t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("the client was written to before the sibling was tried: %s", rec.Body.String())
+	}
+	if logData.state == "failed" {
+		t.Error("the row was finalized on a candidate the loop has not finished with")
+	}
+	if logData.attemptBreaker != breakerCharge {
+		t.Errorf("breaker note = %q, want %q", logData.attemptBreaker, breakerCharge)
+	}
+	// The reject path took this attempt's verdict, so the one armed for the
+	// handler must not still be waiting to fire on a later candidate's row.
+	if logData.judgeAnswer != nil {
+		t.Error("the deferred breaker judgement is still armed after the attempt failed over")
+	}
+}

--- a/internal/proxy/nonstreaming_dispatch.go
+++ b/internal/proxy/nonstreaming_dispatch.go
@@ -1,0 +1,73 @@
+package proxy
+
+import "net/http"
+
+// dispatchNonStreaming serves one non-streaming 2xx: read the answer, decide
+// whether it is a completion at all while a sibling can still be asked, then
+// hand it to the handler that writes it. The non-streaming twin of
+// dispatchStreaming, which makes the same decision from its TTFT probe.
+//
+// r carries the attempt's own context (the client's, under the failover
+// timeout), so every judgement below reads the same clock: an interrupted read
+// is one the client or this gateway's own timeout ended, never the provider.
+func (h *Handler) dispatchNonStreaming(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
+	logData := st.logData
+	// A non-streaming answer clears any gone-strike streak the model had, judged
+	// after the handler on what the handler decoded rather than on the 200 that
+	// preceded it. Both halves of that placement are load-bearing:
+	//
+	//   - Below the dialect translations, which attemptCandidate runs before
+	//     calling this, because any of the three can read the body, fail, and
+	//     send the attempt to failover. A provider that answered 200 with
+	//     something that is not a Responses object, a Gemini answer or an
+	//     Anthropic message has not served the model.
+	//   - Below the handler, because a status is not an answer. `200
+	//     {"choices":[]}` decodes, and on the last candidate it is forwarded as
+	//     a normal completion, and is what an aggregator in front of a retired
+	//     model returns between its gone-shaped 404s, resetting the count so
+	//     three never land consecutively and the model is never nominated.
+	//
+	// producedOutput is where that line is drawn. The breaker verdict is
+	// deferred to the handler's terminal write so the attempt trail's record
+	// carries it; judgeAnswerNow is the fallback for a handler exit that wrote
+	// nothing. It is armed on each of the two dispatches rather than once above
+	// them, because the read between them can still fail over, and a verdict
+	// left armed on a candidate the loop has moved past would fire on the
+	// terminal row of a different one.
+	if st.anthropicNativeAttempt {
+		h.deferAnswerJudgement(st, candidate, logData, resp.StatusCode)
+		outcome := h.handleNativeNonStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, hasMoreCandidates)
+		judgeAnswerNow(logData)
+		if producedOutput(logData) {
+			h.noteModelServed(candidate.model, logData.endpointType)
+		}
+		return outcome
+	}
+
+	// The body is read here rather than inside the handler, and read before
+	// anything is written, so a 2xx that turns out to carry no completion can
+	// still go to a sibling. Past this point the client is committed to this
+	// candidate: the handler writes the answer, or the gateway's own 502, and
+	// neither can be taken back. The streaming twin makes the same decision at
+	// the same moment, from its TTFT probe.
+	//
+	// The read runs under the attempt's context, so that is what an interrupted
+	// read is judged by. With the bare client request instead, this gateway's own
+	// request_timeout looks like the provider dying.
+	ans := readNonStreamingBody(resp, logData.masker)
+	if err := ans.completionFault(r.Context(), resp.StatusCode); err != nil && hasMoreCandidates {
+		// Fully read already (or refused past the cap, where the rest is not
+		// worth draining), so the connection is released here rather than by the
+		// handler that normally owns it.
+		_ = resp.Body.Close()
+		return h.rejectUntranslatableBody(st, candidate, logData, "chat completion", resp.StatusCode, err, attempt, r)
+	}
+
+	h.deferAnswerJudgement(st, candidate, logData, resp.StatusCode)
+	h.handleNonStreamingResponse(w, r, logData, resp, ans, st.startTime, st.proxyOverhead, st.parseMs, st.timings, responseHeaderMs, st.vkHash, attempt)
+	judgeAnswerNow(logData)
+	if producedOutput(logData) {
+		h.noteModelServed(candidate.model, logData.endpointType)
+	}
+	return outcomeServed
+}

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
@@ -94,7 +96,7 @@ func nonStreamingFailureDetail(ctx context.Context, resp *http.Response, body []
 // request and the cap carries that much more headroom.
 const nonStreamingBodyCap = 32 << 20 // 32MB
 
-func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, startTime time.Time, proxyOverhead, parseMs float64, timings resolveTimings, responseHeaderMs float64, vkHash string, attempt int) {
+func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, logData *requestLogData, resp *http.Response, ans nonStreamingAnswer, startTime time.Time, proxyOverhead, parseMs float64, timings resolveTimings, responseHeaderMs float64, vkHash string, attempt int) {
 	defer func() {
 		if r.Context().Err() == nil {
 			_, _ = io.Copy(io.Discard, resp.Body)
@@ -105,21 +107,13 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 
-	// The body is read into memory once, up front, because both branches below
-	// want the same bytes: the success branch decodes them, the failure branch
-	// sanitizes them into the request log. resp.Body can only be consumed once,
-	// so whichever branch read it directly would starve the other.
-	//
-	// json.Decoder, not json.Unmarshal: a decoder stops at the end of the first
-	// JSON value, so a completion with trailing bytes after it still decodes,
-	// where an Unmarshal rejects the whole body.
-	//
-	// The read is bounded (nonStreamingBodyCap) so one upstream cannot make the
-	// gateway buffer an arbitrary amount: cap+1 is read, and a body that reaches
-	// cap+1 is refused as oversized rather than decoded, because a truncated
-	// completion re-encoded as a valid one would hand the client silently
-	// mutilated content.
-	body, chatResp, readErr, decodeErr := readNonStreamingBody(resp, logData.masker)
+	// The body was read into memory once, up front, by the caller (see
+	// readNonStreamingBody), because three places want the same bytes: the
+	// success branch decodes them, the failure branch sanitizes them into the
+	// request log, and the caller asks whether this answer is a completion at
+	// all before any of it is written. resp.Body can only be consumed once, so
+	// whichever of them read it directly would starve the others.
+	body, chatResp, readErr, decodeErr := ans.body, ans.chat, ans.readErr, ans.decodeErr
 
 	// Only a 2xx that decodes is a completion. Some upstreams (OpenCode Zen and
 	// OpenCode Go both do this) answer a failed request with a non-2xx carrying
@@ -163,7 +157,7 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.state = "completed"
 		// Whether the model actually answered, judged where the decoded body is
 		// in hand. The failover loop clears the gone-strike streak on it (see
-		// attemptCandidate): a 200 is only a status, and a decodable-but-empty
+		// dispatchNonStreaming): a 200 is only a status, and a decodable-but-empty
 		// completion is what an aggregator in front of a retired model returns,
 		// which would reset the count so the model is never nominated.
 		logData.deliveredContent = chatAnswerCarriesContent(chatResp)
@@ -313,7 +307,10 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 // production; the other keeps the function total for a handler driven directly.
 //
 // This is not reached for 204/205, which have their own branch, nor for a 2xx
-// that decodes as a completion.
+// that decodes as a completion. Nor for a 2xx that is not a completion while a
+// sibling remains: dispatchNonStreaming asks completionFault before this handler
+// is called and fails over instead, so what is left here is the last candidate's
+// answer, where this gateway owes the client an error it can read.
 func nonCompletionClientStatus(upstreamStatus int) int {
 	if servedSuccessStatus(upstreamStatus) {
 		return http.StatusBadGateway
@@ -328,9 +325,113 @@ func bodilessSuccessStatus(code int) bool {
 	return code == http.StatusNoContent || code == http.StatusResetContent
 }
 
-// readNonStreamingBody reads the upstream body once and decodes it, returning
-// the bytes both branches below need, the decoded completion, and the two
-// failures kept apart: what went wrong on the wire, and what went wrong parsing.
+// errEmptyCompletion is the fault a 2xx that decoded as a completion carrying
+// nothing fails over with. Gateway-authored, so it can be reported as it is:
+// there is no upstream text behind it to mask or fence.
+var errEmptyCompletion = errors.New("upstream answered with a completion carrying no content")
+
+// nonStreamingAnswer is one upstream answer read and decoded once: the bytes,
+// the completion they decoded as, and the two failures kept apart. It is read
+// before anything is written to the client so the caller can decide whether
+// this candidate answered at all (completionFault) while failing over to a
+// sibling is still possible.
+type nonStreamingAnswer struct {
+	body      []byte
+	chat      ChatCompletionResponse
+	readErr   error
+	decodeErr error
+}
+
+// completionFault reports what stopped a success status from being a completion,
+// or nil when the answer can be served. It is the non-streaming twin of the TTFT
+// probe's verdict: an upstream that answers 2xx and then hands over something
+// this gateway cannot turn into a completion has not served the request, and a
+// healthy sibling in the group can.
+//
+// Three exclusions, each of which would otherwise send a good request to another
+// provider:
+//
+//   - A non-2xx is not this question. forwardUpstreamError already owns every
+//     one of them, with the failover rules in shouldFailover.
+//   - 204/205 promise no body, so the empty one they carry is the whole answer
+//     and its decode failure is expected.
+//   - A read this gateway or the caller interrupted is not the provider
+//     failing. Failing over on a cancelled request re-sends the prompt to a
+//     second provider for an answer nobody is waiting for.
+//
+// A body that decoded but carries nothing is a fault too, for the same reason
+// its streaming twin fails over on a stream that ends without a single chunk: a
+// zero-token answer is not a valid one in almost any real use, and the sibling
+// that can serve one is right there. Silence is partly a function of the prompt,
+// so a caller can send every tenant's request down the whole candidate list by
+// coercing a model into saying nothing; that risk is accepted here as the stream
+// probe accepts it, and the breaker charge bounds the provider that does it
+// habitually.
+//
+// The bar for that is completionCarriesAnswer and NOT emptyCompletion's
+// answerCarriesSomething, which is stricter than anything the stream probe
+// applies. The two questions differ: the breaker charges an answer that
+// delivered nothing, while this one asks whether the provider answered at all,
+// and a stated finish_reason is the provider saying how its own generation
+// ended. Routing around that would re-bill a prompt on a sibling for a
+// completion the first provider finished.
+//
+// For a body that did not parse, the decode failure is what decides, and a read
+// error alone never does. A provider that sent the whole document and then
+// dropped the connection without its terminal chunk leaves a body that parses
+// perfectly beside an ErrUnexpectedEOF, and that answer is served
+// (readNonStreamingBody says why). Failing over on it would discard a complete
+// answer and re-bill the prompt. When both are set the read error is the one
+// reported, since the wire is where it started.
+// completionCarriesAnswer reports whether a decoded completion is the provider
+// answering, which is a lower bar than whether it delivered content.
+//
+// Everything answerCarriesSomething counts, plus a choice that states how the
+// generation ended. Its streaming twin sets the bar lower still: any data frame
+// that is neither empty, [DONE] nor an error envelope counts as a token, so a
+// stream carrying one role-only delta is served. This is the closest a decoded
+// body gets to that without letting `{"choices":[]}`, the shape an aggregator in
+// front of a dead model returns, read as an answer.
+func completionCarriesAnswer(out ChatCompletionResponse) bool {
+	if answerCarriesSomething(out) {
+		return true
+	}
+	for _, choice := range out.Choices {
+		if choice.FinishReason != nil && *choice.FinishReason != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (ans nonStreamingAnswer) completionFault(ctx context.Context, status int) error {
+	if !servedSuccessStatus(status) || bodilessSuccessStatus(status) {
+		return nil
+	}
+	err := ans.decodeErr
+	if ans.readErr != nil {
+		err = ans.readErr
+	}
+	// Above both verdicts, not just the decode one: an attempt this gateway or
+	// the caller ended is nobody's answer to serve, and a cancelled read can
+	// leave a body that parses into an empty completion just as easily as one
+	// that does not parse at all. cancelKind reads the context even when nothing
+	// errored, so the empty-answer arm is covered by the same call.
+	if _, aborted := cancelKind(ctx, err); aborted {
+		return nil
+	}
+	if ans.decodeErr != nil {
+		return err
+	}
+	if completionCarriesAnswer(ans.chat) {
+		return nil
+	}
+	return errEmptyCompletion
+}
+
+// readNonStreamingBody reads the upstream body once and decodes it into the
+// answer every later step reads: the bytes, the decoded completion, and the two
+// failures kept apart (what went wrong on the wire, what went wrong parsing).
 //
 // The read is bounded (nonStreamingBodyCap) so one upstream cannot make the
 // gateway buffer an arbitrary amount: cap+1 is read, and a body that reaches
@@ -350,27 +451,33 @@ func bodilessSuccessStatus(code int) bool {
 // parses perfectly, and discarding that throws away a complete answer and
 // charges the provider for it. If the bytes really were cut short the decode
 // fails too, and the read error is what gets reported.
-func readNonStreamingBody(resp *http.Response, masker credentialMasker) (body []byte, chatResp ChatCompletionResponse, readErr, decodeErr error) {
-	body, readErr = io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
-	if readErr == nil && len(body) > nonStreamingBodyCap {
-		decodeErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap", nonStreamingBodyCap)
+func readNonStreamingBody(resp *http.Response, masker credentialMasker) nonStreamingAnswer {
+	var ans nonStreamingAnswer
+	ans.body, ans.readErr = io.ReadAll(io.LimitReader(resp.Body, nonStreamingBodyCap+1))
+	if ans.readErr == nil && len(ans.body) > nonStreamingBodyCap {
+		// Wrapping httpx.ErrBodyTooLarge, the sentinel every other capped read
+		// in this codebase refuses with, so the one rule that a body past a cap
+		// is this gateway's limit and never the provider's fault
+		// (translationIsProviderFault) can be written once and hold for all of
+		// them.
+		ans.decodeErr = fmt.Errorf("upstream response exceeds the %d byte non-streaming body cap: %w", nonStreamingBodyCap, httpx.ErrBodyTooLarge)
 	}
 	// Exact-key scrub on the whole body: the client answer and the failure log
 	// message both derive from it, and a success body is content where the
 	// key-shape regex must not run.
-	body = masker.maskExact(body)
-	if decodeErr != nil {
-		return body, chatResp, readErr, decodeErr
+	ans.body = masker.maskExact(ans.body)
+	if ans.decodeErr != nil {
+		return ans
 	}
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&chatResp); err != nil {
-		if readErr != nil {
-			return body, chatResp, readErr, readErr
+	if err := json.NewDecoder(bytes.NewReader(ans.body)).Decode(&ans.chat); err != nil {
+		// readErr is left as it was rather than cleared. It is only ever
+		// consulted alongside a decode failure, since a clean decode means the
+		// 2xx branch serves the answer without looking at it, so clearing it
+		// would claim a meaning it does not have.
+		ans.decodeErr = err
+		if ans.readErr != nil {
+			ans.decodeErr = ans.readErr
 		}
-		return body, chatResp, readErr, err
 	}
-	// readErr is returned as it was rather than cleared. It is only ever
-	// consulted alongside a decode failure, since a clean decode means the 2xx
-	// branch serves the answer without looking at it, so clearing it would claim
-	// a meaning it does not have.
-	return body, chatResp, readErr, nil
+	return ans
 }

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -164,7 +164,7 @@ func TestPassthrough_OversizedJSONChargesTheEstimate(t *testing.T) {
 	h.serveBufferedJSONPassthrough(rec, httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	const wantCharge = 100 // 400 prompt bytes at the conventional 4 bytes per token
 	if got := singleAddTokens(t, vkRepo); got != wantCharge {
@@ -221,7 +221,7 @@ func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-3"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	const wantCharge = 100 // 400 prompt bytes at 4 bytes per token
 	if got := singleAddTokens(t, vkRepo); got != wantCharge {
@@ -262,7 +262,7 @@ func TestPassthrough_ReportedUsageWinsOverEstimate(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	if got := singleAddTokens(t, vkRepo); got != 7 {
 		t.Errorf("charged %d, want the provider's reported 7", got)
@@ -314,7 +314,7 @@ func TestStreamedPassthrough_BinaryResponseIsMetered(t *testing.T) {
 	h.serveStreamedPassthrough(httptest.NewRecorder(), req, st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "tts-1"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "audio/mpeg", false, 1, 10.0)
+	}, resp, "audio/mpeg", false, 1, 10.0, false)
 
 	const wantCharge = 100 // 400 prompt bytes at 4 bytes per token
 	if got := singleAddTokens(t, vkRepo); got != wantCharge {
@@ -355,7 +355,7 @@ func TestPassthrough_EmptyAnswerIsNotCharged(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-x"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	if len(vkRepo.addTokensCalls) != 0 {
 		t.Errorf("charged %d times for an empty answer, want 0", len(vkRepo.addTokensCalls))
@@ -460,7 +460,7 @@ func TestMultipartPassthrough_NoPromptFieldStillMeters(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	got := singleAddTokens(t, vkRepo)
 	if got == 0 {
@@ -513,7 +513,7 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-		}, resp, "application/json", 1, 10.0)
+		}, resp, "application/json", 1, 10.0, false)
 
 		if got := singleAddTokens(t, vkRepo); got != 100 {
 			t.Errorf("charged %d, want 100: the floor must not replace a real estimate", got)
@@ -540,7 +540,7 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-		}, resp, "application/json", 1, 10.0)
+		}, resp, "application/json", 1, 10.0, false)
 
 		if got := singleAddTokens(t, vkRepo); got != 10 {
 			t.Errorf("charged %d, want 10: a reported figure always wins", got)
@@ -587,7 +587,7 @@ func TestPassthroughFloor_StaysBehindTheDeliveryGate(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	if n := len(vkRepo.addTokensCalls); n != 0 {
 		t.Errorf("charged %d times for an empty answer, want 0: the floor must not defeat the delivery gate", n)
@@ -633,7 +633,7 @@ func TestOversizedPassthrough_ZeroPromptStillMeters(t *testing.T) {
 	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-2"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0)
+	}, resp, "application/json", 1, 10.0, false)
 
 	got := singleAddTokens(t, vkRepo)
 	if got == 0 {
@@ -678,7 +678,7 @@ func TestStreamedPassthrough_ZeroPromptStillMeters(t *testing.T) {
 		st, modelCandidate{
 			model:    &model.Model{ID: uuid.New(), ModelID: "whisper-1"},
 			provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-		}, resp, "text/plain", false, 1, 10.0)
+		}, resp, "text/plain", false, 1, 10.0, false)
 
 	got := singleAddTokens(t, vkRepo)
 	if got == 0 {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -232,43 +232,7 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		return h.dispatchStreaming(w, r, st, candidate, resp, attempt, responseHeaderMs, streamCancelOrigin)
 	}
 
-	// A non-streaming answer clears any gone-strike streak the model had, judged
-	// after the handler on what the handler decoded rather than on the 200 that
-	// preceded it. Both halves of that placement are load-bearing:
-	//
-	//   - Below the dialect translations, because either of them can read the
-	//     body, fail, and send the attempt to failover. A provider that answered
-	//     200 with something that is not a Responses object or a Gemini answer
-	//     has not served the model.
-	//   - Below the handler, because a status is not an answer. `200
-	//     {"choices":[]}` decodes and is forwarded as a normal completion, and
-	//     is what an aggregator in front of a retired model returns between its
-	//     gone-shaped 404s, resetting the count so three never land
-	//     consecutively and the model is never nominated.
-	//
-	// producedOutput is where that line is drawn. The breaker verdict is
-	// deferred to the handler's terminal write so the attempt trail's record
-	// carries it; judgeAnswerNow is the fallback for a handler exit that wrote
-	// nothing.
-	h.deferAnswerJudgement(st, candidate, logData, resp.StatusCode)
-	if st.anthropicNativeAttempt {
-		outcome := h.handleNativeNonStreaming(w, r.WithContext(failoverCtx), st, resp, attempt, responseHeaderMs)
-		judgeAnswerNow(logData)
-		if producedOutput(logData) {
-			h.noteModelServed(candidate.model, logData.endpointType)
-		}
-		return outcome
-	}
-
-	// The handler reads the upstream body under failoverCtx, so that is the
-	// context it judges an interrupted read by. With the bare client request
-	// instead, this gateway's own request_timeout looks like the provider dying.
-	h.handleNonStreamingResponse(w, r.WithContext(failoverCtx), logData, resp, st.startTime, st.proxyOverhead, st.parseMs, st.timings, responseHeaderMs, st.vkHash, attempt)
-	judgeAnswerNow(logData)
-	if producedOutput(logData) {
-		h.noteModelServed(candidate.model, logData.endpointType)
-	}
-	return outcomeServed
+	return h.dispatchNonStreaming(w, r.WithContext(failoverCtx), st, candidate, resp, attempt, responseHeaderMs, hasMoreCandidates)
 }
 
 // classifyProbeError maps any TTFT probe failure to the error recorded for the

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -64,7 +64,7 @@ func TestHandleNonStreamingResponse_Success_Integration(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if inner.Code != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, inner.Code)
@@ -129,7 +129,7 @@ func TestHandleNonStreamingResponse_PromptCacheHitTokens(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -179,7 +179,7 @@ func TestHandleNonStreamingResponse_NonJSONError(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	// Verify status code is 500 (preserved from upstream)
 	if inner.Code != http.StatusInternalServerError {
@@ -243,7 +243,7 @@ func TestHandleNonStreamingResponse_AddTokensError(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=%q, got %q", "completed", logData.state)
@@ -285,7 +285,7 @@ func TestHandleNonStreamingResponse_ChatShapedNon2xxGetsErrorEnvelope(t *testing
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if inner.Code != http.StatusBadRequest {
 		t.Errorf("expected upstream status %d to be forwarded, got %d", http.StatusBadRequest, inner.Code)
@@ -349,7 +349,7 @@ func TestHandleNonStreamingResponse_ChatShaped2xxPassesThrough(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if inner.Code != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, inner.Code)
@@ -401,7 +401,7 @@ func TestHandleNonStreamingResponse_ChatShapedNon2xxDoesNotMeter(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if logData.tokensPrompt != 0 || logData.tokensCompletion != 0 {
 		t.Errorf("metered a failed request: prompt=%d completion=%d", logData.tokensPrompt, logData.tokensCompletion)
@@ -484,7 +484,7 @@ func undecodable2xxDoesNotLogContent(t *testing.T, status int) {
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	logData := nonStreamingLogData()
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if logData.state != "failed" {
 		t.Fatalf("state = %q, want failed", logData.state)
@@ -521,7 +521,7 @@ func TestHandleNonStreamingResponse_Non2xxKeepsUpstreamErrorText(t *testing.T) {
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	logData := nonStreamingLogData()
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if logData.state != "failed" {
 		t.Fatalf("state = %q, want failed", logData.state)
@@ -546,7 +546,7 @@ func TestHandleNonStreamingResponse_UndecodableNon2xxKeepsBody(t *testing.T) {
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	logData := nonStreamingLogData()
 
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if !strings.Contains(logData.errorMessage, "504 Gateway Time-out") {
 		t.Fatalf("upstream error page lost from the request log: %q", logData.errorMessage)
@@ -576,7 +576,7 @@ func TestHandleNonStreamingResponse_OversizedBodyRefused(t *testing.T) {
 	logData := nonStreamingLogData()
 	rec := httptest.NewRecorder()
 
-	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(rec, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if logData.state != "failed" {
 		t.Fatalf("state = %q, want failed for an oversized body", logData.state)
@@ -616,7 +616,7 @@ func TestHandleNonStreamingResponse_BodyAtCapDecodesIntact(t *testing.T) {
 	logData := nonStreamingLogData()
 	rec := httptest.NewRecorder()
 
-	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(rec, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if logData.state != "completed" {
 		t.Fatalf("state = %q (%s), want completed for a body exactly at the cap", logData.state, logData.errorMessage)
@@ -653,7 +653,8 @@ func TestHandleNonStreamingResponse_PreservesUnmodelledFields(t *testing.T) {
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	rec := httptest.NewRecorder()
 
-	h.handleNonStreamingResponse(rec, req, nonStreamingLogData(), resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	logData := nonStreamingLogData()
+	h.handleNonStreamingResponse(rec, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	var got map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {

--- a/internal/proxy/proxy_response_test.go
+++ b/internal/proxy/proxy_response_test.go
@@ -538,7 +538,7 @@ func TestHandleNonStreamingResponse_TPSFallbackWhenTTFTExceedsDuration(t *testin
 	// triggering the else-if fallback at line 719.
 	startTime := time.Now()
 	time.Sleep(2 * time.Millisecond)
-	h.handleNonStreamingResponse(inner, req, logData, resp, startTime, 0, 0, resolveTimings{}, 999999.0, "", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 999999.0, "", 1)
 
 	if logData.state != "completed" {
 		t.Errorf("expected state=completed, got %q", logData.state)
@@ -598,7 +598,7 @@ func TestHandleNonStreamingResponse_ThinkingTagsAppendToReasoningContent(t *test
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	var result ChatCompletionResponse
 	if err := json.Unmarshal(inner.Body.Bytes(), &result); err != nil {
@@ -659,7 +659,7 @@ func TestHandleNonStreamingResponse_UpstreamNonJSONResponse(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	h.handleNonStreamingResponse(inner, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "", 1)
 
 	if logData.state != "failed" {
 		t.Errorf("expected state=failed, got %q", logData.state)

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -160,7 +160,7 @@ func TestHandleNonStreamingResponse_Success(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -220,7 +220,7 @@ func TestHandleNonStreamingResponse_Non200Status(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -277,7 +277,7 @@ func TestHandleNonStreamingResponse_InvalidJSON(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -334,7 +334,7 @@ func TestHandleNonStreamingResponse_EmptyBody(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -410,7 +410,7 @@ func TestHandleNonStreamingResponse_WithVirtualKeyHash(t *testing.T) {
 
 	vkHash := "test-vk-hash-abc123"
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, vkHash, 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, vkHash, 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -471,7 +471,7 @@ func TestHandleNonStreamingResponse_WithReasoningContent(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -538,7 +538,7 @@ func TestHandleNonStreamingResponse_ReasoningFieldNormalized(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -605,7 +605,7 @@ func TestHandleNonStreamingResponse_ReasoningDetailsNormalized(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -668,7 +668,7 @@ func TestHandleNonStreamingResponse_ThinkingTagsNormalized(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -741,7 +741,7 @@ func TestHandleNonStreamingResponse_EncodeError(t *testing.T) {
 	logData.insertWg.Add(1)
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	// Encode error is logged but not propagated; state was already set to "completed" before the write attempt
 	// State should be completed since JSON parsed successfully
@@ -832,7 +832,7 @@ func TestHandleNonStreamingResponse_AddTokensCalled(t *testing.T) {
 
 	vkHash := "test-vk-hash"
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, vkHash, 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, vkHash, 1)
 
 	if len(mockVKRepo.addTokensCalls) != 1 {
 		t.Errorf("expected AddTokens to be called once, got %d calls", len(mockVKRepo.addTokensCalls))
@@ -916,7 +916,7 @@ func TestHandleNonStreamingResponse_AnthropicCacheTokens(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -991,7 +991,7 @@ func TestHandleNonStreamingResponse_AnthropicCacheNegativeMiss(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -1049,7 +1049,7 @@ func TestHandleNonStreamingResponse_AnthropicCacheOpenAITakesPrecedence(t *testi
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -1136,7 +1136,7 @@ func TestHandleNonStreamingResponse_PromptTokensDetailsCachedTokens(t *testing.T
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()
@@ -1236,7 +1236,7 @@ func TestHandleNonStreamingResponse_PromptTokensDetailsNegativeMiss(t *testing.T
 	}
 
 	startTime := time.Now()
-	h.handleNonStreamingResponse(w, req, logData, resp, startTime, 0, 0, resolveTimings{}, 0, "", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 0, "", 1)
 
 	result := w.Result()
 	defer result.Body.Close()

--- a/internal/proxy/success_status_test.go
+++ b/internal/proxy/success_status_test.go
@@ -537,7 +537,7 @@ func TestBreaker_PassthroughDoesNotEraseTheChatChargeForTheSameShape(t *testing.
 		h.insertRequestLogAsync(pst.logData)
 		resp := &http.Response{StatusCode: http.StatusNoContent, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}
 		h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody),
-			pst, modelCandidate{model: m, provider: cand.provider}, resp, "application/json", 1, 5)
+			pst, modelCandidate{model: m, provider: cand.provider}, resp, "application/json", 1, 5, false)
 	}
 
 	chatOnce()

--- a/internal/proxy/tool_arguments_shape_test.go
+++ b/internal/proxy/tool_arguments_shape_test.go
@@ -266,7 +266,7 @@ func TestToolArguments_NonStreamingEmitsTheSpecForm(t *testing.T) {
 	logData.providerName = "tool-shape-provider"
 	h.insertRequestLogAsync(logData)
 
-	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())

--- a/internal/proxy/tps_threshold_test.go
+++ b/internal/proxy/tps_threshold_test.go
@@ -230,7 +230,7 @@ func TestTPSThreshold_NonStreaming_MinGenerationMinimum(t *testing.T) {
 	// minGeneration = max(1.0, 12*0.05) = 1.0
 	// 0.5 < 1.0, so fallback to totalDuration
 	startTime := time.Now().Add(-2 * time.Millisecond)
-	h.handleNonStreamingResponse(inner, req, logData, resp, startTime, 0, 0, resolveTimings{}, 1.5, "", 1)
+	h.handleNonStreamingResponse(inner, req, logData, resp, readNonStreamingBody(resp, logData.masker), startTime, 0, 0, resolveTimings{}, 1.5, "", 1)
 
 	// TPS should use fallback (totalDuration)
 	if logData.tokensPerSecond <= 0 {

--- a/internal/proxy/usage_bounds_test.go
+++ b/internal/proxy/usage_bounds_test.go
@@ -158,7 +158,7 @@ func nonStreamingUsageFixture(t *testing.T, usage string) (logData *requestLogDa
 	time.Sleep(100 * time.Millisecond)
 
 	rec := httptest.NewRecorder()
-	h.handleNonStreamingResponse(rec, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(rec, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 	return logData, vkRepo.addTokensCalls, rec.Body.Bytes()
 }
 
@@ -234,7 +234,7 @@ func TestHandleNativeNonStreaming_ClampsUsage(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+	if outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false); outcome != outcomeServed {
 		t.Fatalf("outcome = %v, want outcomeServed", outcome)
 	}
 	aw.Finalize()
@@ -273,7 +273,7 @@ func TestHandleNativeNonStreaming_NegativeUsageNeverCredits(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(100 * time.Millisecond)
 
-	if outcome := h.handleNativeNonStreaming(aw, req, st, resp, 1, 10.0); outcome != outcomeServed {
+	if outcome := h.handleNativeNonStreaming(aw, req, st, modelCandidate{}, resp, 1, 10.0, false); outcome != outcomeServed {
 		t.Fatalf("outcome = %v, want outcomeServed", outcome)
 	}
 	aw.Finalize()

--- a/internal/proxy/usage_estimate_test.go
+++ b/internal/proxy/usage_estimate_test.go
@@ -339,7 +339,7 @@ func TestHandleNativeNonStreaming_EstimatesUsageWhenOmitted(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(20 * time.Millisecond)
 
-	h.handleNativeNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, resp, 1, 5)
+	h.handleNativeNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, modelCandidate{}, resp, 1, 5, false)
 
 	// 40 prompt bytes → 10; "Hello, world!" (13) + "f" (1) + {"a":1} (7) = 21 bytes → 6.
 	assert.Equal(t, 16, singleAddTokens(t, vkRepo))
@@ -363,7 +363,7 @@ func TestHandleNonStreamingResponse_EstimatesUsageWhenProviderOmitsIt(t *testing
 		state:           "pending",
 		promptTextBytes: 40,
 	}
-	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	// 40 prompt bytes → 10; "Hello, world!" (13) + "hmm" (3) = 16 bytes → 4.
@@ -380,7 +380,7 @@ func TestHandleNonStreamingResponse_NoEstimateForEmptyAnswer(t *testing.T) {
 	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(`{"id":"x","object":"chat.completion","choices":[]}`)), Header: make(http.Header)}
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	logData := &requestLogData{modelID: "gpt-test", providerID: uuid.New(), virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "pending", promptTextBytes: 40}
-	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(httptest.NewRecorder(), req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	assert.Equal(t, 0, singleAddTokens(t, vkRepo))
 }

--- a/internal/proxy/usage_spelling_test.go
+++ b/internal/proxy/usage_spelling_test.go
@@ -125,7 +125,7 @@ func TestHandleNonStreamingResponse_QuotedUsageStillAnswers(t *testing.T) {
 		virtualKeyID:   "00000000-0000-0000-0000-000000000001",
 		state:          "pending",
 	}
-	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Hello, world!")
@@ -236,7 +236,7 @@ func TestHandleNonStreamingResponse_UnreadableUsageStillAnswers(t *testing.T) {
 	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 	logData := &requestLogData{modelID: "gpt-test", providerID: uuid.New(), virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001", state: "pending"}
 
-	h.handleNonStreamingResponse(w, req, logData, resp, time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
+	h.handleNonStreamingResponse(w, req, logData, resp, readNonStreamingBody(resp, logData.masker), time.Now(), 0, 0, resolveTimings{}, 0, "test-hash", 1)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "Hello, world!")


### PR DESCRIPTION
## What was wrong

An upstream that answered 2xx and then handed over something this gateway could not turn into an answer ended the candidate loop. The client got the gateway's own 502, or for an empty completion an answer with nothing in it, and a healthy sibling in the failover group was never asked.

The streaming half has never had this hole: its TTFT probe judges the first frame and fails over on an error envelope or a stream that ends with no chunk. The non-streaming half committed the client to the candidate before it knew whether there was an answer.

## What changed

The non-streaming body is now read and judged before anything is written to the client, which is the same moment the streaming half decides. While a candidate remains, four shapes fail over through the shared reject path:

- a body that would not decode (a relay's HTML error page, an envelope with wrong types)
- a body that died on the wire before it parsed
- a body past the gateway's 32MB cap
- a completion that carries no answer at all

The same rule reaches the native Anthropic path, whose body is forwarded verbatim so a dead read is its only version of this, and the pass-through families (embeddings, images, audio), where a 2xx whose body never arrived, and an embeddings answer carrying no vectors, ended the loop the same way.

## Why a failover, and what stops it repeating

The circuit breaker is charged on the way out, so a relay that answers 200 with an error envelope on every request opens its own circuit and stops being a candidate, instead of burning the whole list on every call. That is the same brake the streaming probe already relies on. The gateway's own body cap is the exception and charges nothing: that limit is ours, not the provider's failure.

Prior art splits here and this follows the more useful half. OpenRouter's provider failover fires on status alone, so a model returning garbage under 200 never triggers it. LiteLLM's regular fallback is a catch-all over remaining errors, and a provider answer it cannot parse becomes one, with its cooldown bounding the repetition.

## What deliberately does not fail over

Each of these would re-bill a prompt for an answer that already exists:

- 204 and 205, which promise no body, so the empty one they carry is the whole answer
- an attempt the caller or this gateway's own request timeout interrupted, on every path
- a body that parsed despite a broken read, where the document arrived and only the terminal chunk was lost
- a completion that states how its generation ended, since a finish reason is the provider saying it generated something

The last candidate answers the client exactly as it did before, everywhere.

## Verification

- Full backend suite green, 7021 tests across 43 packages. Lint and the size gate clean. Diff coverage 100% of changed lines.
- Each new branch was disabled in a throwaway copy to confirm the matching test goes red, including the two that drive the real request loop rather than a sub-handler.
- Rebuilt on the dev stack from this branch: a non-streaming chat through a failover group, an embeddings call through the pass-through path, and a streaming chat all served normally.

Four review rounds, two on a non-Claude model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
