### PR TITLE
fix(proxy): judge rerank and image pass-through answers on content

### DIFF
--- a/internal/proxy/answer_breaker_test.go
+++ b/internal/proxy/answer_breaker_test.go
@@ -536,14 +536,23 @@ func TestHandleNonStreamingResponse_AnOversizedBodyIsNotTheProvidersFault(t *tes
 // breaker success was recorded the moment the buffered read succeeded, so an
 // embeddings provider answering nothing to every request recorded a success
 // every time and its circuit could never open.
-func TestServeBufferedJSONPassthrough_EmptyEmbeddingsChargesTheBreaker(t *testing.T) {
+//
+// Rerank and image generation are JSON-bodied too, and were judged on bytes
+// alone: `{"results":[]}` and `{"data":[]}` credited the circuit on every call.
+func TestServeBufferedJSONPassthrough_EmptyJSONAnswerChargesTheBreaker(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
+		endpoint   string
+		path       string
 		body       string
 		wantCharge bool
 	}{
-		{"no data at all", `{"object":"list","data":[]}`, true},
-		{"a real embedding", `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}]}`, false},
+		{"no data at all", endpointTypeEmbeddings, "/v1/embeddings", `{"object":"list","data":[]}`, true},
+		{"a real embedding", endpointTypeEmbeddings, "/v1/embeddings", `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}]}`, false},
+		{"no rerank results", endpointTypeRerank, "/v1/rerank", `{"results":[],"usage":{"total_tokens":3}}`, true},
+		{"a real ranking", endpointTypeRerank, "/v1/rerank", `{"results":[{"index":0,"relevance_score":0.5}],"usage":{"total_tokens":3}}`, false},
+		{"no image data", endpointTypeImage, "/v1/images/generations", `{"created":1,"data":[]}`, true},
+		{"a real image", endpointTypeImage, "/v1/images/generations", `{"created":1,"data":[{"b64_json":"aW1n"}]}`, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newIntegrationHandler()
@@ -555,18 +564,18 @@ func TestServeBufferedJSONPassthrough_EmptyEmbeddingsChargesTheBreaker(t *testin
 				circuitBreakerEnabled: true,
 				startTime:             time.Now(),
 				logData: &requestLogData{
-					modelID: "text-embedding-3-small", providerID: providerID, providerName: "p",
-					endpointType: endpointTypeEmbeddings, state: "pending",
+					modelID: "m", providerID: providerID, providerName: "p",
+					endpointType: tc.endpoint, state: "pending",
 					virtualKeyName: "k", virtualKeyID: "00000000-0000-0000-0000-000000000001",
 				},
 			}
 			candidate := modelCandidate{
-				model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
+				model:    &model.Model{ID: uuid.New(), ModelID: "m"},
 				provider: &provider.Provider{ID: providerID, Name: "p"},
 			}
 			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewBufferString(tc.body)), Header: make(http.Header)}
 
-			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, candidate, resp, "application/json", 1, 5, false)
+			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", tc.path, http.NoBody), st, candidate, resp, "application/json", 1, 5, false)
 
 			charged := h.circuitBreaker.GetState(providerID, candidate.model.ModelID) == failover.StateOpen
 			if charged != tc.wantCharge {

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -113,10 +113,11 @@ func (v probeVerdict) String() string {
 // and real seconds per call.
 //
 // Rerank is excluded on weaker grounds: a /rerank call with one document is as
-// cheap as an embeddings call, but it would need its own request body, answer
-// shape and content judgement, and an unexercised third judgement path is a
-// worse trade than leaving rerank models enabled until an operator disables one.
-// Cheap to reverse: add the family here plus a body and a content check.
+// cheap as an embeddings call, and probeDeliveredContent already judges a
+// rerank answer for the traffic path, but the probe would still need its own
+// request body, and an unexercised third probe path is a worse trade than
+// leaving rerank models enabled until an operator disables one. Cheap to
+// reverse: add the family here plus a body.
 //
 // Where a family cannot be probed cheaply, the correct outcome is not to
 // auto-retire that family at all. Falling back to the prose classifier would
@@ -480,8 +481,8 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 
 // probeDeliveredContent reports whether a success response actually carried
 // something the model produced. The retirement probe asks it of the chat and
-// embeddings families; the pass-through traffic path asks it of every family
-// that answers in JSON (passthroughAnswered).
+// embeddings families; the pass-through traffic path asks it of the JSON
+// families other than audio (passthroughAnswered says why audio is not).
 //
 // A body that will not parse returns false, which postpones rather than retires:
 // an unreadable answer is not the provider saying the model is gone.
@@ -507,27 +508,13 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 		}
 		return !jsonValueIsEmpty(out.Data[0].Embedding)
 	case endpointTypeRerank:
-		// A ranking of nothing is nothing produced: every rerank API returns one
-		// result per document it scored, and refuses an empty document list
-		// with a 400 rather than answering it with an empty 200.
-		var out struct {
-			Results []json.RawMessage `json:"results"`
-		}
-		return json.Unmarshal(body, &out) == nil && len(out.Results) > 0
+		// Cohere, Jina and the local rerankers answer under "results", Voyage
+		// under "data", and text-embeddings-inference with the bare list.
+		return listAnswerDelivered(body, "results", "data")
 	case endpointTypeImage:
-		// An image is delivered as a URL or as base64 bytes; an entry carrying
-		// neither (a revised prompt alone, say) is not an image. The same
-		// structural emptiness rule as the vector above, for the same reason.
-		var out struct {
-			Data []struct {
-				URL     json.RawMessage `json:"url"`
-				B64JSON json.RawMessage `json:"b64_json"`
-			} `json:"data"`
-		}
-		if json.Unmarshal(body, &out) != nil || len(out.Data) == 0 {
-			return false
-		}
-		return !jsonValueIsEmpty(out.Data[0].URL) || !jsonValueIsEmpty(out.Data[0].B64JSON)
+		// The OpenAI shape every /v1/images provider this gateway fronts
+		// answers in: the images under "data".
+		return listAnswerDelivered(body, "data")
 	}
 
 	var out ChatCompletionResponse
@@ -535,6 +522,34 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 		return false
 	}
 	return chatAnswerCarriesContent(out)
