### PR TITLE
Fail over a stalled 2xx, meter what a rejected answer cost, and close the audit's sibling gaps

### DIFF
--- a/contrib/crowdsec/README.md
+++ b/contrib/crowdsec/README.md
@@ -288,6 +288,14 @@ trusted-proxy resolution, so behind a proxy the source address is unusable no ma
 `TRUSTED_PROXIES` says. Update the instance before arming the scenarios. The parser strips the port
 either way, so an old build produces a plausible-looking address that is simply the wrong one.
 
+## Read this before arming: `FRONTDESK_TRAEFIK_TOKEN`
+
+Front Desk refuses a Traefik config poll that carries the wrong token with
+`frontdesk: traefik config poll with invalid token`, which classifies as `admin_token` and fills the
+same admin brute-force bucket as a human guessing a password, and Traefik polls that endpoint every
+5 seconds. A wrong `FRONTDESK_TRAEFIK_TOKEN` therefore overflows the bucket against Traefik's own
+address inside a minute and bans your load balancer, so fix the token before you arm the scenarios.
+
 ## Prove it bans before you trust it
 
 An armed engine and a broken pipeline look identical from the outside: both leave

--- a/contrib/crowdsec/tests/README.md
+++ b/contrib/crowdsec/tests/README.md
@@ -49,11 +49,11 @@ classify. Scan for the first thing that looks like an address instead of taking 
 token and the bare auth line picks the attacker's. Drop the duplicate-address check and the bare
 lines start naming strangers.
 
-Lines 26 to 31, the last six, are Front Desk's own, in its slog framing: an access record, the two
+Lines 26 to 33, the last eight, are Front Desk's own, in its slog framing: an access record, the two
 admin-gate rejections and the CSRF rejection its control plane emits, a rejected passkey assertion,
-and one
-admin rejection whose path carries an injected address. They pin that Front Desk reaches the same
-`admin_token`, `csrf` and `login` buckets as the gateway with the same messages, that its access
+one admin rejection whose path carries an injected address, and the role refusal and the refused
+Traefik config poll described above. They pin that Front Desk reaches the same `admin_token`,
+`csrf`, `login` and `forbidden` buckets as the gateway with the same messages, that its access
 record is refused by the main parser (it belongs to the opt-in access parser instead), and that its
 escaped path still resolves to the real client.
 

--- a/internal/adminauth/userlogin_test.go
+++ b/internal/adminauth/userlogin_test.go
@@ -25,6 +25,9 @@ import (
 type fakeUserStore struct {
 	byUsername map[string]*user.User
 	touched    []uuid.UUID
+	// lookups records every name GetByUsername was asked for, so a test can
+	// assert a name the handler must refuse never reached the store at all.
+	lookups    []string
 	hasEnabled bool
 	statusErr  error
 	getErr     error // GetByUsername returns this (non-nil) instead of a lookup
@@ -32,6 +35,7 @@ type fakeUserStore struct {
 }
 
 func (s *fakeUserStore) GetByUsername(_ context.Context, username string) (*user.User, error) {
+	s.lookups = append(s.lookups, username)
 	if s.getErr != nil {
 		return nil, s.getErr
 	}
@@ -204,6 +208,33 @@ func TestUserLogin_Failures(t *testing.T) {
 				t.Errorf("status = %d, want %d (body %s)", w.Code, tc.want, w.Body.String())
 			}
 		})
+	}
+}
+
+// TestUserLogin_OverLongUsernameStopsAtTheGuard pins what the length check is
+// for, which a 401 alone cannot: an unknown user answers 401 too. A name past
+// the bound must never reach the user store, and must never become a
+// per-account throttle key, so repeating it from fresh IPs (which leaves the
+// per-IP throttle one failure each) keeps answering 401 instead of locking an
+// account that cannot exist.
+func TestUserLogin_OverLongUsernameStopsAtTheGuard(t *testing.T) {
+	u := testUser(t, "alice", "correct-horse", true)
+	_, store, _, r := newLoginFixture(t, u)
+
+	body := `{"username":"` + strings.Repeat("a", user.MaxUsernameBytes+1) + `","password":"whatever1"}`
+	// Ten is past the per-account throttle's burst: the same run against a
+	// username the handler accepts is throttled well inside it.
+	for i := range 10 {
+		req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader([]byte(body)))
+		req.RemoteAddr = fmt.Sprintf("10.2.%d.1:1234", i)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d = %d, want 401 (%s)", i, w.Code, w.Body.String())
+		}
+	}
+	if len(store.lookups) != 0 {
+		t.Errorf("over-long username reached the user store: %d lookups", len(store.lookups))
 	}
 }
 

--- a/internal/anthropic/native.go
+++ b/internal/anthropic/native.go
@@ -111,6 +111,22 @@ func ResponseCarriesContent(body []byte) bool {
 	return len(resp.Content) > 0
 }
 