+}
+
+// listAnswerDelivered reports whether a JSON answer whose payload is a list
+// under one of the given keys, or is itself that list, carries anything.
+//
+// Only a shape it recognises is ever called empty. A rerank or image provider
+// answering in a dialect this gateway does not translate (an object under
+// "data", the images under a key of its own) is forwarded to the client as it
+// came, and its answer is judged on bytes as before: not understanding a shape
+// is not evidence that it carries nothing, and calling it empty would fail a
+// healthy provider over and charge its circuit on every call. A body that will
+// not parse at all is not an answer on a JSON surface, the verdict the chat
+// path reaches through completionFault.
+func listAnswerDelivered(body []byte, keys ...string) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		return !jsonValueIsEmpty(trimmed)
+	}
+	var out map[string]json.RawMessage
+	if json.Unmarshal(body, &out) != nil {
+		return false
+	}
+	for _, key := range keys {
+		if raw, ok := out[key]; ok {
+			return !jsonValueIsEmpty(raw)
+		}
+	}
+	return true
 }
 
 // jsonValueIsEmpty reports whether a raw JSON value carries nothing: absent,

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -478,13 +478,16 @@ func translateProbeDialect(resp *http.Response, st *requestState, modelID string
 	}
 }
 
-// probeDeliveredContent reports whether a success probe response actually carried
-// something the model produced.
+// probeDeliveredContent reports whether a success response actually carried
+// something the model produced. The retirement probe asks it of the chat and
+// embeddings families; the pass-through traffic path asks it of every family
+// that answers in JSON (passthroughAnswered).
 //
 // A body that will not parse returns false, which postpones rather than retires:
 // an unreadable answer is not the provider saying the model is gone.
 func probeDeliveredContent(endpointType string, body []byte) bool {
-	if endpointType == endpointTypeEmbeddings {
+	switch endpointType {
+	case endpointTypeEmbeddings:
 		// The vector is left undecoded on purpose. Typing it as []float64 makes
 		// the whole document fail to parse when a provider answers with
 		// base64-encoded embeddings, a JSON string where the struct wants an
@@ -503,6 +506,28 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 			return false
 		}
 		return !jsonValueIsEmpty(out.Data[0].Embedding)
+	case endpointTypeRerank:
+		// A ranking of nothing is nothing produced: every rerank API returns one
+		// result per document it scored, and refuses an empty document list
+		// with a 400 rather than answering it with an empty 200.
+		var out struct {
+			Results []json.RawMessage `json:"results"`
+		}
+		return json.Unmarshal(body, &out) == nil && len(out.Results) > 0
+	case endpointTypeImage:
+		// An image is delivered as a URL or as base64 bytes; an entry carrying
+		// neither (a revised prompt alone, say) is not an image. The same
+		// structural emptiness rule as the vector above, for the same reason.
+		var out struct {
+			Data []struct {
+				URL     json.RawMessage `json:"url"`
+				B64JSON json.RawMessage `json:"b64_json"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(body, &out) != nil || len(out.Data) == 0 {
+			return false
+		}
+		return !jsonValueIsEmpty(out.Data[0].URL) || !jsonValueIsEmpty(out.Data[0].B64JSON)
 	}
 
 	var out ChatCompletionResponse

--- a/internal/proxy/model_probe.go
+++ b/internal/proxy/model_probe.go
@@ -538,10 +538,11 @@ func probeDeliveredContent(endpointType string, body []byte) bool {
 func listAnswerDelivered(body []byte, keys ...string) bool {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) > 0 && trimmed[0] == '[' {
-		return !jsonValueIsEmpty(trimmed)
+		var list []json.RawMessage
+		return json.Unmarshal(trimmed, &list) == nil && len(list) > 0
 	}
 	var out map[string]json.RawMessage
-	if json.Unmarshal(body, &out) != nil {
+	if json.Unmarshal(body, &out) != nil || out == nil {
 		return false
 	}
 	for _, key := range keys {

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -539,6 +539,8 @@ func TestProbeDeliveredContent(t *testing.T) {
 		{"no voyage rerank data", endpointTypeRerank, `{"object":"list","data":[]}`, false},
 		{"bare rerank list", endpointTypeRerank, `[{"index":0,"score":0.9}]`, true},
 		{"empty bare rerank list", endpointTypeRerank, `[]`, false},
+		{"truncated bare rerank list", endpointTypeRerank, `[{"index":0`, false},
+		{"null rerank body", endpointTypeRerank, `null`, false},
 		{"rerank dialect not understood", endpointTypeRerank, `{"rankings":[]}`, true},
 		{"unparseable rerank", endpointTypeRerank, `<html>502 Bad Gateway</html>`, false},
 		{"image url", endpointTypeImage, `{"data":[{"url":"https://img/1.png"}]}`, true},

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -529,16 +529,25 @@ func TestProbeDeliveredContent(t *testing.T) {
 		// Rerank and image generation answer in JSON too, so an empty answer
 		// there is as visible as an empty vector: a rerank that ranked nothing
 		// and an image call that produced no image are the provider answering
-		// with nothing, whatever the status line says.
-		{"rerank results", endpointTypeRerank, `{"results":[{"index":0,"relevance_score":0.5}]}`, true},
+		// with nothing, whatever the status line says. Only a recognised shape
+		// is ever called empty: a dialect this gateway does not translate is
+		// forwarded as it came and judged on bytes, as before.
+		{"cohere rerank results", endpointTypeRerank, `{"results":[{"index":0,"relevance_score":0.5}]}`, true},
 		{"no rerank results", endpointTypeRerank, `{"results":[]}`, false},
-		{"rerank results absent", endpointTypeRerank, `{"model":"r"}`, false},
+		{"null rerank results", endpointTypeRerank, `{"results":null}`, false},
+		{"voyage rerank data", endpointTypeRerank, `{"object":"list","data":[{"index":0,"relevance_score":0.9}]}`, true},
+		{"no voyage rerank data", endpointTypeRerank, `{"object":"list","data":[]}`, false},
+		{"bare rerank list", endpointTypeRerank, `[{"index":0,"score":0.9}]`, true},
+		{"empty bare rerank list", endpointTypeRerank, `[]`, false},
+		{"rerank dialect not understood", endpointTypeRerank, `{"rankings":[]}`, true},
 		{"unparseable rerank", endpointTypeRerank, `<html>502 Bad Gateway</html>`, false},
 		{"image url", endpointTypeImage, `{"data":[{"url":"https://img/1.png"}]}`, true},
 		{"image base64", endpointTypeImage, `{"data":[{"b64_json":"aW1n"}]}`, true},
 		{"no image data", endpointTypeImage, `{"created":1,"data":[]}`, false},
-		{"image with neither url nor bytes", endpointTypeImage, `{"data":[{"revised_prompt":"x"}]}`, false},
-		{"empty image url and bytes", endpointTypeImage, `{"data":[{"url":"","b64_json":""}]}`, false},
+		{"null image data", endpointTypeImage, `{"created":1,"data":null}`, false},
+		{"image entry of unknown shape", endpointTypeImage, `{"data":[{"revised_prompt":"x"}]}`, true},
+		{"image dialect not understood", endpointTypeImage, `{"data":{"image_base64":"aW1n"}}`, true},
+		{"image under a key of its own", endpointTypeImage, `{"image":"aW1n"}`, true},
 		{"unparseable image", endpointTypeImage, `<html>502 Bad Gateway</html>`, false},
 	}
 	for _, tc := range cases {

--- a/internal/proxy/model_probe_test.go
+++ b/internal/proxy/model_probe_test.go
@@ -526,6 +526,20 @@ func TestProbeDeliveredContent(t *testing.T) {
 		{"embedding key absent", endpointTypeEmbeddings, `{"data":[{}]}`, false},
 		{"no embedding data", endpointTypeEmbeddings, `{"data":[]}`, false},
 		{"unparseable embeddings", endpointTypeEmbeddings, `<html>502 Bad Gateway</html>`, false},
+		// Rerank and image generation answer in JSON too, so an empty answer
+		// there is as visible as an empty vector: a rerank that ranked nothing
+		// and an image call that produced no image are the provider answering
+		// with nothing, whatever the status line says.
+		{"rerank results", endpointTypeRerank, `{"results":[{"index":0,"relevance_score":0.5}]}`, true},
+		{"no rerank results", endpointTypeRerank, `{"results":[]}`, false},
+		{"rerank results absent", endpointTypeRerank, `{"model":"r"}`, false},
+		{"unparseable rerank", endpointTypeRerank, `<html>502 Bad Gateway</html>`, false},
+		{"image url", endpointTypeImage, `{"data":[{"url":"https://img/1.png"}]}`, true},
+		{"image base64", endpointTypeImage, `{"data":[{"b64_json":"aW1n"}]}`, true},
+		{"no image data", endpointTypeImage, `{"created":1,"data":[]}`, false},
+		{"image with neither url nor bytes", endpointTypeImage, `{"data":[{"revised_prompt":"x"}]}`, false},
+		{"empty image url and bytes", endpointTypeImage, `{"data":[{"url":"","b64_json":""}]}`, false},
+		{"unparseable image", endpointTypeImage, `<html>502 Bad Gateway</html>`, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -210,15 +210,20 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 		contentType = "application/octet-stream"
 	}
 	isSSE := strings.HasPrefix(contentType, "text/event-stream")
-	// An embeddings answer is JSON by definition, so it takes the buffered branch
-	// whatever an aggregator or CDN in front of the provider labelled it.
-	// Letting the content type decide sends an unlabelled one to the streamed
-	// twin, which commits on the first byte and cannot judge what it never
-	// holds, so `{"data":[]}` is eleven bytes that clear the streak and route
-	// around the check passthroughAnswered exists to make. Embeddings is the
-	// only pass-through family that can be auto-retired, hence the only one
-	// named.
-	isJSON := !isSSE && (strings.Contains(contentType, "json") || st.logData.endpointType == endpointTypeEmbeddings)
+	// An embeddings, rerank or image-generation answer is JSON by definition,
+	// so it takes the buffered branch whatever an aggregator or CDN in front of
+	// the provider labelled it. Letting the content type decide sends an
+	// unlabelled one to the streamed twin, which commits on the first byte and
+	// cannot judge what it never holds, so `{"data":[]}` is eleven bytes that
+	// clear the streak, credit the circuit and route around the check
+	// passthroughAnswered exists to make. A body the provider itself declared
+	// binary is left to the streamed twin: nothing JSON is expected inside it.
+	judged := false
+	switch st.logData.endpointType {
+	case endpointTypeEmbeddings, endpointTypeRerank, endpointTypeImage:
+		judged = !strings.HasPrefix(contentType, "image/") && !strings.HasPrefix(contentType, "audio/")
+	}
+	isJSON := !isSSE && (strings.Contains(contentType, "json") || judged)
 
 	if isJSON {
 		return h.serveBufferedJSONPassthrough(w, r, st, candidate, resp, contentType, attempt, responseHeaderMs, hasMoreCandidates)

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -205,7 +205,8 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 		_ = resp.Body.Close()
 	}()
 
-	contentType := resp.Header.Get("Content-Type")
+	declared := resp.Header.Get("Content-Type")
+	contentType := declared
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
@@ -218,10 +219,12 @@ func (h *Handler) servePassthroughResponse(w http.ResponseWriter, r *http.Reques
 	// clear the streak, credit the circuit and route around the check
 	// passthroughAnswered exists to make. A body the provider itself declared
 	// binary is left to the streamed twin: nothing JSON is expected inside it.
+	// Judged on the header as sent, since a missing one reads as octet-stream
+	// above and is exactly the case the forcing exists for.
 	judged := false
 	switch st.logData.endpointType {
 	case endpointTypeEmbeddings, endpointTypeRerank, endpointTypeImage:
-		judged = !strings.HasPrefix(contentType, "image/") && !strings.HasPrefix(contentType, "audio/")
+		judged = !strings.HasPrefix(declared, "image/") && !strings.HasPrefix(declared, "audio/") && !strings.HasPrefix(declared, "application/octet-stream")
 	}
 	isJSON := !isSSE && (strings.Contains(contentType, "json") || judged)
 

--- a/internal/proxy/multimodal.go
+++ b/internal/proxy/multimodal.go
@@ -320,11 +320,12 @@ func (h *Handler) serveBufferedJSONPassthrough(w http.ResponseWriter, r *http.Re
 		// completion.
 	default:
 		// An answer carrying nothing goes to the sibling while there is one, the
-		// rule the chat path applies through completionFault, reached here on the
-		// only pass-through family whose body can be judged (an embeddings `200
-		// {"data":[]}`; passthroughAnswered says why the others cannot be). The
-		// reject path carries the same charge, so this is that verdict reached one
-		// candidate earlier, and nothing has been written to the client yet.
+		// rule the chat path applies through completionFault, reached here on
+		// the pass-through families whose body can be judged (an embeddings,
+		// rerank or image `200` carrying an empty list; passthroughAnswered says
+		// why audio cannot be). The reject path carries the same charge, so this
+		// is that verdict reached one candidate earlier, and nothing has been
+		// written to the client yet.
 		if hasMoreCandidates {
 			return h.rejectUntranslatableBody(st, candidate, logData, "passthrough", resp.StatusCode, errEmptyCompletion, attempt, r)
 		}

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -118,8 +118,9 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 //
 // A request that asked for nothing (no documents, no input) cannot be told
 // apart here either. Every hosted API refuses one with a 400, which is never
-// charged; a lenient local server answering it with an empty 200 is charged
-// as the embeddings family always was, at a rate the per-key limits bound.
+// charged; a lenient local server answering it with an empty 200 has its
+// circuit charged, as the embeddings family always was, at a rate the per-key
+// limits bound.
 func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -115,6 +115,11 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 // gone-strike count on every empty answer. Audio is judged on bytes, because a
 // speech answer is binary and a transcription of silence is legitimately empty
 // text, so neither can be told apart from a failure by its body.
+//
+// A request that asked for nothing (no documents, no input) cannot be told
+// apart here either. Every hosted API refuses one with a 400, which is never
+// charged; a lenient local server answering it with an empty 200 is charged
+// as the embeddings family always was, at a rate the per-key limits bound.
 func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false

--- a/internal/proxy/multimodal_attempt.go
+++ b/internal/proxy/multimodal_attempt.go
@@ -105,13 +105,16 @@ func (h *Handler) attemptPassthroughCandidate(w http.ResponseWriter, r *http.Req
 }
 
 // passthroughAnswered reports whether a buffered pass-through response is the
-// model answering, for the purpose of clearing its gone-strike streak.
+// model answering: what clears its gone-strike streak, credits its circuit,
+// and lets the metering floor charge for it.
 //
-// Embeddings is judged on content, since it is the only pass-through family
-// that can be auto-retired: a provider alternating gone-shaped 404s with
-// 200 {"data":[]} would otherwise reset the count on every empty answer.
-// Everything else is judged on bytes, because image and audio answers are
-// forwarded verbatim and are not parsed here.
+// The families that answer in JSON (embeddings, rerank, image generation) are
+// judged on content, since a 200 carrying `{"data":[]}` or `{"results":[]}` is
+// the provider answering with nothing: crediting it would let a provider that
+// always answers so keep its circuit closed, and reset an embeddings model's
+// gone-strike count on every empty answer. Audio is judged on bytes, because a
+// speech answer is binary and a transcription of silence is legitimately empty
+// text, so neither can be told apart from a failure by its body.
 func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) == 0 {
 		return false
@@ -123,8 +126,9 @@ func passthroughAnswered(endpointType string, body []byte) bool {
 	if len(body) > passthroughJSONBufferCap {
 		return true
 	}
-	if endpointType == endpointTypeEmbeddings {
-		return probeDeliveredContent(endpointTypeEmbeddings, body)
+	switch endpointType {
+	case endpointTypeEmbeddings, endpointTypeRerank, endpointTypeImage:
+		return probeDeliveredContent(endpointType, body)
 	}
 	return true
 }

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -384,20 +384,22 @@ func TestPassthrough2xxWithoutABody_FailsOverToTheSibling(t *testing.T) {
 		}
 	})
 
-	t.Run("binary image answer stays streamed", func(t *testing.T) {
-		st, candidate := nonCompletionState(t)
-		st.logData.endpointType = endpointTypeImage
-		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("\x89PNG\r\n")), Header: http.Header{"Content-Type": []string{"image/png"}}}
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/v1/images/generations", http.NoBody)
+	for _, declared := range []string{"image/png", "application/octet-stream"} {
+		t.Run("binary image answer stays streamed as "+declared, func(t *testing.T) {
+			st, candidate := nonCompletionState(t)
+			st.logData.endpointType = endpointTypeImage
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("\x89PNG\r\n")), Header: http.Header{"Content-Type": []string{declared}}}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/images/generations", http.NoBody)
 
-		if outcome := h.servePassthroughResponse(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeServed {
-			t.Fatalf("outcome = %v, want outcomeServed", outcome)
-		}
-		if w.Body.String() != "\x89PNG\r\n" {
-			t.Errorf("body = %q, want the image bytes forwarded as they came", w.Body.String())
-		}
-	})
+			if outcome := h.servePassthroughResponse(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeServed {
+				t.Fatalf("outcome = %v, want outcomeServed", outcome)
+			}
+			if w.Body.String() != "\x89PNG\r\n" {
+				t.Errorf("body = %q, want the image bytes forwarded as they came", w.Body.String())
+			}
+		})
+	}
 
 	t.Run("streamed", func(t *testing.T) {
 		st, candidate := nonCompletionState(t)

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -363,6 +363,42 @@ func TestPassthrough2xxWithoutABody_FailsOverToTheSibling(t *testing.T) {
 		})
 	}
 
+	// Which twin serves the answer used to be decided by the content type
+	// alone, with only embeddings forced to the buffered one. An empty rerank
+	// or image answer whose content type a CDN dropped then reached the
+	// streamed twin, which commits on the first byte and cannot judge what it
+	// never holds, so the same eleven bytes were served as a success. A body
+	// the provider itself declared binary still takes the streamed twin.
+	t.Run("unlabelled json carrying no ranking", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeRerank
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"results":[]}`)), Header: make(http.Header)}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/rerank", http.NoBody)
+
+		if outcome := h.servePassthroughResponse(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeFailover {
+			t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+		}
+		if w.Body.Len() != 0 {
+			t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+		}
+	})
+
+	t.Run("binary image answer stays streamed", func(t *testing.T) {
+		st, candidate := nonCompletionState(t)
+		st.logData.endpointType = endpointTypeImage
+		resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("\x89PNG\r\n")), Header: http.Header{"Content-Type": []string{"image/png"}}}
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/v1/images/generations", http.NoBody)
+
+		if outcome := h.servePassthroughResponse(w, req, st, candidate, resp, 0, 1.0, true); outcome != outcomeServed {
+			t.Fatalf("outcome = %v, want outcomeServed", outcome)
+		}
+		if w.Body.String() != "\x89PNG\r\n" {
+			t.Errorf("body = %q, want the image bytes forwarded as they came", w.Body.String())
+		}
+	})
+
 	t.Run("streamed", func(t *testing.T) {
 		st, candidate := nonCompletionState(t)
 		st.logData.endpointType = endpointTypeTTS

--- a/internal/proxy/noncompletion_failover_test.go
+++ b/internal/proxy/noncompletion_failover_test.go
@@ -334,6 +334,35 @@ func TestPassthrough2xxWithoutABody_FailsOverToTheSibling(t *testing.T) {
 		}
 	})
 
+	// A body that arrives and carries nothing is the same verdict one read
+	// later. Embeddings had this; rerank and image generation are JSON-bodied
+	// too, and an empty ranking or an image call that produced no image used to
+	// be served to the client as a success with a healthy sibling untried.
+	for _, tc := range []struct {
+		name, endpoint, path, body string
+	}{
+		{"buffered json carrying no ranking", endpointTypeRerank, "/v1/rerank", `{"results":[]}`},
+		{"buffered json carrying no image", endpointTypeImage, "/v1/images/generations", `{"created":1,"data":[]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st, candidate := nonCompletionState(t)
+			st.logData.endpointType = tc.endpoint
+			resp := &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(tc.body)), Header: make(http.Header)}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", tc.path, http.NoBody)
+
+			if outcome := h.serveBufferedJSONPassthrough(w, req, st, candidate, resp, "application/json", 0, 1.0, true); outcome != outcomeFailover {
+				t.Fatalf("outcome = %v, want outcomeFailover", outcome)
+			}
+			if w.Body.Len() != 0 {
+				t.Errorf("the client was written to before the sibling was tried: %s", w.Body.String())
+			}
+			if st.logData.attemptBreaker != breakerCharge {
+				t.Errorf("breaker note = %q, want %q", st.logData.attemptBreaker, breakerCharge)
+			}
+		})
+	}
+
 	t.Run("streamed", func(t *testing.T) {
 		st, candidate := nonCompletionState(t)
 		st.logData.endpointType = endpointTypeTTS

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -212,13 +212,16 @@ func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(20 * time.Millisecond)
 
-	// A perfectly ordinary provider response with no usage block.
+	// A perfectly ordinary provider response with no usage block. The image
+	// has to be under the key providers use for it: the floor sits behind the
+	// delivery gate, and an entry carrying no image under any real key is not
+	// an image delivered.
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(`{"created":1,"data":[{"b64":"AAAA"}]}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"created":1,"data":[{"b64_json":"AAAA"}]}`)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/images/generations", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-3"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0, false)
@@ -554,12 +557,12 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 // bill the caller on every empty answer — the regression the gate was added to
 // prevent.
 //
-// Embeddings is the endpoint this can be shown on: passthroughAnswered only
-// inspects the body for that type. For the multipart and binary families any
-// non-empty 200 body counts as delivered, so a junk answer there does draw the
-// floor. That is the intended trade — one token is the price of not being able
-// to tell a bad transcription from a good one, and per-key RPS limiting bounds
-// how often it can be paid.
+// Embeddings is the endpoint this is shown on; passthroughAnswered inspects the
+// body for every JSON family (rerank and image generation too). For the audio
+// families any non-empty 200 body counts as delivered, so a junk answer there
+// does draw the floor. That is the intended trade — one token is the price of
+// not being able to tell a bad transcription from a good one, and per-key RPS
+// limiting bounds how often it can be paid.
 func TestPassthroughFloor_StaysBehindTheDeliveryGate(t *testing.T) {
 	h := newIntegrationHandler()
 	t.Cleanup(func() { stopUnitHandler(h) })

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -557,43 +557,53 @@ func TestMultipartPassthrough_FloorDoesNotDisplaceRealFigures(t *testing.T) {
 // bill the caller on every empty answer — the regression the gate was added to
 // prevent.
 //
-// Embeddings is the endpoint this is shown on; passthroughAnswered inspects the
-// body for every JSON family (rerank and image generation too). For the audio
-// families any non-empty 200 body counts as delivered, so a junk answer there
-// does draw the floor. That is the intended trade — one token is the price of
-// not being able to tell a bad transcription from a good one, and per-key RPS
-// limiting bounds how often it can be paid.
+// passthroughAnswered inspects the body for every JSON family but audio, so
+// rerank and image generation are behind the same gate. For the audio families
+// any non-empty 200 body counts as delivered, so a junk answer there does draw
+// the floor. That is the intended trade — one token is the price of not being
+// able to tell a bad transcription from a good one, and per-key RPS limiting
+// bounds how often it can be paid.
 func TestPassthroughFloor_StaysBehindTheDeliveryGate(t *testing.T) {
-	h := newIntegrationHandler()
-	t.Cleanup(func() { stopUnitHandler(h) })
-	vkRepo := &mockVirtualKeyRepo{}
-	h.virtualKeyRepo = vkRepo
+	for _, tc := range []struct {
+		endpoint, path, body string
+	}{
+		{endpointTypeEmbeddings, "/v1/embeddings", `{"data":[]}`},
+		{endpointTypeRerank, "/v1/rerank", `{"results":[]}`},
+		{endpointTypeImage, "/v1/images/generations", `{"created":1,"data":[]}`},
+	} {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			h := newIntegrationHandler()
+			t.Cleanup(func() { stopUnitHandler(h) })
+			vkRepo := &mockVirtualKeyRepo{}
+			h.virtualKeyRepo = vkRepo
 
-	logData := &requestLogData{
-		id:              uuid.New().String(),
-		modelID:         "text-embedding-3-small",
-		endpointType:    endpointTypeEmbeddings,
-		virtualKeyName:  "test-key",
-		virtualKeyID:    "00000000-0000-0000-0000-000000000001",
-		state:           "streaming",
-		promptTextBytes: 0,
-	}
-	st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
-	h.insertRequestLogAsync(logData)
-	time.Sleep(20 * time.Millisecond)
+			logData := &requestLogData{
+				id:              uuid.New().String(),
+				modelID:         "m",
+				endpointType:    tc.endpoint,
+				virtualKeyName:  "test-key",
+				virtualKeyID:    "00000000-0000-0000-0000-000000000001",
+				state:           "streaming",
+				promptTextBytes: 0,
+			}
+			st := &requestState{startTime: time.Now(), logData: logData, vkHash: "test-hash"}
+			h.insertRequestLogAsync(logData)
+			time.Sleep(20 * time.Millisecond)
 
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
-	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
-		model:    &model.Model{ID: uuid.New(), ModelID: "text-embedding-3-small"},
-		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
-	}, resp, "application/json", 1, 10.0, false)
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+			h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", tc.path, http.NoBody), st, modelCandidate{
+				model:    &model.Model{ID: uuid.New(), ModelID: "m"},
+				provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
+			}, resp, "application/json", 1, 10.0, false)
 
-	if n := len(vkRepo.addTokensCalls); n != 0 {
-		t.Errorf("charged %d times for an empty answer, want 0: the floor must not defeat the delivery gate", n)
+			if n := len(vkRepo.addTokensCalls); n != 0 {
+				t.Errorf("charged %d times for an empty answer, want 0: the floor must not defeat the delivery gate", n)
+			}
+		})
 	}
 }
 
@@ -633,7 +643,7 @@ func TestOversizedPassthrough_ZeroPromptStillMeters(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(huge)),
 	}
-	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/embeddings", http.NoBody), st, modelCandidate{
+	h.serveBufferedJSONPassthrough(httptest.NewRecorder(), httptest.NewRequest("POST", "/v1/images/generations", http.NoBody), st, modelCandidate{
 		model:    &model.Model{ID: uuid.New(), ModelID: "dall-e-2"},
 		provider: &provider.Provider{ID: uuid.New(), Name: "test-provider"},
 	}, resp, "application/json", 1, 10.0, false)

--- a/internal/proxy/passthrough_metering_test.go
+++ b/internal/proxy/passthrough_metering_test.go
@@ -212,10 +212,8 @@ func TestPassthrough_NoUsageBlockStillMeters(t *testing.T) {
 	h.insertRequestLogAsync(logData)
 	time.Sleep(20 * time.Millisecond)
 
-	// A perfectly ordinary provider response with no usage block. The image
-	// has to be under the key providers use for it: the floor sits behind the
-	// delivery gate, and an entry carrying no image under any real key is not
-	// an image delivered.
+	// A perfectly ordinary provider response with no usage block, under the
+	// key providers actually use for the image.
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},


### PR DESCRIPTION
## What