+// ResponseStopReason is the stop_reason a non-streaming Messages response
+// states, or "" when it states none. It is how the response says its generation
+// ended, so a message carrying no content block but a stop_reason of
+// "max_tokens" or "stop_sequence" is a provider that answered rather than one
+// that went silent. The OpenAI-shaped finish_reason is the same claim, which is
+// why the gateway reads both before deciding a 2xx carried no answer.
+func ResponseStopReason(body []byte) string {
+	var resp struct {
+		StopReason string `json:"stop_reason"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return ""
+	}
+	return resp.StopReason
+}
+
 // ResponseTextBytes is the byte length of the text, thinking, tool name and
 // tool input across a non-streaming Messages response's content blocks, the
 // delivered output a usage estimate works from when the response carries no

--- a/internal/anthropic/native_test.go
+++ b/internal/anthropic/native_test.go
@@ -137,6 +137,33 @@ func TestResponseCarriesContent(t *testing.T) {
 	}
 }
 
+// ResponseStopReason is the wider bar beside ResponseCarriesContent: a message
+// with no content block but a stated stop_reason is a generation that finished,
+// which the proxy serves rather than routing to a sibling. Its OpenAI-shaped
+// twin, finish_reason, is read the same way.
+func TestResponseStopReason(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"capped generation with no content", `{"id":"m","type":"message","content":[],"stop_reason":"max_tokens"}`, "max_tokens"},
+		{"end_turn", `{"id":"m","type":"message","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn"}`, "end_turn"},
+		{"stop_reason absent", `{"id":"m","type":"message","content":[]}`, ""},
+		{"stop_reason null", `{"id":"m","type":"message","stop_reason":null}`, ""},
+		{"stop_reason empty", `{"id":"m","type":"message","stop_reason":""}`, ""},
+		{"not json", `not json`, ""},
+		{"empty body", ``, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResponseStopReason([]byte(tt.body)); got != tt.want {
+				t.Errorf("ResponseStopReason(%s) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStreamTranslator_ToolWithoutID_AndIdempotentFinish(t *testing.T) {
 	tr := NewStreamTranslator("msg_t", "m")
 	// A tool-call fragment with no id forces id synthesis; arguments stream as

--- a/internal/api/applogs.go
+++ b/internal/api/applogs.go
@@ -515,7 +515,7 @@ func buildAppLogHistoryQuery(p appLogHistoryParams, q url.Values) (string, []any
 	conditions, args, argIdx := appendAppLogFilters(nil, nil, 1,
 		q.Get("level"), q.Get("source"), q.Get("search"), q.Get("from"), q.Get("to"))
 	query := fmt.Sprintf(
-		"SELECT timestamp, level, source, message, escaped, attrs_at FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
+		"SELECT id, timestamp, level, source, message, escaped, attrs_at FROM app_logs%s ORDER BY %s %s LIMIT $%d OFFSET $%d",
 		appLogWhereClause(conditions), p.sortCol, p.sortDir, argIdx, argIdx+1,
 	)
 	args = append(args, p.perPage, (p.page-1)*p.perPage)
@@ -556,7 +556,9 @@ func (h *Handler) getAppLogsHistory(w http.ResponseWriter, r *http.Request) {
 	entries := make([]AppLogEntry, 0, 100)
 	var e AppLogEntry
 	var ts time.Time
-	if _, err := pgx.ForEachRow(rows, []any{&ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt}, func() error {
+	// id rides along so the dashboard keys rows on it: two rows written in the
+	// same database tick share every other column and would collide otherwise.
+	if _, err := pgx.ForEachRow(rows, []any{&e.ID, &ts, &e.Level, &e.Source, &e.Message, &e.Escaped, &e.AttrsAt}, func() error {
 		e.Timestamp = ts.UTC().Format(time.RFC3339Nano)
 		entries = append(entries, e)
 		return nil

--- a/internal/api/applogs_cursor_test.go
+++ b/internal/api/applogs_cursor_test.go
@@ -705,6 +705,62 @@ func TestGetAppLogsHistory_SingleEntry(t *testing.T) {
 	}
 }
 
+// TestGetAppLogsHistory_RowsCarryTheirID pins the id on the offset projection.
+// Two rows written in the same database tick differ in nothing else, so the
+// dashboard keys its list and its row stepper on the id; a page served without
+// one collapses the pair into a single key.
+func TestGetAppLogsHistory_RowsCarryTheirID(t *testing.T) {
+	if apiTestDBURL == "" {
+		t.Fatal("apiTestDBURL not set: test database required")
+	}
+	h, r := newTestHandlerWithRouter(t)
+	pool := h.Pool().Pool()
+
+	source := "idsrc-" + uuid.New().String()[:8]
+	defer pool.Exec(context.Background(), "DELETE FROM app_logs WHERE source = $1", source)
+	inserted := make(map[string]bool, 2)
+	for range 2 {
+		id := uuid.New().String()
+		inserted[id] = true
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO app_logs (id, timestamp, level, source, message, created_at)
+			 VALUES ($1, NOW(), 'info', $2, 'same tick', NOW())`,
+			id, source); err != nil {
+			t.Fatalf("insert app log: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/logs/app?history=true&source="+source, http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-admin-token")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var resp appLogsHistoryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(resp.Entries))
+	}
+	seen := make(map[string]bool, 2)
+	for _, e := range resp.Entries {
+		if e.ID == "" {
+			t.Fatal("entry carries no id")
+		}
+		if !inserted[e.ID] {
+			t.Errorf("entry id %q is not one of the inserted rows", e.ID)
+		}
+		if seen[e.ID] {
+			t.Errorf("entry id %q served twice", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}
+
 // TestGetAppLogsHistory_DateRangeBoundary verifies that getAppLogsHistory
 // correctly filters by from/to date range parameters.
 func TestGetAppLogsHistory_DateRangeBoundary(t *testing.T) {

--- a/internal/api/configsync.go
+++ b/internal/api/configsync.go
@@ -238,7 +238,12 @@ type ConfigEnvelope struct {
 
 // ConfigPayload is the config-only body of the envelope.
 type ConfigPayload struct {
-	Providers   []ExportProvider  `json:"providers"`
+	Providers []ExportProvider `json:"providers"`
+	// Same nil-vs-empty contract as FailoverGroups below: exportVirtualKeys always
+	// returns a non-nil slice, so a member running this code emits [] when it has
+	// no keys and the wipe rail reads that as "the primary has none, reconcile to
+	// zero". Absent (nil) is an older primary or a mangled envelope, and a
+	// populated member refuses it rather than dropping every credential it holds.
 	VirtualKeys []ExportVK        `json:"virtual_keys"`
 	Settings    map[string]string `json:"settings"`
 	// Not omitempty: a member running this code always emits the key, as [] when

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -91,6 +91,13 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Ahead of the fence, because the fence's advisory lock is the one wait
+	// guaranteed to contend: it is how two concurrent imports serialize. Set
+	// after it, the second import would wait for as long as the first one runs,
+	// bounded by nothing but the request context.
+	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '`+reconcileLockTimeout+`'`); err != nil {
+		return applyOutcome{}, err
+	}
 	if err := enforceSourceGenFence(ctx, tx, sourceGen); err != nil {
 		return applyOutcome{}, err
 	}
@@ -108,7 +115,7 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 	if err := guardAgainstProviderWipe(ctx, tx, env.Config.Providers); err != nil {
 		return applyOutcome{}, err
 	}
-	hadKeys, err := guardAgainstVirtualKeyWipe(ctx, tx, env.Config.VirtualKeys)
+	keysMustSurvive, err := guardAgainstVirtualKeyWipe(ctx, tx, env.Config.VirtualKeys)
 	if err != nil {
 		return applyOutcome{}, err
 	}
@@ -162,12 +169,12 @@ func (h *ConfigSyncHandler) apply(ctx context.Context, env ConfigEnvelope, sourc
 		return applyOutcome{}, err
 	}
 	// The rail above reads the count before the reconcile, so it only catches an
-	// envelope that carries no keys at all. An envelope whose keys every one fail
-	// to upsert (an unresolvable provider name on each) reaches here having
-	// deleted the member's own keys and inserted nothing, which is the same
-	// outcome by a longer road. Checking after the delete, inside the same
-	// transaction, catches both and rolls the whole import back.
-	if err := guardKeysSurvived(ctx, tx, hadKeys); err != nil {
+	// envelope that omits the key list. An envelope whose keys every one fail to
+	// upsert (an unresolvable provider name on each) reaches here having deleted
+	// the member's own keys and inserted nothing, which is the same outcome by a
+	// longer road. Checking after the delete, inside the same transaction,
+	// catches both and rolls the whole import back.
+	if err := guardKeysSurvived(ctx, tx, keysMustSurvive); err != nil {
 		return applyOutcome{}, err
 	}
 
@@ -227,26 +234,30 @@ func enforceSourceGenFence(ctx context.Context, tx pgx.Tx, sourceGen *int64) err
 	return nil
 }
 
-// reconcileLockTimeout bounds how long an import waits for the tables it is
-// about to reconcile. Without it a slow import holds dashboard CRUD off those
-// tables for as long as it runs, and a wedged one holds it off forever; with it
-// the import fails and Front Desk retries, which is the recoverable direction.
+// reconcileLockTimeout bounds every lock the import transaction waits on: the
+// fence's advisory lock, and the tables the import is about to reconcile.
+// Without it a slow import holds dashboard CRUD off those tables for as long as
+// it runs, and a wedged one holds it off forever; with it the import fails and
+// Front Desk retries, which is the recoverable direction.
 const reconcileLockTimeout = "5s"
 
-// lockReconciledTables takes a write lock on every table the import replaces
-// declaratively, before the first count any rail reads. Each of those deletes
-// removes rows absent from the envelope, so a row created between a rail's count
-// and its delete would be destroyed for being missing from an envelope written
-// before it existed.
+// lockReconciledTables takes a write lock on every table this transaction
+// replaces declaratively, before the first count any rail reads. Each of those
+// deletes removes rows absent from the envelope, so a row created between a
+// rail's count and its delete would be destroyed for being missing from an
+// envelope written before it existed.
+//
+// model_failover_groups is deliberately absent: its reconcile runs in
+// applyFailoverGroups, after this transaction commits and in a transaction of
+// its own, so a lock taken here is long released by the time that delete runs
+// and would do nothing but hold dashboard group edits off for the whole import.
+// There is no count-then-delete rail over groups to protect either.
 //
 // SHARE ROW EXCLUSIVE blocks writers and other imports while still allowing
 // plain reads. The order is fixed here and these are the only LOCK TABLE
 // statements in the codebase, so two imports cannot deadlock against each other.
 func lockReconciledTables(ctx context.Context, tx pgx.Tx) error {
-	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '`+reconcileLockTimeout+`'`); err != nil {
-		return err
-	}
-	for _, table := range []string{"providers", "virtual_keys", "users", "model_failover_groups"} {
+	for _, table := range []string{"providers", "virtual_keys", "users"} {
 		if _, err := tx.Exec(ctx, `LOCK TABLE `+table+` IN SHARE ROW EXCLUSIVE MODE`); err != nil {
 			return err
 		}
@@ -277,32 +288,44 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 }
 
 // guardAgainstVirtualKeyWipe is the same rail for credentials. The delete below
-// removes every key absent from the envelope, so an envelope that carries
-// providers but omits virtual_keys takes every credential off the member and
-// every client loses access at once. Import's structural guard does not catch
-// it: that one only refuses an envelope empty in providers, keys and settings
-// together. An empty key list onto a member that has none is a bootstrap and is
-// allowed, matching the provider rail.
-// It reports whether the member held any keys before the reconcile, which
-// guardKeysSurvived needs to tell a wipe apart from a member that never had
-// keys.
-func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) (hadKeys bool, err error) {
+// removes every key absent from the envelope, so an envelope that omits
+// virtual_keys takes every credential off the member and every client loses
+// access at once. Import's structural guard does not catch it: that one only
+// refuses an envelope empty in providers, keys and settings together.
+//
+// The rail turns on nil versus empty, the contract ConfigPayload already holds
+// FailoverGroups, Users and the two model lists to. An absent field decodes to
+// nil, which is either an envelope from a primary too old to send the key or one
+// that lost it in transit, and neither is an instruction to drop credentials: a
+// populated member refuses. A present but empty list is a primary stating it has
+// zero keys, which is operator intent, so the member reconciles down to zero.
+//
+// It reports whether the reconcile must leave keys behind, which guardKeysSurvived
+// needs to tell a wipe apart from a member that never had keys or was told to
+// have none.
+func guardAgainstVirtualKeyWipe(ctx context.Context, tx pgx.Tx, keys []ExportVK) (mustSurvive bool, err error) {
 	var existing int
 	if err := tx.QueryRow(ctx, `SELECT count(*) FROM virtual_keys`).Scan(&existing); err != nil {
 		return false, err
 	}
-	if len(keys) == 0 && existing > 0 {
-		return true, errWouldWipeVirtualKeys
+	if existing == 0 {
+		return false, nil // nothing to lose: bootstrap, matching the provider rail
 	}
-	return existing > 0, nil
+	if keys == nil {
+		return false, errWouldWipeVirtualKeys
+	}
+	// An explicit empty list reconciles to zero, so the second half of the rail
+	// must not then refuse the outcome the envelope asked for.
+	return len(keys) > 0, nil
 }
 
 // guardKeysSurvived is the second half of the credential rail, run after the
 // upsert and the declarative delete. A populated member that comes out of the
-// reconcile with no keys has been wiped whatever route it took there, so the
-// import is refused and the transaction rolls back.
-func guardKeysSurvived(ctx context.Context, tx pgx.Tx, hadKeys bool) error {
-	if !hadKeys {
+// reconcile with no keys, while the envelope carried some, has been wiped
+// whatever route it took there, so the import is refused and the transaction
+// rolls back.
+func guardKeysSurvived(ctx context.Context, tx pgx.Tx, mustSurvive bool) error {
+	if !mustSurvive {
 		return nil
 	}
 	var remaining int

--- a/internal/api/configsync_apply.go
+++ b/internal/api/configsync_apply.go
@@ -256,6 +256,8 @@ const reconcileLockTimeout = "5s"
 // SHARE ROW EXCLUSIVE blocks writers and other imports while still allowing
 // plain reads. The order is fixed here and these are the only LOCK TABLE
 // statements in the codebase, so two imports cannot deadlock against each other.
+// The waits are bounded by the lock_timeout apply sets before its first lock,
+// not here: a caller that takes this outside apply must set it first.
 func lockReconciledTables(ctx context.Context, tx pgx.Tx) error {
 	for _, table := range []string{"providers", "virtual_keys", "users"} {
 		if _, err := tx.Exec(ctx, `LOCK TABLE `+table+` IN SHARE ROW EXCLUSIVE MODE`); err != nil {
@@ -270,6 +272,8 @@ func lockReconciledTables(ctx context.Context, tx pgx.Tx) error {
 // zero providers would delete the member's entire provider set, cascading to
 // discovered models. buildEnvelope always ships the full config, so a
 // functioning primary never pushes zero providers onto a member that has some.
+// Unlike the key rail there is no explicit-empty case to honour: a gateway with
+// no providers routes nothing, so an empty list is never an intent to sync.
 // The check sits inside the transaction and before any delete, so it and the
 // delete it guards are atomic. An empty-provider envelope onto a member that
 // also has no providers is a harmless no-op and is allowed (fleet bootstrap or
@@ -299,6 +303,11 @@ func guardAgainstProviderWipe(ctx context.Context, tx pgx.Tx, providers []Export
 // that lost it in transit, and neither is an instruction to drop credentials: a
 // populated member refuses. A present but empty list is a primary stating it has
 // zero keys, which is operator intent, so the member reconciles down to zero.
+// That is the one shape this rail lets through on purpose: the exporter never
+// produces it by accident (exportVirtualKeys errors rather than returning a
+// short list), so an explicit empty list reaching a populated member came from
+// a primary with no keys or from an edited envelope pushed with the master key,
+// and both are the operator's hand.
 //
 // It reports whether the reconcile must leave keys behind, which guardKeysSurvived
 // needs to tell a wipe apart from a member that never had keys or was told to

--- a/internal/api/configsync_export.go
+++ b/internal/api/configsync_export.go
@@ -440,6 +440,10 @@ func exportVirtualKeys(ctx context.Context, q querier, idToName map[string]strin
 		return nil, err
 	}
 	defer rows.Close()
+	// Non-nil so a member with no keys marshals "virtual_keys": [] rather than
+	// null. The import's wipe rail refuses null (see ConfigPayload) and reconciles
+	// [] to zero, so this is what lets a genuinely keyless primary converge its
+	// members instead of being read as a lost field.
 	out := []ExportVK{}
 	for rows.Next() {
 		var v ExportVK

--- a/internal/api/configsync_key_wipe_test.go
+++ b/internal/api/configsync_key_wipe_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -10,9 +11,10 @@ import (
 // TestConfigSync_RefusesKeyWipingImport covers the credential half of the
 // destructive-wipe rail. The declarative delete removes every key absent from
 // the envelope, and import's structural guard only refuses an envelope that is
-// empty in providers, keys and settings at once, so an envelope carrying
-// providers but omitting virtual_keys used to reach the delete and take every
-// credential off the member in one push.
+// empty in providers, keys and settings at once, so an envelope whose
+// virtual_keys field is missing used to reach the delete and take every
+// credential off the member in one push. A nil slice is what an absent field
+// decodes to and what it marshals back to (null), so this is that envelope.
 func TestConfigSync_RefusesKeyWipingImport(t *testing.T) {
 	cleanConfigTables(t)
 	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
@@ -60,6 +62,62 @@ func TestConfigSync_EmptyKeyListOntoEmptyMemberApplies(t *testing.T) {
 	}
 	if !providerNames(t)["extra"] {
 		t.Error("a keyless envelope onto a keyless member should apply")
+	}
+}
+
+// TestConfigSync_ExplicitEmptyKeyListReconcilesToZero is the operator-intent
+// side of the rail. A primary that really has zero virtual keys exports
+// "virtual_keys": [], and a member holding keys has to converge to zero on it,
+// or that primary can never sync its fleet. Only the absent field is refused.
+func TestConfigSync_ExplicitEmptyKeyListReconcilesToZero(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	if _, err := apiTestDB.Pool().Exec(context.Background(), `
+		INSERT INTO virtual_keys (name, key_hash, key_preview)
+		VALUES ('live-key', 'hash-live-key', 'mh-***')`); err != nil {
+		t.Fatalf("seed virtual key: %v", err)
+	}
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	env := doExport(t, r)
+	env.Config.VirtualKeys = []ExportVK{}
+
+	resp, rec := doImportGen(t, r, env, nil)
+	if rec.Code != http.StatusOK || !resp.Applied {
+		t.Fatalf("explicit empty key list: code=%d applied=%v body=%s, want 200 applied",
+			rec.Code, resp.Applied, rec.Body.String())
+	}
+	var keys int
+	if err := apiTestDB.Pool().QueryRow(context.Background(),
+		`SELECT count(*) FROM virtual_keys`).Scan(&keys); err != nil {
+		t.Fatalf("count keys: %v", err)
+	}
+	if keys != 0 {
+		t.Errorf("virtual keys after an explicit empty list = %d, want the member reconciled to zero", keys)
+	}
+}
+
+// TestConfigSync_ExportEmitsEmptyKeyListNotNull pins the other end of that
+// contract. The rail can only refuse a null virtual_keys field because a member
+// running this code never sends one: the export of a keyless member has to be
+// [], or every keyless primary would be refused by its own fleet.
+func TestConfigSync_ExportEmitsEmptyKeyListNotNull(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+
+	// doExport decodes the wire bytes, so a non-nil slice here means the wire
+	// carried [] rather than null.
+	env := doExport(t, r)
+	if env.Config.VirtualKeys == nil {
+		t.Fatal("export of a keyless member sent virtual_keys: null, which the import rail refuses")
+	}
+	body, err := json.Marshal(env.Config)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if !strings.Contains(string(body), `"virtual_keys":[]`) {
+		t.Errorf("exported config = %s, want it to carry virtual_keys as []", body)
 	}
 }
 

--- a/internal/api/configsync_lock_test.go
+++ b/internal/api/configsync_lock_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestLockReconciledTables_CoversTheTablesThisTransactionReplaces runs the lock
+// step the way apply runs it and reads back what the transaction actually holds.
+// Two things matter and neither shows up in the call: that the statements name
+// tables Postgres accepts, and that the set is exactly the tables this
+// transaction reconciles. model_failover_groups is reconciled after the commit,
+// in applyFailoverGroups' own transaction, so locking it here would block
+// dashboard group edits for the length of the import and be released before the
+// delete it looks like it guards.
+func TestLockReconciledTables_CoversTheTablesThisTransactionReplaces(t *testing.T) {
+	ctx := context.Background()
+	tx, err := apiTestDB.Pool().Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// apply sets this before the fence, so mirror it here: the LOCK TABLE waits
+	// are bounded by nothing else.
+	if _, err := tx.Exec(ctx, `SET LOCAL lock_timeout = '`+reconcileLockTimeout+`'`); err != nil {
+		t.Fatalf("set lock_timeout: %v", err)
+	}
+	if err := lockReconciledTables(ctx, tx); err != nil {
+		t.Fatalf("lockReconciledTables: %v", err)
+	}
+
+	var timeout string
+	if err := tx.QueryRow(ctx, `SELECT current_setting('lock_timeout')`).Scan(&timeout); err != nil {
+		t.Fatalf("read lock_timeout: %v", err)
+	}
+	if timeout != reconcileLockTimeout {
+		t.Errorf("lock_timeout inside the transaction = %q, want %q", timeout, reconcileLockTimeout)
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT c.relname
+		FROM pg_locks l JOIN pg_class c ON c.oid = l.relation
+		WHERE l.pid = pg_backend_pid() AND l.locktype = 'relation'
+		  AND l.mode = 'ShareRowExclusiveLock' AND l.granted`)
+	if err != nil {
+		t.Fatalf("query pg_locks: %v", err)
+	}
+	held, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		t.Fatalf("collect pg_locks: %v", err)
+	}
+	got := map[string]bool{}
+	for _, name := range held {
+		got[name] = true
+	}
+	for _, table := range []string{"providers", "virtual_keys", "users"} {
+		if !got[table] {
+			t.Errorf("%s is reconciled in this transaction but not locked (held: %v)", table, held)
+		}
+	}
+	if got["model_failover_groups"] {
+		t.Error("model_failover_groups is reconciled after the commit, so locking it here only blocks the dashboard")
+	}
+}
+
+// TestConfigSync_AdvisoryLockWaitIsBounded holds the fence advisory lock from
+// another connection and gives the import a request deadline far longer than
+// lock_timeout. The import has to give up on its own, at the timeout, rather
+// than sitting on the lock until the request context expires: import against
+// import is the one wait guaranteed to contend, so it is the wait the timeout
+// has to cover, which it only does if it is set before the fence takes the lock.
+func TestConfigSync_AdvisoryLockWaitIsBounded(t *testing.T) {
+	cleanConfigTables(t)
+	seedProvider(t, "openai", "sk-secret-value", configSyncMasterKey)
+	r := newConfigSyncRouter(t, configSyncMasterKey)
+	base := doExport(t, r)
+
+	holder, err := apiTestDB.Pool().Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire holder conn: %v", err)
+	}
+	defer holder.Release()
+	if _, err := holder.Exec(context.Background(), `SELECT pg_advisory_lock($1)`, fleetSourceGenLock); err != nil {
+		t.Fatalf("hold advisory lock: %v", err)
+	}
+	defer func() { _, _ = holder.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, fleetSourceGenLock) }()
+
+	deadline := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+	body, _ := json.Marshal(withExtraProvider(base, "extra"))
+	req := httptest.NewRequest(http.MethodPost, "/config/import", bytes.NewReader(body)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	start := time.Now()
+	r.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("import blocked on the fence lock = %d, want 500 (failed closed)", rec.Code)
+	}
+	// Generous: the timeout is 5s and the assertion only has to separate "the
+	// statement timed out" from "the request context did".
+	if elapsed > deadline/2 {
+		t.Errorf("import waited %v on the fence lock, want it bounded by lock_timeout (%s)", elapsed, reconcileLockTimeout)
+	}
+	if providerNames(t)["extra"] {
+		t.Error("an import that gave up on the fence lock must not apply its config")
+	}
+}

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -155,7 +155,7 @@ func (req *userRequest) limits() user.Limits {
 func (req *userRequest) validate() (user.Role, error) {
 	req.Username = strings.TrimSpace(req.Username)
 	if req.Username == "" || len(req.Username) > user.MaxUsernameBytes {
-		return "", errors.New("username must be 1-64 characters")
+		return "", errors.New("username must be 1-64 bytes")
 	}
 	if strings.ContainsAny(req.Username, " \t\n") {
 		return "", errors.New("username must not contain whitespace")

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -155,7 +156,7 @@ func (req *userRequest) limits() user.Limits {
 func (req *userRequest) validate() (user.Role, error) {
 	req.Username = strings.TrimSpace(req.Username)
 	if req.Username == "" || len(req.Username) > user.MaxUsernameBytes {
-		return "", errors.New("username must be 1-64 bytes")
+		return "", fmt.Errorf("username must be 1-%d bytes", user.MaxUsernameBytes)
 	}
 	if strings.ContainsAny(req.Username, " \t\n") {
 		return "", errors.New("username must not contain whitespace")

--- a/internal/db/migration_redacted_marker_test.go
+++ b/internal/db/migration_redacted_marker_test.go
@@ -22,7 +22,7 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
-			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'name-row', 'clean-row', 'empty-row', 'object-row', 'null-row')`)
+			`DELETE FROM request_logs WHERE model_id IN ('marker-row', 'name-row', 'clean-row', 'quiet-row', 'empty-row', 'object-row', 'null-row')`)
 	})
 
 	if _, err := testPool.Exec(ctx, `
@@ -31,14 +31,39 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 		                     {"provider": "Z.ai", "detail": "plain [content] run"}]'::jsonb),
 		('name-row',   200, '[{"provider": "[content] Inc", "model": "m", "detail": "HTTP 503"}]'::jsonb),
 		('clean-row',  200, '[{"provider": "Ollama", "detail": "circuit breaker open"}]'::jsonb),
+		('quiet-row',  200, '[{"provider": "OpenAI", "detail": "HTTP 429"}]'::jsonb),
 		('empty-row',  200, '[]'::jsonb),
 		('object-row', 200, '{"detail": "[content]open"}'::jsonb),
 		('null-row',   200, NULL)`); err != nil {
 		t.Fatalf("seed request logs: %v", err)
 	}
 
+	// xmin changes when a row is rewritten, even to the identical value, so it is
+	// the only way to tell "left alone" from "updated to the same bytes". The
+	// migration's text pre-filter is what has to keep quiet-row out of the
+	// expansion entirely; name-row and object-row pass that filter and have to be
+	// dropped by the array check behind it.
+	xmin := func(model string) string {
+		var v string
+		if err := testPool.QueryRow(ctx,
+			`SELECT xmin::text FROM request_logs WHERE model_id = $1`, model).Scan(&v); err != nil {
+			t.Fatalf("read xmin of %s: %v", model, err)
+		}
+		return v
+	}
+	untouched := map[string]string{}
+	for _, m := range []string{"name-row", "clean-row", "quiet-row", "empty-row", "object-row", "null-row"} {
+		untouched[m] = xmin(m)
+	}
+
 	if _, err := testPool.Exec(ctx, sql); err != nil {
 		t.Fatalf("run migration: %v", err)
+	}
+
+	for m, before := range untouched {
+		if after := xmin(m); after != before {
+			t.Errorf("%s was rewritten (xmin %s -> %s), want the migration to skip it", m, before, after)
+		}
 	}
 
 	for _, tc := range []struct {
@@ -50,6 +75,9 @@ func TestRedactedMarkerMigrationRewritesStoredAttempts(t *testing.T) {
 		// migration has no business editing.
 		{"name-row", `[{"model": "m", "detail": "HTTP 503", "provider": "[content] Inc"}]`},
 		{"clean-row", `[{"detail": "circuit breaker open", "provider": "Ollama"}]`},
+		// Carries the marker nowhere at all, so the text pre-filter drops it before
+		// the array expansion ever runs.
+		{"quiet-row", `[{"detail": "HTTP 429", "provider": "OpenAI"}]`},
 		// A row the column's missing array constraint allows: left alone rather
 		// than aborting the migration, and with it the startup that runs it.
 		{"empty-row", `[]`},

--- a/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
+++ b/internal/db/migrations/083_redacted_marker_in_attempt_details.sql
@@ -34,7 +34,17 @@ SET attempts = (
         CASE WHEN jsonb_typeof(l.attempts) = 'array' THEN l.attempts ELSE '[]'::jsonb END
     ) WITH ORDINALITY AS t(a, ord)
 )
-WHERE EXISTS (
+--
+-- The text LIKE is a cheap superset filter that spares the per-row array
+-- expansion below on every row that cannot possibly match: a marker inside a
+-- detail string always shows up verbatim in the row's own text rendering, so a
+-- row failing it has nothing to rewrite. LIKE has no character classes, so the
+-- brackets are literal and need no escape. The expansion still runs on rows that
+-- pass, which is what keeps the semantics exactly as they were: a row carrying
+-- "[content]" only in a provider or model name passes the LIKE and is then
+-- dropped by the EXISTS, untouched.
+WHERE attempts::text LIKE '%[content]%'
+  AND EXISTS (
     SELECT 1
     FROM jsonb_array_elements(
         CASE WHEN jsonb_typeof(l.attempts) = 'array' THEN l.attempts ELSE '[]'::jsonb END

--- a/internal/provider/catalogs/deepseek.json
+++ b/internal/provider/catalogs/deepseek.json
@@ -1,40 +1,48 @@
 [
   {
     "model_id": "deepseek-flash",
-    "description": "DeepSeek V4.1 Flash, the current Flash model and the target every legacy Flash-family name resolves to. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "DeepSeek V4.1 Flash, the current Flash model and the target every legacy Flash-family name resolves to; accepts image input. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
+    "vision": true,
+    "input_modalities": "[\"text\",\"image\"]",
     "input_price_per_million_cache_hit": 0.003,
     "input_price_per_million_cache_miss": 0.15,
     "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-chat",
-    "description": "Alias onto deepseek-flash with thinking off. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Alias onto deepseek-flash with thinking off; accepts image input. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": false,
+    "vision": true,
+    "input_modalities": "[\"text\",\"image\"]",
     "input_price_per_million_cache_hit": 0.003,
     "input_price_per_million_cache_miss": 0.15,
     "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-reasoner",
-    "description": "Alias onto deepseek-flash with thinking on. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Alias onto deepseek-flash with thinking on; accepts image input. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
+    "vision": true,
+    "input_modalities": "[\"text\",\"image\"]",
     "input_price_per_million_cache_hit": 0.003,
     "input_price_per_million_cache_miss": 0.15,
     "output_price_per_million": 0.6
   },
   {
     "model_id": "deepseek-v4-flash",
-    "description": "Legacy name for DeepSeek V4 Flash; the API now serves deepseek-flash under it and bills at that rate. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
+    "description": "Legacy name for DeepSeek V4 Flash; accepts image input and the API now serves deepseek-flash under it and bills at that rate. Listed price is DeepSeek's off-peak rate; billing doubles during peak hours (01:00-04:00 and 06:00-10:00 UTC).",
     "context_length": 1000000,
     "max_output_tokens": 384000,
     "reasoning": true,
+    "vision": true,
+    "input_modalities": "[\"text\",\"image\"]",
     "input_price_per_million_cache_hit": 0.003,
     "input_price_per_million_cache_miss": 0.15,
     "output_price_per_million": 0.6

--- a/internal/provider/catalogs_embed_test.go
+++ b/internal/provider/catalogs_embed_test.go
@@ -131,32 +131,54 @@ func TestLoadCatalog_DeepSeekCatalog(t *testing.T) {
 	}
 }
 
-// TestDeepSeekCatalog_VisionModel covers the one DeepSeek model models.dev has
-// never heard of. Without a row here it discovers as a bare stub: no price (so
-// it meters at zero), no context window, and no vision flag despite being the
-// only DeepSeek model that accepts an image.
+// TestDeepSeekCatalog_VisionModel covers the DeepSeek rows that accept an
+// image. Every Flash-family id resolves to deepseek-flash upstream and the
+// live API answers a content-parts request carrying an image on all of them;
+// deepseek-v4-pro is the one row that does not, it drops the image and answers
+// the text alone. models.dev declares text-only input for the family and has
+// no entry for the vision alias at all, so without these rows they discover
+// with no vision flag, and the alias as a bare stub on top of that: no price
+// (so it meters at zero) and no context window.
 func TestDeepSeekCatalog_VisionModel(t *testing.T) {
-	spec := deepseekSpec("deepseek-v4-flash-vision-exp")
-	if spec == nil {
-		t.Fatal("deepseek.json must carry deepseek-v4-flash-vision-exp: models.dev has no entry for it")
-	}
-	if !spec.Vision {
-		t.Error("the vision model must declare Vision")
-	}
-	if spec.InputPricePerMillionCacheMiss <= 0 || spec.OutputPricePerMillion <= 0 {
-		t.Error("the vision model must carry prices, or it meters at zero")
+	for _, id := range []string{
+		"deepseek-flash",
+		"deepseek-chat",
+		"deepseek-reasoner",
+		"deepseek-v4-flash",
+		"deepseek-v4-flash-vision-exp",
+	} {
+		t.Run(id, func(t *testing.T) {
+			spec := deepseekSpec(id)
+			if spec == nil {
+				t.Fatalf("deepseek.json must carry %s: models.dev does not flag it for vision", id)
+			}
+			if !spec.Vision {
+				t.Error("the vision model must declare Vision")
+			}
+			if spec.InputPricePerMillionCacheMiss <= 0 || spec.OutputPricePerMillion <= 0 {
+				t.Error("the vision model must carry prices, or it meters at zero")
+			}
+
+			m := deepseekSpecToModel(spec, uuid.New())
+			if m.InputModalities != `["text","image"]` {
+				t.Errorf("InputModalities = %s, want [\"text\",\"image\"]", m.InputModalities)
+			}
+			var caps model.Capability
+			if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
+				t.Fatalf("unmarshal capabilities: %v", err)
+			}
+			if !caps.Vision {
+				t.Error("Vision capability should reach the model")
+			}
+		})
 	}
 
-	m := deepseekSpecToModel(spec, uuid.New())
-	if m.InputModalities != `["text","image"]` {
-		t.Errorf("InputModalities = %s, want [\"text\",\"image\"]", m.InputModalities)
-	}
-	var caps model.Capability
-	if err := json.Unmarshal([]byte(m.Capabilities), &caps); err != nil {
-		t.Fatalf("unmarshal capabilities: %v", err)
-	}
-	if !caps.Vision {
-		t.Error("Vision capability should reach the model")
+	// deepseek-v4-pro answers a request carrying an image without seeing it,
+	// so the row must not advertise vision.
+	if spec := deepseekSpec("deepseek-v4-pro"); spec == nil {
+		t.Error("deepseek.json must carry deepseek-v4-pro")
+	} else if spec.Vision {
+		t.Error("deepseek-v4-pro drops the image; it must not declare Vision")
 	}
 }
 
@@ -232,11 +254,13 @@ func TestDeepSeekCatalog_ThinkingModes(t *testing.T) {
 }
 
 // TestDeepSeekCatalog_DefaultsToTextOnly guards the other side of that field:
-// every other DeepSeek model omits input_modalities and must stay text-only.
+// a DeepSeek row that omits input_modalities stays text-only. deepseek-v4-pro
+// is the row that omits it, and the one model that drops an image rather than
+// reading it.
 func TestDeepSeekCatalog_DefaultsToTextOnly(t *testing.T) {
-	spec := deepseekSpec("deepseek-chat")
+	spec := deepseekSpec("deepseek-v4-pro")
 	if spec == nil {
-		t.Fatal("deepseek.json must keep deepseek-chat: the live listing does not return it")
+		t.Fatal("deepseek.json must keep deepseek-v4-pro: it is the last row on its own price")
 	}
 	m := deepseekSpecToModel(spec, uuid.New())
 	if m.InputModalities != `["text"]` {

--- a/internal/provider/deepseek_catalog.go
+++ b/internal/provider/deepseek_catalog.go
@@ -49,10 +49,13 @@ type DeepSeekModelSpec struct {
 // documents. deepseek-chat, deepseek-reasoner, deepseek-v4-flash and
 // deepseek-v4-flash-vision-exp all resolve to it upstream (verified by the id
 // each one echoes back in its response), so every Flash-family row carries V4.1
-// Flash's price. deepseek-chat still selects the non-thinking preset.
+// Flash's price and its vision flag: the API answers a request carrying an
+// image on each of those ids, and models.dev declares the family text-only.
+// deepseek-chat still selects the non-thinking preset.
 //
-// deepseek-v4-pro is the last row still on its own price, and the only one that
-// answers as itself rather than as deepseek-flash. Once that id stops echoing
+// deepseek-v4-pro is the last row still on its own price, the only one that
+// answers as itself rather than as deepseek-flash, and the only one that drops
+// an image instead of reading it, so it carries no vision flag. Once that id stops echoing
 // itself back, DeepSeek is serving Flash under it at Flash's rate and this row
 // meters every request several times over, so it has to be repriced or dropped
 // then. Dropping it does not retire the model on its own:

--- a/internal/provider/modelsdev.go
+++ b/internal/provider/modelsdev.go
@@ -442,9 +442,8 @@ func mergeSpecCapabilities(spec *ModelsDevModelSpec, caps *model.Capability) boo
 	}
 	// Attachment → Vision mapping, corroborated by the declared input
 	// modalities. models.dev sets attachment on a number of models whose only
-	// input modality is text, among them deepseek-chat and deepseek-reasoner,
-	// which answer an image with HTTP 400 "This model does not support image".
-	// Attachment alone therefore advertises vision the provider will refuse.
+	// input modality is text, so attachment alone advertises vision the
+	// provider may refuse.
 	if spec.Attachment && attachmentImpliesVision(spec.Modalities.Input) && !caps.Vision {
 		caps.Vision = true
 		merged = true

--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/hugalafutro/model-hotel/internal/ctxkeys"
 	"github.com/hugalafutro/model-hotel/internal/failover"
+	"github.com/hugalafutro/model-hotel/internal/httpx"
 	"github.com/hugalafutro/model-hotel/internal/model"
 	"github.com/hugalafutro/model-hotel/internal/provider"
 )
@@ -303,17 +305,27 @@ func cancelledContext() context.Context {
 	return ctx
 }
 
-// End to end: an interrupted body read must classify as the interruption and
-// must not charge, whichever context went down.
-func TestHandleNonStreamingResponse_AnInterruptedReadIsNotCharged(t *testing.T) {
+// End to end, on the last candidate, where this handler renders the client's own
+// error: which context went down decides both the kind and the charge, and the
+// two answers are not the same answer.
+//
+// A caller that hung up is nobody's fault and pays nothing. This gateway's own
+// per-attempt deadline is the opposite: the caller is still waiting, and the
+// provider answered headers and then stopped sending. That is a stall, which the
+// streaming half has always classified provider_timeout and charged from its
+// TTFT probe, so the non-streaming half charges it too. Leaving it uncharged
+// made the ledger depend on where in the group the stall happened, since a
+// candidate with a sibling behind it is charged for the identical event.
+func TestHandleNonStreamingResponse_AnEndedReadIsChargedOnlyWhenTheProviderStalled(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		origin   string
-		readErr  error
-		wantKind ErrorKind
+		name       string
+		origin     string
+		readErr    error
+		wantKind   ErrorKind
+		wantCharge bool
 	}{
-		{"the caller hung up", "", context.Canceled, KindClientDisconnect},
-		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindFailoverTimeout},
+		{"the caller hung up", "", context.Canceled, KindClientDisconnect, false},
+		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindProviderTimeout, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newIntegrationHandler()
@@ -342,19 +354,20 @@ func TestHandleNonStreamingResponse_AnInterruptedReadIsNotCharged(t *testing.T) 
 			if logData.errorKind != tc.wantKind {
 				t.Errorf("errorKind = %q, want %q", logData.errorKind, tc.wantKind)
 			}
-			if h.circuitBreaker.GetState(providerID, "") == failover.StateOpen {
-				t.Error("an interrupted read was charged to the provider")
+			// The threshold is one, so the circuit's state is the charge.
+			charged := h.circuitBreaker.GetState(providerID, "") == failover.StateOpen
+			if charged != tc.wantCharge {
+				t.Errorf("charged = %v, want %v", charged, tc.wantCharge)
 			}
 		})
 	}
 }
 
-// A 2xx this gateway could not decode says nothing about whether the provider is
-// up: it is classified provider_bad_request and, as nonStreamingFailureDetail
-// says, it still holds the model's generated text — a relay quoting its token
-// counts is the named cause. judgeStreamForBreaker calls recording nothing the
-// honest verdict for its own unreadable frames, and it is the honest verdict
-// here.
+// Which kinds reach the circuit at all. provider_bad_request is the one a 2xx
+// can carry and still leave the circuit alone, and on this path it means the
+// gateway's own body cap: a limit this gateway chose, never the provider
+// failing. A body that simply would not decode is provider_error and is charged,
+// the same verdict the reject path records for it one candidate earlier.
 func TestRecordAnswerOutcome_OnlyAProviderFaultIsCharged(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -911,13 +924,22 @@ func TestNonStreamingFailureDetail_ClassifiesTheReadFailure(t *testing.T) {
 	}{
 		{"the client cancelled", context.Canceled, KindClientDisconnect},
 		{"the provider stopped sending", errors.New("connection reset by peer"), KindProviderError},
-		{"a body this gateway could not parse", nil, KindProviderBadRequest},
+		// Charged, and charged as the same kind a sibling-bearing candidate's
+		// reject records for the identical body: the ledger must not depend on
+		// where in the group the answer came from.
+		{"a body this gateway could not parse", nil, KindProviderError},
+		// The one refusal on this path that is the gateway's own limit rather
+		// than the provider's failure, so it stays outside providerAtFault.
+		{"a body past the gateway's cap", nil, KindProviderBadRequest},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			decodeErr := tc.readErr
 			if decodeErr == nil {
 				decodeErr = errors.New("invalid character")
+			}
+			if tc.want == KindProviderBadRequest {
+				decodeErr = fmt.Errorf("upstream response exceeds the cap: %w", httpx.ErrBodyTooLarge)
 			}
 			_, _, kind, _ := nonStreamingFailureDetail(context.Background(), resp, []byte("{"), tc.readErr, decodeErr, "m", nil)
 			if kind != tc.want {
@@ -963,8 +985,10 @@ func TestHandleNonStreamingResponse_ACompleteBodyBehindAnUncleanCloseIsServed(t 
 // failure, so the identical event — a caller hanging up, or this gateway's own
 // request_timeout, mid-read — logged provider_error on /v1/messages and the
 // interruption on /v1/chat/completions, decided by nothing but which dialect the
-// request came in on.
-func TestHandleNativeNonStreaming_AnInterruptedReadIsClassified(t *testing.T) {
+// request came in on. The three kinds below are the ones the OpenAI-shaped twin
+// records for the same three events, deadline included: that one is a stall and
+// is provider_timeout on both.
+func TestHandleNativeNonStreaming_AnEndedReadIsClassified(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		origin   string
@@ -972,7 +996,7 @@ func TestHandleNativeNonStreaming_AnInterruptedReadIsClassified(t *testing.T) {
 		wantKind ErrorKind
 	}{
 		{"the caller hung up", "", context.Canceled, KindClientDisconnect},
-		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindFailoverTimeout},
+		{"this gateway's request_timeout", "failover_timeout", context.DeadlineExceeded, KindProviderTimeout},
 		{"the provider broke", "", errors.New("connection reset by peer"), KindProviderError},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/proxy/anthropic_native.go
+++ b/internal/proxy/anthropic_native.go
@@ -52,25 +52,33 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	body, err := httpx.ReadCappedBody(resp.Body, nonStreamingBodyCap)
 	if err != nil {
 		debuglog.Warn("proxy: native anthropic read failed", "error", err, "provider", logData.providerName)
-		// An interrupted read is excluded the same way the translated path
-		// excludes it: nobody is waiting for the answer a second provider would
-		// produce. Everything else goes to the sibling, charged or not by
-		// rejectUntranslatableBody's own rule.
-		if _, aborted := cancelKind(r.Context(), err); canFailOver && !aborted {
+		// The same two gates the translated path applies, from the same two
+		// helpers: an abandoned attempt has nobody waiting for a second answer,
+		// and a body past this gateway's own cap is not something a sibling can
+		// answer any better. Everything else goes to the sibling, charged or not
+		// by rejectUntranslatableBody's own rule.
+		if canFailOver && !requestAbandoned(r.Context(), err) && answerFaultIsRoutable(err) {
 			return h.rejectUntranslatableBody(st, candidate, logData, "native anthropic", resp.StatusCode, err, attempt, r)
 		}
 		// Finalize the log row so it does not orphan in the in-flight state. A
 		// read failure on a success body is a provider or transport fault,
-		// unless it was interrupted rather than broken, which cancelKind
-		// classifies the same way the translated path does: the identical event
-		// must not log provider_error here and client_disconnect there.
+		// unless nobody was waiting for it, which requestAbandoned decides the
+		// same way the translated path does: the identical event must not log
+		// provider_error here and client_disconnect there.
 		// A body past the cap is refused by THIS gateway, so it is reported the
 		// way the translated path reports its own refusal: a bad request the
 		// provider is not charged for, never a provider fault.
 		kind := KindProviderError
 		switch cancelled, aborted := cancelKind(r.Context(), err); {
-		case aborted:
+		case aborted && requestAbandoned(r.Context(), err):
 			kind = cancelled
+		case aborted:
+			// This gateway's own per-attempt deadline, on a provider that
+			// answered headers and then went quiet, with the caller still
+			// waiting: the stall the streaming probe charges as provider_timeout
+			// (nonStreamingFailureDetail draws the same line on the OpenAI-shaped
+			// path).
+			kind = KindProviderTimeout
 		case errors.Is(err, httpx.ErrBodyTooLarge):
 			kind = KindProviderBadRequest
 		}
@@ -104,12 +112,24 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	// corroborate, for a provider that answers without reporting usage. Same
 	// judgement chatAnswerCarriesContent makes on the OpenAI-shaped path.
 	carriesContent := outputTokens > 0 || anthropic.ResponseCarriesContent(body)
+	// The failover bar, which is wider than the content one, exactly as
+	// completionCarriesAnswer is wider than answerCarriesSomething on the
+	// translated path. A stated stop_reason is the provider saying how its own
+	// generation ended, and `{"content":[],"stop_reason":"max_tokens"}` is a
+	// finished generation whoever asked for it: without this the same upstream
+	// answer is served through /v1/chat/completions and routed to a sibling
+	// through /v1/messages, deciding a re-billed prompt on nothing but the
+	// dialect the caller used.
+	answered := carriesContent || anthropic.ResponseStopReason(body) != ""
 	// An answer carrying nothing goes to the sibling while there is one, the
 	// same rule and the same bar the translated path applies (completionFault).
 	// Above every stamp below, because a candidate the loop is about to leave
 	// must write neither a completed row nor a token charge for an answer the
 	// client will never see.
-	if canFailOver && !carriesContent {
+	if canFailOver && !answered {
+		// Charged before the candidate is left behind: the provider read this
+		// prompt and billed it, whoever ends up serving the request.
+		h.meterRejectedPrompt(st, logData, inputTokens)
 		return h.rejectUntranslatableBody(st, candidate, logData, "native anthropic", resp.StatusCode, errEmptyCompletion, attempt, r)
 	}
 
@@ -122,7 +142,10 @@ func (h *Handler) handleNativeNonStreaming(w http.ResponseWriter, r *http.Reques
 	logData.parseMs = st.parseMs
 	logData.applyTimings(st.timings)
 	logData.responseHeaderMs = responseHeaderMs
-	logData.tokensPrompt = inputTokens
+	// Added, not assigned: an earlier candidate that answered 2xx without an
+	// answer already billed its prompt onto this row (meterRejectedPrompt), and
+	// the row reports what the request cost rather than what its last hop did.
+	logData.tokensPrompt += inputTokens
 	logData.tokensCompletion = outputTokens
 	// The cache split, not just the total: metering the cache-inclusive prompt
 	// without it prices every cached token at full input rate. The translated

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -321,7 +321,8 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 			kind = cancelled
 		}
 	}
-	if !requestAbandoned(r.Context(), err) && translationIsProviderFault(err) {
+	abandoned := requestAbandoned(r.Context(), err)
+	if !abandoned && translationIsProviderFault(err) {
 		h.chargeBreaker(st, candidate, status, "upstream body could not be translated")
 	}
 	// The attempt is over and it did not serve, so its in-flight slot settles as
@@ -330,13 +331,19 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	// that flag gets wrong: letting it stand grows the provider's learned
 	// in-flight window on the strength of an answer the client never saw.
 	//
-	// Both halves are needed because the paths reaching here differ on when the
-	// body ends. Where the verdict comes first the settle carries it; where the
-	// whole body was buffered to reach the verdict at all, the read's EOF has
-	// already settled the slot clean, and noteUnclean takes that credit back.
-	// Each is a no-op after the other.
-	st.attemptSlot.settle(false)
-	h.inflight.noteUnclean(candidate.provider.ID)
+	// This settle is the one that lands because a path that buffers a whole body
+	// before it can judge it holds the slot past the body's own EOF
+	// (holdSlotForVerdict), leaving the close that follows a no-op. Without that
+	// hold the read's EOF would settle the slot clean while the verdict was
+	// still being formed, and nothing said afterwards could take the credit
+	// back.
+	//
+	// Not for an abandoned request: the caller leaving says nothing about the
+	// provider, so its slot settles from the status as the body close always
+	// has, the same way the breaker leaves it alone above.
+	if !abandoned {
+		st.attemptSlot.settle(false)
+	}
 	st.setReqErr(reqError{Kind: kind, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt
 	logData.closeAttemptRecord(status, kind, errString(err), "", 0)
@@ -368,8 +375,11 @@ func (h *Handler) meterRejectedPrompt(st *requestState, logData *requestLogData,
 	if prompt == 0 {
 		return
 	}
-	// Added, so a later candidate's own stamp does not erase it; every path that
-	// stamps a served prompt onto this row adds to it for the same reason.
+	// Added, so a later candidate's own stamp does not erase it. Only the two
+	// non-streaming chat paths add rather than assign, and only they need to:
+	// they are the paths a rejected 2xx can precede. The pass-through and
+	// streaming stamps still assign, since neither loop can reach them behind
+	// one of these rejects.
 	logData.tokensPrompt += prompt
 	h.recordTokenUsage(st.vkHash, logData, prompt, 0, 0)
 }

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -303,16 +303,43 @@ func (h *Handler) creditBreaker(st *requestState, candidate modelCandidate) {
 // logData has not been stamped with it at this point.
 func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCandidate, logData *requestLogData, adapter string, status int, err error, attempt int, r *http.Request) candidateOutcome {
 	debuglog.Warn("proxy: upstream body translation failed", "adapter", adapter, "error", err, "model", logData.modelID, "provider", logData.providerName)
-	// The translators read the body under the attempt's context, so an
-	// interrupted request arrives here as a translation failure: a caller
-	// hanging up or this gateway's own request_timeout, and neither is the
-	// provider's doing.
-	if _, aborted := cancelKind(r.Context(), err); !aborted && translationIsProviderFault(err) {
+	// The translators read the body under the attempt's context, so a request
+	// nobody is waiting for arrives here as a translation failure and is not the
+	// provider's doing. requestAbandoned is the one place that says which
+	// interruptions those are: this gateway's own per-attempt deadline is not one
+	// of them, and a provider that went silent under it is charged for the stall
+	// exactly as the TTFT probe charges its own.
+	//
+	// The kind follows the same split, and is the kind the last candidate
+	// records for the same event (nonStreamingFailureDetail), so a stall reads
+	// as provider_timeout wherever in the group it happened and an abandoned
+	// read keeps the interruption that ended it.
+	kind := KindProviderError
+	if cancelled, aborted := cancelKind(r.Context(), err); aborted {
+		kind = KindProviderTimeout
+		if requestAbandoned(r.Context(), err) {
+			kind = cancelled
+		}
+	}
+	if !requestAbandoned(r.Context(), err) && translationIsProviderFault(err) {
 		h.chargeBreaker(st, candidate, status, "upstream body could not be translated")
 	}
-	st.setReqErr(reqError{Kind: KindProviderError, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
+	// The attempt is over and it did not serve, so its in-flight slot settles as
+	// the failure it was. finishAttemptAdmission fixed the slot's clean flag
+	// from the 2xx headers, and a 2xx whose body carried no answer is the case
+	// that flag gets wrong: letting it stand grows the provider's learned
+	// in-flight window on the strength of an answer the client never saw.
+	//
+	// Both halves are needed because the paths reaching here differ on when the
+	// body ends. Where the verdict comes first the settle carries it; where the
+	// whole body was buffered to reach the verdict at all, the read's EOF has
+	// already settled the slot clean, and noteUnclean takes that credit back.
+	// Each is a no-op after the other.
+	st.attemptSlot.settle(false)
+	h.inflight.noteUnclean(candidate.provider.ID)
+	st.setReqErr(reqError{Kind: kind, Attempt: attempt, Provider: candidate.provider.Name, Underlying: errString(err)})
 	logData.failoverAttempt = attempt
-	logData.closeAttemptRecord(status, KindProviderError, errString(err), "", 0)
+	logData.closeAttemptRecord(status, kind, errString(err), "", 0)
 	// This attempt's breaker verdict is the one just recorded, so a judgement
 	// armed for the handler that never got to write is disarmed here rather than
 	// left to fire on a candidate the loop has already moved past. Only the
@@ -320,6 +347,31 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	// the shared place so a later caller cannot inherit the bug.
 	logData.judgeAnswer = nil
 	return outcomeFailover
+}
+
+// meterRejectedPrompt charges the prompt a candidate reported before its 2xx was
+// rejected and sent to a sibling. The provider generated that answer and billed
+// the operator for reading the prompt, so a request that walks three silent
+// candidates cost three prompts, and metering only the one that finally served
+// hands the tenant two of them free.
+//
+// Prompt only. A completion figure above zero makes the answer an answer
+// (answerCarriesSomething on the chat path, output tokens on the native one), so
+// a rejected attempt reports none by construction.
+//
+// The charge goes everywhere the served path's does: the row's token column, the
+// virtual key's counter and the TPM bucket, through the same recordTokenUsage.
+// Nothing is estimated, unlike the served path: no bytes reached the client, and
+// estimateMissingUsage charges nothing for a delivery that did not happen.
+func (h *Handler) meterRejectedPrompt(st *requestState, logData *requestLogData, promptTokens int) {
+	prompt, _, _ := h.clampReportedUsage(promptTokens, 0, 0, logData)
+	if prompt == 0 {
+		return
+	}
+	// Added, so a later candidate's own stamp does not erase it; every path that
+	// stamps a served prompt onto this row adds to it for the same reason.
+	logData.tokensPrompt += prompt
+	h.recordTokenUsage(st.vkHash, logData, prompt, 0, 0)
 }
 
 // translationIsProviderFault separates "these bytes are not the object this

--- a/internal/proxy/breaker_outcome.go
+++ b/internal/proxy/breaker_outcome.go
@@ -338,9 +338,10 @@ func (h *Handler) rejectUntranslatableBody(st *requestState, candidate modelCand
 	// still being formed, and nothing said afterwards could take the credit
 	// back.
 	//
-	// Not for an abandoned request: the caller leaving says nothing about the
-	// provider, so its slot settles from the status as the body close always
-	// has, the same way the breaker leaves it alone above.
+	// Not for an abandoned request. The caller leaving says nothing about the
+	// provider, and a slot knows only clean or not, so it settles clean from its
+	// 2xx at the close that follows and the provider keeps the run: the same
+	// line the breaker draws above, where an abandoned read is not charged.
 	if !abandoned {
 		st.attemptSlot.settle(false)
 	}

--- a/internal/proxy/egress.go
+++ b/internal/proxy/egress.go
@@ -35,26 +35,34 @@ func translateEgressResponseBody(resp *http.Response, model string, build chatCo
 	// and not the provider failing, which translationIsProviderFault knows.
 	body, err := readCappedBody(resp, nonStreamingBodyCap, errEgressBodyOversized)
 	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		resp.Body = bodyOver(nil, resp.Body)
 		return err
 	}
 	translated, err := build(body, egress.NewChatCompletionID(), model, time.Now().Unix())
 	if err != nil {
-		resp.Body = io.NopCloser(bytes.NewReader(nil))
+		resp.Body = bodyOver(nil, resp.Body)
 		return err
 	}
-	resp.Body = io.NopCloser(bytes.NewReader(translated))
+	resp.Body = bodyOver(translated, resp.Body)
 	return nil
 }
 
-// readCappedBody reads and closes a response body under a byte cap: cap+1 is
-// read, and a body that reaches it comes back as oversized rather than
-// truncated, so a caller never re-encodes a mutilated payload as a whole one.
-// The oversized error is the caller's own limit, never a provider fault, which
+// readCappedBody reads a response body under a byte cap: cap+1 is read, and a
+// body that reaches it comes back as oversized rather than truncated, so a
+// caller never re-encodes a mutilated payload as a whole one. The oversized
+// error is the caller's own limit, never a provider fault, which
 // translationIsProviderFault knows.
+//
+// It does not close the body. The upstream body is the attempt's in-flight
+// wrapper, and its close is what settles the attempt's slot, so closing here
+// would settle it clean from the 2xx before the caller has judged whether the
+// bytes translate. The slot is held past the read instead (holdSlotForVerdict)
+// and the caller keeps the upstream close: bodyOver carries it onto whatever
+// replaces the body, and a caller that replaces nothing closes resp.Body
+// itself once its verdict is recorded.
 func readCappedBody(resp *http.Response, limit int, oversized error) ([]byte, error) {
+	holdSlotForVerdict(resp)
 	body, err := io.ReadAll(io.LimitReader(resp.Body, int64(limit)+1))
-	_ = resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -62,4 +70,14 @@ func readCappedBody(resp *http.Response, limit int, oversized error) ([]byte, er
 		return nil, oversized
 	}
 	return body, nil
+}
+
+// bodyOver puts bytes of this process's own in place of a fully read upstream
+// body while keeping the upstream close, so whoever closes the response still
+// releases the upstream connection and settles the attempt's in-flight slot.
+func bodyOver(b []byte, upstream io.Closer) io.ReadCloser {
+	return struct {
+		io.Reader
+		io.Closer
+	}{bytes.NewReader(b), upstream}
 }

--- a/internal/proxy/gemini_speech.go
+++ b/internal/proxy/gemini_speech.go
@@ -1,10 +1,8 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"slices"
 	"strconv"
@@ -130,19 +128,26 @@ func (h *Handler) serveGeminiSpeechResponse(w http.ResponseWriter, r *http.Reque
 // a reply in the wrong modality) is handed to the loop as an untranslatable
 // body and fails over.
 func (h *Handler) serveGeminiReshaped(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, adapter string, limit int, oversized error, format string, build func([]byte, string) ([]byte, string, gemini.SpeechUsage, error)) candidateOutcome {
+	// readCappedBody leaves the upstream close, which settles the attempt's
+	// in-flight slot, to this function: a reject closes after its verdict, a
+	// served answer carries the close onto the re-shaped body.
 	body, readErr := readCappedBody(resp, limit, oversized)
 	if readErr != nil {
-		return h.rejectUntranslatableBody(st, candidate, st.logData, adapter, resp.StatusCode, readErr, attempt, r)
+		outcome := h.rejectUntranslatableBody(st, candidate, st.logData, adapter, resp.StatusCode, readErr, attempt, r)
+		_ = resp.Body.Close()
+		return outcome
 	}
 	out, contentType, usage, err := build(body, format)
 	if err != nil {
-		return h.rejectUntranslatableBody(st, candidate, st.logData, adapter, resp.StatusCode, err, attempt, r)
+		outcome := h.rejectUntranslatableBody(st, candidate, st.logData, adapter, resp.StatusCode, err, attempt, r)
+		_ = resp.Body.Close()
+		return outcome
 	}
 	st.passthroughUsage = &passthroughUsage{prompt: usage.PromptTokens, completion: usage.CompletionTokens}
 	delivered := &http.Response{
 		StatusCode: resp.StatusCode,
 		Header:     http.Header{"Content-Type": {contentType}, "Content-Length": {strconv.Itoa(len(out))}},
-		Body:       io.NopCloser(bytes.NewReader(out)),
+		Body:       bodyOver(out, resp.Body),
 	}
 	// false: delivered carries this process's own buffer, so its read cannot
 	// fail and there is nothing here to fail over from.

--- a/internal/proxy/inflight.go
+++ b/internal/proxy/inflight.go
@@ -149,25 +149,6 @@ func (l *inflightLimiter) release(providerID uuid.UUID, clean bool, growAfter in
 	l.mu.Unlock()
 }
 
-// noteUnclean takes back the clean-run credit for an attempt that turned out
-// not to have served, without touching the window or the in-flight count.
-//
-// It exists because the verdict can arrive after the slot has settled. The
-// non-streaming paths buffer the whole upstream body before they can tell a
-// served answer from a 2xx that carried nothing, and the read's own EOF settles
-// the slot on the way past, with only the status to go on. Resetting the
-// clean-run count is the entirety of what an unclean completion does to a
-// window (see release), so applying it a moment later is the same correction,
-// and applying it twice is the same as applying it once.
-func (l *inflightLimiter) noteUnclean(providerID uuid.UUID) {
-	if l == nil {
-		return
-	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.window(providerID).goodRuns = 0
-}
-
 // cut shrinks the provider's allowance after a SATURATED 429: the pool is
 // provably smaller than the load that included the refused request. The CALLER
 // settles the drawing request's own slot before cutting, so w.inflight here is
@@ -300,15 +281,37 @@ func (s *attemptSlot) settle(clean bool) {
 // (client disconnect and hedge loss included), so a leaked count, a slow
 // self-inflicted saturation, would need a leaked body, which the bodyclose
 // lint forbids.
+//
+// onEOF is what holdSlotForVerdict turns off. clean is fixed from the response
+// status at header time, which is the whole truth for a stream (its verdict
+// arrives with its last frame, after which the body is closed at once) and not
+// for a path that reads a whole body and only then decides whether the 2xx
+// carried an answer: there the EOF is reached while the verdict is still being
+// formed, so those paths hold the slot until their own close.
 type inflightRelease struct {
 	io.ReadCloser
 	slot  *attemptSlot
 	clean bool
+	onEOF bool
+}
+
+// holdSlotForVerdict stops a body's EOF settling the attempt's in-flight slot,
+// leaving the close to do it. It is for the paths that buffer the whole
+// upstream body before they can tell a served answer from a 2xx that carried
+// none: the reject settles the slot as the failure it was, and a served answer
+// settles it clean on the close its handler already performs.
+//
+// Nothing else changes: the slot still settles exactly once, and still no later
+// than the close every attempt path performs on every exit.
+func holdSlotForVerdict(resp *http.Response) {
+	if rel, ok := resp.Body.(*inflightRelease); ok {
+		rel.onEOF = false
+	}
 }
 
 func (b *inflightRelease) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
-	if err == io.EOF {
+	if err == io.EOF && b.onEOF {
 		b.slot.settle(b.clean)
 	}
 	return n, err
@@ -364,7 +367,7 @@ func (h *Handler) finishAttemptAdmission(st *requestState, candidate modelCandid
 	if remainingBudgetZero(resp.Header) {
 		h.inflight.hintFull(candidate.provider.ID)
 	}
-	resp.Body = &inflightRelease{ReadCloser: resp.Body, slot: st.attemptSlot, clean: servedSuccessStatus(resp.StatusCode)}
+	resp.Body = &inflightRelease{ReadCloser: resp.Body, slot: st.attemptSlot, clean: servedSuccessStatus(resp.StatusCode), onEOF: true}
 }
 
 // remainingBudgetZero reports whether the provider's OpenAI-style rate-limit

--- a/internal/proxy/inflight.go
+++ b/internal/proxy/inflight.go
@@ -149,6 +149,25 @@ func (l *inflightLimiter) release(providerID uuid.UUID, clean bool, growAfter in
 	l.mu.Unlock()
 }
 
+// noteUnclean takes back the clean-run credit for an attempt that turned out
+// not to have served, without touching the window or the in-flight count.
+//
+// It exists because the verdict can arrive after the slot has settled. The
+// non-streaming paths buffer the whole upstream body before they can tell a
+// served answer from a 2xx that carried nothing, and the read's own EOF settles
+// the slot on the way past, with only the status to go on. Resetting the
+// clean-run count is the entirety of what an unclean completion does to a
+// window (see release), so applying it a moment later is the same correction,
+// and applying it twice is the same as applying it once.
+func (l *inflightLimiter) noteUnclean(providerID uuid.UUID) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.window(providerID).goodRuns = 0
+}
+
 // cut shrinks the provider's allowance after a SATURATED 429: the pool is
 // provably smaller than the load that included the refused request. The CALLER
 // settles the drawing request's own slot before cutting, so w.inflight here is

--- a/internal/proxy/logging.go
+++ b/internal/proxy/logging.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -406,24 +405,12 @@ func metricModelLabel(modelID string, kind ErrorKind) string {
 	return modelID
 }
 
-// upstreamModelLogCap bounds the model name in the debug line. A real model id
-// is a short token; the cap is what stops a caller who sends a megabyte in that
-// field from writing a megabyte to the log.
-const upstreamModelLogCap = 120
-
-// debugEnabled reports whether a Debug record can reach the output at all.
-// debuglog.Init and debuglog.SetHandler both install their handler as the slog
-// default and set its level from DEBUG_LOG and DEBUG_LOG_SCOPES together, so
-// the default logger's own answer is the gate, not a second opinion on it.
-// A var so a test can drive both sides of the branch without touching the
-// process-wide logger that parallel tests in this package share.
-var debugEnabled = func() bool {
-	return slog.Default().Enabled(context.Background(), slog.LevelDebug)
-}
-
-// upstreamModelDecodes counts bodies actually decoded, so a test can prove the
-// gate skipped the expensive half rather than merely that nothing was logged.
-var upstreamModelDecodes atomic.Uint64
+// shortLogValueCap bounds a caller-controlled value that a debug line carries
+// whole: the model name an upstream body names, and the image "size" a provider
+// rewrite dropped. Both are short tokens in a real request; the cap is what
+// stops a caller who sends a megabyte in that field from writing a megabyte to
+// the log.
+const shortLogValueCap = 120
 
 // upstreamModelAttr returns the model name the upstream body carries, sanitized
 // and bounded, and whether there is one to log.
@@ -435,14 +422,13 @@ var upstreamModelDecodes atomic.Uint64
 // what keeps a multipart body out of the debug log. The value is caller text
 // like any other, so nothing says it is a short identifier.
 func upstreamModelAttr(upstreamBody []byte) (string, bool) {
-	upstreamModelDecodes.Add(1)
 	var decoded struct {
 		Model string `json:"model"`
 	}
 	if err := json.Unmarshal(upstreamBody, &decoded); err != nil || decoded.Model == "" {
 		return "", false
 	}
-	return util.SanitizeLogBody(decoded.Model, upstreamModelLogCap), true
+	return util.SanitizeLogBody(decoded.Model, shortLogValueCap), true
 }
 
 // logUpstreamModel logs the model name the upstream body carries, for debugging
@@ -450,8 +436,12 @@ func upstreamModelAttr(upstreamBody []byte) (string, bool) {
 // tens of megabytes on the image endpoints and this sits on the hot path once
 // per candidate and again per retry, so parsing one to discard the result would
 // cost every request what only a debugging session wants.
+//
+// debuglog.Init and debuglog.SetHandler both install their handler as the slog
+// default and set its level from DEBUG_LOG and DEBUG_LOG_SCOPES together, so
+// the default logger's own answer is the gate, not a second opinion on it.
 func logUpstreamModel(upstreamBody []byte) {
-	if !debugEnabled() {
+	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		return
 	}
 	if model, ok := upstreamModelAttr(upstreamBody); ok {

--- a/internal/proxy/minimax.go
+++ b/internal/proxy/minimax.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/util"
 )
 
 // miniMaxStatusToHTTP maps MiniMax base_resp business codes onto the HTTP
@@ -130,11 +131,14 @@ func remapMiniMaxBusinessError(providerType, providerName string, resp *http.Res
 	if !ok {
 		mapped = http.StatusBadGateway
 	}
+	// The status message is upstream text that can quote what the request sent,
+	// and Warn reaches the app log whether or not debug output is on, so it is
+	// bounded and sanitized like every other upstream body in this package.
 	debuglog.Warn("proxy: minimax business error inside HTTP 200",
 		"provider", providerName,
 		"minimax_status", envelope.BaseResp.StatusCode,
 		"mapped_status", mapped,
-		"msg", envelope.BaseResp.StatusMsg)
+		"msg", util.SanitizeLogBody(envelope.BaseResp.StatusMsg, logBodyCap))
 	resp.StatusCode = mapped
 	resp.Status = http.StatusText(mapped)
 	return resp

--- a/internal/proxy/minimax_test.go
+++ b/internal/proxy/minimax_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -403,5 +404,36 @@ func TestChatCompletions_MiniMaxBusinessErrorFailsOver(t *testing.T) {
 	}
 	if got := cb.GetState(provider1.ID, "shared-model"); got != failover.StateOpen {
 		t.Errorf("minimax candidate circuit = %v, want open on one exhausted balance error", got)
+	}
+}
+
+// The business-error warning carries upstream text that can quote what the
+// request sent, and a Warn record reaches the app log ring buffer and the
+// database whether or not debug output is on. It is bounded and sanitized like
+// every other upstream body this package logs.
+func TestRemapMiniMaxBusinessError_BoundsTheStatusMessage(t *testing.T) {
+	huge := strings.Repeat("q", 40<<10)
+	envelope, err := json.Marshal(map[string]any{
+		"base_resp": map[string]any{"status_code": 1008, "status_msg": huge},
+	})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	resp, _ := minimaxTestResp(http.StatusOK, "application/json", string(envelope))
+	captured := captureLogsAt(t, slog.LevelWarn)
+
+	if got := remapMiniMaxBusinessError("minimax", "mm", resp).StatusCode; got != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", got)
+	}
+
+	got := captured("proxy: minimax business error inside HTTP 200")
+	if len(got) != 1 {
+		t.Fatalf("expected one warning line, got %d", len(got))
+	}
+	if strings.Contains(got[0], huge) {
+		t.Error("the upstream message reached the log verbatim")
+	}
+	if len(got[0]) > logBodyCap+512 {
+		t.Errorf("warning line is %d bytes, want the message bounded at %d", len(got[0]), logBodyCap)
 	}
 }

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -347,13 +347,15 @@ func (h *Handler) probeModel(ctx context.Context, candidate modelCandidate, endp
 		// twice. The constant promises memory, and that still holds, since this
 		// streams to io.Discard through one 32 KiB buffer.
 		//
-		// Knowingly a no-op on some paths: MiniMax and both dialect translators
-		// read the body to EOF and CLOSE it themselves, so there this copy reads
-		// an already-closed body and discards the error. A body those paths could
-		// finish they already drained, and one they could not finish is past the
-		// cap, where the connection is forfeit either way.
+		// Knowingly a no-op on some paths: MiniMax reads the body to EOF and
+		// closes it itself, so there this copy reads an already-closed body and
+		// discards the error, and both dialect translators read it to EOF and
+		// leave it open at EOF, so there the copy finds nothing left. A body
+		// those paths could finish they already drained, and one they could not
+		// finish is past the cap, where the connection is forfeit either way.
 		_, _ = io.Copy(io.Discard, io.LimitReader(rawBody, goneProbeMaxBody))
-		// Whatever is in the field: the cap above on every path, or the NopCloser
+		// Whatever is in the field: the cap above on every path, the bodyOver
+		// the translators leave with the cap as its closer, or the NopCloser
 		// remapMiniMaxBusinessError leaves behind, and that path has already
 		// closed the cap, and through it the transport's own body. The real body
 		// is closed exactly once either way.

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -295,7 +295,7 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	case requestAbandoned(r.Context(), nil):
 		// Nobody is waiting for this answer; nothing here is the provider's
 		// doing. This gateway's own per-attempt deadline is not that case: the
-		// read succeeded, so the provider earned its credit.
+		// read succeeded, so the answer is judged on what it carries below.
 	case answered || !servedSuccessStatus(resp.StatusCode):
 		// The provider answered: with content, or with a definitive non-2xx,
 		// which says it is plainly alive.

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -236,6 +236,13 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, contentType string, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
 	logData := st.logData
 
+	// The read below reaches the body's end before the answer has been judged,
+	// so the EOF must not settle the attempt's in-flight slot with only the
+	// status to go on: an embeddings answer carrying no vectors would bank a
+	// clean completion toward widening the provider's window. The close in
+	// servePassthroughResponse settles it after the verdict instead, and a
+	// reject settles it first. Same reason as the chat dispatch.
+	holdSlotForVerdict(resp)
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
 	if err != nil {
 		// Not charged, and not failed over, when there is nobody left waiting for

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -238,19 +238,19 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, passthroughJSONBufferCap+1))
 	if err != nil {
-		// Not charged when the read was interrupted rather than broken: it runs
-		// under the attempt's context, so a caller hanging up and this gateway's
-		// own request_timeout both surface here as a failed read, and neither is
-		// the provider's doing. cancelKind is the package's classifier for that.
-		_, aborted := cancelKind(r.Context(), err)
+		// Not charged, and not failed over, when there is nobody left waiting for
+		// the answer a second provider would produce. requestAbandoned is the
+		// package's one classifier for that, and the streamed twin below asks it
+		// the same way: a caller that hung up, never this gateway's own
+		// per-attempt deadline, which is a provider that stalled.
+		abandoned := requestAbandoned(r.Context(), err)
 		// Nothing has been written to the client yet, so while a sibling remains
-		// this is failed over rather than answered. An interrupted read is
-		// excluded there too: nobody is waiting for the answer a second provider
-		// would produce. Same rule, same shared outcome, as the chat path.
-		if hasMoreCandidates && !aborted {
+		// this is failed over rather than answered. Same rule, same shared
+		// outcome, as the chat path.
+		if hasMoreCandidates && !abandoned {
 			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, err, attempt, r)
 		}
-		if !aborted {
+		if !abandoned {
 			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough body read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", err)
@@ -467,12 +467,16 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 	emptyBodyIsFailure := !bodilessSuccessStatus(resp.StatusCode) || !errors.Is(readErr, io.EOF)
 	if n == 0 && readErr != nil && emptyBodyIsFailure {
 		// No headers have been written, so a sibling can still be asked, unless
-		// the attempt was interrupted rather than broken. Same rule and same
-		// shared outcome as the buffered twin above.
-		if hasMoreCandidates && r.Context().Err() == nil {
+		// there is nobody left waiting. requestAbandoned, not a bare
+		// r.Context().Err(): the context is also down when this gateway's own
+		// per-attempt deadline expired, and that is a provider that answered
+		// headers and then went silent, which is the case the sibling exists for.
+		// Same rule, same helper, as the buffered twin above.
+		abandoned := requestAbandoned(r.Context(), readErr)
+		if hasMoreCandidates && !abandoned {
 			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, readErr, attempt, r)
 		}
-		if r.Context().Err() == nil {
+		if !abandoned {
 			h.chargeBreaker(st, candidate, resp.StatusCode, "upstream body read failed")
 		}
 		debuglog.Warn("proxy: passthrough first-byte read failed", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "error", readErr)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -292,8 +292,10 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 	// 200 {"data":[]} to every request record a success every time, so its
 	// circuit could never open.
 	switch {
-	case r.Context().Err() != nil:
-		// The request was interrupted; nothing here is the provider's doing.
+	case requestAbandoned(r.Context(), nil):
+		// Nobody is waiting for this answer; nothing here is the provider's
+		// doing. This gateway's own per-attempt deadline is not that case: the
+		// read succeeded, so the provider earned its credit.
 	case answered || !servedSuccessStatus(resp.StatusCode):
 		// The provider answered: with content, or with a definitive non-2xx,
 		// which says it is plainly alive.
@@ -564,7 +566,9 @@ func (h *Handler) serveStreamedPassthrough(w http.ResponseWriter, r *http.Reques
 
 	if copyErr != nil {
 		errMsg := fmt.Sprintf("response copy error: %v", copyErr)
-		if r.Context().Err() != nil {
+		// r carries the attempt's context, so a bare cancel check would call
+		// this gateway's own per-attempt deadline a client leaving.
+		if requestAbandoned(r.Context(), copyErr) {
 			errMsg = "client disconnected during response"
 		}
 		debuglog.Warn("proxy: passthrough copy interrupted", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "bytes", written, "error", copyErr)

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -88,13 +88,20 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	// 200 headers and then stalls before producing data still accrues breaker
 	// failures.
 	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"))
+	// The dispatch reads the upstream body under the ATTEMPT's context, the same
+	// request the chat path hands dispatchNonStreaming. With the bare client
+	// request instead, a read this gateway's own per-attempt deadline ended
+	// carries no cancel origin, so resolveCancelOrigin calls it a client
+	// disconnect: a provider that answered headers and then stalled would look
+	// like a caller who hung up, and the sibling behind it would never be asked.
+	attemptReq := r.WithContext(failoverCtx)
 	if st.speechFormat != "" {
-		return h.serveGeminiSpeechResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
+		return h.serveGeminiSpeechResponse(w, attemptReq, st, candidate, resp, attempt, responseHeaderMs)
 	}
 	if st.transcriptionFormat != "" {
-		return h.serveGeminiTranscriptionResponse(w, r, st, candidate, resp, attempt, responseHeaderMs)
+		return h.serveGeminiTranscriptionResponse(w, attemptReq, st, candidate, resp, attempt, responseHeaderMs)
 	}
-	return h.servePassthroughResponse(w, r, st, candidate, resp, attempt, responseHeaderMs, hasMoreCandidates)
+	return h.servePassthroughResponse(w, attemptReq, st, candidate, resp, attempt, responseHeaderMs, hasMoreCandidates)
 }
 
 // passthroughAnswered reports whether a buffered pass-through response is the

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -87,7 +87,7 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 	// JSON, the first body byte for SSE/binary), so a provider that returns
 	// 200 headers and then stalls before producing data still accrues breaker
 	// failures.
-	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"))
+	debuglog.Debug("proxy: upstream responded OK, dispatching passthrough", "endpoint", logData.endpointType, "model", logData.modelID, "provider", logData.providerName, "status", resp.StatusCode, "content_type", util.SanitizeLogBody(resp.Header.Get("Content-Type"), shortLogValueCap))
 	// The dispatch reads the upstream body under the ATTEMPT's context, the same
 	// request the chat path hands dispatchNonStreaming. With the bare client
 	// request instead, a read this gateway's own per-attempt deadline ended

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -167,6 +167,7 @@ func TestCompletionFault(t *testing.T) {
 	refused := nonStreamingAnswer{chat: ChatCompletionResponse{
 		Choices: []Choice{{Message: Message{Role: "assistant", Extra: jsonExtras{"refusal": json.RawMessage(`"I cannot help with that"`)}}}},
 	}}
+	lengthFinish := "length"
 
 	for _, tc := range []struct {
 		name    string
@@ -185,6 +186,10 @@ func TestCompletionFault(t *testing.T) {
 		// filtered answer and a reported token count are all the model answering.
 		{"a refusal is an answer", context.Background(), http.StatusOK, refused, false},
 		{"reported completion tokens are an answer", context.Background(), http.StatusOK, nonStreamingAnswer{chat: ChatCompletionResponse{Usage: Usage{CompletionTokens: 7}}}, false},
+		// A stated finish_reason is the provider saying how its own generation
+		// ended, so an emptied answer that hit the output ceiling is served. The
+		// native twin reads stop_reason for the same claim.
+		{"a stated finish_reason is an answer", context.Background(), http.StatusOK, nonStreamingAnswer{chat: ChatCompletionResponse{Choices: []Choice{{FinishReason: &lengthFinish}}}}, false},
 		{"an undecodable 200 is a fault", context.Background(), http.StatusOK, nonStreamingAnswer{decodeErr: errors.New("invalid character '<'")}, true},
 		{"a body that died on the wire is a fault", context.Background(), http.StatusOK, nonStreamingAnswer{readErr: io.ErrUnexpectedEOF, decodeErr: io.ErrUnexpectedEOF}, true},
 		// The whole document arrived and parsed, and only then did the
@@ -204,9 +209,9 @@ func TestCompletionFault(t *testing.T) {
 	}
 }
 
-// A body past the gateway's own cap fails over like any other 2xx that is not a
-// completion, but the provider is not charged for it: the limit is this
-// gateway's, not the provider's failure.
+// A body past the gateway's own cap is a fault, but not one a sibling can
+// answer any better, and not one the provider is charged for: the limit is this
+// gateway's, and the size of an answer is a function of the request.
 func TestOversizedBodyIsNotChargedToTheProvider(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -217,10 +222,13 @@ func TestOversizedBodyIsNotChargedToTheProvider(t *testing.T) {
 
 	err := ans.completionFault(context.Background(), http.StatusOK)
 	if err == nil {
-		t.Fatal("an oversized body is not a completion and must fail over")
+		t.Fatal("an oversized body is not a completion")
 	}
 	if !errors.Is(err, httpx.ErrBodyTooLarge) {
 		t.Fatalf("err = %v, want it to wrap httpx.ErrBodyTooLarge", err)
+	}
+	if answerFaultIsRoutable(err) {
+		t.Error("every later candidate regenerates the same oversized answer; the cap refusal must not walk the group")
 	}
 	if translationIsProviderFault(err) {
 		t.Error("the gateway's own body cap must not charge the provider's circuit")
@@ -243,10 +251,12 @@ func nonCompletionState(t *testing.T) (*requestState, modelCandidate) {
 	return st, goneCandidateAt(&model.Model{ID: uuid.New(), ModelID: "shared-model"}, "relay", "http://relay.test")
 }
 
-// A body past the gateway's own cap goes to the sibling like any other answer
-// that is not a completion, and the provider is not charged on the way: the two
-// halves of the oversized rule, proven on the path rather than on the helper.
-func TestOversizedBody_FailsOverUncharged(t *testing.T) {
+// A body past the gateway's own cap ends the request where it stands, even with
+// a sibling waiting, and the provider is not charged for it. The answer's size
+// is a function of the request, so every later candidate would regenerate the
+// same oversized body and be refused for it: failing over re-bills the prompt at
+// every stop to render the 502 the first candidate already owed the client.
+func TestOversizedBody_IsTerminalAndUncharged(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })
 	oversized := strings.Repeat("x", nonStreamingBodyCap+1)
@@ -257,11 +267,14 @@ func TestOversizedBody_FailsOverUncharged(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
 
-		if outcome := h.dispatchNonStreaming(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
-			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		if outcome := h.dispatchNonStreaming(w, req, st, candidate, resp, 0, 1.0, true); outcome == outcomeFailover {
+			t.Fatal("the cap refusal walked to the sibling, which would regenerate the same oversized answer")
 		}
-		if w.Body.Len() != 0 {
-			t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+		if w.Code != http.StatusBadGateway {
+			t.Errorf("client status = %d, want 502 rendered on the spot", w.Code)
+		}
+		if st.logData.errorKind != KindProviderBadRequest {
+			t.Errorf("error kind = %q, want %q: the cap is this gateway's limit", st.logData.errorKind, KindProviderBadRequest)
 		}
 		if st.logData.attemptBreaker == breakerCharge {
 			t.Error("the gateway's own body cap charged the provider's circuit")
@@ -278,12 +291,15 @@ func TestOversizedBody_FailsOverUncharged(t *testing.T) {
 		aw.bindNativeFlag(&native)
 		req := httptest.NewRequest("POST", "/v1/messages", http.NoBody)
 
-		if outcome := h.dispatchNonStreaming(aw, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
-			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		if outcome := h.dispatchNonStreaming(aw, req, st, candidate, resp, 0, 1.0, true); outcome == outcomeFailover {
+			t.Fatal("the cap refusal walked to the sibling, which would regenerate the same oversized answer")
 		}
 		aw.Finalize()
-		if rec.Body.Len() != 0 {
-			t.Errorf("the client was written to before the sibling was tried: %s", rec.Body.String())
+		if rec.Code != http.StatusBadGateway {
+			t.Errorf("client status = %d, want 502 rendered on the spot", rec.Code)
+		}
+		if st.logData.errorKind != KindProviderBadRequest {
+			t.Errorf("error kind = %q, want %q: the cap is this gateway's limit", st.logData.errorKind, KindProviderBadRequest)
 		}
 		if st.logData.attemptBreaker == breakerCharge {
 			t.Error("the gateway's own body cap charged the provider's circuit")
@@ -503,5 +519,245 @@ func TestNativeNonStreaming_ReadFailureFailsOverWhenASiblingRemains(t *testing.T
 	// handler must not still be waiting to fire on a later candidate's row.
 	if logData.judgeAnswer != nil {
 		t.Error("the deferred breaker judgement is still armed after the attempt failed over")
+	}
+}
+
+// withRequestTimeout narrows the per-attempt deadline for one test and puts the
+// setting back afterwards. The cache is invalidated on both edges: the handler
+// reads request_timeout once per request, from the cache.
+func withRequestTimeout(t *testing.T, h *Handler, value string) {
+	t.Helper()
+	ctx := context.Background()
+	previous := h.settingsRepo.GetDuration(ctx, "request_timeout", time.Minute)
+	if err := h.settingsRepo.Set(ctx, "request_timeout", value); err != nil {
+		t.Fatalf("set request_timeout: %v", err)
+	}
+	h.settingsRepo.InvalidateCache("request_timeout")
+	t.Cleanup(func() {
+		_ = h.settingsRepo.Set(ctx, "request_timeout", previous.String())
+		h.settingsRepo.InvalidateCache("request_timeout")
+	})
+}
+
+// A provider that answers 200 headers and then says nothing until this gateway's
+// own per-attempt deadline has stalled; it has not been cancelled by anyone who
+// stopped caring. The streaming half has always sent that event to the sibling
+// from its TTFT probe and charged the provider for it, while the non-streaming
+// half read its own timeout as an interruption and ended the request with a
+// terminal error, siblings untouched.
+func TestStalled2xx_FailsOverToTheSibling(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasPrefix(r.Host, "one-slot") {
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			// Headers and then silence, until the gateway gives up on the body.
+			<-r.Context().Done()
+			return
+		}
+		_, _ = io.WriteString(w, siblingCompletion)
+	}))
+	t.Cleanup(upstream.Close)
+	env := buildReplayEnv(t, upstream)
+	withRequestTimeout(t, env.h, "500ms")
+
+	w := replayRequest(t, env)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the sibling can serve this); body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "the sibling answered") {
+		t.Fatalf("the stall ended the request instead of reaching the sibling: %s", w.Body.String())
+	}
+	trail := waitForTrail(t, "hotel/"+env.group, 2)
+	if len(trail) != 2 {
+		t.Fatalf("trail has %d attempts, want 2 (the stall and the sibling): %+v", len(trail), trail)
+	}
+	// Charged exactly as the TTFT probe charges its own stall. A provider that
+	// answers headers and then goes quiet on every request must open its circuit
+	// rather than cost every caller a full deadline before the real answer.
+	if trail[0].Breaker != breakerCharge {
+		t.Errorf("attempt 0 breaker = %q, want %q", trail[0].Breaker, breakerCharge)
+	}
+	// The same kind the last candidate records for a stall, so the trail reads
+	// the event the same way wherever in the group it happened.
+	if trail[0].ErrorKind != string(KindProviderTimeout) {
+		t.Errorf("attempt 0 error_kind = %q, want %q", trail[0].ErrorKind, KindProviderTimeout)
+	}
+	if trail[1].Breaker != breakerSuccess {
+		t.Errorf("attempt 1 breaker = %q, want %q", trail[1].Breaker, breakerSuccess)
+	}
+}
+
+// rowPromptTokens reads the prompt-token column of the request's own row.
+func rowPromptTokens(t *testing.T, modelID string) int {
+	t.Helper()
+	var tokens int
+	if err := testDB.Pool().QueryRow(context.Background(),
+		`SELECT COALESCE(tokens_prompt, 0) FROM request_logs WHERE model_id = $1 ORDER BY created_at DESC LIMIT 1`,
+		modelID).Scan(&tokens); err != nil {
+		t.Fatalf("read tokens_prompt: %v", err)
+	}
+	return tokens
+}
+
+// keyTokensUsed reads the virtual key's own usage counter.
+func keyTokensUsed(t *testing.T, keyHash string) int {
+	t.Helper()
+	var tokens int
+	if err := testDB.Pool().QueryRow(context.Background(),
+		`SELECT tokens_used FROM virtual_keys WHERE key_hash = $1`, keyHash).Scan(&tokens); err != nil {
+		t.Fatalf("read tokens_used: %v", err)
+	}
+	return tokens
+}
+
+// A candidate whose 2xx is rejected still generated that answer, and the
+// provider billed the prompt it read to do so. Only the provider that finally
+// served was metered, so a request that walked the group cost the operator
+// several prompts and charged the tenant for one.
+func TestRejected2xx_ItsPromptIsStillMetered(t *testing.T) {
+	env := replayUpstream(t, http.StatusOK,
+		`{"id":"chatcmpl-empty","object":"chat.completion","created":1,"model":"shared-model",`+
+			`"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":0,"total_tokens":11}}`)
+
+	w := replayRequest(t, env)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	waitForTrail(t, "hotel/"+env.group, 2)
+	// 11 from the candidate that answered nothing, 1 from the sibling that
+	// answered: the row reports what the request cost, not what its last hop did.
+	if got := rowPromptTokens(t, "hotel/"+env.group); got != 12 {
+		t.Errorf("row tokens_prompt = %d, want 12 (the rejected candidate's 11 plus the sibling's 1)", got)
+	}
+	// The key's counter and the TPM bucket take the same charge through
+	// recordTokenUsage: 11 for the rejected prompt, 3 for the served answer.
+	if got := keyTokensUsed(t, env.keyHash); got != 14 {
+		t.Errorf("virtual key tokens_used = %d, want 14 (11 rejected prompt + 3 served)", got)
+	}
+}
+
+// finishAttemptAdmission fixes the slot's clean flag from the 2xx headers, and a
+// 2xx that carried no answer is precisely where that flag is wrong: counting the
+// attempt toward the consecutive clean completions that widen the provider's
+// learned in-flight window lets a relay answering 200 with nothing earn more
+// concurrency the more often it does it.
+//
+// The clean-run count is what the assertion reads, because the body's own EOF
+// settles the slot before this path can tell a served answer from a rejected
+// one: what matters is the credit the attempt ends up holding, not which of the
+// two writes got there first.
+func TestRejected2xx_DoesNotEarnACleanRun(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+	limiter := newInflightLimiter()
+	h.inflight = limiter
+
+	st, candidate := nonCompletionState(t)
+	st.inflightEnabled = true
+	pid := candidate.provider.ID
+	// A capped window with one clean completion already banked: only a capped
+	// one counts runs at all, and the second clean completion is the one a
+	// rejected 2xx must not be.
+	limiter.cut(pid, 0)
+	if !limiter.tryAcquire(pid, 0) {
+		t.Fatal("setup: slot not acquired")
+	}
+	limiter.release(pid, true, 0, 0)
+	if got := limiter.windowFor(t, pid).goodRuns; got != 1 {
+		t.Fatalf("setup: clean-run count = %d, want 1", got)
+	}
+
+	if !h.admitCandidate(st, candidate) {
+		t.Fatal("setup: the candidate was not admitted")
+	}
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"choices":[]}`)), Header: make(http.Header)}
+	h.finishAttemptAdmission(st, candidate, resp)
+	req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+
+	if outcome := h.dispatchNonStreaming(httptest.NewRecorder(), req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
+		t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+	}
+
+	if got := limiter.windowFor(t, pid).goodRuns; got != 0 {
+		t.Errorf("clean-run count = %d, want 0: a 2xx the client never saw counted toward widening the provider's window", got)
+	}
+}
+
+// The native message bar and the translated completion bar must be the same bar.
+// `content: [], stop_reason: max_tokens` is a generation that finished at the
+// output ceiling, which completionCarriesAnswer serves; rejecting it on
+// /v1/messages alone re-bills the prompt on a sibling for an answer the same
+// upstream already produced, decided by nothing but the caller's dialect.
+func TestNativeStopReason_IsAnAnswer(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	st, candidate := nonCompletionState(t)
+	st.anthropicNativeAttempt = true
+	body := `{"id":"msg_capped","type":"message","role":"assistant","content":[],"stop_reason":"max_tokens","usage":{"input_tokens":9,"output_tokens":0}}`
+	resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+	rec := httptest.NewRecorder()
+	native := true
+	aw := newAnthropicResponseWriter(rec, "msg_capped", "m")
+	aw.bindNativeFlag(&native)
+
+	outcome := h.dispatchNonStreaming(aw, httptest.NewRequest("POST", "/v1/messages", http.NoBody), st, candidate, resp, 0, 1.0, true)
+	aw.Finalize()
+
+	if outcome == outcomeFailover {
+		t.Fatal("a message that states how its generation ended was sent to a sibling")
+	}
+	if !strings.Contains(rec.Body.String(), "max_tokens") {
+		t.Errorf("the message was not forwarded to the client: %s", rec.Body.String())
+	}
+	// The content bar is untouched and stays narrow: no block arrived, so the
+	// breaker still charges the emptied answer and the retirement streak is not
+	// cleared by it.
+	if !st.logData.emptyCompletion {
+		t.Error("a message with no content block was recorded as carrying content")
+	}
+}
+
+// The same undecodable 2xx at both positions in the group. With a sibling it
+// goes through rejectUntranslatableBody; on the last candidate the handler
+// renders the client's 502 instead. Both are the same fault, so both report the
+// same kind and both charge: routing order alone must not decide whether a
+// provider's circuit hears about it.
+func TestUndecodable2xx_ChargesTheSameAtEitherPosition(t *testing.T) {
+	h := newIntegrationHandler()
+	t.Cleanup(func() { stopUnitHandler(h) })
+
+	for _, tc := range []struct {
+		name    string
+		hasMore bool
+	}{
+		{"a sibling remains", true},
+		{"the last candidate", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st, candidate := nonCompletionState(t)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("<html>not a completion</html>")),
+				Header:     http.Header{"Content-Type": []string{"text/html"}},
+			}
+			req := withAuthContext(httptest.NewRequest("POST", "/v1/chat/completions", http.NoBody))
+
+			h.dispatchNonStreaming(httptest.NewRecorder(), req, st, candidate, resp, 0, 1.0, tc.hasMore)
+
+			if st.logData.attemptBreaker != breakerCharge {
+				t.Errorf("breaker note = %q, want %q", st.logData.attemptBreaker, breakerCharge)
+			}
+			kind := st.lastReqErr.Kind
+			if !tc.hasMore {
+				kind = st.logData.errorKind
+			}
+			if kind != KindProviderError {
+				t.Errorf("error kind = %q, want %q", kind, KindProviderError)
+			}
+		})
 	}
 }

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -528,13 +528,23 @@ func TestNativeNonStreaming_ReadFailureFailsOverWhenASiblingRemains(t *testing.T
 func withRequestTimeout(t *testing.T, h *Handler, value string) {
 	t.Helper()
 	ctx := context.Background()
-	previous := h.settingsRepo.GetDuration(ctx, "request_timeout", time.Minute)
+	previous, hadRow, err := h.settingsRepo.GetChecked(ctx, "request_timeout")
+	if err != nil {
+		t.Fatalf("read request_timeout: %v", err)
+	}
 	if err := h.settingsRepo.Set(ctx, "request_timeout", value); err != nil {
 		t.Fatalf("set request_timeout: %v", err)
 	}
 	h.settingsRepo.InvalidateCache("request_timeout")
+	// Put back what was there, including nothing: writing the default in
+	// place of an absent row would leave every later test reading an explicit
+	// value where it expects the built-in one.
 	t.Cleanup(func() {
-		_ = h.settingsRepo.Set(ctx, "request_timeout", previous.String())
+		if hadRow {
+			_ = h.settingsRepo.Set(ctx, "request_timeout", previous)
+		} else {
+			_ = h.settingsRepo.DeleteKey(ctx, "request_timeout")
+		}
 		h.settingsRepo.InvalidateCache("request_timeout")
 	})
 }
@@ -658,16 +668,21 @@ func TestRejected2xx_DoesNotEarnACleanRun(t *testing.T) {
 	st, candidate := nonCompletionState(t)
 	st.inflightEnabled = true
 	pid := candidate.provider.ID
-	// A capped window with one clean completion already banked: only a capped
-	// one counts runs at all, and the second clean completion is the one a
-	// rejected 2xx must not be.
+	// A capped window one clean completion short of the grow threshold: only a
+	// capped window counts runs at all, and this is the run where the difference
+	// shows in the allowance itself rather than just the counter. A correction
+	// applied after the fact cannot reach the allowance, which is why the slot
+	// has to be held until the verdict instead.
 	limiter.cut(pid, 0)
-	if !limiter.tryAcquire(pid, 0) {
-		t.Fatal("setup: slot not acquired")
+	for range defaultInflightGrowAfter - 1 {
+		if !limiter.tryAcquire(pid, 0) {
+			t.Fatal("setup: slot not acquired")
+		}
+		limiter.release(pid, true, 0, 0)
 	}
-	limiter.release(pid, true, 0, 0)
-	if got := limiter.windowFor(t, pid).goodRuns; got != 1 {
-		t.Fatalf("setup: clean-run count = %d, want 1", got)
+	before := *limiter.windowFor(t, pid)
+	if before.goodRuns != defaultInflightGrowAfter-1 {
+		t.Fatalf("setup: clean-run count = %d, want %d", before.goodRuns, defaultInflightGrowAfter-1)
 	}
 
 	if !h.admitCandidate(st, candidate) {
@@ -681,8 +696,12 @@ func TestRejected2xx_DoesNotEarnACleanRun(t *testing.T) {
 		t.Fatalf("outcome = %v, want outcomeFailover", outcome)
 	}
 
-	if got := limiter.windowFor(t, pid).goodRuns; got != 0 {
-		t.Errorf("clean-run count = %d, want 0: a 2xx the client never saw counted toward widening the provider's window", got)
+	after := *limiter.windowFor(t, pid)
+	if after.goodRuns != 0 {
+		t.Errorf("clean-run count = %d, want 0: a 2xx the client never saw counted toward widening the provider's window", after.goodRuns)
+	}
+	if after.limit != before.limit {
+		t.Errorf("allowance = %d, want %d: a 2xx the client never saw was the clean run that widened the window", after.limit, before.limit)
 	}
 }
 
@@ -759,5 +778,109 @@ func TestUndecodable2xx_ChargesTheSameAtEitherPosition(t *testing.T) {
 				t.Errorf("error kind = %q, want %q", kind, KindProviderError)
 			}
 		})
+	}
+}
+
+// streamedPassthroughPair builds a two-provider text-to-speech failover group:
+// the first provider runs firstHandler, the second answers real audio bytes.
+// Text-to-speech is the shape that reaches serveStreamedPassthrough, where the
+// commit point is the first body byte rather than a buffered read.
+func streamedPassthroughPair(t *testing.T, firstHandler http.HandlerFunc) (*multimodalTestEnv, string, *atomic.Int32) {
+	t.Helper()
+	env := newMultimodalEnv(t, firstHandler)
+	var siblingCalls atomic.Int32
+	sibling := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		siblingCalls.Add(1)
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = io.WriteString(w, "ID3 the sibling's audio")
+	}))
+	t.Cleanup(sibling.Close)
+	_, _, siblingModelUUID, _ := createMultimodalProvider(t, sibling.URL)
+
+	group := env.modelName
+	if _, err := failover.NewRepository(testDB.Pool()).UpsertWithConfig(context.Background(), group,
+		[]uuid.UUID{env.modelUUID, siblingModelUUID},
+		map[string]bool{env.modelUUID.String(): true, siblingModelUUID.String(): true},
+		nil, nil, nil, nil); err != nil {
+		t.Fatalf("failed to create failover group: %v", err)
+	}
+	return env, group, &siblingCalls
+}
+
+// speechRequest asks the group for audio, which is what puts the answer on the
+// streamed half of the pass-through.
+func speechRequest(env *multimodalTestEnv, group string) *http.Request {
+	return env.request("/v1/audio/speech", "application/json",
+		strings.NewReader(fmt.Sprintf(`{"model":"hotel/%s","input":"hi","voice":"alloy"}`, group)))
+}
+
+// The pass-through twin of the stalled chat 2xx, and the reason the attempt's
+// own context has to reach these handlers. A provider that answers audio headers
+// and then sends no byte until this gateway's per-attempt deadline has stalled,
+// and the sibling behind it can serve. Handed the bare client request instead,
+// the deadline arrives carrying no cancel origin, resolveCancelOrigin calls it a
+// client disconnect, and the request ends there with the provider uncharged.
+func TestStreamedPassthroughStall_FailsOverToTheSibling(t *testing.T) {
+	env, group, siblingCalls := streamedPassthroughPair(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// Headers and then silence, until the gateway gives up on the body.
+		<-r.Context().Done()
+	})
+	// Long-running endpoints get ten times the request timeout, so this is a
+	// one-second per-attempt budget and a two-second budget for the request.
+	withRequestTimeout(t, env.handler, "100ms")
+	withBreakerThresholdOne(t, env.handler)
+
+	w := httptest.NewRecorder()
+	env.handler.AudioSpeech(w, speechRequest(env, group))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failover; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "the sibling's audio") {
+		t.Fatalf("the stall ended the request instead of reaching the sibling: %q", w.Body.String())
+	}
+	if got := siblingCalls.Load(); got != 1 {
+		t.Errorf("sibling called %d times, want 1", got)
+	}
+	if env.handler.circuitBreaker.GetState(env.providerID, env.modelName) != failover.StateOpen {
+		t.Error("the stalled provider was not charged, so a provider that does this on every request stays a candidate")
+	}
+}
+
+// The other half of the same rule on the same path: a caller that hangs up is
+// not a stall. Nobody is waiting for the answer a second provider would produce,
+// so the sibling is not asked and the provider is not charged for someone else's
+// cancellation.
+func TestStreamedPassthroughDisconnect_IsNotFailedOverOrCharged(t *testing.T) {
+	reached := make(chan struct{})
+	env, group, siblingCalls := streamedPassthroughPair(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/mpeg")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		close(reached)
+		<-r.Context().Done()
+	})
+	withBreakerThresholdOne(t, env.handler)
+
+	req := speechRequest(env, group)
+	ctx, cancel := context.WithCancel(req.Context())
+	t.Cleanup(cancel)
+	go func() {
+		<-reached
+		// The headers are out and the gateway is on the first-byte read.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	env.handler.AudioSpeech(httptest.NewRecorder(), req.WithContext(ctx))
+
+	if got := siblingCalls.Load(); got != 0 {
+		t.Errorf("sibling called %d times, want 0: the prompt was re-billed for an answer nobody was waiting for", got)
+	}
+	if env.handler.circuitBreaker.GetState(env.providerID, env.modelName) == failover.StateOpen {
+		t.Error("a caller that hung up was charged to the provider")
 	}
 }

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -884,3 +884,69 @@ func TestStreamedPassthroughDisconnect_IsNotFailedOverOrCharged(t *testing.T) {
 		t.Error("a caller that hung up was charged to the provider")
 	}
 }
+
+// The egress adapters read a whole 200 body before they can tell whether it is
+// the dialect's object at all, and the upstream close is what settles the
+// attempt's in-flight slot. That close has to wait for the verdict, and it has
+// to happen: settling on the read banks a clean completion for an answer nobody
+// could use, which on the grow-threshold run widens the provider's allowance for
+// good, and dropping the close instead leaks the slot and slowly saturates the
+// provider on this gateway's own arithmetic.
+//
+// Driven through the real chat pipeline against an Anthropic-typed provider, so
+// the translator, the reject and the close are the production ones rather than a
+// test's copy of them.
+func TestUntranslatableEgress2xx_NeitherGrowsTheWindowNorLeaksTheSlot(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Valid JSON, and not a Messages object: what a relay in front of
+		// Anthropic answers with, and nothing BuildChatCompletion can turn into
+		// a completion.
+		_, _ = io.WriteString(w, `{"detail":"upstream pool exhausted"}`)
+	}))
+	defer upstream.Close()
+
+	env := newAnthropicEgressEnv(t, upstream)
+	limiter := newInflightLimiter()
+	env.Handler.inflight = limiter
+	pid := env.ProviderID
+	// A capped window one clean completion short of the grow threshold: only a
+	// capped window counts runs, and this is the run where a wrong verdict shows
+	// in the allowance itself rather than only in the counter.
+	limiter.cut(pid, 0)
+	for range defaultInflightGrowAfter - 1 {
+		if !limiter.tryAcquire(pid, 0) {
+			t.Fatal("setup: slot not acquired")
+		}
+		limiter.release(pid, true, 0, 0)
+	}
+	before := *limiter.windowFor(t, pid)
+	if before.goodRuns != defaultInflightGrowAfter-1 {
+		t.Fatalf("setup: clean-run count = %d, want %d", before.goodRuns, defaultInflightGrowAfter-1)
+	}
+
+	// A document part is what routes this provider through the egress adapter
+	// rather than its OpenAI-compatible route.
+	body := fmt.Sprintf(`{"model":"%s/%s","stream":false,"messages":[{"role":"user","content":[{"type":"text","text":"what is the code?"},{"type":"file","file":{"file_data":"%s"}}]}]}`,
+		env.ProviderName, env.ModelName, pdfDataURI)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), virtualKeyNameKey, "test-key")
+	ctx = context.WithValue(ctx, virtualKeyIDKey, uuid.New().String())
+	ctx = context.WithValue(ctx, VirtualKeyHashKey, env.KeyHash)
+	w := httptest.NewRecorder()
+	env.Handler.ChatCompletions(w, req.WithContext(ctx))
+
+	if w.Code == http.StatusOK {
+		t.Fatalf("a body the adapter cannot translate was served to the client: %s", w.Body.String())
+	}
+	after := *limiter.windowFor(t, pid)
+	if after.limit != before.limit {
+		t.Errorf("allowance = %d, want %d: an answer the client never saw was the clean run that widened the window", after.limit, before.limit)
+	}
+	if after.goodRuns != 0 {
+		t.Errorf("clean-run count = %d, want 0: a 2xx that did not translate counted toward widening the window", after.goodRuns)
+	}
+	if after.inflight != 0 {
+		t.Errorf("in-flight count = %d, want 0: the attempt's slot was never settled, so the provider loses it for the life of the process", after.inflight)
+	}
+}

--- a/internal/proxy/nonstreaming_dispatch.go
+++ b/internal/proxy/nonstreaming_dispatch.go
@@ -55,12 +55,18 @@ func (h *Handler) dispatchNonStreaming(w http.ResponseWriter, r *http.Request, s
 	// read is judged by. With the bare client request instead, this gateway's own
 	// request_timeout looks like the provider dying.
 	ans := readNonStreamingBody(resp, logData.masker)
-	if err := ans.completionFault(r.Context(), resp.StatusCode); err != nil && hasMoreCandidates {
+	if err := ans.completionFault(r.Context(), resp.StatusCode); err != nil && hasMoreCandidates && answerFaultIsRoutable(err) {
+		// The provider generated this answer and billed the prompt for it, so
+		// the charge is recorded before the candidate is left behind.
+		h.meterRejectedPrompt(st, logData, ans.chat.Usage.PromptTokens)
+		outcome := h.rejectUntranslatableBody(st, candidate, logData, "chat completion", resp.StatusCode, err, attempt, r)
 		// Fully read already (or refused past the cap, where the rest is not
 		// worth draining), so the connection is released here rather than by the
-		// handler that normally owns it.
+		// handler that normally owns it. After the reject, which settles the
+		// attempt's in-flight slot as the failure it is before the close can
+		// settle it as a clean success.
 		_ = resp.Body.Close()
-		return h.rejectUntranslatableBody(st, candidate, logData, "chat completion", resp.StatusCode, err, attempt, r)
+		return outcome
 	}
 
 	h.deferAnswerJudgement(st, candidate, logData, resp.StatusCode)

--- a/internal/proxy/nonstreaming_dispatch.go
+++ b/internal/proxy/nonstreaming_dispatch.go
@@ -12,6 +12,12 @@ import "net/http"
 // is one the client or this gateway's own timeout ended, never the provider.
 func (h *Handler) dispatchNonStreaming(w http.ResponseWriter, r *http.Request, st *requestState, candidate modelCandidate, resp *http.Response, attempt int, responseHeaderMs float64, hasMoreCandidates bool) candidateOutcome {
 	logData := st.logData
+	// Both dispatches below read the whole body before they can tell a served
+	// answer from a 2xx that carried none, so the body's EOF must not settle the
+	// attempt's in-flight slot on the way past: at that moment the verdict does
+	// not exist yet, and a slot settled clean cannot be taken back. Every exit
+	// from here closes the body, which is what settles it instead.
+	holdSlotForVerdict(resp)
 	// A non-streaming answer clears any gone-strike streak the model had, judged
 	// after the handler on what the handler decoded rather than on the 200 that
 	// preceded it. Both halves of that placement are load-bearing:

--- a/internal/proxy/nonstreaming_response.go
+++ b/internal/proxy/nonstreaming_response.go
@@ -42,30 +42,49 @@ import (
 func nonStreamingFailureDetail(ctx context.Context, resp *http.Response, body []byte, readErr, decodeErr error, modelID string, fence *contentFence) (logMsg, detail string, kind ErrorKind, reason string) {
 	if servedSuccessStatus(resp.StatusCode) {
 		if readErr != nil {
-			// A read the provider did not break is not the provider failing. The
-			// body is read under the attempt's context, so a caller hanging up
-			// and this gateway's own request_timeout both arrive here as read
-			// errors, and reporting either as a provider fault puts someone
-			// else's cancellation on the provider's row and on its circuit.
-			// cancelKind is the package's classifier for that.
+			// A read nobody was waiting for is not the provider failing. The body
+			// is read under the attempt's context, so a caller hanging up arrives
+			// here as a read error, and reporting that as a provider fault puts
+			// someone else's cancellation on the provider's row and on its
+			// circuit. requestAbandoned is the package's spelling of which
+			// interruptions those are.
 			if kind, aborted := cancelKind(ctx, readErr); aborted {
-				detail = "the request was interrupted before the response was read"
-				return detail, detail, kind, "the request was interrupted"
+				if requestAbandoned(ctx, readErr) {
+					detail = "the request was interrupted before the response was read"
+					return detail, detail, kind, "the request was interrupted"
+				}
+				// The rest of them are this gateway's own per-attempt deadline
+				// expiring on a provider that answered headers and then said
+				// nothing: a stall, with the caller still waiting for it. The
+				// streaming half classifies the identical event provider_timeout
+				// and charges it (classifyProbeFailure), so this half does too,
+				// and the last candidate in a group records what a candidate with
+				// a sibling behind it would have.
+				detail = fmt.Sprintf("upstream stopped sending before the per-attempt deadline: %s (body_bytes=%d)", errString(readErr), len(body))
+				return detail, detail, KindProviderTimeout, "the provider stopped sending its response"
 			}
-			// A body that died on the wire is not a body this gateway could not
-			// parse. The parse failure is provider_bad_request because the answer
-			// is probably still in there; a transport failure is the provider
-			// breaking after it committed the status, which is what the breaker
-			// exists to catch.
+			// A body that died on the wire is the provider breaking after it
+			// committed the status, which is what the breaker exists to catch.
 			detail = fmt.Sprintf("upstream body read error: %s (body_bytes=%d)", errString(readErr), len(body))
 			return detail, detail, KindProviderError, "the provider stopped sending its response"
 		}
 		detail = fmt.Sprintf("response decode error: %s (body_bytes=%d, content_type=%q)",
 			errString(decodeErr), len(body), resp.Header.Get("Content-Type"))
+		// The gateway's own cap is not the provider failing, so it is the one
+		// refusal here that leaves the circuit alone (translationIsProviderFault
+		// draws the same line for the paths that fail over).
+		if errors.Is(decodeErr, httpx.ErrBodyTooLarge) {
+			return detail, detail, KindProviderBadRequest, "the provider returned a response larger than the gateway will read"
+		}
+		// provider_error, the same kind and the same charge rejectUntranslatableBody
+		// records when a sibling is still available. A 2xx whose body is not a
+		// completion is one fault, and which candidate in the group happened to
+		// produce it must not decide whether its provider is charged for it.
+		//
 		// Not "upstream provider returned HTTP 200": reporting the status as the
 		// failure sends operators hunting a provider outage that is not
 		// happening.
-		return detail, detail, KindProviderBadRequest, "the provider returned a response the gateway could not decode"
+		return detail, detail, KindProviderError, "the provider returned a response the gateway could not decode"
 	}
 	// Classify from the provider's own words, before the fence can take them:
 	// the classification decides routing and the breaker and stores nothing,
@@ -149,7 +168,11 @@ func (h *Handler) handleNonStreamingResponse(w http.ResponseWriter, r *http.Requ
 		logData.durationMs = totalDuration
 		logData.responseHeaderMs = responseHeaderMs
 		logData.tokensPerSecond = tps
-		logData.tokensPrompt = promptTokens
+		// Added, not assigned: a candidate that answered 2xx without an answer
+		// and was failed over already billed its prompt, and meterRejectedPrompt
+		// put that charge here. The row reports what the request cost, which on a
+		// walked group is more than the provider that finally served it charged.
+		logData.tokensPrompt += promptTokens
 		logData.tokensCompletion = completionTokens
 		logData.tokensCompletionReasoning = reasoningTokens
 		logData.tokensPromptCacheHit, logData.tokensPromptCacheMiss = extractCacheTokens(chatResp.Usage)
@@ -342,6 +365,27 @@ type nonStreamingAnswer struct {
 	decodeErr error
 }
 
+// completionCarriesAnswer reports whether a decoded completion is the provider
+// answering, which is a lower bar than whether it delivered content.
+//
+// Everything answerCarriesSomething counts, plus a choice that states how the
+// generation ended. Its streaming twin sets the bar lower still: any data frame
+// that is neither empty, [DONE] nor an error envelope counts as a token, so a
+// stream carrying one role-only delta is served. This is the closest a decoded
+// body gets to that without letting `{"choices":[]}`, the shape an aggregator in
+// front of a dead model returns, read as an answer.
+func completionCarriesAnswer(out ChatCompletionResponse) bool {
+	if answerCarriesSomething(out) {
+		return true
+	}
+	for _, choice := range out.Choices {
+		if choice.FinishReason != nil && *choice.FinishReason != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // completionFault reports what stopped a success status from being a completion,
 // or nil when the answer can be served. It is the non-streaming twin of the TTFT
 // probe's verdict: an upstream that answers 2xx and then hands over something
@@ -355,9 +399,10 @@ type nonStreamingAnswer struct {
 //     one of them, with the failover rules in shouldFailover.
 //   - 204/205 promise no body, so the empty one they carry is the whole answer
 //     and its decode failure is expected.
-//   - A read this gateway or the caller interrupted is not the provider
-//     failing. Failing over on a cancelled request re-sends the prompt to a
-//     second provider for an answer nobody is waiting for.
+//   - An attempt nobody is waiting for. requestAbandoned draws that line, and
+//     draws it narrowly: a caller that hung up and a superseded hedge, never
+//     this gateway's own per-attempt deadline, which is a provider that stalled
+//     after its headers and is exactly what the sibling exists for.
 //
 // A body that decoded but carries nothing is a fault too, for the same reason
 // its streaming twin fails over on a stream that ends without a single chunk: a
@@ -383,27 +428,9 @@ type nonStreamingAnswer struct {
 // (readNonStreamingBody says why). Failing over on it would discard a complete
 // answer and re-bill the prompt. When both are set the read error is the one
 // reported, since the wire is where it started.
-// completionCarriesAnswer reports whether a decoded completion is the provider
-// answering, which is a lower bar than whether it delivered content.
 //
-// Everything answerCarriesSomething counts, plus a choice that states how the
-// generation ended. Its streaming twin sets the bar lower still: any data frame
-// that is neither empty, [DONE] nor an error envelope counts as a token, so a
-// stream carrying one role-only delta is served. This is the closest a decoded
-// body gets to that without letting `{"choices":[]}`, the shape an aggregator in
-// front of a dead model returns, read as an answer.
-func completionCarriesAnswer(out ChatCompletionResponse) bool {
-	if answerCarriesSomething(out) {
-		return true
-	}
-	for _, choice := range out.Choices {
-		if choice.FinishReason != nil && *choice.FinishReason != "" {
-			return true
-		}
-	}
-	return false
-}
-
+// A fault is not automatically worth a sibling: answerFaultIsRoutable says which
+// ones are.
 func (ans nonStreamingAnswer) completionFault(ctx context.Context, status int) error {
 	if !servedSuccessStatus(status) || bodilessSuccessStatus(status) {
 		return nil
@@ -412,12 +439,12 @@ func (ans nonStreamingAnswer) completionFault(ctx context.Context, status int) e
 	if ans.readErr != nil {
 		err = ans.readErr
 	}
-	// Above both verdicts, not just the decode one: an attempt this gateway or
-	// the caller ended is nobody's answer to serve, and a cancelled read can
-	// leave a body that parses into an empty completion just as easily as one
-	// that does not parse at all. cancelKind reads the context even when nothing
-	// errored, so the empty-answer arm is covered by the same call.
-	if _, aborted := cancelKind(ctx, err); aborted {
+	// Above both verdicts, not just the decode one: an attempt nobody is waiting
+	// for is nobody's answer to serve, and an abandoned read can leave a body
+	// that parses into an empty completion just as easily as one that does not
+	// parse at all. requestAbandoned reads the context even when nothing errored,
+	// so the empty-answer arm is covered by the same call.
+	if requestAbandoned(ctx, err) {
 		return nil
 	}
 	if ans.decodeErr != nil {
@@ -427,6 +454,23 @@ func (ans nonStreamingAnswer) completionFault(ctx context.Context, status int) e
 		return nil
 	}
 	return errEmptyCompletion
+}
+
+// answerFaultIsRoutable reports whether a 2xx that carried no answer is worth
+// asking a sibling about. Every fault is, except this gateway's own body cap.
+//
+// An answer's size is a function of the request, so a prompt that draws a body
+// past the cap from one provider draws one past it from the next: failing over
+// walks the whole group, re-billing the prompt at every stop, to render the same
+// 502 the first candidate already owed the client. It is also not the provider's
+// failure, which is why translationIsProviderFault leaves the circuit alone for
+// the same sentinel, so a group would burn itself down with nothing recorded
+// anywhere.
+//
+// Shared by the chat dispatch and the native Anthropic handler, the two paths
+// whose reads are capped.
+func answerFaultIsRoutable(err error) bool {
+	return !errors.Is(err, httpx.ErrBodyTooLarge)
 }
 
 // readNonStreamingBody reads the upstream body once and decodes it into the

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -206,7 +206,11 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		} else if err := translateResponsesResponseBody(resp, st.reqModel); err != nil {
 			// A 200 whose body cannot be read or is not a Responses object is
 			// a provider fault; fail over like any other malformed upstream.
-			return h.rejectUntranslatableBody(st, candidate, logData, "responses api", resp.StatusCode, err, attempt, r)
+			// Closed after the verdict: readCappedBody left the upstream close,
+			// which settles the in-flight slot, to whoever judges the bytes.
+			outcome := h.rejectUntranslatableBody(st, candidate, logData, "responses api", resp.StatusCode, err, attempt, r)
+			_ = resp.Body.Close()
+			return outcome
 		}
 	}
 	if st.geminiAttempt {
@@ -214,7 +218,9 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = gemini.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, gemini.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "gemini", resp.StatusCode, err, attempt, r)
+			outcome := h.rejectUntranslatableBody(st, candidate, logData, "gemini", resp.StatusCode, err, attempt, r)
+			_ = resp.Body.Close()
+			return outcome
 		}
 	}
 	if st.anthropicEgressAttempt {
@@ -222,7 +228,9 @@ func (h *Handler) attemptCandidate(w http.ResponseWriter, r *http.Request, st *r
 		if st.isStreaming {
 			resp.Body = anthropicegress.NewStreamAdapter(resp.Body, st.reqModel)
 		} else if err := translateEgressResponseBody(resp, st.reqModel, anthropicegress.BuildChatCompletion); err != nil {
-			return h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", resp.StatusCode, err, attempt, r)
+			outcome := h.rejectUntranslatableBody(st, candidate, logData, "anthropic egress", resp.StatusCode, err, attempt, r)
+			_ = resp.Body.Close()
+			return outcome
 		}
 	}
 	if st.isStreaming {

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -741,8 +741,16 @@ func (h *Handler) doUpstream(ctx context.Context, req *http.Request, st *request
 		return nil, false
 	}
 
-	// Log upstream response metadata for debugging.
-	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode, "content_type", resp.Header.Get("Content-Type"), "x_request_id", resp.Header.Get("X-Request-Id"), "x_ratelimit_remaining", resp.Header.Get("X-RateLimit-Remaining"), "attempt", attempt+1)
+	// Log upstream response metadata for debugging. The three header values are
+	// the upstream's own text, so they are bounded and sanitized the way every
+	// other upstream-controlled value a log line carries is: a provider is free
+	// to answer with a megabyte of newlines in a header, and an app log the
+	// dashboard renders is not the place to find that out.
+	debuglog.Debug("proxy: upstream response received", "provider", candidate.provider.Name, "provider_id", candidate.provider.ID, "model", candidate.model.ModelID, "status", resp.StatusCode,
+		"content_type", util.SanitizeLogBody(resp.Header.Get("Content-Type"), shortLogValueCap),
+		"x_request_id", util.SanitizeLogBody(resp.Header.Get("X-Request-Id"), shortLogValueCap),
+		"x_ratelimit_remaining", util.SanitizeLogBody(resp.Header.Get("X-RateLimit-Remaining"), shortLogValueCap),
+		"attempt", attempt+1)
 	return resp, true
 }
 

--- a/internal/proxy/proxy_failover.go
+++ b/internal/proxy/proxy_failover.go
@@ -563,7 +563,11 @@ func (h *Handler) buildCandidateRequest(ctx context.Context, st *requestState, c
 			var droppedSize, ratio string
 			upstreamBody, droppedSize, ratio = paramrewrite.RewriteImageRequest(upstreamBody, providerType, candidate.model.ModelID)
 			if droppedSize != "" {
-				debuglog.Debug("proxy: image size rewritten for the provider", "provider_type", providerType, "resolved_model", candidate.model.ModelID, "dropped_size", droppedSize, "aspect_ratio", ratio)
+				// The dropped size is whatever JSON value the caller put under
+				// "size", of any type and any length, so it is bounded and
+				// sanitized like every other caller string that reaches a log.
+				// The ratio beside it comes from this gateway's own table.
+				debuglog.Debug("proxy: image size rewritten for the provider", "provider_type", providerType, "resolved_model", candidate.model.ModelID, "dropped_size", util.SanitizeLogBody(droppedSize, shortLogValueCap), "aspect_ratio", ratio)
 			}
 		}
 	} else {

--- a/internal/proxy/proxy_failover_model_log_test.go
+++ b/internal/proxy/proxy_failover_model_log_test.go
@@ -170,10 +170,12 @@ func TestLogUpstreamModel_WritesTheModelAtDebug(t *testing.T) {
 	}
 }
 
-// With a handler that refuses Debug records nothing is written, and the body is
-// never parsed: a body that is not JSON at all is handed over, which the decode
-// would have to reach to reject. Bodies are tens of megabytes on the image
-// endpoints, so the parse skipped here is what the gate exists for.
+// With a handler that refuses Debug records nothing is written. The gate also
+// skips the decode on that path, which is what it exists for on bodies that
+// reach tens of megabytes, but that is not observable from outside without a
+// hook production code must not carry; it holds by construction, the gate
+// being the first statement of logUpstreamModel. What this pins is the visible
+// contract: nothing about the body, parseable or not, reaches the log.
 func TestLogUpstreamModel_SilentBelowDebug(t *testing.T) {
 	captured := captureLogsAt(t, slog.LevelInfo)
 

--- a/internal/proxy/proxy_failover_model_log_test.go
+++ b/internal/proxy/proxy_failover_model_log_test.go
@@ -1,10 +1,79 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/hugalafutro/model-hotel/internal/debuglog"
+	"github.com/hugalafutro/model-hotel/internal/model"
+	"github.com/hugalafutro/model-hotel/internal/provider"
 )
+
+// logRecorder keeps every record at or above its level, message and attributes
+// together. The attributes are the point: the leak these tests guard against
+// travels in an attribute value, so a recorder that kept only the message would
+// assert nothing. Enabled answers the level question the same way a production
+// handler configured at that level does, which is what the debug gate reads.
+type logRecorder struct {
+	level slog.Level
+	mu    *sync.Mutex
+	lines *[]string
+	attrs []slog.Attr
+}
+
+func (h *logRecorder) Enabled(_ context.Context, l slog.Level) bool { return l >= h.level }
+
+func (h *logRecorder) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%v", a.Key, a.Value)
+		return true
+	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.lines = append(*h.lines, b.String())
+	return nil
+}
+
+func (h *logRecorder) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &logRecorder{level: h.level, mu: h.mu, lines: h.lines, attrs: append(append([]slog.Attr{}, h.attrs...), attrs...)}
+}
+
+func (h *logRecorder) WithGroup(string) slog.Handler { return h }
+
+// captureLogsAt installs a recording handler at the given level through
+// debuglog, the way the binaries install theirs, and returns a lookup for the
+// captured lines whose message starts with the given prefix. The process-wide
+// default logger is restored when the test ends, so a test using this must not
+// run in parallel.
+func captureLogsAt(t *testing.T, level slog.Level) func(prefix string) []string {
+	t.Helper()
+	var lines []string
+	var mu sync.Mutex
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	debuglog.SetHandler(&logRecorder{level: level, mu: &mu, lines: &lines})
+	return func(prefix string) []string {
+		mu.Lock()
+		defer mu.Unlock()
+		var got []string
+		for _, l := range lines {
+			if strings.HasPrefix(l, prefix) {
+				got = append(got, l)
+			}
+		}
+		return got
+	}
+}
 
 // TestUpstreamModelAttr_CarriesTheModelNotTheBody pins the no-content-logging
 // invariant on the one debug line that reads the upstream body. The value used
@@ -66,7 +135,7 @@ func TestUpstreamModelAttr_BoundsTheValue(t *testing.T) {
 	}
 	// The sanitizer marks a value it truncated, so the result is the cap plus
 	// that marker rather than exactly the cap.
-	if len(got) > upstreamModelLogCap+16 {
+	if len(got) > shortLogValueCap+16 {
 		t.Errorf("logged value is %d bytes, want the cap plus a truncation marker", len(got))
 	}
 	if !strings.HasPrefix(got, strings.Repeat("m", 64)) {
@@ -74,24 +143,87 @@ func TestUpstreamModelAttr_BoundsTheValue(t *testing.T) {
 	}
 }
 
-// TestLogUpstreamModel_SkipsTheDecodeWhenDebugIsOff proves the gate does the
-// thing it exists for. Asserting that nothing was logged would pass either way,
-// since the handler drops the record anyway; the decode counter is what
-// distinguishes a skipped parse from a parsed-then-dropped one.
-func TestLogUpstreamModel_SkipsTheDecodeWhenDebugIsOff(t *testing.T) {
-	original := debugEnabled
-	t.Cleanup(func() { debugEnabled = original })
+// With a handler that accepts Debug records the line is written, and it carries
+// the model alone.
+func TestLogUpstreamModel_WritesTheModelAtDebug(t *testing.T) {
+	const secret = "caller text with no comma at all"
+	body, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"model": secret},
+		"model":    "gpt-5",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	captured := captureLogsAt(t, slog.LevelDebug)
 
-	debugEnabled = func() bool { return false }
-	before := upstreamModelDecodes.Load()
+	logUpstreamModel(body)
+
+	got := captured("proxy: upstream body model")
+	if len(got) != 1 {
+		t.Fatalf("expected one model line, got %v", got)
+	}
+	if !strings.Contains(got[0], "upstream_model=gpt-5") {
+		t.Errorf("the line should carry the model under upstream_model, got %q", got[0])
+	}
+	if strings.Contains(got[0], secret) {
+		t.Errorf("request content reached the log: %q", got[0])
+	}
+}
+
+// With a handler that refuses Debug records nothing is written, and the body is
+// never parsed: a body that is not JSON at all is handed over, which the decode
+// would have to reach to reject. Bodies are tens of megabytes on the image
+// endpoints, so the parse skipped here is what the gate exists for.
+func TestLogUpstreamModel_SilentBelowDebug(t *testing.T) {
+	captured := captureLogsAt(t, slog.LevelInfo)
+
 	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
-	if after := upstreamModelDecodes.Load(); after != before {
-		t.Errorf("decode ran with debug off: %d -> %d", before, after)
+	logUpstreamModel([]byte(`not json at all, secret`))
+
+	if got := captured("proxy: upstream body model"); len(got) != 0 {
+		t.Errorf("expected nothing logged below debug, got %v", got)
+	}
+}
+
+// The image rewrite reports the "size" it dropped so the change is debuggable,
+// and that value is whatever JSON the caller put under the key: any type, any
+// length. It reaches the log bounded and sanitized, not verbatim.
+func TestBuildCandidateRequest_BoundsTheDroppedImageSize(t *testing.T) {
+	huge := strings.Repeat("z", 100<<10)
+	body, err := json.Marshal(map[string]any{
+		"model":  "grok-imagine",
+		"prompt": "a cat",
+		"size":   huge,
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	h := &Handler{}
+	st := &requestState{
+		bodyBytes:        body,
+		reqModel:         "grok-imagine",
+		endpointPath:     "/images/generations",
+		logData:          &requestLogData{endpointType: endpointTypeImage},
+		makeUpstreamBody: func(string) ([]byte, string, error) { return body, "application/json", nil },
+	}
+	candidate := modelCandidate{
+		model:    &model.Model{ModelID: "grok-imagine"},
+		provider: &provider.Provider{Name: "xAI", BaseURL: "https://api.x.ai/v1", ProviderType: "xai"},
+	}
+	captured := captureLogsAt(t, slog.LevelDebug)
+
+	if _, _, _, err := h.buildCandidateRequest(context.Background(), st, candidate); err != nil {
+		t.Fatalf("buildCandidateRequest: %v", err)
 	}
 
-	debugEnabled = func() bool { return true }
-	logUpstreamModel([]byte(`{"model":"gpt-5"}`))
-	if after := upstreamModelDecodes.Load(); after == before {
-		t.Error("decode should run when debug is on")
+	got := captured("proxy: image size rewritten for the provider")
+	if len(got) != 1 {
+		t.Fatalf("expected one rewrite line, got %v lines", len(got))
+	}
+	if strings.Contains(got[0], huge) {
+		t.Error("the caller's size reached the log verbatim")
+	}
+	if len(got[0]) > 1024 {
+		t.Errorf("rewrite line is %d bytes, want the dropped size bounded", len(got[0]))
 	}
 }

--- a/internal/proxy/proxy_nonstreaming_test.go
+++ b/internal/proxy/proxy_nonstreaming_test.go
@@ -500,8 +500,11 @@ func undecodable2xxDoesNotLogContent(t *testing.T, status int) {
 			t.Errorf("errorMessage missing diagnostic %q: %q", want, logData.errorMessage)
 		}
 	}
-	if logData.errorKind != KindProviderBadRequest {
-		t.Errorf("error kind = %v, want %v", logData.errorKind, KindProviderBadRequest)
+	// The same kind rejectUntranslatableBody records for the identical body one
+	// candidate earlier: which position in the group produced it must not decide
+	// whether its provider is charged.
+	if logData.errorKind != KindProviderError {
+		t.Errorf("error kind = %v, want %v", logData.errorKind, KindProviderError)
 	}
 }
 
@@ -711,8 +714,8 @@ func TestNonStreamingFailureDetail(t *testing.T) {
 				t.Errorf("diagnostics missing: %q", s)
 			}
 		}
-		if kind != KindProviderBadRequest {
-			t.Errorf("kind = %v, want %v", kind, KindProviderBadRequest)
+		if kind != KindProviderError {
+			t.Errorf("kind = %v, want %v", kind, KindProviderError)
 		}
 		if !strings.Contains(reason, "could not decode") || strings.Contains(reason, "200") {
 			t.Errorf("reason = %q", reason)

--- a/internal/proxy/reqerror.go
+++ b/internal/proxy/reqerror.go
@@ -139,6 +139,28 @@ func cancelOriginToKind(origin string) ErrorKind {
 	}
 }
 
+// requestAbandoned reports whether an interruption means there is nobody left to
+// serve, which is the one reason a 2xx that carried no answer is not offered to
+// a sibling. It is the single spelling of that rule, asked by every path that
+// judges an upstream body: the chat dispatch, the native Anthropic handler and
+// both pass-through halves.
+//
+// Only two of cancelKind's kinds qualify. A caller that hung up
+// (client_disconnect) and a hedge the winning branch superseded
+// (hedge_superseded) leave an answer nobody would read, so asking a second
+// provider would re-bill the prompt for nothing.
+//
+// This gateway's OWN per-attempt deadlines (failover_timeout, retry_timeout) are
+// the opposite case: the caller is still waiting, and a provider that answered
+// 2xx headers and then went silent until the deadline is a provider that
+// stalled. The streaming twin has always read it that way, failing the TTFT
+// probe over to the sibling and charging the stall, and a stalled body read is
+// the same event on the non-streaming side.
+func requestAbandoned(ctx context.Context, err error) bool {
+	kind, aborted := cancelKind(ctx, err)
+	return aborted && (kind == KindClientDisconnect || kind == KindHedgeSuperseded)
+}
+
 // providerLabel renders the provider name for prose, falling back to a generic
 // phrase when the failure is not attributable to a named provider.
 func (e reqError) providerLabel() string {

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -302,7 +302,7 @@ func TestHandleNonStreamingResponse_InvalidJSON(t *testing.T) {
 
 	assert.Equal(t, "failed", logData.state)
 	assert.Contains(t, logData.errorMessage, "response decode error")
-	assert.Equal(t, KindProviderBadRequest, logData.errorKind)
+	assert.Equal(t, KindProviderError, logData.errorKind)
 	// Note: "invalid json response" may be truncated/omitted by SanitizeLogBody
 	// depending on the exact error message format
 }

--- a/web/src/components/AttemptTrail.tsx
+++ b/web/src/components/AttemptTrail.tsx
@@ -175,9 +175,9 @@ export function AttemptTrail({
 							// column so it lines up with the provider name. The verdict
 							// lives here rather than beside the timing because a row that
 							// runs long wraps it to its own line anyway, and a wrapped
-							// flex child starts at the left edge, under the number.
+							// flex child starts at the row's start edge, under the number.
 							<span
-								className="basis-full flex items-baseline gap-x-2 pl-8"
+								className="basis-full flex flex-wrap items-baseline gap-x-2 ps-8"
 								data-testid="attempt-trail-meta"
 							>
 								{showsVerdict(a) && (

--- a/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
+++ b/web/src/components/__tests__/RequestLogDetail.attempts.test.tsx
@@ -225,7 +225,7 @@ describe("RequestLogDetail attempt trail", () => {
 			/>,
 		);
 		const line = screen.getByTestId("attempt-trail-meta");
-		expect(line).toHaveClass("basis-full", "pl-8");
+		expect(line).toHaveClass("basis-full", "ps-8", "flex-wrap");
 		expect(line.firstElementChild).toHaveAttribute("title");
 	});
 

--- a/wiki/Model-Discovery.md
+++ b/wiki/Model-Discovery.md
@@ -481,7 +481,7 @@ Its quota endpoint is the part that needed code: see [Additional Provider APIs](
 
 **Method:** Calls `GET /models` (OpenAI-compatible list endpoint), converts the listing to clean stubs, and merges them with the built-in `deepseekCatalog` (6 rows) via [`mergeLiveAndCatalog`](#live--catalog-merge). The catalog backfills context length, max output, reasoning flag, input modalities, and pricing (cache-miss maps to the standard input price; cache-hit is carried separately). Uncatalogued models are clean stubs filled by models.dev; there is no hardcoded context default.
 
-Two of the six rows are not price overrides but the only source of the model at all: `deepseek-chat` and `deepseek-reasoner` are permanent aliases (thinking off and on) and are absent from the live listing entirely. The rest exist because models.dev carries no entry for `deepseek-flash` and still lists DeepSeek's pre-V4 rates under the V4 IDs. `deepseek-flash` is V4.1 Flash and the only Flash id DeepSeek documents; `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` all resolve to it upstream, so every Flash-family row carries its price. `deepseek-v4-pro` is the one row still on its own rate. Catalog prices are DeepSeek's **off-peak** rates, which apply for 17 of every 24 hours; peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at exactly double, and a model row holds one figure, so metering under-reports during that window.
+Two of the six rows are not price overrides but the only source of the model at all: `deepseek-chat` and `deepseek-reasoner` are permanent aliases (thinking off and on) and are absent from the live listing entirely. The rest exist because models.dev carries no entry for `deepseek-flash` and still lists DeepSeek's pre-V4 rates under the V4 IDs. `deepseek-flash` is V4.1 Flash and the only Flash id DeepSeek documents; `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` all resolve to it upstream, so every Flash-family row carries its price and its vision flag: the live API answers an image on each of those ids, while models.dev declares the family text-only. `deepseek-v4-pro` is the one row still on its own rate. Catalog prices are DeepSeek's **off-peak** rates, which apply for 17 of every 24 hours; peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at exactly double, and a model row holds one figure, so metering under-reports during that window.
 
 **Catalog provides:**
 
@@ -899,7 +899,7 @@ The `lookupFuzzyIn` helper implements this logic (the canonical-provider and cro
 | Reasoning capability | Only if false |
 | Tool calling capability | Only if false |
 | Structured output capability | Only if false, and never for an image-output model on a provider that reaches Google's own route (Google AI Studio, Vertex AI express, and OpenCode Zen for its `gemini-*` ids), whose JSON mode the API refuses (google-gemini/cookbook#1028) |
-| Vision capability | Only if false, and only when the `attachment` flag is corroborated by an `image` input modality (or by no input list at all). models.dev sets `attachment` on models whose only input is text, `deepseek-chat` among them. |
+| Vision capability | Only if false, and only when the `attachment` flag is corroborated by an `image` input modality (or by no input list at all). models.dev sets `attachment` on models whose only input is text, so the flag on its own would advertise vision a provider can refuse. |
 | Input modalities | Only if empty or `"[]"` |
 | Output modalities | Only if empty or `"[]"` |
 | Owned by / family | Only if empty |
@@ -925,7 +925,7 @@ Models.dev is particularly valuable for providers that lack built-in catalogs or
 | **OpenAI** (generic) | 2 rows (`gpt-5.5-pro`, `gpt-5.4-pro`) | Pricing and specs for older GPT-4.x, the o-series, and any new models |
 | **Anthropic** | Pricing channel, currently empty | Pricing, capabilities, modalities and context limits for Claude models |
 | **Google AI Studio** | Pricing channel, currently empty | Pricing for Gemini models |
-| **DeepSeek** | 5 rows | Specs for older DeepSeek models and any not yet in the catalog |
+| **DeepSeek** | 6 rows | Specs for older DeepSeek models and any not yet in the catalog |
 | **Ollama** | None | Pricing, capabilities for well-known models available through Ollama |
 | **OpenRouter** | None (API-driven) | Pricing and specs for any OpenRouter-hosted model not covered by the API |
 | **Any unknown provider** | None | Full metadata for any model that exists in the models.dev database |


### PR DESCRIPTION
## What

Closes the gaps an independent review of the PRs merged between 2026-09-09 and 2026-09-11 (#968, #970, #971, #972, #974, #978, #979) found. Every item is a small, tested change to the code those PRs touched.

### Failover past a 2xx (#978)

- A non-streaming 200 that then stalls until this gateway's own per-attempt deadline now fails over to the sibling and charges the stall, the same way the streaming TTFT probe always has. `requestAbandoned` is the one rule for "nobody is waiting" (client hung up, hedge superseded); every path that failed over on a bare cancel check now uses it, including the streamed pass-through that used the raw client context.
- The prompt a rejected 2xx reported is metered (row token column, virtual-key counter, TPM debit) through the same `recordTokenUsage` the served path uses. Prompt stamps on the served path add rather than overwrite so the row carries every prompt the request cost upstream.
- The gateway's own body-cap refusal is terminal again: it is a function of the request, so walking the candidate list only re-billed the same oversized answer at every provider.
- The buffered paths (non-streaming chat, native, buffered pass-through) hold the in-flight slot until the verdict instead of settling it clean at the body's EOF, so a rejected 2xx settles unclean and a provider answering `{"choices":[]}` no longer widens its learned concurrency window while its circuit is being charged. Streams keep their last-byte release. The egress translators and the Gemini reshaping adapters read through a helper that used to close the body before the translation was judged; it now holds the slot too and hands the upstream close to whoever records the verdict, so those five paths settle the same way.
- The pass-through handlers now receive the per-attempt failover context like the chat path, so a stalled streamed pass-through 2xx fails over and is charged, and a client disconnect on that path still does neither.
- The native `/v1/messages` bar accepts a non-empty `stop_reason` like the chat bar accepts a non-empty `finish_reason`; `content: [], stop_reason: max_tokens` is served on both surfaces.
- An undecodable 2xx is `provider_error` and charged whether it arrives on the last candidate or an earlier one; a stall is `provider_timeout` at either position.

### Debug-log content (#974)

- The `dropped_size` attribute on the image-rewrite debug line is sanitised and bounded like the model name beside it; it was the caller's raw `size` JSON value.
- MiniMax's `status_msg` goes through `util.SanitizeLogBody` before the Warn line, like every other upstream body in the package.
- The `var debugEnabled` function hook and the decode counter that existed only for tests are gone; the tests assert through a per-test debuglog handler at Debug and Info. The skipped decode below Debug is no longer observable from a test (that observability was the seam); it holds by construction, the gate being the first statement of the function, and the test says so.
- The over-long-username login test now proves the guard: ten over-long logins from ten addresses never reach the user store and never mint a per-account throttle key.
- The username length message says bytes, which is what it measures.

### Config sync (#972)

- `model_failover_groups` is no longer locked inside the import transaction: the group reconcile runs after commit in its own transaction, so the lock protected nothing and blocked dashboard group writes for the whole import. A `pg_locks` test pins which tables are held.
- `SET LOCAL lock_timeout` runs before the advisory fence lock, so an import waiting on another import is bounded too.
- `virtual_keys` follows the nil-vs-empty contract the payload already uses for groups, users and model lists: an explicit `[]` from a primary that has no keys reconciles a member to zero; an absent or `null` field still refuses; the post-reconcile survival check still refuses a populated envelope whose keys all failed to land.
- Migration 083 pre-filters on `attempts::text LIKE '%[content]%'` so rows without the marker never enter `jsonb_array_elements`; an `xmin` snapshot proves untouched rows stay untouched. The migration is recorded by name, is applied on dev and not yet on production.

### Catalog and UI

- Every DeepSeek Flash-family id (`deepseek-flash`, `deepseek-chat`, `deepseek-reasoner`, `deepseek-v4-flash`) carries the vision flag: each one answered a probe image live (223 prompt tokens against 97 without the image), while `deepseek-v4-pro` silently drops it and stays text-only. Chat's image button follows the flag.
- The attempt-trail meta line indents with `ps-8` so it sits under the provider name in RTL too, and wraps.
- The paginated app-log query selects `id`, so two rows written in one tick no longer share the stepper's fallback key.
- CrowdSec README: the fixture description covers all 33 lines, and a new arming note says the Traefik config poll's refusals count toward the admin brute-force bucket at one every 5 seconds.

## Test

Full sharded Go suite, `golangci-lint run ./...`, `make size-check`, gofmt and gci clean. Frontend: the attempt-trail test file, `pnpm lint`, `pnpm exec tsc -b`. New tests for every behaviour change; each was checked to fail with its fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