A pass-through HTTP 200 was judged as "the model answered" by its content for embeddings only. Rerank and image generation were judged by bytes alone, so an upstream answering `{"results":[]}` or `{"data":[]}` credited its circuit on every call, drew the metering floor, and was served to the client as a success while a healthy failover sibling went untried.

Both families now go through the same content judgement embeddings already had, and the judgement only ever calls a shape empty when it can read it:

- Rerank: the list under `results` (Cohere, Jina, local rerankers), under `data` (Voyage), or the bare list (text-embeddings-inference). An empty or null list is nothing produced.
- Image generation: the list under `data` (the OpenAI shape every fronted image provider answers in).
- A dialect this gateway does not translate (an object under `data`, the image under a key of its own, an unknown envelope) is forwarded as it came and judged on bytes, as before. Not understanding a shape is not evidence it carries nothing.
- Audio stays byte-judged on purpose: speech is binary, and a transcription of silence is legitimately empty text.

Rerank and image answers also join embeddings on the buffered branch when the upstream sent no content type, so an unlabelled empty answer cannot reach the streamed twin, which commits on the first byte and cannot judge what it never holds. A body the provider itself declared binary (`image/*`, `audio/*`, `application/octet-stream`) still takes the streamed twin.

## Origin

Leftover from the 2026-08-30 queue sweep, the last item on that list. Three review rounds (Opus, GLM-5.3, DeepSeek V4.1 Flash each round). Round one caught that the first cut hard-coded one envelope per family and would have failed every Voyage and text-embeddings-inference rerank over. Round two caught the binary carve-out reading the content type after a missing header had been defaulted to octet-stream, and a bare list judged on its first byte rather than parsed.

## Deliberately left as is

A request that asks for nothing (no documents, `top_n` 0) can produce a legitimately empty 200 from a lenient self-hosted server, which then charges that circuit. Every hosted API refuses such a request with a 400, which is never charged (verified live against Cohere through the dev stack). The embeddings family has carried the same exposure since its content check shipped, it is bounded by the per-key rate limits, and closing it means re-parsing the request body on the response path. Recorded in a comment at the judgement.

## Proof

- `go test ./internal/proxy/` green, `golangci-lint` clean, size gate passes, every changed production line covered.
- Dev stack rebuilt from the final commit. A live Cohere rerank through it completed with both results; an empty-documents request came back as Cohere's own 400, not the empty verdict.
- New tests fail on revert: the empty rerank and image answers charge the breaker and fail over to the sibling; the metering floor is skipped for all three JSON families; an unlabelled empty rerank is judged; a declared-binary image answer stays streamed under both `image/png` and `application/octet-stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
